### PR TITLE
Move imspy-search to base dependency of imspy-simulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN pip install --no-cache-dir /tmp/packages/imspy-core && \
     pip install --no-cache-dir "/tmp/packages/imspy-predictors[koina]" && \
     pip install --no-cache-dir /tmp/packages/imspy-dia && \
     pip install --no-cache-dir /tmp/packages/imspy-search && \
-    pip install --no-cache-dir "/tmp/packages/imspy-simulation[search,gui]" && \
+    pip install --no-cache-dir "/tmp/packages/imspy-simulation[gui]" && \
     pip install --no-cache-dir /tmp/packages/imspy-vis && \
     rm -rf /tmp/packages
 

--- a/packages/imspy-simulation/pyproject.toml
+++ b/packages/imspy-simulation/pyproject.toml
@@ -20,10 +20,10 @@ dependencies = [
     "tqdm>=4.66",
     "zstd>=1.5",
     "matplotlib>=3.5",
+    "imspy-search>=0.4.0",
 ]
 
 [project.optional-dependencies]
-search = ["imspy-search>=0.4.0"]
 gui = [
     "nicegui>=1.4.0",
     "qdarkstyle>=3.0",


### PR DESCRIPTION
## Summary
- `timsim` imports `sagepy` unconditionally, but `sagepy` was only available via the `[search]` optional extra
- This caused `pip install imspy-simulation && timsim --help` to crash with `ModuleNotFoundError: No module named 'sagepy'`
- Fix: move `imspy-search>=0.4.0` from `[project.optional-dependencies.search]` to `[project.dependencies]`
- Update Dockerfile: `imspy-simulation[search,gui]` → `imspy-simulation[gui]` (search is now always included)

## Test plan
- [ ] `pip install imspy-simulation && timsim --help` works without manually installing sagepy

🤖 Generated with [Claude Code](https://claude.com/claude-code)