### PR TITLE
Fix Dockerfile: use PATH instead of ENTRYPOINT for venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,5 +125,6 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 WORKDIR /workspace
 
-ENTRYPOINT ["/opt/venv/bin/python"]
-CMD ["--version"]
+# Ensure venv is on PATH for all commands (python, timsim, etc.)
+ENV PATH="/opt/venv/bin:${PATH}"
+CMD ["python", "--version"]


### PR DESCRIPTION
## Summary
- Replace fixed `ENTRYPOINT ["/opt/venv/bin/python"]` with `ENV PATH="/opt/venv/bin:${PATH}"`
- Users can now run any command directly: `docker run rustims timsim --help`
- Default CMD remains `python --version`

## Test plan
- [ ] `docker run --rm rustims timsim --help` → shows timsim usage
- [ ] `docker run --rm rustims python -c "import torch"` → works
- [ ] `docker run --rm rustims` → prints Python version

🤖 Generated with [Claude Code](https://claude.com/claude-code)