### PR TITLE
fix(imspy-predictors): upload missing model assets and add local fall…

### DIFF
--- a/packages/imspy-predictors/pyproject.toml
+++ b/packages/imspy-predictors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imspy-predictors"
-version = "0.5.0"
+version = "0.5.1"
 description = "ML-based predictors for CCS, retention time, and fragment intensity in mass spectrometry."
 authors = [
     { name = "theGreatHerrLebert", email = "davidteschner@googlemail.com" }


### PR DESCRIPTION
…back in hub.py

The wheel excludes .pt files to keep it small, but the GitHub release was missing the task-specific model assets (rt-, ccs-, charge-, intensity-best_model.pt). This caused a 404 on first use for pip-installed users.

- Upload the 4 missing assets to the models-v0.5.0 release
- Add _find_bundled_model() fallback in hub.py for editable/source installs
- Bump version to 0.5.1