### PR TITLE
fix(imspy-predictors): model download 404 + bump to 0.5.1

### DIFF
--- a/packages/imspy-predictors/pyproject.toml
+++ b/packages/imspy-predictors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imspy-predictors"
-version = "0.5.0"
+version = "0.5.1"
 description = "ML-based predictors for CCS, retention time, and fragment intensity in mass spectrometry."
 authors = [
     { name = "theGreatHerrLebert", email = "davidteschner@googlemail.com" }


### PR DESCRIPTION
## Summary
- Uploaded the 4 missing task-specific model assets (`rt-best_model.pt`, `ccs-best_model.pt`, `charge-best_model.pt`, `intensity-best_model.pt`) to the `models-v0.5.0` GitHub release
- Added `_find_bundled_model()` fallback in `hub.py` for editable/source installs where `.pt` files live next to the module
- Bumped version to 0.5.1 so the fix can be published to PyPI

## Context
`pip install imspy-predictors` users hit an HTTP 404 on first model load because:
1. The wheel excludes `.pt` files (intentional, keeps wheel small)
2. The download fallback in `hub.py` referenced filenames (`rt-best_model.pt`, etc.) that were never uploaded to the GitHub release

## After merge
Trigger `workflow_dispatch` on **Build and Publish Python Packages** to publish `imspy-predictors==0.5.1`. All other packages use `--skip-existing` and will be silently skipped by PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)