### PR TITLE
CI/imspy-docs: versioning and updates

### DIFF
--- a/.github/workflows/imspy-docs.yml
+++ b/.github/workflows/imspy-docs.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           cd imspy
           poetry install
-      
+
       # Step 5: Build the documentation
       - name: Build Documentation
         run: |
@@ -44,11 +44,11 @@ jobs:
           mkdir -p docs/source/_static  # Create the static folder if it doesn't exist
           poetry run sphinx-build docs/source/ docs/build/html
 
-      # Step 6: Deploy to GitHub Pages (to the 'imspy' subfolder)
+      # Step 6: Deploy to GitHub Pages (dev documentation)
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: imspy/docs/build/html
-          destination_dir: imspy  # This ensures the docs go into the 'imspy' subfolder
+          destination_dir: imspy/main

--- a/.github/workflows/imspy-docs.yml
+++ b/.github/workflows/imspy-docs.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-docs:

--- a/.github/workflows/imspy-docs.yml
+++ b/.github/workflows/imspy-docs.yml
@@ -45,6 +45,7 @@ jobs:
 
       # Step 6: Deploy to GitHub Pages (to the 'imspy' subfolder)
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/imspy-docs.yml
+++ b/.github/workflows/imspy-docs.yml
@@ -16,17 +16,17 @@ jobs:
     steps:
       # Step 1: Checkout the repository
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Step 2: Set up Python
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11' # or your preferred version of Python
 
       # Step 3: Install Poetry
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2
+        uses: abatilo/actions-poetry@v3
         with:
           poetry-version: 'latest'
 
@@ -45,7 +45,7 @@ jobs:
 
       # Step 6: Deploy to GitHub Pages (to the 'imspy' subfolder)
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: imspy/docs/build/html

--- a/.github/workflows/imspy-docs.yml
+++ b/.github/workflows/imspy-docs.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
   pull_request:
     branches:
       - main
@@ -15,40 +17,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Step 1: Checkout the repository
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # Step 2: Set up Python
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11' # or your preferred version of Python
+          python-version: '3.11'
 
-      # Step 3: Install Poetry
       - name: Install Poetry
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: 'latest'
 
-      # Step 4: Install dependencies
       - name: Install Dependencies
         run: |
           cd imspy
           poetry install
 
-      # Step 5: Build the documentation
       - name: Build Documentation
         run: |
           cd imspy
           mkdir -p docs/source/_static  # Create the static folder if it doesn't exist
           poetry run sphinx-build docs/source/ docs/build/html
 
-      # Step 6: Deploy to GitHub Pages (dev documentation)
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages (dev documentation)
         if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: imspy/docs/build/html
           destination_dir: imspy/main
+
+      - name: Deploy to GitHub Pages (release documentation)
+        if: startswith(github.ref, 'refs/tags/')
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: imspy/docs/build/html
+          destination_dir: 'imspy/${{ github.ref_name }}'

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ __pycache__/
 
 # vscode developing
 .vscode/
+
+# generated documentation
+imspy/docs/build
+


### PR DESCRIPTION
This PR
- bumps the used actions to avoid node <20 usage (which GitHub will disable soon-ish),
- disables deployment for pull requests (currently, the documentation is overwritten by PRs),
- moves the dev documentation (i.e., based on the `main` branch) to a `main` subdir, and
- allows automatic build and deployment of release documentation (whenever a tag is pushed, using the tag name as subdir name)

Please note that the current main branch triggers dependency errors:
> Because tensorflow (2.15.0.post1) depends on tensorflow-intel (2.15.0.post1) which doesn't match any versions, tensorflow is forbidden.
> So, because imspy depends on tensorflow (2.15.0.post1), version solving failed.

In my fork, I simply reverted 95a24b4825f0feebe9e86b0eb608e6804043f973 but this might not be a great solution here. I guess this should be fixed first. ^^"