### PR TITLE
Merge feature/predictor-finetune: native Chronologer RT adapter + per-task fine-tuning

### DIFF
--- a/packages/imspy-predictors/scripts/finetune_dia_pasef.py
+++ b/packages/imspy-predictors/scripts/finetune_dia_pasef.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python
+"""Phase 1.0 — RT-only smoke test for the calibrated-library pipeline.
+
+Takes a rescored DIA-PASEF PSM table (sagepy/sage canonical schema), filters
+to high-confidence target PSMs, fine-tunes the pretrained RT predictor on
+this run's observations, and reports RT MAE on a peptide-level holdout
+(20% of unique sequences, seeded) before vs. after fine-tuning.
+
+If the held-out MAE drops meaningfully on the same run, the calibration
+hypothesis is alive and we expand to multi-task (RT + CCS + intensity)
+on UnifiedPeptideModel. If it doesn't, we go back to the drawing board.
+
+Inputs:
+  - --rescore-dir: directory containing the canonical rescore output:
+      * rescored_canonical.csv      (pre-TDC, has `retention_time_projected`)
+      * rescored_canonical.tdc.csv  (post-TDC, has `q_value` + `decoy`)
+    Joined on (spec_idx, match_idx) — match_idx is the peptide sequence.
+  - --out-dir: where to write the fine-tuned checkpoint + metrics JSON.
+
+Holdout strategy: random 20% of UNIQUE peptide sequences (no train/test
+leak across charge states). Per-PSM aggregation: mean
+retention_time_projected per peptide reduces noise from multiple PSMs of
+the same sequence — RT predictors are sequence-conditional.
+
+Usage:
+    python scripts/finetune_dia_pasef.py \\
+        --psm-csv /path/to/rescored_canonical.csv \\
+        --out-dir ./checkpoints/finetune_o240206_rt
+"""
+
+import argparse
+import copy
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+from imspy_predictors.rt.predictors import (
+    DeepChromatographyApex,
+    load_deep_retention_time_predictor,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("finetune_dia_pasef")
+
+
+def load_and_aggregate(
+    rescore_dir: Path, q_cutoff: float
+) -> pd.DataFrame:
+    """Join pre-TDC features with post-TDC q-values, filter, aggregate per peptide.
+
+    The canonical rescore output splits across two files:
+      * rescored_canonical.csv      — full feature matrix incl. observed `rt` (minutes)
+      * rescored_canonical.tdc.csv  — post-TDC q_value + decoy flag
+    Both keyed by (spec_idx, match_idx). Inner join → high-conf target PSMs
+    with their observed RT.
+
+    Supervision target is OBSERVED `rt` (minutes from the .d file) — NOT
+    `retention_time_projected`. The latter is sage's projection into ITS
+    predictor's space (different scale than imspy_predictors' RT model;
+    using it as a target gives nonsense MAE numbers because the imspy
+    predictor's pretrained output is on yet another scale).
+    """
+    psm_path = rescore_dir / "rescored_canonical.csv"
+    tdc_path = rescore_dir / "rescored_canonical.tdc.csv"
+
+    log.info(f"reading {tdc_path}")
+    tdc = pd.read_csv(
+        tdc_path,
+        usecols=["spec_idx", "match_idx", "decoy", "q_value"],
+    )
+    log.info(f"  tdc rows: {len(tdc):,}")
+    tdc = tdc[(~tdc.decoy.astype(bool)) & (tdc.q_value <= q_cutoff)]
+    log.info(f"  tdc rows q≤{q_cutoff} & target: {len(tdc):,}")
+    if len(tdc) == 0:
+        raise SystemExit("no high-confidence PSMs in tdc table after filter")
+
+    log.info(f"reading {psm_path} (observed rt + keys only)")
+    psm = pd.read_csv(
+        psm_path,
+        usecols=["spec_idx", "match_idx", "rt"],
+    )
+    log.info(f"  psm rows: {len(psm):,}")
+
+    df = tdc.merge(psm, on=["spec_idx", "match_idx"], how="inner")
+    log.info(f"  joined rows: {len(df):,}")
+    if len(df) == 0:
+        raise SystemExit("inner join produced no rows — check rescore-dir contents")
+
+    agg = (
+        df.rename(columns={"match_idx": "sequence", "rt": "observed_rt"})
+        .groupby("sequence", as_index=False)
+        .agg(
+            observed_rt=("observed_rt", "mean"),
+            n_psm=("spec_idx", "size"),
+        )
+    )
+    log.info(
+        f"  unique peptides: {len(agg):,}  "
+        f"(median PSMs/peptide={int(agg.n_psm.median())}, "
+        f"observed_rt min={agg.observed_rt.min():.2f} max={agg.observed_rt.max():.2f})"
+    )
+    return agg
+
+
+def split_peptide_holdout(
+    agg: pd.DataFrame, holdout_frac: float, seed: int
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(len(agg))
+    n_hold = int(round(len(agg) * holdout_frac))
+    hold_idx = perm[:n_hold]
+    train_idx = perm[n_hold:]
+    train = agg.iloc[train_idx].reset_index(drop=True)
+    hold = agg.iloc[hold_idx].reset_index(drop=True)
+    log.info(
+        f"  holdout split (seed={seed}): "
+        f"train {len(train):,} / hold {len(hold):,}"
+    )
+    return train, hold
+
+
+def evaluate_in_observed_space(
+    predictor: DeepChromatographyApex,
+    hold: pd.DataFrame,
+    tag: str,
+    projection: tuple[float, float] | None = None,
+) -> dict:
+    """Predict for holdout, optionally apply a (slope, intercept) linear
+    projection to land in observed-RT minutes, then MAE vs observed RT.
+
+    Pre-fine-tune the predictor outputs in its own native scale
+    (~70-115 for typical peptides on the v0.5.0 checkpoint); a fair
+    "before" baseline projects via least-squares onto observed RT,
+    so we measure prediction *quality* rather than scale offset.
+    Post-fine-tune the predictor itself outputs in observed-RT
+    minutes — pass projection=None there.
+    """
+    pred = predictor.simulate_separation_times(hold.sequence.tolist())
+    pred = pred.astype(np.float64)
+    obs = hold.observed_rt.values.astype(np.float64)
+    if projection is not None:
+        slope, intercept = projection
+        pred = slope * pred + intercept
+    abs_err = np.abs(pred - obs)
+    metrics = {
+        "tag": tag,
+        "n": int(len(hold)),
+        "mae_min": float(np.mean(abs_err)),
+        "median_ae_min": float(np.median(abs_err)),
+        "p90_ae_min": float(np.percentile(abs_err, 90)),
+        "rmse_min": float(np.sqrt(np.mean(abs_err ** 2))),
+        "projected": projection is not None,
+    }
+    log.info(
+        f"  [{tag}] n={metrics['n']:,}  "
+        f"MAE={metrics['mae_min']:.3f} min  "
+        f"median={metrics['median_ae_min']:.3f}  "
+        f"p90={metrics['p90_ae_min']:.3f}  "
+        f"RMSE={metrics['rmse_min']:.3f}"
+    )
+    return metrics
+
+
+def fit_linear_projection(
+    predictor: DeepChromatographyApex, train: pd.DataFrame
+) -> tuple[float, float]:
+    """Least-squares fit predictor_output → observed_rt on training set.
+    Returns (slope, intercept) such that observed ≈ slope * pred + intercept.
+    """
+    pred = predictor.simulate_separation_times(train.sequence.tolist())
+    pred = pred.astype(np.float64)
+    obs = train.observed_rt.values.astype(np.float64)
+    slope, intercept = np.polyfit(pred, obs, deg=1)
+    log.info(
+        f"  pretrained → observed RT projection: "
+        f"observed ≈ {slope:.4f} * pred + {intercept:.4f}"
+    )
+    return float(slope), float(intercept)
+
+
+def custom_finetune_loop(
+    predictor: DeepChromatographyApex,
+    train: pd.DataFrame,
+    *,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    patience: int,
+    val_frac: float,
+    seed: int,
+    device: torch.device,
+) -> None:
+    """Bypass the legacy fine_tune_model() — it calls bare model(tokens)
+    which on UnifiedPeptideModel returns a dict, not a tensor (loss
+    function chokes). We call model.predict_rt(tokens) which extracts
+    `outputs['rt']` and returns a tensor.
+
+    Trains the predictor to output observed RT in minutes directly.
+    Internal 80/20 split for early-stopping val (no overlap with the
+    outer caller's holdout — that's a separate set).
+    """
+    import torch.nn.functional as F
+    from torch.utils.data import DataLoader, TensorDataset
+
+    rng = np.random.default_rng(seed)
+    n = len(train)
+    perm = rng.permutation(n)
+    n_val = int(round(n * val_frac))
+    val_idx = perm[:n_val]
+    train_idx = perm[n_val:]
+
+    seqs_train = train.sequence.values[train_idx].tolist()
+    seqs_val = train.sequence.values[val_idx].tolist()
+    rt_train = train.observed_rt.values[train_idx].astype(np.float32)
+    rt_val = train.observed_rt.values[val_idx].astype(np.float32)
+
+    tokens_train = predictor._preprocess_sequences(seqs_train)
+    tokens_val = predictor._preprocess_sequences(seqs_val)
+    rt_train_t = torch.tensor(rt_train, device=device).unsqueeze(1)
+    rt_val_t = torch.tensor(rt_val, device=device).unsqueeze(1)
+
+    train_loader = DataLoader(
+        TensorDataset(tokens_train, rt_train_t),
+        batch_size=batch_size, shuffle=True,
+    )
+    val_loader = DataLoader(
+        TensorDataset(tokens_val, rt_val_t),
+        batch_size=batch_size, shuffle=False,
+    )
+
+    model = predictor.model
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, patience=2, factor=0.5, min_lr=1e-6
+    )
+
+    best_val = float("inf")
+    best_state = None
+    bad_epochs = 0
+    for ep in range(1, epochs + 1):
+        model.train()
+        train_loss = 0.0
+        n_batches = 0
+        for tok_b, rt_b in train_loader:
+            optimizer.zero_grad()
+            pred = model.predict_rt(tok_b)
+            loss = F.l1_loss(pred, rt_b)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            train_loss += loss.item()
+            n_batches += 1
+        train_loss /= max(1, n_batches)
+
+        model.eval()
+        val_loss = 0.0
+        nv = 0
+        with torch.no_grad():
+            for tok_b, rt_b in val_loader:
+                pred = model.predict_rt(tok_b)
+                val_loss += F.l1_loss(pred, rt_b).item()
+                nv += 1
+        val_loss /= max(1, nv)
+        scheduler.step(val_loss)
+        log.info(
+            f"  epoch {ep:3d}/{epochs}  "
+            f"train_L1={train_loss:.4f}  val_L1={val_loss:.4f}  "
+            f"lr={optimizer.param_groups[0]['lr']:.2e}"
+        )
+
+        if val_loss < best_val - 1e-4:
+            best_val = val_loss
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+            bad_epochs = 0
+        else:
+            bad_epochs += 1
+            if bad_epochs >= patience:
+                log.info(f"  early stop at epoch {ep} (best val L1 {best_val:.4f})")
+                break
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--rescore-dir", type=Path, required=True,
+                        help="dir containing rescored_canonical.csv and "
+                             "rescored_canonical.tdc.csv")
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--q-cutoff", type=float, default=0.01)
+    parser.add_argument("--holdout-frac", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=1e-4,
+                        help="Lower than fine_tune_model's default 1e-3 — "
+                             "we're starting from a well-trained checkpoint, "
+                             "want to nudge not retrain.")
+    parser.add_argument("--patience", type=int, default=6)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Load, filter, split, print stats; do not fine-tune.")
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    log.info(f"out_dir: {args.out_dir}")
+
+    # 1) data
+    agg = load_and_aggregate(args.rescore_dir, q_cutoff=args.q_cutoff)
+    train_df, hold_df = split_peptide_holdout(
+        agg, holdout_frac=args.holdout_frac, seed=args.seed
+    )
+
+    if args.dry_run:
+        log.info("--dry-run: stopping after data prep")
+        return 0
+
+    # 2) load pretrained RT predictor
+    log.info("loading pretrained RT predictor")
+    rt_model = load_deep_retention_time_predictor()
+    predictor = DeepChromatographyApex(model=rt_model)
+    device = next(rt_model.parameters()).device
+    log.info(f"  predictor device: {device}")
+
+    # Snapshot pretrained weights so the post-fine-tune evaluation can
+    # report a true before/after on the SAME predictor instance.
+    pretrained_state = copy.deepcopy(rt_model.state_dict())
+
+    # 3) baseline eval — projects pretrained predictions onto observed RT
+    #    via least-squares on the training set first. Without projection,
+    #    the pretrained checkpoint outputs in its own scale (~70-115 for
+    #    typical peptides) and observed is in minutes (~1-20), so raw MAE
+    #    is mostly the scale offset, not prediction quality.
+    log.info("fitting pretrained → observed RT projection on training set")
+    proj = fit_linear_projection(predictor, train_df)
+
+    log.info("baseline (pretrained, linearly projected) eval on holdout")
+    baseline = evaluate_in_observed_space(
+        predictor, hold_df, "baseline_projected", projection=proj
+    )
+
+    # 4) fine-tune via custom loop (legacy fine_tune_model crashes on
+    #    UnifiedPeptideModel — its bare forward returns a dict).
+    log.info(
+        f"fine-tuning RT predictor: epochs={args.epochs} "
+        f"batch_size={args.batch_size} lr={args.lr}"
+    )
+    custom_finetune_loop(
+        predictor, train_df,
+        epochs=args.epochs, batch_size=args.batch_size,
+        lr=args.lr, patience=args.patience,
+        val_frac=0.2, seed=args.seed,
+        device=device,
+    )
+
+    # 5) post-finetune eval — predictor now outputs in observed-RT
+    #    minutes; no projection needed.
+    log.info("fine-tuned eval on holdout (no projection)")
+    finetuned = evaluate_in_observed_space(
+        predictor, hold_df, "finetuned", projection=None
+    )
+
+    # 6) save artifacts
+    finetuned_state = copy.deepcopy(rt_model.state_dict())
+    torch.save(
+        {
+            "model_state_dict": finetuned_state,
+            "pretrained_state_dict": pretrained_state,
+            "metrics": {"baseline": baseline, "finetuned": finetuned},
+            "args": vars(args) | {"rescore_dir": str(args.rescore_dir),
+                                  "out_dir": str(args.out_dir)},
+        },
+        args.out_dir / "rt_finetuned.pt",
+    )
+    metrics_summary = {
+        "baseline_projected": baseline,
+        "finetuned": finetuned,
+        "delta_mae_min": baseline["mae_min"] - finetuned["mae_min"],
+        "delta_mae_pct": (
+            100.0 * (baseline["mae_min"] - finetuned["mae_min"]) / baseline["mae_min"]
+            if baseline["mae_min"] > 0 else 0.0
+        ),
+        "projection": {"slope": proj[0], "intercept": proj[1]},
+        "n_train_peptides": int(len(train_df)),
+        "n_hold_peptides": int(len(hold_df)),
+        "n_train_psms": int(train_df.n_psm.sum()),
+        "args": {k: (str(v) if isinstance(v, Path) else v)
+                 for k, v in vars(args).items()},
+    }
+    metrics_path = args.out_dir / "metrics.json"
+    metrics_path.write_text(json.dumps(metrics_summary, indent=2))
+    log.info(f"wrote {metrics_path}")
+
+    # 7) summary
+    log.info("=" * 60)
+    log.info(f"baseline (projected)  MAE: {baseline['mae_min']:.3f} min")
+    log.info(f"fine-tuned            MAE: {finetuned['mae_min']:.3f} min")
+    log.info(
+        f"delta:                     {metrics_summary['delta_mae_min']:+.3f} min  "
+        f"({metrics_summary['delta_mae_pct']:+.2f}%)"
+    )
+    log.info("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/imspy-predictors/scripts/finetune_dia_pasef_ccs.py
+++ b/packages/imspy-predictors/scripts/finetune_dia_pasef_ccs.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python
+"""Phase 1.1 CCS-only diagnostic — standalone fine-tune of the CCS head.
+
+The multi-task fine-tune (finetune_dia_pasef_multi.py) only moved CCS
+~3% on the holdout — likely because cross-task gradient interference
+and a 1e-4 LR is undersized for the CCS head's SquareRootProjectionLayer
+slopes/intercepts (charge-specific, big-target params). This is the
+diagnostic isolation: just CCS, more epochs, higher LR, no RT loss.
+
+If this converges to <10 Å² MAE on holdout, the multi-task hyperparameters
+were the bottleneck. If it plateaus at ~30 Å² MAE (≈ pretrained + linear
+projection), the architecture has a real ceiling and we need a
+1/K0-native head.
+
+Supervises in CCS Å² (head's native output scale). Reports:
+  - CCS Å² MAE (head's space)
+  - 1/K0 MAE (predicted CCS converted via Mason-Schamp; library use)
+  - Per-charge breakdown (z=2 vs z=3 — the dominant charges)
+  - Pre/post per-charge slope+intercept of the physics layer
+    (sanity: did the physics-prior parameters move at all?)
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+from imspy_predictors.models.unified import UnifiedPeptideModel
+from imspy_predictors.utilities import ProformaTokenizer
+from imspy_predictors.utility import get_model_path
+from imspy_core.chemistry.mobility import (
+    ccs_to_one_over_k0_par, one_over_k0_to_ccs_par,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("finetune_ccs")
+
+PROTON = 1.007276466879
+
+
+def read_pseudo_bin_apex_scans(bin_path: Path) -> np.ndarray:
+    with open(bin_path, "rb") as f:
+        magic = f.read(4)
+        if magic != b"PSSP":
+            raise SystemExit(f"bad magic {magic!r}")
+        version, n_spec, _ = struct.unpack("<III", f.read(12))
+        if version != 2:
+            raise SystemExit(f"version {version}")
+        f.seek(4 * n_spec, 1)
+        f.seek(8 * n_spec, 1)
+        f.seek(4 * n_spec, 1)
+        return np.frombuffer(f.read(4 * n_spec), dtype="<f4").copy()
+
+
+def build_scan_to_im_lut(d_path: Path, sample_frame_id: int = 1) -> np.ndarray:
+    from imspy_core.timstof import TimsDataset
+    ds = TimsDataset(str(d_path))
+    n_scans = ds.num_scans
+    scans = np.arange(1, n_scans + 1, dtype=np.int32)
+    im = np.asarray(ds.scan_to_inverse_mobility(sample_frame_id, scans),
+                    dtype=np.float64)
+    lut = np.zeros(n_scans + 2, dtype=np.float64)
+    lut[1:n_scans + 1] = im
+    return lut
+
+
+def lookup_im(scan, lut):
+    s = np.asarray(scan, dtype=np.float64)
+    s_lo = np.floor(s).astype(np.int64)
+    s_hi = s_lo + 1
+    s_lo = np.clip(s_lo, 1, len(lut) - 2)
+    s_hi = np.clip(s_hi, 1, len(lut) - 1)
+    f = s - s_lo
+    return lut[s_lo] * (1.0 - f) + lut[s_hi] * f
+
+
+def load_psm_data(rescore_dir: Path, q_cutoff: float, pseudo_bin: Path, d_path: Path):
+    tdc = pd.read_csv(rescore_dir / "rescored_canonical.tdc.csv",
+                      usecols=["spec_idx", "match_idx", "decoy", "q_value"])
+    tdc = tdc[(~tdc.decoy.astype(bool)) & (tdc.q_value <= q_cutoff)]
+    log.info(f"  high-conf PSMs: {len(tdc):,}")
+    psm = pd.read_csv(rescore_dir / "rescored_canonical.csv",
+                      usecols=["spec_idx", "match_idx", "rt", "charge", "calcmass"])
+    df = tdc.merge(psm, on=["spec_idx", "match_idx"], how="inner")
+    apex_scan = read_pseudo_bin_apex_scans(pseudo_bin)
+    lut = build_scan_to_im_lut(d_path)
+    bin_idx = df.spec_idx.str.removeprefix("pseudo_").astype(np.int64).values
+    one_over_k0 = lookup_im(apex_scan[bin_idx], lut)
+    charge_arr = df.charge.values.astype(np.float64)
+    mz_arr = (df.calcmass.values + charge_arr * PROTON) / charge_arr
+    observed_ccs = np.asarray(
+        one_over_k0_to_ccs_par(one_over_k0, mz_arr, charge_arr.astype(np.int32)),
+        dtype=np.float64,
+    )
+    df = df.assign(
+        observed_ims=one_over_k0,
+        observed_ccs=observed_ccs,
+    )
+    df = df.rename(columns={"match_idx": "sequence"})
+    # Per-(peptide, charge) aggregation — fragmentation isn't relevant for CCS
+    # but charge IS, so we keep separate rows per charge state of same peptide.
+    agg = df.groupby(["sequence", "charge"], as_index=False).agg(
+        observed_rt=("rt", "mean"),
+        observed_ims=("observed_ims", "mean"),
+        observed_ccs=("observed_ccs", "mean"),
+        calcmass=("calcmass", "mean"),
+        n_psm=("spec_idx", "size"),
+    )
+    log.info(
+        f"  unique (peptide, charge) pairs: {len(agg):,}  "
+        f"CCS Å²: {agg.observed_ccs.min():.1f}-{agg.observed_ccs.max():.1f}  "
+        f"1/K0: {agg.observed_ims.min():.4f}-{agg.observed_ims.max():.4f}  "
+        f"charge counts: {dict(agg.charge.astype(int).value_counts().head())}"
+    )
+    return agg
+
+
+def split_peptide_holdout(df: pd.DataFrame, holdout_frac: float, seed: int):
+    rng = np.random.default_rng(seed)
+    seqs = df.sequence.unique()
+    perm = rng.permutation(len(seqs))
+    n_hold = int(round(len(seqs) * holdout_frac))
+    holdout_set = set(seqs[perm[:n_hold]])
+    train = df[~df.sequence.isin(holdout_set)].reset_index(drop=True)
+    hold = df[df.sequence.isin(holdout_set)].reset_index(drop=True)
+    log.info(f"  split (seed={seed}): train {len(train):,} / hold {len(hold):,}")
+    return train, hold
+
+
+def make_tensors(df: pd.DataFrame, tokenizer, device, pad_len=50):
+    result = tokenizer(df.sequence.tolist(), padding=True, return_tensors="pt")
+    tokens = result["input_ids"]
+    if tokens.shape[1] < pad_len:
+        pad = torch.zeros(tokens.shape[0], pad_len - tokens.shape[1], dtype=torch.long)
+        tokens = torch.cat([tokens, pad], dim=1)
+    elif tokens.shape[1] > pad_len:
+        tokens = tokens[:, :pad_len]
+    tokens = tokens.to(device)
+    charge = torch.tensor(df.charge.values.astype(np.int64), dtype=torch.long, device=device)
+    mz = (df.calcmass.values + df.charge.values * PROTON) / df.charge.values
+    mz_t = torch.tensor(mz, dtype=torch.float32, device=device).unsqueeze(1)
+    ccs = torch.tensor(df.observed_ccs.values, dtype=torch.float32, device=device).unsqueeze(1)
+    ims = torch.tensor(df.observed_ims.values, dtype=torch.float32, device=device).unsqueeze(1)
+    return {"tokens": tokens, "charge": charge, "mz": mz_t,
+            "ccs": ccs, "ims": ims}
+
+
+@torch.no_grad()
+def predict_ccs(model, batch, batch_size=512):
+    n = batch["tokens"].shape[0]
+    out_chunks = []
+    model.eval()
+    for i in range(0, n, batch_size):
+        sl = slice(i, i + batch_size)
+        ccs_mean, _ = model.predict_ccs(
+            batch["tokens"][sl],
+            mz=batch["mz"][sl],
+            charge=batch["charge"][sl],
+        )
+        out_chunks.append(ccs_mean.squeeze(-1).cpu().numpy())
+    return np.concatenate(out_chunks, axis=0).astype(np.float64)
+
+
+def report_per_charge_mae(pred_ccs, obs_ccs, charges, label):
+    log.info(f"  [{label}] per-charge:")
+    for z in (1, 2, 3, 4):
+        m = charges == z
+        if m.sum() == 0: continue
+        mae = float(np.mean(np.abs(pred_ccs[m] - obs_ccs[m])))
+        log.info(f"    z={z}: n={int(m.sum()):,}  MAE={mae:.2f} Å²")
+
+
+def custom_finetune_loop(
+    model, train_t, *, epochs, batch_size, lr, patience, val_frac, seed
+):
+    import torch.nn.functional as F
+    n = train_t["tokens"].shape[0]
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(n)
+    n_val = int(round(n * val_frac))
+    val_idx = torch.tensor(perm[:n_val], device=train_t["tokens"].device)
+    train_idx = torch.tensor(perm[n_val:], device=train_t["tokens"].device)
+
+    def _slice(b, idx):
+        return {k: v[idx] for k, v in b.items()}
+
+    tr = _slice(train_t, train_idx)
+    va = _slice(train_t, val_idx)
+    n_tr = tr["tokens"].shape[0]
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, patience=4, factor=0.5, min_lr=1e-6
+    )
+
+    best_val = float("inf")
+    best_state = None
+    bad_epochs = 0
+    log.info(f"CCS-only fine-tune: epochs={epochs} batch={batch_size} lr={lr:.2e}")
+
+    for ep in range(1, epochs + 1):
+        model.train()
+        epoch_perm = torch.randperm(n_tr, device=tr["tokens"].device)
+        t_loss = 0.0; nb = 0
+        for i in range(0, n_tr, batch_size):
+            idx = epoch_perm[i:i + batch_size]
+            optimizer.zero_grad()
+            ccs_mean, _ = model.predict_ccs(
+                tr["tokens"][idx], mz=tr["mz"][idx], charge=tr["charge"][idx],
+            )
+            loss = F.l1_loss(ccs_mean, tr["ccs"][idx])
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            t_loss += loss.item(); nb += 1
+        t_loss /= nb
+
+        model.eval()
+        v_loss = 0.0; vb = 0
+        with torch.no_grad():
+            for i in range(0, va["tokens"].shape[0], batch_size):
+                sl = slice(i, i + batch_size)
+                ccs_mean, _ = model.predict_ccs(
+                    va["tokens"][sl], mz=va["mz"][sl], charge=va["charge"][sl],
+                )
+                v_loss += F.l1_loss(ccs_mean, va["ccs"][sl]).item()
+                vb += 1
+            v_loss /= max(1, vb)
+        scheduler.step(v_loss)
+        if ep <= 5 or ep % 5 == 0:
+            log.info(
+                f"  ep {ep:3d}/{epochs}  tr={t_loss:.3f} val={v_loss:.3f}  "
+                f"lr={optimizer.param_groups[0]['lr']:.2e}"
+            )
+        if v_loss < best_val - 1e-3:
+            best_val = v_loss
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+            bad_epochs = 0
+        else:
+            bad_epochs += 1
+            if bad_epochs >= patience:
+                log.info(f"  early stop at ep {ep} (best val L1 {best_val:.4f})")
+                break
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--rescore-dir", type=Path, required=True)
+    parser.add_argument("--pseudo-bin", type=Path, required=True)
+    parser.add_argument("--d-path", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--q-cutoff", type=float, default=0.01)
+    parser.add_argument("--holdout-frac", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--epochs", type=int, default=200)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=5e-4)
+    parser.add_argument("--patience", type=int, default=15)
+    args = parser.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    df = load_psm_data(args.rescore_dir, args.q_cutoff, args.pseudo_bin, args.d_path)
+    train_df, hold_df = split_peptide_holdout(df, args.holdout_frac, args.seed)
+
+    log.info("loading pretrained UnifiedPeptideModel with CCS head")
+    ccs_path = get_model_path("ccs/best_model.pt")
+    model = UnifiedPeptideModel.from_pretrained(str(ccs_path), tasks=["ccs"])
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    log.info(f"  device: {device}  params: {sum(p.numel() for p in model.parameters()):,}")
+
+    # Sanity: print physics-layer slopes/intercepts before
+    sqrt_proj = model.heads["ccs"].sqrt_proj
+    log.info(f"  pre-finetune SquareRootProjectionLayer: "
+             f"slopes={sqrt_proj.slopes.detach().cpu().numpy()}  "
+             f"intercepts={sqrt_proj.intercepts.detach().cpu().numpy()}")
+
+    pretrained_state = copy.deepcopy(model.state_dict())
+    tokenizer = ProformaTokenizer.with_defaults()
+    train_t = make_tensors(train_df, tokenizer, device)
+    hold_t = make_tensors(hold_df, tokenizer, device)
+
+    obs_hold_ccs = hold_df.observed_ccs.values.astype(np.float64)
+    obs_hold_ims = hold_df.observed_ims.values.astype(np.float64)
+    z_hold = hold_df.charge.values.astype(np.int32)
+    mz_hold = (hold_df.calcmass.values + hold_df.charge.values * PROTON) / hold_df.charge.values
+
+    # Baseline: pretrained predictions, with optional linear projection on train
+    ccs_pred_pre = predict_ccs(model, hold_t)
+    ccs_pred_train_pre = predict_ccs(model, train_t)
+    train_obs_ccs = train_df.observed_ccs.values.astype(np.float64)
+    slope, intercept = np.polyfit(ccs_pred_train_pre, train_obs_ccs, 1)
+    log.info(f"baseline: pretrained CCS → observed projection: "
+             f"obs ≈ {slope:.4f}*pred + {intercept:.4f} Å²")
+    pre_raw_mae = float(np.mean(np.abs(ccs_pred_pre - obs_hold_ccs)))
+    pre_proj_mae = float(np.mean(np.abs(slope * ccs_pred_pre + intercept - obs_hold_ccs)))
+    pre_ims_proj_mae = float(np.mean(np.abs(
+        np.asarray(ccs_to_one_over_k0_par(slope * ccs_pred_pre + intercept, mz_hold, z_hold),
+                   dtype=np.float64) - obs_hold_ims
+    )))
+    log.info(f"  pretrained raw       MAE: {pre_raw_mae:.2f} Å²  (no projection)")
+    log.info(f"  pretrained+proj      MAE: {pre_proj_mae:.2f} Å²")
+    log.info(f"  pretrained+proj→1/K0 MAE: {pre_ims_proj_mae:.4f}")
+    report_per_charge_mae(slope * ccs_pred_pre + intercept, obs_hold_ccs, z_hold,
+                          "baseline+proj")
+
+    # Fine-tune
+    custom_finetune_loop(
+        model, train_t,
+        epochs=args.epochs, batch_size=args.batch_size,
+        lr=args.lr, patience=args.patience,
+        val_frac=0.2, seed=args.seed,
+    )
+
+    # Post
+    sqrt_proj = model.heads["ccs"].sqrt_proj
+    log.info(f"  post-finetune SquareRootProjectionLayer: "
+             f"slopes={sqrt_proj.slopes.detach().cpu().numpy()}  "
+             f"intercepts={sqrt_proj.intercepts.detach().cpu().numpy()}")
+    ccs_pred_post = predict_ccs(model, hold_t)
+    post_mae = float(np.mean(np.abs(ccs_pred_post - obs_hold_ccs)))
+    post_ims_mae = float(np.mean(np.abs(
+        np.asarray(ccs_to_one_over_k0_par(ccs_pred_post, mz_hold, z_hold),
+                   dtype=np.float64) - obs_hold_ims
+    )))
+    log.info(f"  finetuned       MAE: {post_mae:.2f} Å²")
+    log.info(f"  finetuned→1/K0  MAE: {post_ims_mae:.4f}")
+    report_per_charge_mae(ccs_pred_post, obs_hold_ccs, z_hold, "finetuned")
+
+    # Save
+    torch.save(
+        {
+            "model_state_dict": model.state_dict(),
+            "pretrained_state_dict": pretrained_state,
+            "metrics": {
+                "baseline_raw_mae_a2": pre_raw_mae,
+                "baseline_proj_mae_a2": pre_proj_mae,
+                "baseline_proj_ims_mae": pre_ims_proj_mae,
+                "finetuned_mae_a2": post_mae,
+                "finetuned_ims_mae": post_ims_mae,
+            },
+            "ccs_projection": {"slope": float(slope), "intercept": float(intercept)},
+        },
+        args.out_dir / "ccs_finetuned.pt",
+    )
+    summary = {
+        "ccs_a2": {"baseline_proj": pre_proj_mae, "finetuned": post_mae,
+                   "delta": pre_proj_mae - post_mae,
+                   "delta_pct": 100.0 * (pre_proj_mae - post_mae) / pre_proj_mae if pre_proj_mae > 0 else 0.0},
+        "ims": {"baseline_proj": pre_ims_proj_mae, "finetuned": post_ims_mae,
+                "delta": pre_ims_proj_mae - post_ims_mae,
+                "delta_pct": 100.0 * (pre_ims_proj_mae - post_ims_mae) / pre_ims_proj_mae if pre_ims_proj_mae > 0 else 0.0},
+        "n_train": int(len(train_df)),
+        "n_hold": int(len(hold_df)),
+        "args": {k: (str(v) if isinstance(v, Path) else v) for k, v in vars(args).items()},
+    }
+    (args.out_dir / "metrics.json").write_text(json.dumps(summary, indent=2))
+
+    log.info("=" * 60)
+    log.info(f"CCS Å² baseline+proj MAE={pre_proj_mae:.2f}  finetuned MAE={post_mae:.2f}  "
+             f"delta={summary['ccs_a2']['delta']:+.2f} ({summary['ccs_a2']['delta_pct']:+.2f}%)")
+    log.info(f"1/K0   baseline+proj MAE={pre_ims_proj_mae:.4f}  finetuned MAE={post_ims_mae:.4f}  "
+             f"delta={summary['ims']['delta']:+.4f} ({summary['ims']['delta_pct']:+.2f}%)")
+    log.info("=" * 60)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/imspy-predictors/scripts/finetune_dia_pasef_intensity.py
+++ b/packages/imspy-predictors/scripts/finetune_dia_pasef_intensity.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python
+"""Phase 1.2 — fragment-intensity fine-tune for the calibrated-library pipeline.
+
+Loads `rescored_canonical.fragments.parquet` (per-PSM fragment annotations
+from sage with `annotate_matches=True`, dumped by the patched
+rescore_canonical.py), filters to high-confidence target PSMs via
+rescored_canonical.tdc.csv, encodes targets to the canonical Prosit
+174-dim layout via intensity_target_encoder, fine-tunes the
+UnifiedPeptideModel intensity head jointly with the shared encoder,
+and reports spectral angle similarity on a peptide-level holdout.
+
+The training-data unit is one row per PSM (NOT aggregated per peptide):
+fragmentation depends on precursor charge AND collision energy, so a
+peptide observed at z=2 vs z=3 produces different ground-truth vectors.
+Holdout is by sequence — no peptide overlap between train and test.
+
+Loss: masked_spectral_distance (canonical Prosit loss; treats zeros as
+"unmatched" → ignored in the masked metric).
+
+Usage:
+    python finetune_dia_pasef_intensity.py \\
+        --rescore-dir /path/to/rescore-output \\
+        --out-dir ./checkpoints/finetune_o240206_intensity
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+from imspy_predictors.models.unified import UnifiedPeptideModel
+from imspy_predictors.utilities import ProformaTokenizer
+from imspy_predictors.losses import masked_spectral_distance
+from imspy_predictors.utility import get_model_path
+
+# Encoder lives next to this script.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from intensity_target_encoder import (
+    encode_psm_target_vec, PROSIT_DIM, ION_INT_TO_LABEL,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("finetune_intensity")
+
+
+def load_psm_targets(rescore_dir: Path, q_cutoff: float):
+    """Returns DataFrame keyed by PSM (one row per high-conf PSM) with
+    columns sequence, charge, collision_energy, target (174-vec).
+    """
+    tdc_path = rescore_dir / "rescored_canonical.tdc.csv"
+    psm_path = rescore_dir / "rescored_canonical.csv"
+    frag_path = rescore_dir / "rescored_canonical.fragments.parquet"
+
+    log.info(f"reading {tdc_path}")
+    tdc = pd.read_csv(tdc_path,
+                      usecols=["spec_idx", "match_idx", "decoy", "q_value"])
+    tdc = tdc[(~tdc.decoy.astype(bool)) & (tdc.q_value <= q_cutoff)]
+    log.info(f"  high-conf PSMs: {len(tdc):,}")
+
+    log.info(f"reading {psm_path} (charge + CE only)")
+    psm = pd.read_csv(psm_path,
+                      usecols=["spec_idx", "match_idx", "charge",
+                               "collision_energy", "calcmass"])
+
+    log.info(f"reading {frag_path}")
+    frag = pd.read_parquet(frag_path)
+    log.info(f"  fragments: {len(frag):,}")
+
+    # Keep only fragments belonging to high-conf PSMs (inner join on
+    # the (spec_idx, sequence) pair the parquet uses).
+    hc_keys = tdc.rename(columns={"match_idx": "sequence"})[
+        ["spec_idx", "sequence"]]
+    frag_hc = frag.merge(hc_keys, on=["spec_idx", "sequence"], how="inner")
+    log.info(f"  fragments ∩ high-conf: {len(frag_hc):,}")
+
+    # Encode targets per PSM.
+    log.info("encoding 174-dim targets per PSM …")
+    t0 = time.time()
+    psm_groups = frag_hc.groupby(["spec_idx", "sequence"], sort=False)
+    rows = []
+    for (spec_idx, seq), grp in psm_groups:
+        target = encode_psm_target_vec(grp)
+        rows.append({"spec_idx": spec_idx, "sequence": seq, "target": target})
+    target_df = pd.DataFrame(rows)
+    log.info(f"  encoded {len(target_df):,} PSM targets in {time.time() - t0:.1f}s")
+
+    # Join charge + CE per PSM. Use the rank-1 match per (spec_idx, sequence).
+    psm_meta = psm.rename(columns={"match_idx": "sequence"}).drop_duplicates(
+        subset=["spec_idx", "sequence"], keep="first"
+    )
+    out = target_df.merge(
+        psm_meta[["spec_idx", "sequence", "charge", "collision_energy"]],
+        on=["spec_idx", "sequence"], how="inner",
+    )
+    log.info(f"  joined → {len(out):,} training examples  "
+             f"(charge mode counts: {out.charge.astype(int).value_counts().head().to_dict()})")
+    return out
+
+
+def split_peptide_holdout(df: pd.DataFrame, holdout_frac: float, seed: int):
+    rng = np.random.default_rng(seed)
+    seqs = df.sequence.unique()
+    perm = rng.permutation(len(seqs))
+    n_hold = int(round(len(seqs) * holdout_frac))
+    holdout_set = set(seqs[perm[:n_hold]])
+    train = df[~df.sequence.isin(holdout_set)].reset_index(drop=True)
+    hold = df[df.sequence.isin(holdout_set)].reset_index(drop=True)
+    log.info(f"  split (seed={seed}): train {len(train):,} examples "
+             f"({train.sequence.nunique():,} peptides) / hold {len(hold):,} "
+             f"examples ({hold.sequence.nunique():,} peptides)")
+    return train, hold
+
+
+def make_tensors(df: pd.DataFrame, tokenizer, device, pad_len=50):
+    """Build a dict of tensors ready for forward()."""
+    result = tokenizer(df.sequence.tolist(), padding=True, return_tensors="pt")
+    tokens = result["input_ids"]
+    if tokens.shape[1] < pad_len:
+        pad = torch.zeros(tokens.shape[0], pad_len - tokens.shape[1],
+                          dtype=torch.long)
+        tokens = torch.cat([tokens, pad], dim=1)
+    elif tokens.shape[1] > pad_len:
+        tokens = tokens[:, :pad_len]
+    tokens = tokens.to(device)
+
+    charge = torch.tensor(df.charge.values.astype(np.int64),
+                          dtype=torch.long, device=device)
+    ce = torch.tensor(df.collision_energy.values.astype(np.float32),
+                      dtype=torch.float32, device=device).unsqueeze(1)
+    targets = np.stack(df.target.values).astype(np.float32)
+    target_t = torch.tensor(targets, dtype=torch.float32, device=device)
+    return {"tokens": tokens, "charge": charge, "ce": ce, "target": target_t}
+
+
+@torch.no_grad()
+def predict_intensity(model, batch, batch_size=256):
+    n = batch["tokens"].shape[0]
+    out_chunks = []
+    model.eval()
+    for i in range(0, n, batch_size):
+        sl = slice(i, i + batch_size)
+        out = model.predict_intensity(
+            batch["tokens"][sl],
+            charge=batch["charge"][sl],
+            collision_energy=batch["ce"][sl],
+        )
+        # Intensity head outputs may be (B, 29, 2, 3) or flat (B, 174).
+        # Flatten to (B, 174) for consistent comparison.
+        if out.dim() == 4:
+            out = out.reshape(out.shape[0], -1)
+        elif out.dim() == 2 and out.shape[1] != 174:
+            out = out.reshape(out.shape[0], -1)
+        out_chunks.append(out.cpu().numpy())
+    return np.concatenate(out_chunks, axis=0)
+
+
+def spectral_angle(pred: np.ndarray, target: np.ndarray, eps: float = 1e-12):
+    """Spectral angle similarity per sample, ignoring positions where
+    target is zero (canonical Prosit metric). Returns (B,) array."""
+    mask = target > 0
+    sims = np.zeros(pred.shape[0], dtype=np.float64)
+    for i in range(pred.shape[0]):
+        m = mask[i]
+        if m.sum() < 2:
+            sims[i] = np.nan
+            continue
+        p = pred[i][m]
+        t = target[i][m]
+        # L2 normalize and compute cosine
+        p_norm = p / max(eps, np.linalg.norm(p))
+        t_norm = t / max(eps, np.linalg.norm(t))
+        cos = float(np.clip(np.dot(p_norm, t_norm), -1.0, 1.0))
+        sims[i] = 1.0 - 2.0 * np.arccos(cos) / np.pi  # spectral angle (1 = identical)
+    return sims
+
+
+def custom_finetune_loop(
+    model, train_t, *, epochs, batch_size, lr, patience, val_frac, seed
+):
+    n = train_t["tokens"].shape[0]
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(n)
+    n_val = int(round(n * val_frac))
+    val_idx = torch.tensor(perm[:n_val], device=train_t["tokens"].device)
+    train_idx = torch.tensor(perm[n_val:], device=train_t["tokens"].device)
+
+    def _slice(b, idx):
+        return {k: v[idx] for k, v in b.items()}
+
+    tr = _slice(train_t, train_idx)
+    va = _slice(train_t, val_idx)
+    n_tr = tr["tokens"].shape[0]
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, patience=2, factor=0.5, min_lr=1e-6
+    )
+
+    best_val = float("inf")
+    best_state = None
+    bad_epochs = 0
+    log.info(f"intensity fine-tune: epochs={epochs} batch={batch_size} lr={lr:.2e}")
+
+    for ep in range(1, epochs + 1):
+        model.train()
+        epoch_perm = torch.randperm(n_tr, device=tr["tokens"].device)
+        t_loss = 0.0; nb = 0
+        for i in range(0, n_tr, batch_size):
+            idx = epoch_perm[i:i + batch_size]
+            optimizer.zero_grad()
+            pred = model.predict_intensity(
+                tr["tokens"][idx],
+                charge=tr["charge"][idx],
+                collision_energy=tr["ce"][idx],
+            )
+            target = tr["target"][idx]
+            # Prosit head may output (B, 29, 2, 3) — flatten target to match.
+            if pred.dim() == 4:
+                target = target.reshape(pred.shape)
+            loss = masked_spectral_distance(target, pred)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            t_loss += loss.item(); nb += 1
+        t_loss /= nb
+
+        model.eval()
+        v_loss = 0.0; vb = 0
+        with torch.no_grad():
+            for i in range(0, va["tokens"].shape[0], batch_size):
+                sl = slice(i, i + batch_size)
+                pred = model.predict_intensity(
+                    va["tokens"][sl],
+                    charge=va["charge"][sl],
+                    collision_energy=va["ce"][sl],
+                )
+                target = va["target"][sl]
+                if pred.dim() == 4:
+                    target = target.reshape(pred.shape)
+                v_loss += masked_spectral_distance(target, pred).item()
+                vb += 1
+            v_loss /= max(1, vb)
+        scheduler.step(v_loss)
+        log.info(
+            f"  ep {ep:3d}/{epochs}  train_msd={t_loss:.4f}  val_msd={v_loss:.4f}  "
+            f"lr={optimizer.param_groups[0]['lr']:.2e}"
+        )
+        if v_loss < best_val - 1e-4:
+            best_val = v_loss
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+            bad_epochs = 0
+        else:
+            bad_epochs += 1
+            if bad_epochs >= patience:
+                log.info(f"  early stop at ep {ep} (best val msd {best_val:.4f})")
+                break
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--rescore-dir", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--q-cutoff", type=float, default=0.01)
+    parser.add_argument("--holdout-frac", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--patience", type=int, default=5)
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    psm_df = load_psm_targets(args.rescore_dir, q_cutoff=args.q_cutoff)
+    train_df, hold_df = split_peptide_holdout(psm_df, args.holdout_frac, args.seed)
+
+    log.info("loading pretrained UnifiedPeptideModel with intensity head")
+    intensity_path = get_model_path("intensity/best_model.pt")
+    model = UnifiedPeptideModel.from_pretrained(str(intensity_path),
+                                                tasks=["intensity"])
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    log.info(f"  device: {device}  params: {sum(p.numel() for p in model.parameters()):,}")
+    pretrained_state = copy.deepcopy(model.state_dict())
+
+    tokenizer = ProformaTokenizer.with_defaults()
+    train_t = make_tensors(train_df, tokenizer, device)
+    hold_t = make_tensors(hold_df, tokenizer, device)
+
+    # Baseline eval on holdout.
+    log.info("baseline (pretrained) eval on holdout")
+    pred_pre = predict_intensity(model, hold_t)
+    target_hold = hold_t["target"].cpu().numpy()
+    sa_pre = spectral_angle(pred_pre, target_hold)
+    log.info(f"  baseline spectral angle: mean={np.nanmean(sa_pre):.4f}  "
+             f"median={np.nanmedian(sa_pre):.4f}  n_nan={int(np.isnan(sa_pre).sum())}")
+
+    # Fine-tune.
+    custom_finetune_loop(
+        model, train_t,
+        epochs=args.epochs, batch_size=args.batch_size,
+        lr=args.lr, patience=args.patience,
+        val_frac=0.2, seed=args.seed,
+    )
+
+    # Post eval.
+    log.info("fine-tuned eval on holdout")
+    pred_post = predict_intensity(model, hold_t)
+    sa_post = spectral_angle(pred_post, target_hold)
+    log.info(f"  finetuned spectral angle: mean={np.nanmean(sa_post):.4f}  "
+             f"median={np.nanmedian(sa_post):.4f}")
+
+    # Save artifacts.
+    finetuned_state = copy.deepcopy(model.state_dict())
+    torch.save(
+        {
+            "model_state_dict": finetuned_state,
+            "pretrained_state_dict": pretrained_state,
+            "metrics": {
+                "baseline_sa_mean": float(np.nanmean(sa_pre)),
+                "baseline_sa_median": float(np.nanmedian(sa_pre)),
+                "finetuned_sa_mean": float(np.nanmean(sa_post)),
+                "finetuned_sa_median": float(np.nanmedian(sa_post)),
+            },
+            "args": {k: (str(v) if isinstance(v, Path) else v)
+                     for k, v in vars(args).items()},
+        },
+        args.out_dir / "intensity_finetuned.pt",
+    )
+    summary = {
+        "baseline": {"sa_mean": float(np.nanmean(sa_pre)),
+                     "sa_median": float(np.nanmedian(sa_pre))},
+        "finetuned": {"sa_mean": float(np.nanmean(sa_post)),
+                      "sa_median": float(np.nanmedian(sa_post))},
+        "delta_sa_mean": float(np.nanmean(sa_post) - np.nanmean(sa_pre)),
+        "n_train": int(len(train_df)),
+        "n_hold": int(len(hold_df)),
+        "args": {k: (str(v) if isinstance(v, Path) else v)
+                 for k, v in vars(args).items()},
+    }
+    (args.out_dir / "metrics.json").write_text(json.dumps(summary, indent=2))
+
+    log.info("=" * 60)
+    log.info(f"baseline    SA mean={summary['baseline']['sa_mean']:.4f}  "
+             f"median={summary['baseline']['sa_median']:.4f}")
+    log.info(f"fine-tuned  SA mean={summary['finetuned']['sa_mean']:.4f}  "
+             f"median={summary['finetuned']['sa_median']:.4f}")
+    log.info(f"delta:           {summary['delta_sa_mean']:+.4f}")
+    log.info("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/imspy-predictors/scripts/finetune_dia_pasef_joint.py
+++ b/packages/imspy-predictors/scripts/finetune_dia_pasef_joint.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python
+"""Phase B — joint RT+CCS+intensity fine-tune ablation.
+
+Built on the Phase A finding: loading from rt/best_model.pt with
+tasks=['rt','ccs','intensity'] and swapping the ccs/intensity heads from
+their per-task checkpoints gives baselines within 2% of standalone for
+all three tasks. So joint training IS viable — Phase B answers WHICH
+fine-tune flavor wins on the per-run calibration task.
+
+Five flavors of fine-tune (all from the same joint-init):
+
+  B1: Heads only, encoder frozen. Safest, no encoder drift.
+  B2: Heads + encoder, joint loss with static weights.
+  B3: Heads + encoder with split LR groups (heads 1e-3, encoder 1e-5).
+  B4: Heads + encoder with uncertainty weighting (Kendall et al.).
+  B5: Sequential — intensity-only first, then RT+CCS on top.
+
+Reports per-task held-out MAE/SA after each flavor; picks winner.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+import math
+import struct
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from imspy_predictors.models.unified import UnifiedPeptideModel
+from imspy_predictors.utilities import ProformaTokenizer
+from imspy_predictors.utility import get_model_path
+from imspy_predictors.losses import masked_spectral_distance
+from imspy_core.chemistry.mobility import (
+    ccs_to_one_over_k0_par, one_over_k0_to_ccs_par,
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from intensity_target_encoder import encode_psm_target_vec, PROSIT_DIM
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("joint_finetune")
+
+PROTON = 1.007276466879
+TASK_NAMES = ("rt", "ccs", "intensity")
+BASE_ENCODER = "rt"  # Phase A winner — RT-encoder + swapped CCS/intensity heads
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def read_pseudo_bin_apex_scans(bin_path: Path) -> np.ndarray:
+    with open(bin_path, "rb") as f:
+        magic = f.read(4)
+        assert magic == b"PSSP", magic
+        version, n_spec, _ = struct.unpack("<III", f.read(12))
+        assert version == 2, version
+        f.seek(4 * n_spec, 1)
+        f.seek(8 * n_spec, 1)
+        f.seek(4 * n_spec, 1)
+        return np.frombuffer(f.read(4 * n_spec), dtype="<f4").copy()
+
+
+def build_scan_to_im_lut(d_path: Path, sample_frame_id: int = 1) -> np.ndarray:
+    from imspy_core.timstof import TimsDataset
+    ds = TimsDataset(str(d_path))
+    n_scans = ds.num_scans
+    scans = np.arange(1, n_scans + 1, dtype=np.int32)
+    im = np.asarray(ds.scan_to_inverse_mobility(sample_frame_id, scans),
+                    dtype=np.float64)
+    lut = np.zeros(n_scans + 2, dtype=np.float64)
+    lut[1:n_scans + 1] = im
+    return lut
+
+
+def lookup_im(scan, lut):
+    s = np.asarray(scan, dtype=np.float64)
+    s_lo = np.floor(s).astype(np.int64)
+    s_hi = s_lo + 1
+    s_lo = np.clip(s_lo, 1, len(lut) - 2)
+    s_hi = np.clip(s_hi, 1, len(lut) - 1)
+    f = s - s_lo
+    return lut[s_lo] * (1.0 - f) + lut[s_hi] * f
+
+
+def load_data(rescore_dir: Path, q_cutoff: float, pseudo_bin: Path, d_path: Path):
+    """Build per-PSM training table with all three tasks' targets attached.
+
+    Per-PSM unit so we can supervise intensity per fragment-set. RT and
+    CCS targets are the per-(peptide, charge) means (avoids noise from
+    individual PSM RT/IM jitter).
+    """
+    tdc = pd.read_csv(rescore_dir / "rescored_canonical.tdc.csv",
+                      usecols=["spec_idx", "match_idx", "decoy", "q_value"])
+    tdc = tdc[(~tdc.decoy.astype(bool)) & (tdc.q_value <= q_cutoff)]
+    psm = pd.read_csv(rescore_dir / "rescored_canonical.csv",
+                      usecols=["spec_idx", "match_idx", "rt", "charge",
+                               "calcmass", "collision_energy"])
+    df = tdc.merge(psm, on=["spec_idx", "match_idx"], how="inner")
+
+    apex_scan = read_pseudo_bin_apex_scans(pseudo_bin)
+    lut = build_scan_to_im_lut(d_path)
+    bin_idx = df.spec_idx.str.removeprefix("pseudo_").astype(np.int64).values
+    one_over_k0 = lookup_im(apex_scan[bin_idx], lut)
+    charge_arr = df.charge.values.astype(np.float64)
+    mz_arr = (df.calcmass.values + charge_arr * PROTON) / charge_arr
+    observed_ccs = np.asarray(
+        one_over_k0_to_ccs_par(one_over_k0, mz_arr, charge_arr.astype(np.int32)),
+        dtype=np.float64,
+    )
+    df = df.assign(observed_ims=one_over_k0, observed_ccs=observed_ccs,
+                   precursor_mz=mz_arr)
+    df = df.rename(columns={"match_idx": "sequence"})
+
+    # Per-(peptide, charge) means for RT/CCS
+    pep_charge = df.groupby(["sequence", "charge"], as_index=False).agg(
+        rt_target=("rt", "mean"),
+        ccs_target=("observed_ccs", "mean"),
+        ims_target=("observed_ims", "mean"),
+    )
+    df = df.merge(pep_charge, on=["sequence", "charge"], how="inner")
+    log.info(f"  PSMs joined: {len(df):,}  unique (pep, z): {len(pep_charge):,}")
+
+    # Encode intensity targets per PSM
+    log.info("encoding intensity targets per PSM …")
+    t0 = time.time()
+    frag_df = pd.read_parquet(rescore_dir / "rescored_canonical.fragments.parquet")
+    hc = df[["spec_idx", "sequence"]]
+    frag_hc = frag_df.merge(hc, on=["spec_idx", "sequence"], how="inner")
+    grp = frag_hc.groupby(["spec_idx", "sequence"], sort=False)
+    intensity_target = {}
+    for key, g in grp:
+        intensity_target[key] = encode_psm_target_vec(g)
+    log.info(f"  encoded {len(intensity_target):,} PSM intensity targets in {time.time()-t0:.1f}s")
+
+    # Attach intensity target column (numpy array per row)
+    df["intensity_target"] = df.apply(
+        lambda r: intensity_target.get((r.spec_idx, r.sequence)), axis=1
+    )
+    n_before = len(df)
+    df = df[df.intensity_target.notna()].reset_index(drop=True)
+    log.info(f"  PSMs with intensity targets: {len(df):,} (dropped {n_before-len(df):,})")
+    return df
+
+
+def split_seq_holdout(df: pd.DataFrame, holdout_frac: float, seed: int):
+    rng = np.random.default_rng(seed)
+    seqs = df.sequence.unique()
+    perm = rng.permutation(len(seqs))
+    n_hold = int(round(len(seqs) * holdout_frac))
+    holdout_set = set(seqs[perm[:n_hold]])
+    train = df[~df.sequence.isin(holdout_set)].reset_index(drop=True)
+    hold = df[df.sequence.isin(holdout_set)].reset_index(drop=True)
+    return train, hold
+
+
+def make_tensors(df: pd.DataFrame, tokenizer, device, pad_len=50):
+    result = tokenizer(df.sequence.tolist(), padding=True, return_tensors="pt")
+    tokens = result["input_ids"]
+    if tokens.shape[1] < pad_len:
+        pad = torch.zeros(tokens.shape[0], pad_len - tokens.shape[1], dtype=torch.long)
+        tokens = torch.cat([tokens, pad], dim=1)
+    elif tokens.shape[1] > pad_len:
+        tokens = tokens[:, :pad_len]
+    return {
+        "tokens": tokens.to(device),
+        "charge": torch.tensor(df.charge.values.astype(np.int64),
+                               dtype=torch.long, device=device),
+        "mz": torch.tensor(df.precursor_mz.values, dtype=torch.float32, device=device).unsqueeze(1),
+        "ce": torch.tensor(df.collision_energy.values.astype(np.float32),
+                           dtype=torch.float32, device=device).unsqueeze(1),
+        "rt_target": torch.tensor(df.rt_target.values, dtype=torch.float32, device=device).unsqueeze(1),
+        "ccs_target": torch.tensor(df.ccs_target.values, dtype=torch.float32, device=device).unsqueeze(1),
+        "ims_target": torch.tensor(df.ims_target.values, dtype=torch.float32, device=device).unsqueeze(1),
+        "intensity_target": torch.tensor(np.stack(df.intensity_target.values).astype(np.float32),
+                                          dtype=torch.float32, device=device),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Joint init + flavor configuration
+# ---------------------------------------------------------------------------
+
+def make_joint_init(device: torch.device) -> UnifiedPeptideModel:
+    base_path = get_model_path(f"{BASE_ENCODER}/best_model.pt")
+    log.info(f"  joint init: encoder + heads from {base_path.parent.parent}")
+    model = UnifiedPeptideModel.from_pretrained(
+        str(base_path), tasks=list(TASK_NAMES),
+    )
+    for task in TASK_NAMES:
+        if task == BASE_ENCODER: continue
+        task_path = get_model_path(f"{task}/best_model.pt")
+        ckpt = torch.load(str(task_path), map_location="cpu", weights_only=False)
+        head_state = ckpt["heads_state_dict"][task]
+        model.heads[task].load_state_dict(head_state)
+    return model.to(device)
+
+
+def configure_optimizer(model, flavor: str, lr: float):
+    """Returns (optimizer, extra_params_dict) — extra_params for B4 (uncertainty weighting)."""
+    extras = {}
+    if flavor == "B1":
+        # Heads only, encoder frozen
+        for p in model.encoder.parameters():
+            p.requires_grad = False
+        head_params = [p for h in model.heads.values() for p in h.parameters()]
+        opt = torch.optim.AdamW(head_params, lr=lr, weight_decay=1e-4)
+    elif flavor == "B2":
+        # All trainable, single LR
+        opt = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    elif flavor == "B3":
+        # Split LR: heads at lr, encoder at lr/100
+        head_params = [p for h in model.heads.values() for p in h.parameters()]
+        enc_params = list(model.encoder.parameters())
+        opt = torch.optim.AdamW(
+            [
+                {"params": head_params, "lr": lr},
+                {"params": enc_params, "lr": lr / 100.0},
+            ],
+            weight_decay=1e-4,
+        )
+    elif flavor == "B4":
+        # Uncertainty weighting: log_sigma per task, learnable
+        log_sigmas = nn.ParameterDict({
+            task: nn.Parameter(torch.zeros(1, device=next(model.parameters()).device))
+            for task in TASK_NAMES
+        })
+        all_params = list(model.parameters()) + list(log_sigmas.parameters())
+        opt = torch.optim.AdamW(all_params, lr=lr, weight_decay=1e-4)
+        extras["log_sigmas"] = log_sigmas
+    elif flavor == "B5":
+        # Phase 1 of B5: only intensity head + encoder.
+        # The training loop handles the two phases separately.
+        head_params = list(model.heads["intensity"].parameters())
+        enc_params = list(model.encoder.parameters())
+        opt = torch.optim.AdamW(
+            [
+                {"params": head_params, "lr": lr},
+                {"params": enc_params, "lr": lr / 100.0},
+            ],
+            weight_decay=1e-4,
+        )
+    else:
+        raise ValueError(f"unknown flavor {flavor}")
+    return opt, extras
+
+
+def compute_joint_loss(model, batch, idx, flavor, extras, weights):
+    """Forward all three tasks, compute weighted loss. Returns (total_loss,
+    per-task losses dict, raw per-task losses dict)."""
+    out = model.forward(
+        tokens=batch["tokens"][idx],
+        mz=batch["mz"][idx],
+        charge=batch["charge"][idx],
+        collision_energy=batch["ce"][idx],
+        tasks=list(TASK_NAMES),
+    )
+    rt_loss = F.l1_loss(out["rt"], batch["rt_target"][idx])
+    ccs_mean, _ = out["ccs"]
+    ccs_loss = F.l1_loss(ccs_mean, batch["ccs_target"][idx])
+    int_pred = out["intensity"]
+    int_target = batch["intensity_target"][idx]
+    if int_pred.dim() == 4:
+        int_target = int_target.reshape(int_pred.shape)
+    int_loss = masked_spectral_distance(int_target, int_pred)
+
+    raw = {"rt": rt_loss.item(), "ccs": ccs_loss.item(), "intensity": int_loss.item()}
+
+    if flavor == "B4":
+        # Kendall et al. uncertainty weighting:
+        #   L = sum_t [ exp(-2*log_sigma_t) * loss_t + log_sigma_t ]
+        # (simplified Laplace-likelihood for L1 / spectral distance).
+        ls = extras["log_sigmas"]
+        total = (
+            torch.exp(-2 * ls["rt"]) * rt_loss + ls["rt"]
+            + torch.exp(-2 * ls["ccs"]) * ccs_loss + ls["ccs"]
+            + torch.exp(-2 * ls["intensity"]) * int_loss + ls["intensity"]
+        ).sum()
+    else:
+        total = (
+            weights["rt"] * rt_loss
+            + weights["ccs"] * ccs_loss
+            + weights["intensity"] * int_loss
+        )
+
+    return total, raw
+
+
+def train_one_flavor(
+    flavor: str, train_t, val_t, hold_t, *, epochs, batch_size, lr, patience,
+    weights, device,
+):
+    """Build joint init, train per flavor, return (model, best_val_loss, n_epochs_run, time_s)."""
+    model = make_joint_init(device)
+    optimizer, extras = configure_optimizer(model, flavor, lr)
+
+    n_tr = train_t["tokens"].shape[0]
+    best_val = float("inf")
+    best_state = None
+    bad_epochs = 0
+    t0 = time.time()
+
+    if flavor == "B5":
+        # Phase 1: intensity only. Phase 2: full joint.
+        log.info(f"  [{flavor}] phase 1 — intensity-only fine-tune")
+        for ep in range(1, epochs // 2 + 1):
+            model.train()
+            perm = torch.randperm(n_tr, device=device)
+            for i in range(0, n_tr, batch_size):
+                idx = perm[i:i + batch_size]
+                optimizer.zero_grad()
+                out = model.forward(
+                    tokens=train_t["tokens"][idx],
+                    charge=train_t["charge"][idx],
+                    collision_energy=train_t["ce"][idx],
+                    tasks=["intensity"],
+                )
+                int_target = train_t["intensity_target"][idx]
+                int_pred = out["intensity"]
+                if int_pred.dim() == 4:
+                    int_target = int_target.reshape(int_pred.shape)
+                loss = masked_spectral_distance(int_target, int_pred)
+                loss.backward()
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+                optimizer.step()
+        log.info(f"  [{flavor}] phase 2 — joint RT+CCS+intensity")
+        # Reconfigure optimizer to update all heads
+        head_params = [p for h in model.heads.values() for p in h.parameters()]
+        enc_params = list(model.encoder.parameters())
+        optimizer = torch.optim.AdamW(
+            [{"params": head_params, "lr": lr},
+             {"params": enc_params, "lr": lr / 100.0}],
+            weight_decay=1e-4,
+        )
+
+    n_val = val_t["tokens"].shape[0]
+    n_epochs_run = 0
+    for ep in range(1, epochs + 1):
+        model.train()
+        perm = torch.randperm(n_tr, device=device)
+        train_loss = 0.0; nb = 0
+        train_raw = {"rt": 0.0, "ccs": 0.0, "intensity": 0.0}
+        for i in range(0, n_tr, batch_size):
+            idx = perm[i:i + batch_size]
+            optimizer.zero_grad()
+            total, raw = compute_joint_loss(model, train_t, idx, flavor, extras, weights)
+            total.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            train_loss += total.item(); nb += 1
+            for k, v in raw.items(): train_raw[k] += v
+        train_loss /= max(1, nb)
+        for k in train_raw: train_raw[k] /= max(1, nb)
+
+        # Val
+        model.eval()
+        v_loss = 0.0; vb = 0
+        v_raw = {"rt": 0.0, "ccs": 0.0, "intensity": 0.0}
+        with torch.no_grad():
+            for i in range(0, n_val, batch_size):
+                sl = slice(i, i + batch_size)
+                idx = torch.arange(i, min(i + batch_size, n_val), device=device)
+                total, raw = compute_joint_loss(model, val_t, idx, flavor, extras, weights)
+                v_loss += total.item(); vb += 1
+                for k, v in raw.items(): v_raw[k] += v
+        v_loss /= max(1, vb)
+        for k in v_raw: v_raw[k] /= max(1, vb)
+
+        n_epochs_run = ep
+        if ep <= 3 or ep % 5 == 0:
+            log.info(
+                f"  [{flavor}] ep {ep:3d}/{epochs}  "
+                f"tr[rt={train_raw['rt']:.3f} ccs={train_raw['ccs']:.2f} int={train_raw['intensity']:.3f}]  "
+                f"val[rt={v_raw['rt']:.3f} ccs={v_raw['ccs']:.2f} int={v_raw['intensity']:.3f}]"
+            )
+
+        if v_loss < best_val - 1e-3:
+            best_val = v_loss
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+            bad_epochs = 0
+        else:
+            bad_epochs += 1
+            if bad_epochs >= patience:
+                log.info(f"  [{flavor}] early stop at ep {ep}")
+                break
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+    return model, best_val, n_epochs_run, time.time() - t0
+
+
+# ---------------------------------------------------------------------------
+# Eval
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+def eval_all_tasks(model, hold_t, batch_size=256):
+    """Per-task held-out metrics. RT MAE in min, CCS MAE in Å²,
+    1/K0 MAE via Mason-Schamp, intensity SA mean/median."""
+    model.eval()
+    n = hold_t["tokens"].shape[0]
+    rt_p, ccs_p, int_p = [], [], []
+    for i in range(0, n, batch_size):
+        sl = slice(i, i + batch_size)
+        out = model.forward(
+            tokens=hold_t["tokens"][sl],
+            mz=hold_t["mz"][sl],
+            charge=hold_t["charge"][sl],
+            collision_energy=hold_t["ce"][sl],
+            tasks=list(TASK_NAMES),
+        )
+        rt_p.append(out["rt"].squeeze(-1).cpu().numpy())
+        ccs_mean, _ = out["ccs"]
+        ccs_p.append(ccs_mean.squeeze(-1).cpu().numpy())
+        int_pred = out["intensity"]
+        if int_pred.dim() == 4:
+            int_pred = int_pred.reshape(int_pred.shape[0], -1)
+        int_p.append(int_pred.cpu().numpy())
+    rt_pred = np.concatenate(rt_p).astype(np.float64)
+    ccs_pred = np.concatenate(ccs_p).astype(np.float64)
+    int_pred_arr = np.concatenate(int_p).astype(np.float64)
+
+    rt_obs = hold_t["rt_target"].squeeze(-1).cpu().numpy().astype(np.float64)
+    ccs_obs = hold_t["ccs_target"].squeeze(-1).cpu().numpy().astype(np.float64)
+    ims_obs = hold_t["ims_target"].squeeze(-1).cpu().numpy().astype(np.float64)
+    int_obs = hold_t["intensity_target"].cpu().numpy().astype(np.float64)
+    mz_obs = hold_t["mz"].squeeze(-1).cpu().numpy().astype(np.float64)
+    z_obs = hold_t["charge"].cpu().numpy().astype(np.int32)
+
+    # CCS → 1/K0 via Mason-Schamp for library-relevant metric
+    ims_pred = np.asarray(
+        ccs_to_one_over_k0_par(ccs_pred, mz_obs, z_obs), dtype=np.float64
+    )
+
+    # Spectral angle (masked)
+    sas = []
+    for i in range(len(int_pred_arr)):
+        m = int_obs[i] > 0
+        if m.sum() < 2: continue
+        p = int_pred_arr[i][m]; t = int_obs[i][m]
+        p_n = p / max(1e-12, np.linalg.norm(p))
+        t_n = t / max(1e-12, np.linalg.norm(t))
+        cos = float(np.clip(np.dot(p_n, t_n), -1.0, 1.0))
+        sas.append(1.0 - 2.0 * np.arccos(cos) / np.pi)
+
+    return {
+        "rt_mae_min": float(np.mean(np.abs(rt_pred - rt_obs))),
+        "ccs_mae_a2": float(np.mean(np.abs(ccs_pred - ccs_obs))),
+        "ims_mae": float(np.mean(np.abs(ims_pred - ims_obs))),
+        "intensity_sa_mean": float(np.mean(sas)) if sas else float("nan"),
+        "intensity_sa_median": float(np.median(sas)) if sas else float("nan"),
+        "n": n,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--rescore-dir", type=Path, required=True)
+    parser.add_argument("--pseudo-bin", type=Path, required=True)
+    parser.add_argument("--d-path", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--q-cutoff", type=float, default=0.01)
+    parser.add_argument("--holdout-frac", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--patience", type=int, default=8)
+    parser.add_argument("--flavors", type=str, default="B1,B2,B3,B4,B5")
+    args = parser.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    df = load_data(args.rescore_dir, args.q_cutoff, args.pseudo_bin, args.d_path)
+
+    train_df, hold_df = split_seq_holdout(df, args.holdout_frac, args.seed)
+    # Internal val split for early stopping (within train)
+    rng = np.random.default_rng(args.seed + 1)
+    seqs_tr = train_df.sequence.unique()
+    perm = rng.permutation(len(seqs_tr))
+    n_inner_val = int(round(len(seqs_tr) * 0.2))
+    inner_val_seqs = set(seqs_tr[perm[:n_inner_val]])
+    real_train = train_df[~train_df.sequence.isin(inner_val_seqs)].reset_index(drop=True)
+    inner_val = train_df[train_df.sequence.isin(inner_val_seqs)].reset_index(drop=True)
+    log.info(f"split: real train {len(real_train):,} / inner val {len(inner_val):,} / hold {len(hold_df):,}")
+
+    tokenizer = ProformaTokenizer.with_defaults()
+    train_t = make_tensors(real_train, tokenizer, device)
+    val_t = make_tensors(inner_val, tokenizer, device)
+    hold_t = make_tensors(hold_df, tokenizer, device)
+
+    weights = {"rt": 1.0, "ccs": 0.1, "intensity": 1.0}
+    log.info(f"loss weights (B2/B3/B5): {weights}")
+
+    flavors = args.flavors.split(",")
+    summary = []
+    for flavor in flavors:
+        log.info("")
+        log.info("=" * 70)
+        log.info(f"FLAVOR {flavor}")
+        log.info("=" * 70)
+        model, best_val, n_ep, t_s = train_one_flavor(
+            flavor, train_t, val_t, hold_t,
+            epochs=args.epochs, batch_size=args.batch_size, lr=args.lr,
+            patience=args.patience, weights=weights, device=device,
+        )
+        metrics = eval_all_tasks(model, hold_t)
+        log.info(f"  [{flavor}] {n_ep} ep, {t_s:.1f}s wall")
+        log.info(
+            f"  [{flavor}] HOLDOUT: RT={metrics['rt_mae_min']:.3f} min  "
+            f"CCS={metrics['ccs_mae_a2']:.2f} Å²  1/K0={metrics['ims_mae']:.4f}  "
+            f"SA={metrics['intensity_sa_mean']:.4f}"
+        )
+        summary.append({
+            "flavor": flavor, "epochs": n_ep, "wall_s": round(t_s, 1),
+            **metrics,
+        })
+
+    log.info("")
+    log.info("=" * 80)
+    log.info("PHASE B SUMMARY (held-out 20% of unique peptides)")
+    log.info("=" * 80)
+    log.info(f"{'flavor':<5} {'eps':>4} {'time':>7}  {'RT min':>8}  {'CCS Å²':>8}  {'1/K0':>8}  {'SA':>7}")
+    log.info("Reference (per-task standalone):  RT 0.43       CCS 6.85    1/K0 0.0139  SA 0.620")
+    for s in summary:
+        log.info(
+            f"{s['flavor']:<5} {s['epochs']:>4} {s['wall_s']:>7.1f}s  "
+            f"{s['rt_mae_min']:>8.3f}  {s['ccs_mae_a2']:>8.2f}  {s['ims_mae']:>8.4f}  "
+            f"{s['intensity_sa_mean']:>7.4f}"
+        )
+    log.info("=" * 80)
+
+    (args.out_dir / "phase_b_summary.json").write_text(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/imspy-predictors/scripts/finetune_dia_pasef_multi.py
+++ b/packages/imspy-predictors/scripts/finetune_dia_pasef_multi.py
@@ -1,11 +1,28 @@
 #!/usr/bin/env python
-"""Phase 1.1 — multi-task RT+CCS fine-tune for the calibrated-library pipeline.
+"""Phase 1.1 — multi-task RT+CCS fine-tune (DIAGNOSTIC ONLY, not production).
 
-Extends finetune_dia_pasef.py (RT-only) to fine-tune both retention time
-and CCS heads jointly on UnifiedPeptideModel. Same encoder is shared
-across heads, so one training pass calibrates both predictors against
-this run's anchor PSMs. Holdout is peptide-level (20% of unique
-sequences, seeded); MAE for each head reported on the same holdout.
+ARCHITECTURAL LIMITATION (discovered 2026-05-02): the off-the-shelf
+`imspy_predictors` checkpoints (rt/best_model.pt, ccs/best_model.pt,
+intensity/best_model.pt) are each pre-trained STANDALONE — each carries
+its own encoder weights paired with its own task head. There is no
+unified pre-trained encoder paired with all three heads.
+
+Loading from rt/best_model.pt with tasks=['rt', 'ccs'] gets the
+RT-paired encoder + RT head (good) + a FRESH RANDOMLY-INITIALIZED CCS
+head (bad). Linear projection then fits the random head's output to
+observed CCS, giving a ~30 Å² baseline MAE — much worse than the
+standalone CCS run's 13 Å² baseline (same data, but from
+ccs/best_model.pt where encoder + CCS head are correctly paired).
+
+For the production calibration-library pipeline, use the 3 per-task
+scripts: finetune_dia_pasef.py (RT), finetune_dia_pasef_ccs.py (CCS),
+finetune_dia_pasef_intensity.py (intensity). Each loads its own
+pre-trained checkpoint and fine-tunes cleanly. Library generation
+loads all three checkpoints independently.
+
+This multi-task script remains for future research (e.g., when a
+unified pre-trained encoder lands), and to validate the per-(peptide,
+charge) data-prep fix that this commit also lands.
 
 Intensity (the third predictor in UnifiedPeptideModel) is deferred to
 Phase 1.2 — the rescored CSV only carries scalar ms2_intensity, not the
@@ -180,18 +197,22 @@ def load_and_aggregate(
         f"CCS {df.observed_ccs.min():.1f}–{df.observed_ccs.max():.1f} Å²"
     )
 
-    # Aggregate per peptide.
+    # Aggregate per (peptide, charge). CCS depends on charge — averaging
+    # observed_ccs across charge states for the same peptide mixes two
+    # distinct targets and gives meaningless supervision. The CCS-only
+    # diagnostic (finetune_dia_pasef_ccs.py) caught this: switching to
+    # per-(peptide, charge) aggregation drops baseline+proj MAE from
+    # 31 Å² to 13 Å², and fine-tuned MAE from 30 → 6.85 Å² (−48%).
     df = df.rename(columns={"match_idx": "sequence"})
 
     def _mode_or_first(s: pd.Series):
         v = s.mode()
         return v.iloc[0] if len(v) else s.iloc[0]
 
-    agg = df.groupby("sequence", as_index=False).agg(
+    agg = df.groupby(["sequence", "charge"], as_index=False).agg(
         observed_rt=("rt", "mean"),
         observed_ims=("observed_ims", "mean"),
         observed_ccs=("observed_ccs", "mean"),
-        charge=("charge", _mode_or_first),
         calcmass=("calcmass", "mean"),
         collision_energy=("collision_energy", _mode_or_first),
         n_psm=("spec_idx", "size"),
@@ -210,13 +231,18 @@ def load_and_aggregate(
 def split_peptide_holdout(
     agg: pd.DataFrame, holdout_frac: float, seed: int
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Holdout split by UNIQUE peptide sequence (not row index). With
+    per-(peptide, charge) aggregation a peptide may appear at multiple
+    charges; splitting by row could leak the same sequence into both
+    train and test, defeating the held-out-peptide eval."""
     rng = np.random.default_rng(seed)
-    perm = rng.permutation(len(agg))
-    n_hold = int(round(len(agg) * holdout_frac))
-    return (
-        agg.iloc[perm[n_hold:]].reset_index(drop=True),
-        agg.iloc[perm[:n_hold]].reset_index(drop=True),
-    )
+    seqs = agg.sequence.unique()
+    perm = rng.permutation(len(seqs))
+    n_hold = int(round(len(seqs) * holdout_frac))
+    holdout_set = set(seqs[perm[:n_hold]])
+    train = agg[~agg.sequence.isin(holdout_set)].reset_index(drop=True)
+    hold = agg[agg.sequence.isin(holdout_set)].reset_index(drop=True)
+    return train, hold
 
 
 def make_tensors(

--- a/packages/imspy-predictors/scripts/finetune_dia_pasef_multi.py
+++ b/packages/imspy-predictors/scripts/finetune_dia_pasef_multi.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python
+"""Phase 1.1 — multi-task RT+CCS fine-tune for the calibrated-library pipeline.
+
+Extends finetune_dia_pasef.py (RT-only) to fine-tune both retention time
+and CCS heads jointly on UnifiedPeptideModel. Same encoder is shared
+across heads, so one training pass calibrates both predictors against
+this run's anchor PSMs. Holdout is peptide-level (20% of unique
+sequences, seeded); MAE for each head reported on the same holdout.
+
+Intensity (the third predictor in UnifiedPeptideModel) is deferred to
+Phase 1.2 — the rescored CSV only carries scalar ms2_intensity, not the
+per-peak vectors the intensity head expects. Fragment-level targets
+live in the .pseudo.bin / upstream.
+
+Usage:
+    python scripts/finetune_dia_pasef_multi.py \\
+        --rescore-dir /path/to/rescore-output \\
+        --out-dir ./checkpoints/finetune_o240206_multi
+"""
+
+import argparse
+import copy
+import json
+import logging
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+from imspy_predictors.models.unified import UnifiedPeptideModel
+from imspy_predictors.utilities import ProformaTokenizer
+from imspy_core.chemistry.mobility import (
+    ccs_to_one_over_k0_par, one_over_k0_to_ccs_par,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("finetune_dia_pasef_multi")
+
+# Proton mass for m/z calculation: (M + z*H+) / z.
+PROTON = 1.007276466879
+
+
+def read_pseudo_bin_apex_scans(bin_path: Path) -> np.ndarray:
+    """Read env_apex_scan (float32) from a .pseudo.bin produced by
+    pipeline_spec_centric_real. Header layout (little-endian):
+        char[4] magic = "PSSP" ; u32 version=2 ; u32 n_spec ; u32 total_frag
+    Then per-spec arrays in order: env_charge[u32], env_mono_mz[f64],
+    env_apex_rt_s[f32], env_apex_scan[f32], env_intensity[u64], ...
+    We only read the apex_scan slice and skip the rest.
+    """
+    with open(bin_path, "rb") as f:
+        magic = f.read(4)
+        if magic != b"PSSP":
+            raise SystemExit(f"bad magic {magic!r} in {bin_path}")
+        version, n_spec, _ = struct.unpack("<III", f.read(12))
+        if version != 2:
+            raise SystemExit(f"pseudo.bin version {version}, expected 2")
+        # skip env_charge (4*n) + env_mono_mz (8*n) + env_apex_rt_s (4*n)
+        f.seek(4 * n_spec, 1)
+        f.seek(8 * n_spec, 1)
+        f.seek(4 * n_spec, 1)
+        apex_scan = np.frombuffer(f.read(4 * n_spec), dtype="<f4").copy()
+    log.info(f"  pseudo.bin: {n_spec:,} spectra, apex_scan range "
+             f"{apex_scan.min():.1f}–{apex_scan.max():.1f}")
+    return apex_scan
+
+
+def build_scan_to_im_lut(d_path: Path, sample_frame_id: int = 1) -> np.ndarray:
+    """Sample scan→1/K0 from one mid-run frame. TimsTOF mobility is
+    near-frame-invariant (drift tube settings don't change across the
+    run), so a single-frame LUT is fine for the per-peptide aggregate
+    1/K0 we feed the predictor. For sub-percent accuracy, sample
+    multiple frames and average — out of scope here.
+    """
+    from imspy_core.timstof import TimsDataset
+    ds = TimsDataset(str(d_path))
+    n_scans = ds.num_scans
+    scans = np.arange(1, n_scans + 1, dtype=np.int32)
+    im = np.asarray(ds.scan_to_inverse_mobility(sample_frame_id, scans),
+                    dtype=np.float64)
+    log.info(f"  scan→1/K0 LUT: n_scans={n_scans}, "
+             f"1/K0 range {im.min():.4f}–{im.max():.4f} "
+             f"(sampled at frame_id={sample_frame_id})")
+    # Build a flat lookup with index 0 unused (scan 1-indexed)
+    lut = np.zeros(n_scans + 2, dtype=np.float64)
+    lut[1:n_scans + 1] = im
+    return lut
+
+
+def lookup_im(scan: np.ndarray, lut: np.ndarray) -> np.ndarray:
+    """Convert apex_scan (float32 fractional) to 1/K0 by linear
+    interpolation between integer scan slots in `lut`."""
+    s = np.asarray(scan, dtype=np.float64)
+    s_lo = np.floor(s).astype(np.int64)
+    s_hi = s_lo + 1
+    s_lo = np.clip(s_lo, 1, len(lut) - 2)
+    s_hi = np.clip(s_hi, 1, len(lut) - 1)
+    f = s - s_lo
+    return lut[s_lo] * (1.0 - f) + lut[s_hi] * f
+
+
+def load_and_aggregate(
+    rescore_dir: Path, q_cutoff: float, pseudo_bin: Path, d_path: Path
+) -> pd.DataFrame:
+    """Join pre-TDC features with post-TDC q-values, side-load 1/K0
+    from the .pseudo.bin's env_apex_scan + .d's scan→1/K0 LUT, filter,
+    aggregate per peptide.
+
+    Returns a DataFrame with columns:
+      sequence, observed_rt (min), observed_ims (1/K0), charge, calcmass,
+      collision_energy, n_psm.
+
+    Why side-load: the rescore_canonical.py pipeline calls build_query
+    without inverse_ion_mobility, so sage stores 0.0 in the `ims` column
+    of rescored_canonical.csv. The right long-term fix is upstream
+    (rescore computes scan→1/K0 once and passes per-spectrum 1/K0 to
+    build_query); this side-load avoids re-running rescore.
+    """
+    psm_path = rescore_dir / "rescored_canonical.csv"
+    tdc_path = rescore_dir / "rescored_canonical.tdc.csv"
+
+    log.info(f"reading {tdc_path}")
+    tdc = pd.read_csv(
+        tdc_path,
+        usecols=["spec_idx", "match_idx", "decoy", "q_value"],
+    )
+    tdc = tdc[(~tdc.decoy.astype(bool)) & (tdc.q_value <= q_cutoff)]
+    log.info(f"  tdc rows q≤{q_cutoff} & target: {len(tdc):,}")
+
+    log.info(f"reading {psm_path} (rt/charge/mass/CE + keys only)")
+    psm = pd.read_csv(
+        psm_path,
+        usecols=["spec_idx", "match_idx", "rt", "charge",
+                 "calcmass", "collision_energy"],
+    )
+    log.info(f"  psm rows: {len(psm):,}")
+
+    df = tdc.merge(psm, on=["spec_idx", "match_idx"], how="inner")
+    log.info(f"  joined rows: {len(df):,}")
+    if len(df) == 0:
+        raise SystemExit("inner join produced no rows")
+
+    # Side-load observed 1/K0. spec_idx like "pseudo_NNN" → bin index NNN.
+    log.info(f"side-loading 1/K0 from {pseudo_bin}")
+    apex_scan = read_pseudo_bin_apex_scans(pseudo_bin)
+    log.info(f"building scan→1/K0 LUT from {d_path}")
+    lut = build_scan_to_im_lut(d_path)
+
+    bin_idx = df.spec_idx.str.removeprefix("pseudo_").astype(np.int64).values
+    if bin_idx.max() >= len(apex_scan):
+        raise SystemExit(
+            f"spec_idx {bin_idx.max()} out of bin range "
+            f"({len(apex_scan)}) — pseudo.bin / rescore mismatch")
+    one_over_k0 = lookup_im(apex_scan[bin_idx], lut).astype(np.float64)
+    # m/z = (calcmass + z*proton)/z; needed for the Mason-Schamp
+    # 1/K0 ↔ CCS conversion. The pretrained CCS head outputs CCS in Å²
+    # (with a physics-informed sqrt(m/z * z) projection layer); supervising
+    # in 1/K0 directly fights that prior and the head can't shift its
+    # output scale fast enough during fine-tune. Supervise in CCS Å²
+    # instead; convert predicted CCS → 1/K0 at inference for library use.
+    charge_arr = df.charge.values.astype(np.float64)
+    mz_arr = (df.calcmass.values + charge_arr * PROTON) / charge_arr
+    observed_ccs = one_over_k0_to_ccs_par(
+        one_over_k0, mz_arr, charge_arr.astype(np.int32)
+    )
+    observed_ccs = np.asarray(observed_ccs, dtype=np.float64)
+    df = df.assign(
+        observed_ims=one_over_k0,
+        observed_ccs=observed_ccs,
+    )
+    log.info(
+        f"  joined+1/K0+CCS: rows={len(df):,}  "
+        f"1/K0 {df.observed_ims.min():.4f}–{df.observed_ims.max():.4f}  "
+        f"CCS {df.observed_ccs.min():.1f}–{df.observed_ccs.max():.1f} Å²"
+    )
+
+    # Aggregate per peptide.
+    df = df.rename(columns={"match_idx": "sequence"})
+
+    def _mode_or_first(s: pd.Series):
+        v = s.mode()
+        return v.iloc[0] if len(v) else s.iloc[0]
+
+    agg = df.groupby("sequence", as_index=False).agg(
+        observed_rt=("rt", "mean"),
+        observed_ims=("observed_ims", "mean"),
+        observed_ccs=("observed_ccs", "mean"),
+        charge=("charge", _mode_or_first),
+        calcmass=("calcmass", "mean"),
+        collision_energy=("collision_energy", _mode_or_first),
+        n_psm=("spec_idx", "size"),
+    )
+
+    log.info(
+        f"  unique peptides: {len(agg):,}  "
+        f"(rt {agg.observed_rt.min():.2f}-{agg.observed_rt.max():.2f} min, "
+        f"1/K0 {agg.observed_ims.min():.4f}-{agg.observed_ims.max():.4f}, "
+        f"charge mode counts: "
+        f"{dict(agg.charge.astype(int).value_counts().head(5))})"
+    )
+    return agg
+
+
+def split_peptide_holdout(
+    agg: pd.DataFrame, holdout_frac: float, seed: int
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(len(agg))
+    n_hold = int(round(len(agg) * holdout_frac))
+    return (
+        agg.iloc[perm[n_hold:]].reset_index(drop=True),
+        agg.iloc[perm[:n_hold]].reset_index(drop=True),
+    )
+
+
+def make_tensors(
+    df: pd.DataFrame, tokenizer, device: torch.device, pad_len: int = 50
+) -> dict:
+    """Tokenise + tensorise a dataframe slice. Returns dict ready for forward().
+
+    Mirrors DeepChromatographyApex._preprocess_sequences: pad to pad_len,
+    pass tokens (zeros = padding) without an explicit padding_mask — the
+    transformer encoder treats the zero token as padding by convention
+    in this codebase (and forward() accepts padding_mask=None).
+    """
+    result = tokenizer(df.sequence.tolist(), padding=True, return_tensors="pt")
+    tokens = result["input_ids"]
+    if tokens.shape[1] < pad_len:
+        pad = torch.zeros(tokens.shape[0], pad_len - tokens.shape[1], dtype=torch.long)
+        tokens = torch.cat([tokens, pad], dim=1)
+    elif tokens.shape[1] > pad_len:
+        tokens = tokens[:, :pad_len]
+    tokens = tokens.to(device)
+
+    charge = torch.tensor(df.charge.values, dtype=torch.long, device=device)
+    # m/z = (calcmass + z * proton) / z. calcmass is monoisotopic mass.
+    mz = (df.calcmass.values + df.charge.values * PROTON) / df.charge.values
+    mz_t = torch.tensor(mz, dtype=torch.float32, device=device).unsqueeze(1)
+    ce = torch.tensor(df.collision_energy.values,
+                      dtype=torch.float32, device=device).unsqueeze(1)
+
+    rt = torch.tensor(df.observed_rt.values, dtype=torch.float32, device=device).unsqueeze(1)
+    ims = torch.tensor(df.observed_ims.values, dtype=torch.float32, device=device).unsqueeze(1)
+    ccs = torch.tensor(df.observed_ccs.values, dtype=torch.float32, device=device).unsqueeze(1)
+
+    return {
+        "tokens": tokens, "padding_mask": None,
+        "charge": charge, "mz": mz_t, "ce": ce,
+        "rt": rt, "ims": ims, "ccs": ccs,
+    }
+
+
+def fit_linear_projection(pred: np.ndarray, obs: np.ndarray) -> tuple[float, float]:
+    slope, intercept = np.polyfit(pred, obs, deg=1)
+    return float(slope), float(intercept)
+
+
+@torch.no_grad()
+def predict_rt_ccs(
+    model: UnifiedPeptideModel, batch: dict, batch_size: int = 256
+) -> tuple[np.ndarray, np.ndarray]:
+    """Predict (rt, ccs_mean) on a tensor batch in chunks. Returns 1-D arrays."""
+    n = batch["tokens"].shape[0]
+    rt_out = []
+    ccs_out = []
+    model.eval()
+    for i in range(0, n, batch_size):
+        sl = slice(i, i + batch_size)
+        out = model.forward(
+            tokens=batch["tokens"][sl],
+            padding_mask=(None if batch["padding_mask"] is None
+                              else batch["padding_mask"][sl]),
+            mz=batch["mz"][sl],
+            charge=batch["charge"][sl],
+            tasks=["rt", "ccs"],
+        )
+        rt_out.append(out["rt"].squeeze(-1).cpu().numpy())
+        # CCS head returns (mean, std).
+        ccs_mean, _ = out["ccs"]
+        ccs_out.append(ccs_mean.squeeze(-1).cpu().numpy())
+    return (
+        np.concatenate(rt_out, axis=0).astype(np.float64),
+        np.concatenate(ccs_out, axis=0).astype(np.float64),
+    )
+
+
+def report_mae(
+    pred: np.ndarray, obs: np.ndarray, label: str, unit: str
+) -> dict:
+    abs_err = np.abs(pred - obs)
+    metrics = {
+        "n": int(len(obs)),
+        "mae": float(np.mean(abs_err)),
+        "median_ae": float(np.median(abs_err)),
+        "p90_ae": float(np.percentile(abs_err, 90)),
+        "rmse": float(np.sqrt(np.mean(abs_err ** 2))),
+        "unit": unit,
+    }
+    log.info(
+        f"  [{label}] n={metrics['n']:,}  "
+        f"MAE={metrics['mae']:.4f} {unit}  "
+        f"median={metrics['median_ae']:.4f}  "
+        f"p90={metrics['p90_ae']:.4f}  "
+        f"RMSE={metrics['rmse']:.4f}"
+    )
+    return metrics
+
+
+def custom_finetune_loop(
+    model: UnifiedPeptideModel,
+    train_batch: dict,
+    *,
+    epochs: int,
+    batch_size: int,
+    lr: float,
+    patience: int,
+    val_frac: float,
+    seed: int,
+    rt_weight: float,
+    ccs_weight: float,
+) -> None:
+    """Multi-task L1 fine-tune. Loss = w_rt * L1(rt_pred, rt_obs)
+    + w_ccs * L1(ccs_mean, ccs_obs). Internal val split for early stop.
+    """
+    import torch.nn.functional as F
+
+    n = train_batch["tokens"].shape[0]
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(n)
+    n_val = int(round(n * val_frac))
+    val_idx = torch.tensor(perm[:n_val], device=train_batch["tokens"].device)
+    train_idx = torch.tensor(perm[n_val:], device=train_batch["tokens"].device)
+
+    def _slice(b: dict, idx: torch.Tensor) -> dict:
+        return {k: (None if v is None else v[idx]) for k, v in b.items()}
+
+    tr = _slice(train_batch, train_idx)
+    va = _slice(train_batch, val_idx)
+    n_tr = tr["tokens"].shape[0]
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=1e-4)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, patience=2, factor=0.5, min_lr=1e-6
+    )
+
+    best_val = float("inf")
+    best_state = None
+    bad_epochs = 0
+    log.info(
+        f"multi-task fine-tune: epochs={epochs} batch={batch_size} "
+        f"lr={lr:.2e} weights rt={rt_weight} ccs={ccs_weight}"
+    )
+
+    for ep in range(1, epochs + 1):
+        model.train()
+        epoch_perm = torch.randperm(n_tr, device=tr["tokens"].device)
+        t_loss = t_rt = t_ccs = 0.0
+        nb = 0
+        for i in range(0, n_tr, batch_size):
+            idx = epoch_perm[i:i + batch_size]
+            optimizer.zero_grad()
+            out = model.forward(
+                tokens=tr["tokens"][idx],
+                padding_mask=(None if tr["padding_mask"] is None
+                              else tr["padding_mask"][idx]),
+                mz=tr["mz"][idx],
+                charge=tr["charge"][idx],
+                tasks=["rt", "ccs"],
+            )
+            rt_loss = F.l1_loss(out["rt"], tr["rt"][idx])
+            ccs_mean, _ = out["ccs"]
+            # Supervise CCS in Å² (the head's native output scale);
+            # convert predictions back to 1/K0 at inference time for
+            # library generation downstream.
+            ccs_loss = F.l1_loss(ccs_mean, tr["ccs"][idx])
+            loss = rt_weight * rt_loss + ccs_weight * ccs_loss
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            t_loss += loss.item(); t_rt += rt_loss.item(); t_ccs += ccs_loss.item()
+            nb += 1
+        t_loss /= nb; t_rt /= nb; t_ccs /= nb
+
+        # Val
+        model.eval()
+        with torch.no_grad():
+            v_rt = v_ccs = 0.0
+            vb = 0
+            for i in range(0, va["tokens"].shape[0], batch_size):
+                sl = slice(i, i + batch_size)
+                out = model.forward(
+                    tokens=va["tokens"][sl],
+                    padding_mask=(None if va["padding_mask"] is None
+                                  else va["padding_mask"][sl]),
+                    mz=va["mz"][sl],
+                    charge=va["charge"][sl],
+                    tasks=["rt", "ccs"],
+                )
+                v_rt += F.l1_loss(out["rt"], va["rt"][sl]).item()
+                ccs_mean, _ = out["ccs"]
+                v_ccs += F.l1_loss(ccs_mean, va["ccs"][sl]).item()
+                vb += 1
+            v_rt /= vb; v_ccs /= vb
+            v_loss = rt_weight * v_rt + ccs_weight * v_ccs
+
+        scheduler.step(v_loss)
+        log.info(
+            f"  ep {ep:3d}/{epochs}  "
+            f"tr[rt={t_rt:.4f} ccs={t_ccs:.4f}]  "
+            f"val[rt={v_rt:.4f} ccs={v_ccs:.4f}]  "
+            f"lr={optimizer.param_groups[0]['lr']:.2e}"
+        )
+
+        if v_loss < best_val - 1e-4:
+            best_val = v_loss
+            best_state = {k: v.detach().clone() for k, v in model.state_dict().items()}
+            bad_epochs = 0
+        else:
+            bad_epochs += 1
+            if bad_epochs >= patience:
+                log.info(f"  early stop at epoch {ep} (best val combined L1 {best_val:.4f})")
+                break
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--rescore-dir", type=Path, required=True)
+    parser.add_argument("--pseudo-bin", type=Path, required=True,
+                        help="path to <stem>.pseudo.bin (for env_apex_scan)")
+    parser.add_argument("--d-path", type=Path, required=True,
+                        help="path to .d folder (for scan→1/K0 calibration)")
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--q-cutoff", type=float, default=0.01)
+    parser.add_argument("--holdout-frac", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--epochs", type=int, default=30)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--patience", type=int, default=6)
+    parser.add_argument("--rt-weight", type=float, default=1.0)
+    parser.add_argument("--ccs-weight", type=float, default=10.0,
+                        help="ims values are ~0.7-1.5 (1/K0); RT is ~1-20 min. "
+                             "Boosting CCS weight prevents the tiny-magnitude "
+                             "loss from being ignored by the optimizer.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Data
+    agg = load_and_aggregate(
+        args.rescore_dir,
+        q_cutoff=args.q_cutoff,
+        pseudo_bin=args.pseudo_bin,
+        d_path=args.d_path,
+    )
+    train_df, hold_df = split_peptide_holdout(agg, args.holdout_frac, args.seed)
+    log.info(f"  split: train {len(train_df):,} / hold {len(hold_df):,}")
+    if args.dry_run:
+        return 0
+
+    # Model
+    log.info("loading pretrained UnifiedPeptideModel with rt+ccs heads")
+    from imspy_predictors.utility import get_model_path
+    rt_path = get_model_path("rt/best_model.pt")
+    model = UnifiedPeptideModel.from_pretrained(str(rt_path), tasks=["rt", "ccs"])
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+    log.info(f"  device: {device}  params: {sum(p.numel() for p in model.parameters()):,}")
+    pretrained_state = copy.deepcopy(model.state_dict())
+
+    # Tokenise (one-shot for the full train + hold sets — fits in mem at this scale).
+    tokenizer = ProformaTokenizer.with_defaults()
+    train_t = make_tensors(train_df, tokenizer, device)
+    hold_t = make_tensors(hold_df, tokenizer, device)
+
+    # Baseline — fit linear projections of pretrained predictions onto observed
+    # so MAE measures prediction quality, not scale offset.
+    log.info("baseline (pretrained, linear-projected) eval")
+    rt_pred_pre, ccs_pred_pre = predict_rt_ccs(model, hold_t)
+    rt_obs_hold = hold_df.observed_rt.values.astype(np.float64)
+    ccs_obs_hold = hold_df.observed_ccs.values.astype(np.float64)
+    ims_obs_hold = hold_df.observed_ims.values.astype(np.float64)
+    mz_hold = (hold_df.calcmass.values + hold_df.charge.values * PROTON) / hold_df.charge.values
+    z_hold = hold_df.charge.values.astype(np.int32)
+
+    # Fit projections on the TRAINING set (avoid leakage from holdout).
+    rt_pred_train, ccs_pred_train = predict_rt_ccs(model, train_t)
+    rt_proj = fit_linear_projection(
+        rt_pred_train, train_df.observed_rt.values.astype(np.float64)
+    )
+    ccs_proj = fit_linear_projection(
+        ccs_pred_train, train_df.observed_ccs.values.astype(np.float64)
+    )
+    log.info(
+        f"  rt projection:  obs ≈ {rt_proj[0]:.4f} * pred + {rt_proj[1]:.4f}"
+    )
+    log.info(
+        f"  ccs projection: obs ≈ {ccs_proj[0]:.4f} * pred + {ccs_proj[1]:.4f} (Å²)"
+    )
+    rt_baseline = report_mae(
+        rt_proj[0] * rt_pred_pre + rt_proj[1], rt_obs_hold,
+        "baseline_rt_proj", "min"
+    )
+    ccs_baseline_a2 = report_mae(
+        ccs_proj[0] * ccs_pred_pre + ccs_proj[1], ccs_obs_hold,
+        "baseline_ccs_proj", "Å²"
+    )
+    # Library-relevant baseline: convert projected CCS prediction → 1/K0 and
+    # MAE vs observed 1/K0.
+    ccs_baseline_pred_a2 = ccs_proj[0] * ccs_pred_pre + ccs_proj[1]
+    ims_baseline_pred = np.asarray(
+        ccs_to_one_over_k0_par(ccs_baseline_pred_a2, mz_hold, z_hold),
+        dtype=np.float64,
+    )
+    ims_baseline = report_mae(
+        ims_baseline_pred, ims_obs_hold,
+        "baseline_1/K0_via_ccs_proj", "1/K0"
+    )
+
+    # Multi-task fine-tune
+    custom_finetune_loop(
+        model, train_t,
+        epochs=args.epochs, batch_size=args.batch_size,
+        lr=args.lr, patience=args.patience,
+        val_frac=0.2, seed=args.seed,
+        rt_weight=args.rt_weight, ccs_weight=args.ccs_weight,
+    )
+
+    # Post-finetune eval. RT is in observed minutes; CCS is in Å² (the
+    # head's native scale, what we supervised). For library use we also
+    # convert predicted CCS → 1/K0 and report that MAE.
+    log.info("fine-tuned eval (no projection)")
+    rt_pred_post, ccs_pred_post = predict_rt_ccs(model, hold_t)
+    rt_finetuned = report_mae(rt_pred_post, rt_obs_hold, "finetuned_rt", "min")
+    ccs_finetuned_a2 = report_mae(
+        ccs_pred_post, ccs_obs_hold, "finetuned_ccs", "Å²"
+    )
+    ims_finetuned_pred = np.asarray(
+        ccs_to_one_over_k0_par(ccs_pred_post, mz_hold, z_hold),
+        dtype=np.float64,
+    )
+    ims_finetuned = report_mae(
+        ims_finetuned_pred, ims_obs_hold,
+        "finetuned_1/K0_via_ccs", "1/K0"
+    )
+
+    # Save
+    finetuned_state = copy.deepcopy(model.state_dict())
+    torch.save(
+        {
+            "model_state_dict": finetuned_state,
+            "pretrained_state_dict": pretrained_state,
+            "metrics": {
+                "rt_baseline_proj": rt_baseline, "rt_finetuned": rt_finetuned,
+                "ccs_baseline_proj": ccs_baseline_a2,
+                "ccs_finetuned": ccs_finetuned_a2,
+                "ims_baseline_via_ccs_proj": ims_baseline,
+                "ims_finetuned_via_ccs": ims_finetuned,
+            },
+            "rt_projection": {"slope": rt_proj[0], "intercept": rt_proj[1]},
+            "ccs_projection": {"slope": ccs_proj[0], "intercept": ccs_proj[1]},
+            "args": {k: (str(v) if isinstance(v, Path) else v)
+                     for k, v in vars(args).items()},
+        },
+        args.out_dir / "rt_ccs_multi_finetuned.pt",
+    )
+    def _delta(b, f):
+        return {"baseline": b, "finetuned": f,
+                "delta": b["mae"] - f["mae"],
+                "delta_pct": 100.0 * (b["mae"] - f["mae"]) / b["mae"]
+                if b["mae"] > 0 else 0.0}
+
+    summary = {
+        "rt": _delta(rt_baseline, rt_finetuned),
+        "ccs_a2": _delta(ccs_baseline_a2, ccs_finetuned_a2),
+        "ims_via_ccs": _delta(ims_baseline, ims_finetuned),
+        "n_train_peptides": int(len(train_df)),
+        "n_hold_peptides": int(len(hold_df)),
+        "args": {k: (str(v) if isinstance(v, Path) else v)
+                 for k, v in vars(args).items()},
+    }
+    (args.out_dir / "metrics.json").write_text(json.dumps(summary, indent=2))
+
+    log.info("=" * 60)
+    log.info(f"RT      baseline MAE={rt_baseline['mae']:.3f} min   "
+             f"finetuned MAE={rt_finetuned['mae']:.3f} min   "
+             f"delta={summary['rt']['delta']:+.3f} ({summary['rt']['delta_pct']:+.2f}%)")
+    log.info(f"CCS Å²  baseline MAE={ccs_baseline_a2['mae']:.2f}  "
+             f"finetuned MAE={ccs_finetuned_a2['mae']:.2f}  "
+             f"delta={summary['ccs_a2']['delta']:+.2f} ({summary['ccs_a2']['delta_pct']:+.2f}%)")
+    log.info(f"1/K0    baseline MAE={ims_baseline['mae']:.4f}  "
+             f"finetuned MAE={ims_finetuned['mae']:.4f}  "
+             f"delta={summary['ims_via_ccs']['delta']:+.4f} ({summary['ims_via_ccs']['delta_pct']:+.2f}%)")
+    log.info("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/imspy-predictors/scripts/intensity_target_encoder.py
+++ b/packages/imspy-predictors/scripts/intensity_target_encoder.py
@@ -1,0 +1,372 @@
+"""Phase 1.2 — fragment → Prosit-shape target vector encoder + sanity checks.
+
+Encodes the per-PSM `fragments_observed` data from sagepy
+(written to rescored_canonical.fragments.parquet by the patched
+rescore_canonical.py) into the canonical Prosit-2023-TimsTOF intensity
+target vector layout: 174-dim flat = 29 positions × {y,b} × {+1,+2,+3}.
+
+Verified mapping (physics check, see verify_ion_type_mapping.py):
+  parquet `ion_type` int → label
+    0 → "b"     (b-ion, N-terminal fragment)
+    1 → "y"     (y-ion, C-terminal fragment)
+
+Layout (matches imspy_predictors.intensity.utility.get_prosit_intensity_flat_labels):
+  index = 6 * (ordinal - 1)
+        + (0 if ion_type == "y" else 3)
+        + (frag_charge - 1)
+
+Layout per ordinal:
+  pos 0: y+1   pos 1: y+2   pos 2: y+3
+  pos 3: b+1   pos 4: b+2   pos 5: b+3
+
+This was the user-flagged "ugly hotspot" — sagepy's
+observed_fragments_map() returns a different key order than
+fragments_to_dict(Fragments(...)), and the int values for ion_type need
+physics verification. Both are now nailed down.
+
+Usage:
+    python intensity_target_encoder.py \\
+        --parquet /path/to/rescored_canonical.fragments.parquet \\
+        --tdc-csv /path/to/rescored_canonical.tdc.csv \\
+        --q-cutoff 0.01
+
+Runs all sanity checks (s1/s2/s3) and exits non-zero on failure.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+PROSIT_DIM = 174
+PROSIT_MAX_POSITIONS = 29
+PROSIT_CHARGES = (1, 2, 3)
+PROSIT_ION_LABELS = ("y", "b")  # canonical order in the layout
+
+# Canonical mapping verified by physics on real DIA-PASEF rescore output
+# (verify_ion_type_mapping.py): int 0 = b-ion, int 1 = y-ion.
+ION_INT_TO_LABEL = {0: "b", 1: "y"}
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("intensity_target_encoder")
+
+
+def fragment_index(ordinal: int, ion_label: str, frag_charge: int) -> int:
+    """Compute the flat-layout index for a single fragment.
+
+    Ordinal is 1-indexed (y1..y29, b1..b29). Returns -1 for out-of-range
+    inputs so the caller can skip cleanly without exceptions in a hot
+    loop.
+    """
+    if not (1 <= ordinal <= PROSIT_MAX_POSITIONS):
+        return -1
+    if frag_charge not in PROSIT_CHARGES:
+        return -1
+    if ion_label not in ("b", "y"):
+        return -1
+    ion_offset = 0 if ion_label == "y" else 3
+    return 6 * (ordinal - 1) + ion_offset + (frag_charge - 1)
+
+
+def encode_psm_target(
+    psm_fragments: pd.DataFrame, normalize_per_psm: bool = True
+) -> Tuple[np.ndarray, dict]:
+    """Encode one PSM's fragments → 174-dim Prosit target vector.
+
+    Args:
+        psm_fragments: rows for ONE PSM, with columns
+            (ordinal, frag_charge, ion_type, intensity_observed).
+            ion_type is the int ‐0/1 from sagepy.
+        normalize_per_psm: if True, divide vector by its max so the
+            strongest matched fragment has intensity 1.0. Sagepy already
+            normalizes per-spectrum (max=1) on its way out — this is a
+            defence against subtle deviations. Set False if you want to
+            preserve the raw sagepy-normalized values.
+
+    Returns:
+        (target, stats) where target is shape (174,) float32 and stats
+        is a dict with keys {n_total, n_emitted, n_skipped_ordinal,
+        n_skipped_charge, n_skipped_ion}.
+    """
+    target = np.zeros(PROSIT_DIM, dtype=np.float32)
+    stats = {
+        "n_total": len(psm_fragments),
+        "n_emitted": 0,
+        "n_skipped_ordinal": 0,
+        "n_skipped_charge": 0,
+        "n_skipped_ion": 0,
+    }
+    for _, row in psm_fragments.iterrows():
+        ordinal = int(row.ordinal)
+        frag_charge = int(row.frag_charge)
+        ion_int = int(row.ion_type)
+        intensity = float(row.intensity_observed)
+
+        ion_label = ION_INT_TO_LABEL.get(ion_int)
+        if ion_label is None:
+            stats["n_skipped_ion"] += 1
+            continue
+        if not (1 <= ordinal <= PROSIT_MAX_POSITIONS):
+            stats["n_skipped_ordinal"] += 1
+            continue
+        if frag_charge not in PROSIT_CHARGES:
+            stats["n_skipped_charge"] += 1
+            continue
+
+        idx = fragment_index(ordinal, ion_label, frag_charge)
+        # No silent overwrite — same (ord, charge, ion) reaching the
+        # same index twice means upstream produced duplicates; sum to
+        # be safe (sagepy shouldn't, but defensive).
+        target[idx] += intensity
+        stats["n_emitted"] += 1
+
+    if normalize_per_psm and target.max() > 0:
+        target = target / target.max()
+    return target, stats
+
+
+def encode_psm_target_vec(psm_fragments: pd.DataFrame) -> np.ndarray:
+    """Vectorized variant of encode_psm_target — for hot loops over many
+    PSMs. Same semantics, no per-row stats tracking."""
+    ord_arr = psm_fragments.ordinal.to_numpy(dtype=np.int64)
+    chg_arr = psm_fragments.frag_charge.to_numpy(dtype=np.int64)
+    ion_arr = psm_fragments.ion_type.to_numpy(dtype=np.int64)
+    int_arr = psm_fragments.intensity_observed.to_numpy(dtype=np.float32)
+
+    valid = (
+        (ord_arr >= 1) & (ord_arr <= PROSIT_MAX_POSITIONS)
+        & (chg_arr >= 1) & (chg_arr <= 3)
+        & ((ion_arr == 0) | (ion_arr == 1))
+    )
+    ord_v = ord_arr[valid]
+    chg_v = chg_arr[valid]
+    ion_v = ion_arr[valid]
+    int_v = int_arr[valid]
+
+    # ion_v == 1 (y) maps to offset 0; ion_v == 0 (b) maps to offset 3.
+    ion_offset = np.where(ion_v == 1, 0, 3)
+    idx = 6 * (ord_v - 1) + ion_offset + (chg_v - 1)
+
+    target = np.zeros(PROSIT_DIM, dtype=np.float32)
+    np.add.at(target, idx, int_v)
+    if target.max() > 0:
+        target = target / target.max()
+    return target
+
+
+# ----------------------- Sanity checks -------------------------------
+
+
+def s1_round_trip(df_psm: pd.DataFrame, sequences_for_psms: list) -> int:
+    """s1 — Round-trip: encode each PSM's fragments → 174-vec, then
+    use imspy_predictors' Prosit→Fragments helper to re-derive a
+    fragment list from the vector. Verify the (ordinal, charge, ion)
+    keys match the input fragment set.
+
+    Returns the number of failures.
+    """
+    log.info("s1 — round-trip encode → decode (5 PSMs)")
+    failures = 0
+    psms = list(df_psm.groupby(["spec_idx", "sequence"]))[:5]
+    for (spec_idx, seq), group in psms:
+        target = encode_psm_target_vec(group)
+        # Build the input set of (ord, charge, ion_label) from the parquet
+        in_set = set()
+        for _, r in group.iterrows():
+            ord_ = int(r.ordinal)
+            chg = int(r.frag_charge)
+            ion_int = int(r.ion_type)
+            label = ION_INT_TO_LABEL.get(ion_int)
+            if label is None: continue
+            if not (1 <= ord_ <= PROSIT_MAX_POSITIONS): continue
+            if chg not in PROSIT_CHARGES: continue
+            in_set.add((ord_, chg, label))
+
+        # Decode the target by walking non-zero indices and inverting the
+        # layout formula.
+        decoded = set()
+        for idx in np.flatnonzero(target):
+            ordinal = (idx // 6) + 1
+            within = idx % 6  # 0..5
+            ion_offset = within // 3   # 0=y, 1=b
+            chg = (within % 3) + 1
+            label = "y" if ion_offset == 0 else "b"
+            decoded.add((ordinal, chg, label))
+
+        if in_set != decoded:
+            extra = decoded - in_set
+            missing = in_set - decoded
+            log.error(
+                f"s1 FAIL: {spec_idx}/{seq} — "
+                f"missing={missing}  extra={extra}"
+            )
+            failures += 1
+        else:
+            log.info(
+                f"  {spec_idx}/{seq:<25s} (len={len(seq)}) "
+                f"in/out={len(in_set):3d}  ✓"
+            )
+    return failures
+
+
+def s2_distribution(df_all: pd.DataFrame, n_psms: int = 1000) -> int:
+    """s2 — Distribution sanity: aggregate ~1000 PSMs into the 174-dim
+    layout, look at mean intensity per position. Earlier positions (y2,
+    y3, b2, b3) should be commonly populated; very late positions
+    (y29, b29) should rarely be populated.
+
+    Returns 1 if the pattern is grossly inconsistent.
+    """
+    log.info(f"s2 — distribution sanity ({n_psms} PSMs)")
+    psm_groups = list(df_all.groupby(["spec_idx", "sequence"]))[:n_psms]
+    sums = np.zeros(PROSIT_DIM, dtype=np.float64)
+    counts = np.zeros(PROSIT_DIM, dtype=np.int64)
+    for _, group in psm_groups:
+        target = encode_psm_target_vec(group)
+        sums += target
+        counts += (target > 0).astype(np.int64)
+
+    means = sums / max(1, len(psm_groups))
+    fill_rate = counts / max(1, len(psm_groups))
+
+    # Reshape to (29, 6) for readability: rows=position, cols=(y+1,y+2,y+3,b+1,b+2,b+3)
+    fill_rate_2d = fill_rate.reshape(PROSIT_MAX_POSITIONS, 6)
+    log.info("  fill rate (frac of PSMs with this position populated):")
+    log.info("              y+1     y+2     y+3     b+1     b+2     b+3")
+    for ord_ in range(1, 30):
+        if ord_ in (1, 2, 3, 5, 10, 15, 20, 25, 29):
+            row = fill_rate_2d[ord_ - 1]
+            log.info(
+                f"  ord {ord_:2d}:   "
+                + "  ".join(f"{x:5.3f}" for x in row)
+            )
+
+    # Sanity: mid-range y (y2..y8) should be MORE populated than y29.
+    mid_y = fill_rate_2d[1:8, 0:3].mean()  # y+1..y+3 for ord 2..8
+    late_y = fill_rate_2d[28, 0:3].mean()
+    log.info(f"  mid-y mean fill={mid_y:.4f}  late-y29 mean fill={late_y:.4f}")
+    if mid_y < 0.05:
+        log.error(f"s2 FAIL: mid-range y fill rate {mid_y:.4f} unexpectedly low")
+        return 1
+    if late_y > mid_y:
+        log.error(f"s2 FAIL: late y29 fill rate exceeds mid-range — bug")
+        return 1
+    return 0
+
+
+def s3_spot_check(df_all: pd.DataFrame) -> int:
+    """s3 — Spot check: pick 3 peptides at different lengths (short,
+    mid, long) and inspect their target vectors. Verify populated
+    positions are in [1..L-1] (no fragments past peptide length) and
+    that the brightest peak is at a sensible position.
+    """
+    log.info("s3 — spot check on 3 peptides")
+    psms = df_all.groupby(["spec_idx", "sequence"]).size().reset_index(name="n_frag")
+    # Pick by sequence length: short (≤8), mid (12-16), long (≥22).
+    psms["seq_len"] = psms.sequence.str.len()
+    picks = []
+    for length_filter, label in [
+        (psms.seq_len <= 8, "short"),
+        ((psms.seq_len >= 12) & (psms.seq_len <= 16), "mid"),
+        (psms.seq_len >= 22, "long"),
+    ]:
+        candidates = psms[length_filter].sort_values("n_frag", ascending=False)
+        if len(candidates):
+            picks.append((label, candidates.iloc[0]))
+
+    failures = 0
+    for label, pick in picks:
+        spec_idx, seq = pick.spec_idx, pick.sequence
+        L = len(seq)
+        sub = df_all[(df_all.spec_idx == spec_idx) & (df_all.sequence == seq)]
+        target = encode_psm_target_vec(sub)
+        log.info(
+            f"  [{label}] {spec_idx} {seq} (len={L}, "
+            f"matched_frags={pick.n_frag})"
+        )
+        nz_indices = np.flatnonzero(target)
+        max_ordinal_emitted = 0
+        beyond_L = []
+        for idx in nz_indices:
+            ordinal = (idx // 6) + 1
+            within = idx % 6
+            ion_offset = within // 3
+            chg = (within % 3) + 1
+            ion = "y" if ion_offset == 0 else "b"
+            if ordinal > L - 1:
+                beyond_L.append((ordinal, ion, chg))
+            max_ordinal_emitted = max(max_ordinal_emitted, ordinal)
+        log.info(
+            f"    max emitted ordinal={max_ordinal_emitted}  (peptide L-1={L-1})"
+            f"   #unique positions={len(nz_indices)}"
+        )
+        if beyond_L:
+            log.error(
+                f"s3 FAIL: {len(beyond_L)} fragments past peptide length "
+                f"L-1={L-1}: {beyond_L[:5]}"
+            )
+            failures += 1
+        # Brightest peak position
+        argmax_idx = int(np.argmax(target))
+        ord_max = (argmax_idx // 6) + 1
+        within = argmax_idx % 6
+        ion_max = "y" if within // 3 == 0 else "b"
+        chg_max = (within % 3) + 1
+        log.info(
+            f"    brightest: {ion_max}{ord_max}+{chg_max} "
+            f"(intensity={target[argmax_idx]:.3f}, idx={argmax_idx})"
+        )
+    return failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--parquet", type=Path, required=True,
+                        help="rescored_canonical.fragments.parquet")
+    parser.add_argument("--tdc-csv", type=Path, required=True,
+                        help="rescored_canonical.tdc.csv")
+    parser.add_argument("--q-cutoff", type=float, default=0.01)
+    parser.add_argument("--n-psms-s2", type=int, default=1000)
+    args = parser.parse_args()
+
+    log.info(f"reading {args.parquet}")
+    df_all = pd.read_parquet(args.parquet)
+    log.info(f"  {len(df_all):,} fragment rows")
+
+    log.info(f"reading {args.tdc_csv}, filtering to q≤{args.q_cutoff} targets")
+    tdc = pd.read_csv(args.tdc_csv,
+                      usecols=["spec_idx", "match_idx", "decoy", "q_value"])
+    tdc = tdc[(~tdc.decoy.astype(bool)) & (tdc.q_value <= args.q_cutoff)]
+    log.info(f"  {len(tdc):,} high-confidence target PSMs")
+
+    # Filter parquet to high-confidence PSMs (sequence == match_idx, spec_idx).
+    df_hc = df_all.merge(
+        tdc[["spec_idx", "match_idx"]].rename(columns={"match_idx": "sequence"}),
+        on=["spec_idx", "sequence"], how="inner",
+    )
+    log.info(f"  parquet ∩ high-conf: {len(df_hc):,} fragment rows  "
+             f"({df_hc.groupby(['spec_idx','sequence']).ngroups} unique PSMs)")
+
+    failures = 0
+    failures += s1_round_trip(df_hc, sequences_for_psms=None)
+    failures += s2_distribution(df_hc, n_psms=args.n_psms_s2)
+    failures += s3_spot_check(df_hc)
+
+    if failures:
+        log.error(f"{failures} sanity check(s) FAILED")
+        return 1
+    log.info("all sanity checks PASSED ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/imspy-predictors/scripts/joint_init_baseline.py
+++ b/packages/imspy-predictors/scripts/joint_init_baseline.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python
+"""Phase A — does merging the 3 pretrained heads into one UnifiedPeptideModel
+regress per-task baselines?
+
+For each choice of base encoder (rt / ccs / intensity), load that
+checkpoint as the encoder, then swap in the OTHER two heads from their
+respective per-task checkpoints. Measure per-task baseline MAE on the
+same M3 holdout used by the standalone fine-tune scripts.
+
+Decision rule: if all 3 baselines are within ±10% of the standalone
+references, joint training is viable; we proceed to Phase B (fine-tune
+flavor ablation). If any regresses by >20%, the encoder-head pairing
+matters task-specifically and joint is a regression — per-task wins.
+
+Standalone reference baselines (from M3 anchor set, q≤0.01, peptide-level
+or per-(peptide, charge) holdout, seed=0):
+    RT       (linear-projected pretrained):  1.535 min MAE  on 5,371 peptides
+    CCS Å²   (linear-projected pretrained):  13.24 Å²       on 5,335 (pep, z) pairs
+    Intensity (raw pretrained):              SA mean 0.380  on 5,335 PSMs
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+from imspy_predictors.models.unified import UnifiedPeptideModel
+from imspy_predictors.utilities import ProformaTokenizer
+from imspy_predictors.utility import get_model_path
+from imspy_core.chemistry.mobility import (
+    ccs_to_one_over_k0_par, one_over_k0_to_ccs_par,
+)
+
+# Re-use the encoder + sanity-check infra from intensity_target_encoder
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from intensity_target_encoder import encode_psm_target_vec
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("joint_init_baseline")
+
+PROTON = 1.007276466879
+TASK_NAMES = ("rt", "ccs", "intensity")
+
+
+def read_pseudo_bin_apex_scans(bin_path: Path) -> np.ndarray:
+    with open(bin_path, "rb") as f:
+        magic = f.read(4)
+        assert magic == b"PSSP", magic
+        version, n_spec, _ = struct.unpack("<III", f.read(12))
+        assert version == 2, version
+        f.seek(4 * n_spec, 1)
+        f.seek(8 * n_spec, 1)
+        f.seek(4 * n_spec, 1)
+        return np.frombuffer(f.read(4 * n_spec), dtype="<f4").copy()
+
+
+def build_scan_to_im_lut(d_path: Path, sample_frame_id: int = 1) -> np.ndarray:
+    from imspy_core.timstof import TimsDataset
+    ds = TimsDataset(str(d_path))
+    n_scans = ds.num_scans
+    scans = np.arange(1, n_scans + 1, dtype=np.int32)
+    im = np.asarray(ds.scan_to_inverse_mobility(sample_frame_id, scans),
+                    dtype=np.float64)
+    lut = np.zeros(n_scans + 2, dtype=np.float64)
+    lut[1:n_scans + 1] = im
+    return lut
+
+
+def lookup_im(scan, lut):
+    s = np.asarray(scan, dtype=np.float64)
+    s_lo = np.floor(s).astype(np.int64)
+    s_hi = s_lo + 1
+    s_lo = np.clip(s_lo, 1, len(lut) - 2)
+    s_hi = np.clip(s_hi, 1, len(lut) - 1)
+    f = s - s_lo
+    return lut[s_lo] * (1.0 - f) + lut[s_hi] * f
+
+
+def make_merged_model(base: str, device: torch.device) -> UnifiedPeptideModel:
+    """Load `base` checkpoint as encoder + base-task head; load the other
+    two task heads' weights from their respective checkpoints. Returns
+    a UnifiedPeptideModel with all three heads pretrained."""
+    base_path = get_model_path(f"{base}/best_model.pt")
+    log.info(f"  building joint init: encoder + heads from {base_path}")
+    model = UnifiedPeptideModel.from_pretrained(
+        str(base_path), tasks=list(TASK_NAMES),
+    )
+    # Load the other two heads' weights from their per-task checkpoints
+    for task in TASK_NAMES:
+        if task == base:
+            continue
+        task_path = get_model_path(f"{task}/best_model.pt")
+        ckpt = torch.load(str(task_path), map_location="cpu", weights_only=False)
+        head_state = ckpt.get("heads_state_dict", {}).get(task)
+        if head_state is None:
+            raise RuntimeError(
+                f"checkpoint {task_path} has no heads_state_dict[{task}]"
+            )
+        model.heads[task].load_state_dict(head_state)
+        log.info(f"    swapped in pretrained {task} head from {task_path}")
+    model = model.to(device)
+    model.eval()
+    return model
+
+
+def load_psm_data(rescore_dir: Path, q_cutoff: float, pseudo_bin: Path, d_path: Path):
+    tdc = pd.read_csv(rescore_dir / "rescored_canonical.tdc.csv",
+                      usecols=["spec_idx", "match_idx", "decoy", "q_value"])
+    tdc = tdc[(~tdc.decoy.astype(bool)) & (tdc.q_value <= q_cutoff)]
+    psm = pd.read_csv(rescore_dir / "rescored_canonical.csv",
+                      usecols=["spec_idx", "match_idx", "rt", "charge",
+                               "calcmass", "collision_energy"])
+    df = tdc.merge(psm, on=["spec_idx", "match_idx"], how="inner")
+    apex_scan = read_pseudo_bin_apex_scans(pseudo_bin)
+    lut = build_scan_to_im_lut(d_path)
+    bin_idx = df.spec_idx.str.removeprefix("pseudo_").astype(np.int64).values
+    one_over_k0 = lookup_im(apex_scan[bin_idx], lut)
+    charge_arr = df.charge.values.astype(np.float64)
+    mz_arr = (df.calcmass.values + charge_arr * PROTON) / charge_arr
+    observed_ccs = np.asarray(
+        one_over_k0_to_ccs_par(one_over_k0, mz_arr, charge_arr.astype(np.int32)),
+        dtype=np.float64,
+    )
+    df = df.assign(observed_ims=one_over_k0, observed_ccs=observed_ccs)
+    df = df.rename(columns={"match_idx": "sequence"})
+    log.info(f"  high-conf PSMs: {len(df):,}")
+    return df
+
+
+def aggregate_per_pepcharge(df_psm: pd.DataFrame) -> pd.DataFrame:
+    """For RT and CCS evaluation — per-(peptide, charge)."""
+    return df_psm.groupby(["sequence", "charge"], as_index=False).agg(
+        observed_rt=("rt", "mean"),
+        observed_ims=("observed_ims", "mean"),
+        observed_ccs=("observed_ccs", "mean"),
+        calcmass=("calcmass", "mean"),
+        collision_energy=("collision_energy", "first"),
+        n_psm=("spec_idx", "size"),
+    )
+
+
+def split_seq_holdout(df: pd.DataFrame, holdout_frac: float, seed: int):
+    rng = np.random.default_rng(seed)
+    seqs = df.sequence.unique()
+    perm = rng.permutation(len(seqs))
+    n_hold = int(round(len(seqs) * holdout_frac))
+    holdout_set = set(seqs[perm[:n_hold]])
+    train = df[~df.sequence.isin(holdout_set)].reset_index(drop=True)
+    hold = df[df.sequence.isin(holdout_set)].reset_index(drop=True)
+    return train, hold
+
+
+def make_token_batch(seqs: list[str], tokenizer, device, pad_len=50):
+    result = tokenizer(seqs, padding=True, return_tensors="pt")
+    tokens = result["input_ids"]
+    if tokens.shape[1] < pad_len:
+        pad = torch.zeros(tokens.shape[0], pad_len - tokens.shape[1], dtype=torch.long)
+        tokens = torch.cat([tokens, pad], dim=1)
+    elif tokens.shape[1] > pad_len:
+        tokens = tokens[:, :pad_len]
+    return tokens.to(device)
+
+
+@torch.no_grad()
+def eval_rt(model, train_df, hold_df, tokenizer, device, batch_size=512):
+    """RT baseline with linear projection fit on train (predicted → observed)."""
+    train_tokens = make_token_batch(train_df.sequence.tolist(), tokenizer, device)
+    hold_tokens = make_token_batch(hold_df.sequence.tolist(), tokenizer, device)
+    def _predict(tokens):
+        out = []
+        for i in range(0, tokens.shape[0], batch_size):
+            sl = slice(i, i + batch_size)
+            out.append(model.predict_rt(tokens[sl]).squeeze(-1).cpu().numpy())
+        return np.concatenate(out, axis=0).astype(np.float64)
+    train_pred = _predict(train_tokens)
+    hold_pred = _predict(hold_tokens)
+    train_obs = train_df.observed_rt.values.astype(np.float64)
+    hold_obs = hold_df.observed_rt.values.astype(np.float64)
+    slope, intercept = np.polyfit(train_pred, train_obs, 1)
+    proj = slope * hold_pred + intercept
+    return float(np.mean(np.abs(proj - hold_obs))), (float(slope), float(intercept))
+
+
+@torch.no_grad()
+def eval_ccs(model, train_df, hold_df, tokenizer, device, batch_size=512):
+    """CCS baseline with linear projection fit on train. Reports CCS Å²."""
+    def _build_inputs(df):
+        tokens = make_token_batch(df.sequence.tolist(), tokenizer, device)
+        charge = torch.tensor(df.charge.values.astype(np.int64),
+                              dtype=torch.long, device=device)
+        mz = (df.calcmass.values + df.charge.values * PROTON) / df.charge.values
+        mz_t = torch.tensor(mz, dtype=torch.float32, device=device).unsqueeze(1)
+        return tokens, charge, mz_t
+    def _predict(tokens, charge, mz):
+        out = []
+        for i in range(0, tokens.shape[0], batch_size):
+            sl = slice(i, i + batch_size)
+            ccs_mean, _ = model.predict_ccs(
+                tokens[sl], mz=mz[sl], charge=charge[sl],
+            )
+            out.append(ccs_mean.squeeze(-1).cpu().numpy())
+        return np.concatenate(out, axis=0).astype(np.float64)
+    tk_t, ch_t, mz_t = _build_inputs(train_df)
+    tk_h, ch_h, mz_h = _build_inputs(hold_df)
+    train_pred = _predict(tk_t, ch_t, mz_t)
+    hold_pred = _predict(tk_h, ch_h, mz_h)
+    train_obs = train_df.observed_ccs.values.astype(np.float64)
+    hold_obs = hold_df.observed_ccs.values.astype(np.float64)
+    slope, intercept = np.polyfit(train_pred, train_obs, 1)
+    proj = slope * hold_pred + intercept
+    return float(np.mean(np.abs(proj - hold_obs))), (float(slope), float(intercept))
+
+
+@torch.no_grad()
+def eval_intensity(
+    model, hold_psms, frag_df, tokenizer, device, batch_size=256,
+):
+    """Intensity baseline as spectral angle (raw, no projection — SA is
+    scale-invariant). hold_psms is a per-PSM dataframe; frag_df is
+    fragment rows used to encode targets per (spec_idx, sequence)."""
+    # Encode targets per PSM
+    psm_keys = list(zip(hold_psms.spec_idx, hold_psms.sequence))
+    psm_groups = {key: g for key, g in frag_df.groupby(["spec_idx", "sequence"])}
+    targets = []
+    seqs_for_eval = []
+    charges = []
+    ces = []
+    for key in psm_keys:
+        if key not in psm_groups:
+            continue
+        target = encode_psm_target_vec(psm_groups[key])
+        targets.append(target)
+        seqs_for_eval.append(key[1])
+        # Recover charge/CE from the PSM row
+        match = hold_psms[(hold_psms.spec_idx == key[0]) & (hold_psms.sequence == key[1])].iloc[0]
+        charges.append(int(match.charge))
+        ces.append(float(match.collision_energy))
+    if not targets:
+        return float("nan"), float("nan"), 0
+    target_arr = np.stack(targets).astype(np.float64)
+    tokens = make_token_batch(seqs_for_eval, tokenizer, device)
+    charge_t = torch.tensor(charges, dtype=torch.long, device=device)
+    ce_t = torch.tensor(ces, dtype=torch.float32, device=device).unsqueeze(1)
+
+    pred_chunks = []
+    for i in range(0, tokens.shape[0], batch_size):
+        sl = slice(i, i + batch_size)
+        pred = model.predict_intensity(
+            tokens[sl], charge=charge_t[sl], collision_energy=ce_t[sl],
+        )
+        if pred.dim() == 4:
+            pred = pred.reshape(pred.shape[0], -1)
+        pred_chunks.append(pred.cpu().numpy())
+    pred_arr = np.concatenate(pred_chunks, axis=0).astype(np.float64)
+
+    # Spectral angle (Prosit canonical, masked on target>0)
+    sas = []
+    for i in range(len(target_arr)):
+        m = target_arr[i] > 0
+        if m.sum() < 2:
+            continue
+        p = pred_arr[i][m]; t = target_arr[i][m]
+        p_norm = p / max(1e-12, np.linalg.norm(p))
+        t_norm = t / max(1e-12, np.linalg.norm(t))
+        cos = float(np.clip(np.dot(p_norm, t_norm), -1.0, 1.0))
+        sas.append(1.0 - 2.0 * np.arccos(cos) / np.pi)
+    return float(np.mean(sas)), float(np.median(sas)), len(sas)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--rescore-dir", type=Path, required=True)
+    parser.add_argument("--pseudo-bin", type=Path, required=True)
+    parser.add_argument("--d-path", type=Path, required=True)
+    parser.add_argument("--q-cutoff", type=float, default=0.01)
+    parser.add_argument("--holdout-frac", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    log.info(f"device: {device}")
+
+    log.info("loading PSM data + side-loaded 1/K0 / CCS")
+    df_psm = load_psm_data(args.rescore_dir, args.q_cutoff,
+                           args.pseudo_bin, args.d_path)
+
+    # For RT/CCS — per-(peptide, charge), holdout by sequence
+    pep_charge = aggregate_per_pepcharge(df_psm)
+    train_pc, hold_pc = split_seq_holdout(pep_charge, args.holdout_frac, args.seed)
+    log.info(f"  RT/CCS eval: train {len(train_pc):,} (pep, z) / hold {len(hold_pc):,}")
+
+    # For intensity — per-PSM, holdout by sequence
+    psm_train, psm_hold = split_seq_holdout(df_psm, args.holdout_frac, args.seed)
+    log.info(f"  intensity eval: train {len(psm_train):,} PSMs / hold {len(psm_hold):,}")
+
+    log.info("loading fragments parquet")
+    frag_df = pd.read_parquet(args.rescore_dir / "rescored_canonical.fragments.parquet")
+    # Filter to fragments belonging to PSMs in our high-conf set (for intensity eval)
+    hc_keys = df_psm[["spec_idx", "sequence"]]
+    frag_hc = frag_df.merge(hc_keys, on=["spec_idx", "sequence"], how="inner")
+    log.info(f"  fragments ∩ high-conf: {len(frag_hc):,}")
+
+    tokenizer = ProformaTokenizer.with_defaults()
+
+    # Standalone reference baselines (from prior runs in the session)
+    references = {
+        "rt_mae_min":     1.535,   # finetune_dia_pasef.py baseline
+        "ccs_mae_a2":    13.240,   # finetune_dia_pasef_ccs.py baseline+proj
+        "intensity_sa_mean": 0.380, # finetune_dia_pasef_intensity.py baseline
+    }
+
+    log.info("=" * 70)
+    log.info("REFERENCE BASELINES (standalone per-task checkpoints):")
+    log.info(f"  RT MAE min:       {references['rt_mae_min']:.3f}")
+    log.info(f"  CCS MAE Å²:       {references['ccs_mae_a2']:.3f}")
+    log.info(f"  Intensity SA mean:{references['intensity_sa_mean']:.4f}")
+    log.info("=" * 70)
+
+    results = []
+    for base in ("intensity", "rt", "ccs"):
+        log.info("")
+        log.info("=" * 70)
+        log.info(f"BASE = {base}")
+        log.info("=" * 70)
+        model = make_merged_model(base, device)
+
+        rt_mae, rt_proj = eval_rt(model, train_pc, hold_pc, tokenizer, device)
+        log.info(f"  RT  MAE: {rt_mae:.3f} min   "
+                 f"(ref {references['rt_mae_min']:.3f}, "
+                 f"delta {100*(rt_mae - references['rt_mae_min']) / references['rt_mae_min']:+.1f}%)")
+
+        ccs_mae, ccs_proj = eval_ccs(model, train_pc, hold_pc, tokenizer, device)
+        log.info(f"  CCS MAE: {ccs_mae:.3f} Å²   "
+                 f"(ref {references['ccs_mae_a2']:.3f}, "
+                 f"delta {100*(ccs_mae - references['ccs_mae_a2']) / references['ccs_mae_a2']:+.1f}%)")
+
+        sa_mean, sa_median, n_sa = eval_intensity(
+            model, psm_hold, frag_hc, tokenizer, device,
+        )
+        log.info(f"  Intensity SA mean: {sa_mean:.4f}  median: {sa_median:.4f}  "
+                 f"n={n_sa:,}  (ref {references['intensity_sa_mean']:.4f}, "
+                 f"delta {100*(sa_mean - references['intensity_sa_mean']) / references['intensity_sa_mean']:+.1f}%)")
+
+        results.append({
+            "base": base,
+            "rt_mae_min": rt_mae,
+            "ccs_mae_a2": ccs_mae,
+            "intensity_sa_mean": sa_mean,
+        })
+
+    log.info("")
+    log.info("=" * 70)
+    log.info("SUMMARY (positive delta = WORSE than per-task standalone)")
+    log.info("=" * 70)
+    log.info(f"{'base':<12} {'RT MAE':>10} {'Δ%':>7} | "
+             f"{'CCS MAE':>9} {'Δ%':>7} | {'Int SA':>9} {'Δ%':>7}")
+    for r in results:
+        rt_d = 100*(r['rt_mae_min'] - references['rt_mae_min'])/references['rt_mae_min']
+        ccs_d = 100*(r['ccs_mae_a2'] - references['ccs_mae_a2'])/references['ccs_mae_a2']
+        sa_d = 100*(r['intensity_sa_mean'] - references['intensity_sa_mean'])/references['intensity_sa_mean']
+        log.info(
+            f"{r['base']:<12} {r['rt_mae_min']:>10.3f} {rt_d:+6.1f}% | "
+            f"{r['ccs_mae_a2']:>9.3f} {ccs_d:+6.1f}% | "
+            f"{r['intensity_sa_mean']:>9.4f} {sa_d:+6.1f}%"
+        )
+    log.info("=" * 70)
+    log.info("decision: if all 3 deltas are within ±10% for at least one base, "
+             "joint training is viable; pick that base for Phase B.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/imspy-predictors/src/imspy_predictors/ccs/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/ccs/predictors.py
@@ -573,13 +573,29 @@ class DeepPeptideIonMobilityApex(PeptideIonMobilityApex):
         ).float()
         ccs_tensor = torch.tensor(ccs, dtype=torch.float32, device=self._device).unsqueeze(1)
 
-        # Split data
+        # Group-aware (peptide × charge) split: same (modseq, charge) → same
+        # fold. PSM-level random split would leak — the predictor is
+        # deterministic per (sequence, charge) so identical inputs in
+        # train and val collapse val loss to the instrument's IM-noise
+        # floor, not the model's generalization.
         n = len(sequences)
-        n_train = int(0.8 * n)
-        indices = torch.randperm(n)
-
-        train_idx = indices[:n_train]
-        val_idx = indices[n_train:]
+        group_keys = np.array([f"{s}_{int(c)}" for s, c in zip(sequences, charges)])
+        uniq, inv = np.unique(group_keys, return_inverse=True)
+        n_groups = len(uniq)
+        n_val_groups = max(1, int(n_groups * 0.2))
+        if n_val_groups >= n_groups:
+            n_val_groups = n_groups - 1
+        rng_np = np.random.default_rng(42)
+        perm_groups = rng_np.permutation(n_groups)
+        val_groups = set(perm_groups[:n_val_groups].tolist())
+        mask_val = np.fromiter((g in val_groups for g in inv),
+                                   dtype=bool, count=n)
+        val_idx   = torch.from_numpy(np.flatnonzero(mask_val))
+        train_idx = torch.from_numpy(np.flatnonzero(~mask_val))
+        if verbose:
+            print(f"[im-ft] {n} PSMs ({n_groups:,} unique (modseq,charge)) → "
+                  f"train {len(train_idx):,}, val {len(val_idx):,} "
+                  f"(val groups: {n_val_groups:,})")
 
         # Create datasets
         train_dataset = TensorDataset(

--- a/packages/imspy-predictors/src/imspy_predictors/ccs/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/ccs/predictors.py
@@ -606,6 +606,7 @@ class DeepPeptideIonMobilityApex(PeptideIonMobilityApex):
         )
         checkpoint = InMemoryCheckpoint(patience=patience)
 
+        history = {"epochs": [], "train_loss": [], "val_loss": []}
         for epoch in range(epochs):
             # Training
             self.model.train()
@@ -630,6 +631,7 @@ class DeepPeptideIonMobilityApex(PeptideIonMobilityApex):
                 loss.backward()
                 optimizer.step()
                 train_loss += loss.item()
+            train_loss /= max(len(train_loader), 1)
 
             # Validation
             self.model.eval()
@@ -654,8 +656,15 @@ class DeepPeptideIonMobilityApex(PeptideIonMobilityApex):
             val_loss /= len(val_loader)
             scheduler.step(val_loss)
 
-            if verbose and epoch % 10 == 0:
-                print(f"Epoch {epoch}: val_loss={val_loss:.4f}")
+            history["epochs"].append(epoch)
+            history["train_loss"].append(float(train_loss))
+            history["val_loss"].append(float(val_loss))
+
+            # Print every 5 epochs (was 10) — matches RT/intensity pattern so
+            # the report's per-head FT plot has comparable point density.
+            if verbose and epoch % 5 == 0:
+                print(f"Epoch {epoch}: im train_loss={train_loss:.4f} "
+                      f"val_loss={val_loss:.4f}")
 
             if checkpoint.step(val_loss, self.model):
                 if verbose:
@@ -664,6 +673,7 @@ class DeepPeptideIonMobilityApex(PeptideIonMobilityApex):
 
         checkpoint.restore(self.model)
         self.model.eval()
+        self._finetune_history = history
 
     def simulate_ion_mobilities_pandas(
         self,

--- a/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
@@ -1012,12 +1012,28 @@ class DeepPeptideIntensityPredictor(IonIntensityPredictor):
         )
 
         n = len(sequences)
-        n_train = max(1, int(0.8 * n))
-        if n_train >= n:
-            n_train = n - 1
-        indices = self._torch.randperm(n, device=self._device)
-        train_idx = indices[:n_train]
-        val_idx = indices[n_train:]
+        # Group-aware (peptide × charge) split: same (modseq, charge) → same
+        # fold. PSM-level random split would leak — the predictor is
+        # deterministic per (sequence, charge, CE) so identical inputs in
+        # train and val collapse val loss to the instrument's intensity-
+        # noise floor, not the model's generalization.
+        group_keys = np.array([f"{s}_{int(c)}" for s, c in zip(sequences, charges)])
+        uniq, inv = np.unique(group_keys, return_inverse=True)
+        n_groups = len(uniq)
+        n_val_groups = max(1, int(n_groups * 0.2))
+        if n_val_groups >= n_groups:
+            n_val_groups = n_groups - 1
+        rng_np = np.random.default_rng(42)
+        perm_groups = rng_np.permutation(n_groups)
+        val_groups = set(perm_groups[:n_val_groups].tolist())
+        mask_val = np.fromiter((g in val_groups for g in inv),
+                                   dtype=bool, count=n)
+        val_idx   = self._torch.from_numpy(np.flatnonzero(mask_val)).to(self._device)
+        train_idx = self._torch.from_numpy(np.flatnonzero(~mask_val)).to(self._device)
+        if verbose:
+            print(f"[intens-ft] {n} PSMs ({n_groups:,} unique (modseq,charge)) → "
+                  f"train {len(train_idx):,}, val {len(val_idx):,} "
+                  f"(val groups: {n_val_groups:,})")
 
         train_ds = TensorDataset(
             tokens[train_idx], charge_tensor[train_idx],

--- a/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
@@ -62,23 +62,38 @@ def observed_fragments_to_intensity_target(
 ) -> np.ndarray:
     """Build a native Prosit-layout target vector from observed Sage fragments.
 
-    Output layout is ordinal-major:
-    ``[y1+1, y1+2, y1+3, b1+1, b1+2, b1+3, y2+1, ...]``. Impossible
-    fragments are marked ``-1`` so ``masked_spectral_distance`` ignores
-    them; valid but unmatched fragments remain zero (so the model learns
-    "this ion is possible but wasn't observed").
+    Output layout is **charge-major** matching
+    ``imspy_simulation.utility.flatten_prosit_array`` (the canonical
+    Prosit/imspy 174-vec decoder):
+
+        [0:29]   y+1   (positions 1..29)
+        [29:58]  b+1
+        [58:87]  y+2
+        [87:116] b+2
+        [116:145] y+3
+        [145:174] b+3
+
+    so ``slot = (charge-1)*58 + (0 if ion=="y" else 29) + (ordinal-1)``.
+
+    Impossible fragments are marked ``-1`` so ``masked_spectral_distance``
+    ignores them; valid but unmatched fragments remain zero (so the model
+    learns "this ion is possible but wasn't observed").
     """
     sequence_length = len(remove_unimod_annotation(sequence))
     target = np.zeros(174, dtype=np.float32)
 
-    target_3d = target.reshape(29, 6)
     max_frag_pos = max(sequence_length - 1, 0)
-    if max_frag_pos < 29:
-        target_3d[max_frag_pos:, :] = -1.0
-    for ion_charge in range(1, 4):
-        if ion_charge > int(precursor_charge):
-            target_3d[:, ion_charge - 1] = -1.0
-            target_3d[:, ion_charge + 2] = -1.0
+    for c_idx in range(3):
+        base_y = c_idx * 58
+        base_b = c_idx * 58 + 29
+        # Positions past sequence_length-1 are impossible.
+        if max_frag_pos < 29:
+            target[base_y + max_frag_pos: base_y + 29] = -1.0
+            target[base_b + max_frag_pos: base_b + 29] = -1.0
+        # Charges above the precursor charge are impossible.
+        if (c_idx + 1) > int(precursor_charge):
+            target[base_y: base_y + 29] = -1.0
+            target[base_b: base_b + 29] = -1.0
 
     intensities = np.asarray(fragments.intensities, dtype=np.float32)
     if intensities.size == 0:
@@ -100,7 +115,7 @@ def observed_fragments_to_intensity_target(
             continue
         if not (1 <= ordinal <= 29 and 1 <= charge <= 3):
             continue
-        slot = (ordinal - 1) * 6 + (charge - 1 if ion == "y" else 3 + charge - 1)
+        slot = (charge - 1) * 58 + (0 if ion == "y" else 29) + (ordinal - 1)
         if target[slot] >= 0:
             target[slot] = float(intensity) / max_intensity
     return target

--- a/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
@@ -62,38 +62,23 @@ def observed_fragments_to_intensity_target(
 ) -> np.ndarray:
     """Build a native Prosit-layout target vector from observed Sage fragments.
 
-    Output layout is **charge-major** matching
-    ``imspy_simulation.utility.flatten_prosit_array`` (the canonical
-    Prosit/imspy 174-vec decoder):
-
-        [0:29]   y+1   (positions 1..29)
-        [29:58]  b+1
-        [58:87]  y+2
-        [87:116] b+2
-        [116:145] y+3
-        [145:174] b+3
-
-    so ``slot = (charge-1)*58 + (0 if ion=="y" else 29) + (ordinal-1)``.
-
-    Impossible fragments are marked ``-1`` so ``masked_spectral_distance``
-    ignores them; valid but unmatched fragments remain zero (so the model
-    learns "this ion is possible but wasn't observed").
+    Output layout is ordinal-major:
+    ``[y1+1, y1+2, y1+3, b1+1, b1+2, b1+3, y2+1, ...]``. Impossible
+    fragments are marked ``-1`` so ``masked_spectral_distance`` ignores
+    them; valid but unmatched fragments remain zero (so the model learns
+    "this ion is possible but wasn't observed").
     """
     sequence_length = len(remove_unimod_annotation(sequence))
     target = np.zeros(174, dtype=np.float32)
 
+    target_3d = target.reshape(29, 6)
     max_frag_pos = max(sequence_length - 1, 0)
-    for c_idx in range(3):
-        base_y = c_idx * 58
-        base_b = c_idx * 58 + 29
-        # Positions past sequence_length-1 are impossible.
-        if max_frag_pos < 29:
-            target[base_y + max_frag_pos: base_y + 29] = -1.0
-            target[base_b + max_frag_pos: base_b + 29] = -1.0
-        # Charges above the precursor charge are impossible.
-        if (c_idx + 1) > int(precursor_charge):
-            target[base_y: base_y + 29] = -1.0
-            target[base_b: base_b + 29] = -1.0
+    if max_frag_pos < 29:
+        target_3d[max_frag_pos:, :] = -1.0
+    for ion_charge in range(1, 4):
+        if ion_charge > int(precursor_charge):
+            target_3d[:, ion_charge - 1] = -1.0
+            target_3d[:, ion_charge + 2] = -1.0
 
     intensities = np.asarray(fragments.intensities, dtype=np.float32)
     if intensities.size == 0:
@@ -115,7 +100,7 @@ def observed_fragments_to_intensity_target(
             continue
         if not (1 <= ordinal <= 29 and 1 <= charge <= 3):
             continue
-        slot = (charge - 1) * 58 + (0 if ion == "y" else 29) + (ordinal - 1)
+        slot = (ordinal - 1) * 6 + (charge - 1 if ion == "y" else 3 + charge - 1)
         if target[slot] >= 0:
             target[slot] = float(intensity) / max_intensity
     return target

--- a/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
@@ -33,6 +33,78 @@ from imspy_predictors.lazy_imports import (
     get_simulation_flatten_prosit,
 )
 
+from imspy_predictors.utility import InMemoryCheckpoint
+from imspy_predictors.losses import masked_spectral_distance
+
+
+# -----------------------------------------------------------------------------
+# Fragment label helpers (used by DeepPeptideIntensityPredictor.fine_tune_psms)
+# -----------------------------------------------------------------------------
+
+def _ion_to_text(ion) -> str:
+    """Coerce sagepy's IonType enum / string to ``"b"`` or ``"y"``."""
+    text = str(ion).lower()
+    if text in ("b", "y"):
+        return text
+    if text in ("iontype(b)", "iontype(y)"):
+        return text[-2]
+    if text.endswith(" b") or text.endswith(".b"):
+        return "b"
+    if text.endswith(" y") or text.endswith(".y"):
+        return "y"
+    return text[-1:]
+
+
+def observed_fragments_to_intensity_target(
+    sequence: str,
+    precursor_charge: int,
+    fragments,
+) -> np.ndarray:
+    """Build a native Prosit-layout target vector from observed Sage fragments.
+
+    Output layout is ordinal-major:
+    ``[y1+1, y1+2, y1+3, b1+1, b1+2, b1+3, y2+1, ...]``. Impossible
+    fragments are marked ``-1`` so ``masked_spectral_distance`` ignores
+    them; valid but unmatched fragments remain zero (so the model learns
+    "this ion is possible but wasn't observed").
+    """
+    sequence_length = len(remove_unimod_annotation(sequence))
+    target = np.zeros(174, dtype=np.float32)
+
+    target_3d = target.reshape(29, 6)
+    max_frag_pos = max(sequence_length - 1, 0)
+    if max_frag_pos < 29:
+        target_3d[max_frag_pos:, :] = -1.0
+    for ion_charge in range(1, 4):
+        if ion_charge > int(precursor_charge):
+            target_3d[:, ion_charge - 1] = -1.0
+            target_3d[:, ion_charge + 2] = -1.0
+
+    intensities = np.asarray(fragments.intensities, dtype=np.float32)
+    if intensities.size == 0:
+        return target
+    max_intensity = float(np.max(intensities))
+    if max_intensity <= 0:
+        return target
+
+    for ion_type, ordinal, charge, intensity in zip(
+        fragments.ion_types,
+        fragments.fragment_ordinals,
+        fragments.charges,
+        intensities,
+    ):
+        ion = _ion_to_text(ion_type)
+        ordinal = int(ordinal)
+        charge = int(charge)
+        if ion not in ("b", "y"):
+            continue
+        if not (1 <= ordinal <= 29 and 1 <= charge <= 3):
+            continue
+        slot = (ordinal - 1) * 6 + (charge - 1 if ion == "y" else 3 + charge - 1)
+        if target[slot] >= 0:
+            target[slot] = float(intensity) / max_intensity
+    return target
+
 
 def predict_intensities_prosit(
         psm_collection: List,
@@ -880,3 +952,185 @@ class DeepPeptideIntensityPredictor(IonIntensityPredictor):
             ion_collections.append(series)
 
         return ion_collections
+
+
+    # -------------------------------------------------------------------
+    # Fine-tuning
+    # -------------------------------------------------------------------
+
+    def fine_tune_model(
+        self,
+        data: pd.DataFrame,
+        batch_size: int = 64,
+        epochs: int = 50,
+        learning_rate: float = 1e-4,
+        patience: int = 5,
+        divide_collision_energy_by: float = 1e2,
+        verbose: bool = False,
+    ) -> None:
+        """Fine-tune the native intensity model on observed 174-vec targets.
+
+        Required ``data`` columns:
+            ``sequence`` (str, UNIMOD-bracket modified),
+            ``charge`` (int),
+            ``collision_energy`` (float),
+            ``intensity_target`` (np.ndarray shape (174,) — observed
+            intensities in the canonical ordinal-major layout; impossible
+            ions marked -1; unobserved valid ions = 0).
+        """
+        assert 'sequence' in data.columns, 'Data must contain column "sequence"'
+        assert 'charge' in data.columns, 'Data must contain column "charge"'
+        assert 'collision_energy' in data.columns, 'Data must contain column "collision_energy"'
+        assert 'intensity_target' in data.columns, 'Data must contain column "intensity_target"'
+
+        from torch.utils.data import DataLoader, TensorDataset
+
+        if len(data) < 2:
+            if verbose:
+                print("Skipping intensity fine-tune: need at least two PSMs")
+            return
+
+        sequences = data.sequence.tolist()
+        charges = data.charge.astype(np.int64).tolist()
+        collision_energies = (
+            data.collision_energy.astype(float) / divide_collision_energy_by
+        ).tolist()
+        targets = np.vstack(data.intensity_target.to_numpy()).astype(np.float32)
+        if targets.shape != (len(data), 174):
+            raise ValueError(
+                f"intensity_target must have shape (n, 174), got {targets.shape}"
+            )
+
+        tokens, charge_tensor, ce_tensor = self._preprocess(
+            sequences, charges, collision_energies,
+        )
+        tokens = tokens.to(self._device)
+        charge_tensor = charge_tensor.to(self._device)
+        ce_tensor = ce_tensor.to(self._device)
+        target_tensor = self._torch.tensor(
+            targets, dtype=self._torch.float32, device=self._device,
+        )
+
+        n = len(sequences)
+        n_train = max(1, int(0.8 * n))
+        if n_train >= n:
+            n_train = n - 1
+        indices = self._torch.randperm(n, device=self._device)
+        train_idx = indices[:n_train]
+        val_idx = indices[n_train:]
+
+        train_ds = TensorDataset(
+            tokens[train_idx], charge_tensor[train_idx],
+            ce_tensor[train_idx], target_tensor[train_idx],
+        )
+        val_ds = TensorDataset(
+            tokens[val_idx], charge_tensor[val_idx],
+            ce_tensor[val_idx], target_tensor[val_idx],
+        )
+        train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+        val_loader = DataLoader(val_ds, batch_size=batch_size)
+
+        self.model.train()
+        optimizer = self._torch.optim.Adam(self.model.parameters(), lr=learning_rate)
+        scheduler = self._torch.optim.lr_scheduler.ReduceLROnPlateau(
+            optimizer, patience=3, min_lr=1e-6,
+        )
+        checkpoint = InMemoryCheckpoint(patience=patience)
+
+        history = {"epochs": [], "train_loss": [], "val_loss": []}
+        for epoch in range(epochs):
+            self.model.train()
+            train_loss = 0.0
+            for tokens_b, charge_b, ce_b, target_b in train_loader:
+                optimizer.zero_grad()
+                outputs = self.model(
+                    tokens_b, charge=charge_b, collision_energy=ce_b,
+                )
+                pred = (outputs['intensity'] if 'intensity' in outputs
+                          else list(outputs.values())[0])
+                loss = masked_spectral_distance(target_b, pred)
+                loss.backward()
+                optimizer.step()
+                train_loss += loss.item()
+            train_loss /= max(len(train_loader), 1)
+
+            self.model.eval()
+            val_loss = 0.0
+            with self._torch.no_grad():
+                for tokens_b, charge_b, ce_b, target_b in val_loader:
+                    outputs = self.model(
+                        tokens_b, charge=charge_b, collision_energy=ce_b,
+                    )
+                    pred = (outputs['intensity'] if 'intensity' in outputs
+                              else list(outputs.values())[0])
+                    val_loss += masked_spectral_distance(target_b, pred).item()
+            val_loss /= max(len(val_loader), 1)
+            scheduler.step(val_loss)
+
+            history["epochs"].append(epoch)
+            history["train_loss"].append(float(train_loss))
+            history["val_loss"].append(float(val_loss))
+
+            if verbose and epoch % 5 == 0:
+                print(
+                    f"Epoch {epoch}: intensity train_loss={train_loss:.4f} "
+                    f"val_loss={val_loss:.4f}"
+                )
+
+            if checkpoint.step(val_loss, self.model):
+                if verbose:
+                    print(f"Early stopping intensity fine-tune at epoch {epoch}")
+                break
+
+        checkpoint.restore(self.model)
+        self.model.eval()
+        self._finetune_history = history
+
+    def fine_tune_psms(
+        self,
+        psm_collection: List,
+        batch_size: int = 64,
+        epochs: int = 50,
+        learning_rate: float = 1e-4,
+        patience: int = 5,
+        verbose: bool = False,
+    ) -> None:
+        """Fine-tune the intensity model on a list of sagepy PSM objects.
+
+        Matches the signature ``sagepy-rescore`` calls
+        (``fine_tune_psms(psms, batch_size=..., verbose=...)``). Labels are
+        built from each PSM's matched fragments via
+        :func:`observed_fragments_to_intensity_target`. CE is read from
+        ``psm.collision_energy`` (rescore wrapper should have set the
+        per-tile value beforehand).
+        """
+        rows = []
+        for psm in psm_collection:
+            sequence = (psm.sequence_modified if not psm.decoy
+                          else psm.sequence_decoy_modified)
+            target = observed_fragments_to_intensity_target(
+                sequence,
+                psm.charge,
+                psm.sage_feature.fragments,
+            )
+            if np.any(target > 0):
+                rows.append({
+                    'sequence': sequence,
+                    'charge': int(psm.charge),
+                    'collision_energy': float(psm.collision_energy),
+                    'intensity_target': target,
+                })
+
+        if len(rows) < 2:
+            if verbose:
+                print("Skipping intensity fine-tune: no usable fragment targets")
+            return
+
+        self.fine_tune_model(
+            pd.DataFrame(rows),
+            batch_size=batch_size,
+            epochs=epochs,
+            learning_rate=learning_rate,
+            patience=patience,
+            verbose=verbose,
+        )

--- a/packages/imspy-predictors/src/imspy_predictors/rt/__init__.py
+++ b/packages/imspy-predictors/src/imspy_predictors/rt/__init__.py
@@ -7,15 +7,18 @@ from imspy_predictors.rt.predictors import (
     predict_retention_time_with_koina,
     linear_map,
 )
+from imspy_predictors.rt.chronologer import Chronologer, unimod_to_chronologer
 
 __all__ = [
     # Predictors
     'PeptideChromatographyApex',
     'DeepChromatographyApex',
+    'Chronologer',
     # Loaders
     'load_deep_retention_time_predictor',
     # Utilities
     'linear_map',
+    'unimod_to_chronologer',
     # Koina
     'predict_retention_time_with_koina',
 ]

--- a/packages/imspy-predictors/src/imspy_predictors/rt/chronologer.py
+++ b/packages/imspy-predictors/src/imspy_predictors/rt/chronologer.py
@@ -268,13 +268,26 @@ if _TORCH_AVAILABLE:
 
             n = len(kept_idx)
             gen = torch.Generator(device='cpu').manual_seed(42)
-            perm = torch.randperm(n, generator=gen).to(self.device)
-            n_val = max(1, int(n * val_frac))
-            val_idx = perm[:n_val]
-            train_idx = perm[n_val:]
+            # Group-aware (peptide-level) split: same sequence -> same fold.
+            # PSM-level random split leaks because the same modseq often
+            # appears at many spectra; the predictor is deterministic per
+            # sequence, so val loss collapses to the instrument's RT-noise
+            # floor (~10 s) and doesn't measure generalization.
+            kept_seqs = [str(sequences[i]) for i in kept_idx]
+            uniq_seqs, inv = np.unique(np.asarray(kept_seqs), return_inverse=True)
+            n_groups = len(uniq_seqs)
+            n_val_groups = max(1, int(n_groups * val_frac))
+            perm_groups = torch.randperm(n_groups, generator=gen).numpy()
+            val_groups = set(perm_groups[:n_val_groups].tolist())
+            mask_val = np.fromiter((g in val_groups for g in inv),
+                                       dtype=bool, count=n)
+            val_idx   = torch.from_numpy(np.flatnonzero(mask_val)).to(self.device)
+            train_idx = torch.from_numpy(np.flatnonzero(~mask_val)).to(self.device)
             if verbose:
-                print(f"[chrono-ft] {n} encodable samples → "
-                      f"train {len(train_idx)}, val {len(val_idx)}")
+                print(f"[chrono-ft] {n} encodable samples ({n_groups:,} "
+                      f"unique modseqs) → train PSMs {len(train_idx):,}, "
+                      f"val PSMs {len(val_idx):,} "
+                      f"(val groups: {n_val_groups:,})")
 
             if freeze_base:
                 for p in self.model.base.parameters():

--- a/packages/imspy-predictors/src/imspy_predictors/rt/chronologer.py
+++ b/packages/imspy-predictors/src/imspy_predictors/rt/chronologer.py
@@ -1,0 +1,532 @@
+"""Chronologer-based retention-time predictor.
+
+Wraps the Chronologer residual-CNN architecture from the Searle Lab
+(University of Wisconsin-Madison) as a drop-in alternative to
+``DeepChromatographyApex``. Designed for timsTOF-class datasets where the
+~500K-parameter residual CNN reaches ~8 s median residual on q ≤ 0.01
+anchor PSMs — roughly 4× tighter than the transformer baseline.
+
+Attribution
+-----------
+Chronologer is **not vendored**. The model weights and architecture come
+from ``searlelab/chronologer`` (https://github.com/searlelab/chronologer),
+released under the Apache License 2.0. To use this predictor, install the
+upstream package and point ``Chronologer.from_checkpoint`` at:
+  * the base ``.pt`` model bundled with the upstream release
+    (e.g. ``Chronologer_20220601193755.pt``), and
+  * (optionally) a fine-tuned checkpoint produced by retraining on your
+    dataset's q ≤ 0.01 anchor PSMs.
+
+Citation
+--------
+If you publish results that depend on this predictor, please cite:
+
+    Pino LK, et al. *Chronologer: a peptide retention-time predictor for
+    LC-MS proteomics.* (Searle Lab, U. Wisconsin-Madison)
+
+Reference implementation
+------------------------
+- https://github.com/searlelab/chronologer/blob/main/Predict_RT.py
+- https://github.com/searlelab/chronologer/blob/main/Train_Chronologer.py
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+
+try:
+    import torch
+    import torch.nn as nn
+    _TORCH_AVAILABLE = True
+except ImportError:
+    _TORCH_AVAILABLE = False
+
+
+# Mass-bracket mapping used by Chronologer's tokenizer. Keep in sync with
+# upstream's `chronologer_utils.constants` mod table.
+_UNIMOD_TO_MASS: dict[int, str] = {
+    1:  "+42.01057",   # Acetyl (N-term or K)
+    4:  "+57.02146",   # Carbamidomethyl on C
+    21: "+79.96633",   # Phospho on STY
+    35: "+15.99491",   # Oxidation on M
+}
+_UNIMOD_RE = re.compile(r"\[UNIMOD:(\d+)\]")
+
+
+def unimod_to_chronologer(seq: str) -> Optional[str]:
+    """Convert ``M[UNIMOD:35]VEYR → M[+15.99]VEYR``.
+
+    Returns ``None`` when any UNIMOD code can't be mapped — caller should
+    treat that sequence as unsupported.
+    """
+    if not isinstance(seq, str) or not seq:
+        return None
+    has_unmapped = False
+    def _sub(m):
+        nonlocal has_unmapped
+        u = int(m.group(1))
+        if u not in _UNIMOD_TO_MASS:
+            has_unmapped = True
+            return m.group(0)
+        return f"[{_UNIMOD_TO_MASS[u]}]"
+    out = _UNIMOD_RE.sub(_sub, seq)
+    return None if has_unmapped else out
+
+
+if _TORCH_AVAILABLE:
+
+    class _ChronoToMin(nn.Module):
+        """Wraps the residual CNN with a learnable scalar (HI → minutes)."""
+
+        def __init__(self, base, scale: float, bias: float):
+            super().__init__()
+            self.base = base
+            self.scale = nn.Parameter(torch.tensor([float(scale)]))
+            self.bias = nn.Parameter(torch.tensor([float(bias)]))
+
+        def forward(self, x):
+            return self.base(x) * self.scale + self.bias
+
+
+    class Chronologer:
+        """Drop-in alternative to :class:`DeepChromatographyApex`.
+
+        Mirrors the ``simulate_separation_times`` API so downstream code
+        (build_library.py, rescore wrappers) can switch RT predictors via
+        a single flag.
+
+        Example
+        -------
+        >>> from imspy_predictors.rt.chronologer import Chronologer
+        >>> chrono = Chronologer.from_checkpoint(
+        ...     checkpoint_path="finetuned_kde.pt",
+        ...     base_model_path="Chronologer_20220601193755.pt",
+        ... )
+        >>> rt_min = chrono.simulate_separation_times(["MAGM[UNIMOD:35]VK"])
+        """
+
+        def __init__(self, model: "_ChronoToMin", device: str,
+                       spline=None, bounds=None):
+            self.model = model
+            self.device = device
+            self.spline = spline
+            self.bounds = bounds
+
+        @classmethod
+        def from_checkpoint(cls, checkpoint_path, base_model_path,
+                              device: Optional[str] = None) -> "Chronologer":
+            """Load a fine-tuned Chronologer wrapper.
+
+            Parameters
+            ----------
+            checkpoint_path : str | Path
+                Path to a ``.pt`` produced by our fine-tune routine. Must
+                contain ``model_state_dict``, ``scale``, ``bias`` keys;
+                optional ``spline_x``, ``spline_y``, ``bounds`` populate
+                the KDE post-correction.
+            base_model_path : str | Path
+                Path to upstream Chronologer base model (e.g.
+                ``Chronologer_20220601193755.pt``).
+            device : str | None
+                ``"cuda"`` / ``"cpu"`` / ``"mps"``. ``None`` auto-detects.
+            """
+            try:
+                from chronologer.model import initialize_chronologer_model
+            except ImportError as e:
+                raise ImportError(
+                    "Chronologer base package not installed. Install from "
+                    "https://github.com/searlelab/chronologer (Apache-2.0)."
+                ) from e
+            from scipy.interpolate import interp1d
+
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+
+            ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+            base = initialize_chronologer_model(str(base_model_path)).to(device)
+            model = _ChronoToMin(
+                base,
+                ckpt.get("scale", 1.0),
+                ckpt.get("bias", 0.0),
+            ).to(device)
+            model.load_state_dict(ckpt["model_state_dict"])
+            model.eval()
+
+            spline = None
+            bounds = None
+            if "spline_x" in ckpt and "spline_y" in ckpt:
+                spline = interp1d(np.array(ckpt["spline_x"]),
+                                   np.array(ckpt["spline_y"]),
+                                   kind="slinear")
+                bounds = tuple(ckpt["bounds"])
+            return cls(model, device, spline, bounds)
+
+        @classmethod
+        def from_base(cls, base_model_path, device: Optional[str] = None,
+                       scale_init: float = 0.79, bias_init: float = 0.69) -> "Chronologer":
+            """Instantiate with the upstream base model + a learnable HI→min
+            wrapper. Defaults to ``scale=0.79, bias=0.69`` — empirical priors
+            from prior real-o240206 fine-tunes that converged to those values
+            (using identity init forces an extra ~10-20 epochs of warmup and
+            hits a worse residual under the same epoch budget).
+            """
+            try:
+                from chronologer.model import initialize_chronologer_model
+            except ImportError as e:
+                raise ImportError(
+                    "Chronologer base package not installed. Install from "
+                    "https://github.com/searlelab/chronologer (Apache-2.0)."
+                ) from e
+            if device is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+            base = initialize_chronologer_model(str(base_model_path)).to(device)
+            model = _ChronoToMin(base, scale=scale_init, bias=bias_init).to(device)
+            model.eval()
+            return cls(model, device, spline=None, bounds=None)
+
+        # ------------------------------------------------------------------
+        # Encoding helper — shared between predict + fine-tune
+        # ------------------------------------------------------------------
+        @staticmethod
+        def _encode_sequences(sequences: Iterable[str]):
+            """Convert UNIMOD modseqs → (kept_indices, encoded int64 array)."""
+            try:
+                from chronologer.chronologer_utils.tensorize import (
+                    modseq_to_codedseq, codedseq_to_array, aa_to_int,
+                )
+                import chronologer.chronologer_utils.constants as constants
+            except ImportError as e:
+                raise ImportError(
+                    "Chronologer base package not installed."
+                ) from e
+            valid_chars = set(aa_to_int.keys())
+            kept_indices = []
+            coded = []
+            for i, s in enumerate(sequences):
+                chrono_s = unimod_to_chronologer(s)
+                if chrono_s is None:
+                    continue
+                c = modseq_to_codedseq(chrono_s)
+                if not isinstance(c, str):
+                    continue
+                plen = len(c) - 2
+                if plen < constants.min_peptide_len or plen > constants.max_peptide_len:
+                    continue
+                if not all(ch in valid_chars for ch in c):
+                    continue
+                kept_indices.append(i)
+                coded.append(c)
+            if not coded:
+                return kept_indices, np.empty((0, 0), dtype=np.int64)
+            seq_arr = np.asarray([codedseq_to_array(p) for p in coded], "int64")
+            return kept_indices, seq_arr
+
+        # ------------------------------------------------------------------
+        # Fine-tuning
+        # ------------------------------------------------------------------
+        def fine_tune(
+            self,
+            sequences: Iterable[str],
+            observed_rt_min: Iterable[float],
+            epochs: int = 50,
+            batch_size: int = 128,
+            lr: float = 1e-4,
+            val_frac: float = 0.2,
+            patience: int = 8,
+            freeze_base: bool = False,
+            verbose: bool = False,
+        ) -> dict:
+            """Fine-tune on (modseq, observed_rt_min) pairs.
+
+            Loss is L1 (median residual minimization aligns with how this
+            predictor is benchmarked — per `project_chronologer_pivot`,
+            target is 7.8 s median residual on real-o240206 anchors, 4×
+            tighter than DCA's ~30 s).
+
+            Returns ``{"epochs": [...], "train_loss": [...], "val_loss": [...]}``.
+            """
+            sequences = list(sequences)
+            observed = np.asarray(list(observed_rt_min), dtype=np.float32)
+            if len(sequences) != len(observed):
+                raise ValueError(
+                    f"len(sequences)={len(sequences)} != "
+                    f"len(observed_rt_min)={len(observed)}"
+                )
+
+            kept_idx, seq_arr = self._encode_sequences(sequences)
+            if len(kept_idx) < 2:
+                raise RuntimeError(
+                    f"too few encodable sequences ({len(kept_idx)}); "
+                    "need ≥2 to fine-tune"
+                )
+            y = torch.tensor(observed[kept_idx], dtype=torch.float32,
+                              device=self.device)
+            x = torch.from_numpy(seq_arr).to(self.device).to(torch.int64)
+
+            n = len(kept_idx)
+            gen = torch.Generator(device='cpu').manual_seed(42)
+            perm = torch.randperm(n, generator=gen).to(self.device)
+            n_val = max(1, int(n * val_frac))
+            val_idx = perm[:n_val]
+            train_idx = perm[n_val:]
+            if verbose:
+                print(f"[chrono-ft] {n} encodable samples → "
+                      f"train {len(train_idx)}, val {len(val_idx)}")
+
+            if freeze_base:
+                for p in self.model.base.parameters():
+                    p.requires_grad = False
+            params = [p for p in self.model.parameters() if p.requires_grad]
+            optim = torch.optim.Adam(params, lr=lr)
+            loss_fn = nn.L1Loss()
+
+            best_val = float('inf')
+            best_state = None
+            patience_left = patience
+            history = {"epochs": [], "train_loss": [], "val_loss": []}
+
+            for epoch in range(1, epochs + 1):
+                # train
+                self.model.train()
+                tr_perm = train_idx[torch.randperm(len(train_idx),
+                                                      device=self.device)]
+                tloss, nb = 0.0, 0
+                for i in range(0, len(tr_perm), batch_size):
+                    batch_ids = tr_perm[i:i + batch_size]
+                    optim.zero_grad()
+                    pred = self.model(x[batch_ids]).squeeze(-1)
+                    loss = loss_fn(pred, y[batch_ids])
+                    loss.backward()
+                    optim.step()
+                    tloss += loss.item()
+                    nb += 1
+                tloss /= max(nb, 1)
+                # val
+                self.model.eval()
+                vloss, nb = 0.0, 0
+                with torch.no_grad():
+                    for i in range(0, len(val_idx), batch_size):
+                        batch_ids = val_idx[i:i + batch_size]
+                        pred = self.model(x[batch_ids]).squeeze(-1)
+                        vloss += loss_fn(pred, y[batch_ids]).item()
+                        nb += 1
+                vloss /= max(nb, 1)
+                history["epochs"].append(epoch)
+                history["train_loss"].append(tloss)
+                history["val_loss"].append(vloss)
+                if verbose:
+                    print(f"[chrono-ft] epoch {epoch}/{epochs}: "
+                          f"train_L1={tloss:.3f}min, val_L1={vloss:.3f}min")
+                if vloss < best_val - 1e-4:
+                    best_val = vloss
+                    best_state = {k: v.detach().cpu().clone()
+                                    for k, v in self.model.state_dict().items()}
+                    patience_left = patience
+                else:
+                    patience_left -= 1
+                    if patience_left <= 0:
+                        if verbose:
+                            print(f"[chrono-ft] early stop at epoch {epoch}")
+                        break
+
+            if best_state is not None:
+                self.model.load_state_dict(best_state)
+            self.model.eval()
+            self._finetune_history = history
+            return history
+
+        def fit_kde_correction(
+            self,
+            sequences: Iterable[str],
+            observed_rt_min: Iterable[float],
+            n_bins: int = 2000,
+        ) -> None:
+            """Fit a post-correction spline on (predicted → observed) residuals.
+
+            Preferred path: use the upstream Searle Lab
+            ``chronologer.chronologer_utils.kde_alignment.KDE_align`` (2000
+            bins by default — gives the tightest residuals on real-o240206
+            anchors per the empirical training recipe that reached 7.8 s
+            median residual). Falls back to a quantile-bin spline if the
+            upstream KDE_align is unavailable.
+            """
+            from scipy.interpolate import interp1d
+            sequences = list(sequences)
+            observed = np.asarray(list(observed_rt_min), dtype=np.float64)
+            preds = self.simulate_separation_times(sequences)
+            mask = (~np.isnan(preds)) & np.isfinite(observed)
+            if mask.sum() < 50:
+                lo, hi = float(np.nanmin(preds)), float(np.nanmax(preds))
+                self.spline = interp1d([lo, hi], [lo, hi], kind="slinear")
+                self.bounds = (lo, hi)
+                return
+            x = preds[mask].astype(np.float64)
+            y = observed[mask].astype(np.float64)
+            # Preferred: upstream KDE_align (handles smoothing + monotonicity).
+            try:
+                from chronologer.chronologer_utils.kde_alignment import KDE_align
+                spline, bounds, *_ = KDE_align(x, y, n=n_bins)
+                self.spline = spline
+                self.bounds = tuple(bounds)
+                return
+            except Exception:
+                pass
+            # Fallback: quantile-bin median spline with monotonicity enforced.
+            order = np.argsort(x)
+            x_sorted, y_sorted = x[order], y[order]
+            edges = np.quantile(x_sorted, np.linspace(0, 1, n_bins + 1))
+            bin_centers, bin_medians = [], []
+            for i in range(n_bins):
+                lo_b, hi_b = edges[i], edges[i + 1]
+                m = (x_sorted >= lo_b) & (x_sorted <= hi_b)
+                if m.sum() < 2:
+                    continue
+                bin_centers.append(float(0.5 * (lo_b + hi_b)))
+                bin_medians.append(float(np.median(y_sorted[m])))
+            bin_centers = np.asarray(bin_centers)
+            bin_medians = np.asarray(bin_medians)
+            for i in range(1, len(bin_medians)):
+                if bin_medians[i] < bin_medians[i - 1]:
+                    bin_medians[i] = bin_medians[i - 1]
+            self.spline = interp1d(bin_centers, bin_medians, kind="slinear",
+                                     fill_value="extrapolate")
+            self.bounds = (float(bin_centers.min()), float(bin_centers.max()))
+
+        def save_checkpoint(self, path) -> None:
+            """Save model_state_dict + scale/bias + optional spline to ``path``.
+
+            Format matches what :meth:`from_checkpoint` consumes — same
+            convention used by our local ``chrono_predictor.py``.
+            """
+            ckpt: dict = {
+                "model_state_dict": {k: v.detach().cpu()
+                                       for k, v in self.model.state_dict().items()},
+                "scale": float(self.model.scale.item()),
+                "bias": float(self.model.bias.item()),
+            }
+            if self.spline is not None and self.bounds is not None:
+                ckpt["spline_x"] = self.spline.x.tolist()
+                ckpt["spline_y"] = self.spline.y.tolist()
+                ckpt["bounds"] = list(self.bounds)
+            torch.save(ckpt, str(path))
+
+        # Convenience: extract observed RT from a list of sagepy PSMs and
+        # delegate to ``fine_tune``. Filters to rank-1 q≤0.01 targets.
+        def fine_tune_psms(
+            self,
+            psm_collection: Iterable,
+            q_threshold: float = 0.01,
+            **fine_tune_kwargs,
+        ) -> dict:
+            seqs, rts = [], []
+            for p in psm_collection:
+                if getattr(p, "decoy", True):
+                    continue
+                feat = getattr(p, "sage_feature", None)
+                if feat is None or int(getattr(feat, "rank", 99)) != 1:
+                    continue
+                q = (getattr(feat, "spectrum_q", None)
+                      or getattr(feat, "peptide_q", None))
+                if q is None or float(q) > q_threshold:
+                    continue
+                rt = getattr(p, "retention_time", None)
+                if rt is None:
+                    continue
+                seqs.append(p.sequence_modified)
+                # sagepy RT is in minutes (from .pmsms reader's /60.0).
+                rts.append(float(rt))
+            if len(seqs) < 50:
+                raise RuntimeError(
+                    f"too few anchors for Chronologer fine-tune ({len(seqs)})"
+                )
+            return self.fine_tune(seqs, rts, **fine_tune_kwargs)
+
+        def simulate_separation_times(
+            self, sequences: Iterable[str], batch_size: int = 4096,
+        ) -> np.ndarray:
+            """Predict RT (in minutes) for each modseq.
+
+            Returns ``np.nan`` for sequences the Chronologer tokenizer
+            can't accept (unsupported mods, out-of-range length, etc.).
+            """
+            try:
+                from chronologer.chronologer_utils.tensorize import (
+                    modseq_to_codedseq, codedseq_to_array, aa_to_int,
+                )
+                import chronologer.chronologer_utils.constants as constants
+            except ImportError as e:
+                raise ImportError(
+                    "Chronologer base package not installed."
+                ) from e
+
+            valid_chars = set(aa_to_int.keys())
+            seqs = list(sequences)
+            n = len(seqs)
+            out = np.full(n, np.nan, dtype=np.float64)
+            idxs, coded = [], []
+            for i, s in enumerate(seqs):
+                chrono_s = unimod_to_chronologer(s)
+                if chrono_s is None:
+                    continue
+                c = modseq_to_codedseq(chrono_s)
+                if not isinstance(c, str):
+                    continue
+                plen = len(c) - 2
+                if plen < constants.min_peptide_len or plen > constants.max_peptide_len:
+                    continue
+                if not all(ch in valid_chars for ch in c):
+                    continue
+                idxs.append(i)
+                coded.append(c)
+            if not coded:
+                return out
+
+            seq_arr = np.asarray([codedseq_to_array(p) for p in coded], "int64")
+            preds_min = []
+            with torch.no_grad():
+                for j in range(0, len(seq_arr), batch_size):
+                    t = (torch.from_numpy(seq_arr[j:j + batch_size])
+                          .to(self.device).to(torch.int64))
+                    preds_min.append(self.model(t).cpu().T[0].numpy())
+            preds_min = np.concatenate(preds_min)
+            if self.spline is not None and self.bounds is not None:
+                lo, hi = self.bounds
+                preds_min = np.array(
+                    [float(self.spline(np.clip(p, lo, hi)))
+                      for p in preds_min]
+                )
+            for i, p in zip(idxs, preds_min):
+                out[i] = float(p)
+            return out
+
+        # API parity stub — pandas frontend used by some imspy-predictors
+        # callers. Wraps ``simulate_separation_times`` to fill a column.
+        def simulate_separation_times_pandas(self, data, sequence_col: str = "sequence_modified"):
+            import pandas as pd
+            df = data.copy()
+            df["rt_predicted"] = self.simulate_separation_times(
+                df[sequence_col].astype(str).tolist()
+            )
+            return df
+
+
+else:
+
+    class Chronologer:
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "PyTorch not installed; Chronologer requires torch. "
+                "Install with: pip install torch"
+            )
+
+        @classmethod
+        def from_checkpoint(cls, *args, **kwargs):
+            raise ImportError(
+                "PyTorch not installed; Chronologer requires torch."
+            )
+
+
+__all__ = ["Chronologer", "unimod_to_chronologer"]

--- a/rustdf/examples/dump_bruker_centroids.rs
+++ b/rustdf/examples/dump_bruker_centroids.rs
@@ -1,0 +1,138 @@
+// Dump Bruker SDK-centroided spectra for a DIA-PASEF .d file.
+//
+// For each MS2 frame, query its window-group → quad list (scan ranges +
+// iso m/z), then call tims_extract_centroided_spectrum_for_frame_v2 per
+// (frame, scan_lo, scan_hi). Write the resulting (frame, quad_id, mz,
+// intensity) tuples to a TSV.
+//
+// Usage:
+//   cargo run --release --example dump_bruker_centroids -- \
+//       <path-to-libtimsdata.so> <path-to-.d-folder> <out.tsv> [max_frames]
+//
+// The .d folder must contain analysis.tdf (sqlite) — we read DIA window
+// definitions from `dia_ms_ms_windows` and `dia_ms_ms_info`.
+
+use rusqlite::Connection;
+use rustdf::data::raw::BrukerTimsDataLibrary;
+use std::env;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::time::Instant;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 4 {
+        eprintln!("usage: dump_bruker_centroids <libtimsdata.so> <data.d> <out.tsv> [max_frames]");
+        std::process::exit(2);
+    }
+    let lib_path = &args[1];
+    let d_path = &args[2];
+    let out_path = &args[3];
+    let max_frames: Option<usize> = args.get(4).and_then(|s| s.parse().ok());
+
+    eprintln!("[bruker] opening {}", d_path);
+    let bd = BrukerTimsDataLibrary::new(lib_path, d_path)?;
+
+    // Read DIA quad definitions from analysis.tdf.
+    let tdf_path = Path::new(d_path).join("analysis.tdf");
+    let con = Connection::open(&tdf_path)?;
+
+    // Quads: window_group, scan_lo, scan_hi, iso_mz, iso_width.
+    let mut stmt = con.prepare(
+        "SELECT WindowGroup, ScanNumBegin, ScanNumEnd, IsolationMz, IsolationWidth \
+         FROM DiaFrameMsMsWindows ORDER BY WindowGroup, ScanNumBegin",
+    )?;
+    let mut quads: Vec<(i64, u32, u32, f64, f64)> = Vec::new();
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, i64>(0)?,
+            r.get::<_, i64>(1)? as u32,
+            r.get::<_, i64>(2)? as u32,
+            r.get::<_, f64>(3)?,
+            r.get::<_, f64>(4)?,
+        ))
+    })?;
+    for row in rows {
+        quads.push(row?);
+    }
+    eprintln!("[bruker] {} quads (across all window groups)", quads.len());
+
+    // Frame → window_group mapping.
+    let mut stmt = con.prepare(
+        "SELECT Frame, WindowGroup FROM DiaFrameMsMsInfo ORDER BY Frame",
+    )?;
+    let frame_iter = stmt.query_map([], |r| {
+        Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?))
+    })?;
+    let mut frames: Vec<(i64, i64)> = Vec::new();
+    for row in frame_iter {
+        frames.push(row?);
+    }
+    eprintln!("[bruker] {} MS2 frames", frames.len());
+
+    // Group quads by window-group for fast lookup.
+    let mut wg_to_quads: std::collections::HashMap<i64, Vec<&(i64, u32, u32, f64, f64)>> =
+        std::collections::HashMap::new();
+    for q in &quads {
+        wg_to_quads.entry(q.0).or_default().push(q);
+    }
+
+    let f = File::create(out_path)?;
+    let mut out = BufWriter::new(f);
+    writeln!(out, "frame_id\tquad_id\tscan_lo\tscan_hi\tiso_mz\tiso_width\tn_peaks\tmz\tintensity")?;
+
+    let n_iter = max_frames.unwrap_or(frames.len()).min(frames.len());
+    let t0 = Instant::now();
+    let mut total_calls: u64 = 0;
+    let mut total_peaks: u64 = 0;
+    for (fi, &(frame_id, wg)) in frames[..n_iter].iter().enumerate() {
+        let qs = match wg_to_quads.get(&wg) {
+            Some(v) => v,
+            None => continue,
+        };
+        for q in qs {
+            let (_, scan_lo, scan_hi, iso_mz, iso_width) = **q;
+            let (mzs, intens) = bd.tims_extract_centroided_spectrum_for_frame(
+                frame_id, scan_lo, scan_hi,
+            )?;
+            total_calls += 1;
+            total_peaks += mzs.len() as u64;
+            // For TSV brevity, dump compact per-spectrum row with
+            // semicolon-joined peak arrays. Peak arrays can hit ~1k
+            // entries; that's fine for an exploratory dump.
+            let mz_str: String = mzs
+                .iter()
+                .map(|x| format!("{:.5}", x))
+                .collect::<Vec<_>>()
+                .join(";");
+            let in_str: String = intens
+                .iter()
+                .map(|x| format!("{:.1}", x))
+                .collect::<Vec<_>>()
+                .join(";");
+            // Quad id is a synthetic index in the sorted list — write the
+            // (wg, scan_lo, scan_hi) tuple as a primary key instead.
+            writeln!(
+                out,
+                "{}\t{}\t{}\t{}\t{:.4}\t{:.4}\t{}\t{}\t{}",
+                frame_id, wg, scan_lo, scan_hi, iso_mz, iso_width,
+                mzs.len(), mz_str, in_str
+            )?;
+        }
+        if (fi + 1) % 100 == 0 {
+            let dt = t0.elapsed().as_secs_f64();
+            eprintln!(
+                "[bruker] {}/{} frames; {} extract calls; {} peaks; {:.1} calls/s",
+                fi + 1, n_iter, total_calls, total_peaks, total_calls as f64 / dt,
+            );
+        }
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    eprintln!(
+        "[bruker] DONE: {} frames; {} extract calls; {} peaks total; {:.1}s ({:.1} calls/s)",
+        n_iter, total_calls, total_peaks, dt, total_calls as f64 / dt,
+    );
+    eprintln!("[bruker] wrote {}", out_path);
+    Ok(())
+}

--- a/rustdf/src/data/raw.rs
+++ b/rustdf/src/data/raw.rs
@@ -1,5 +1,6 @@
 use libloading::{Library, Symbol};
-use std::os::raw::{c_char, c_double};
+use std::os::raw::{c_char, c_double, c_float};
+use std::sync::Mutex;
 
 //
 // A struct that holds a handle to the raw data
@@ -203,7 +204,155 @@ impl BrukerTimsDataLibrary {
         }
         Ok(())
     }
+
+    // ----------------------------------------------------------------- //
+    // Centroided spectrum extraction (Bruker's built-in peak picker).
+    //
+    // SDK function:
+    //   uint32_t tims_extract_centroided_spectrum_for_frame_v2(
+    //       uint64_t handle,
+    //       int64_t  frame_id,
+    //       uint32_t scan_begin,
+    //       uint32_t scan_end,
+    //       void (*callback)(int64_t precursor_id, uint32_t num_peaks,
+    //                        double* mzs, float* intensities),
+    //       void* user_data);
+    //
+    // Bruker invokes the callback ONCE per scan-range with the centroided
+    // (m/z, intensity) arrays. We use a thread-local Mutex<Vec<...>> trick
+    // to hand the data back to Rust without dealing with `void*` user_data
+    // closures (libloading + C function pointers don't compose with Rust
+    // closures cleanly).
+    //
+    // Signatures recovered from pyTDFSDK (gtluu/pyTDFSDK init_tdf_sdk.py).
+    // Same callback shape as Bruker's published `MSMS_SPECTRUM_FUNCTOR`.
+    // ----------------------------------------------------------------- //
+
+    /// Extract a centroided spectrum for a (frame, scan-range) tile via
+    /// Bruker's built-in peak picker. Returns `(mz, intensity)` pairs.
+    pub fn tims_extract_centroided_spectrum_for_frame(
+        &self,
+        frame_id: i64,
+        scan_begin: u32,
+        scan_end: u32,
+    ) -> Result<(Vec<f64>, Vec<f32>), Box<dyn std::error::Error>> {
+        // Stash the result in a thread-local-ish global; only one extract
+        // call may run at a time per process. We serialise on a Mutex.
+        let mut result_mz: Vec<f64> = Vec::new();
+        let mut result_int: Vec<f32> = Vec::new();
+        // We trampoline through a global: the C callback writes into
+        // EXTRACT_BUF.
+        let _guard = EXTRACT_BUF
+            .lock()
+            .map_err(|_| "EXTRACT_BUF poisoned")?;
+        unsafe { EXTRACT_BUF_DATA = Some((Vec::new(), Vec::new())); }
+        unsafe {
+            let func: Symbol<
+                unsafe extern "C" fn(
+                    u64, i64, u32, u32,
+                    extern "C" fn(i64, u32, *const f64, *const f32),
+                    *mut std::ffi::c_void,
+                ) -> u32,
+            > = self.lib.get(b"tims_extract_centroided_spectrum_for_frame_v2")?;
+            let rc = func(
+                self.handle,
+                frame_id,
+                scan_begin,
+                scan_end,
+                centroid_trampoline,
+                std::ptr::null_mut(),
+            );
+            if rc == 0 {
+                return Err("tims_extract_centroided_spectrum_for_frame_v2 returned 0".into());
+            }
+        }
+        if let Some((mz, intens)) = unsafe { EXTRACT_BUF_DATA.take() } {
+            result_mz = mz;
+            result_int = intens;
+        }
+        Ok((result_mz, result_int))
+    }
+
+    /// PASEF MS/MS centroided peaks for one MS2 frame.
+    /// SDK: tims_read_pasef_msms_for_frame_v2(handle, frame_id, callback, void**)
+    /// Bruker invokes the callback ONCE PER PRECURSOR found in the frame
+    /// (DDA-PASEF). We accumulate all (precursor_id, mz, intensity) hits.
+    pub fn tims_read_pasef_msms_for_frame(
+        &self,
+        frame_id: i64,
+    ) -> Result<Vec<(i64, Vec<f64>, Vec<f32>)>, Box<dyn std::error::Error>> {
+        let _guard = PASEF_BUF.lock().map_err(|_| "PASEF_BUF poisoned")?;
+        unsafe { PASEF_BUF_DATA = Some(Vec::new()); }
+        unsafe {
+            let func: Symbol<
+                unsafe extern "C" fn(
+                    u64, i64,
+                    extern "C" fn(i64, u32, *const f64, *const f32, *mut *mut std::ffi::c_void),
+                    *mut *mut std::ffi::c_void,
+                ) -> u32,
+            > = self.lib.get(b"tims_read_pasef_msms_for_frame_v2")?;
+            let rc = func(
+                self.handle,
+                frame_id,
+                pasef_trampoline,
+                std::ptr::null_mut(),
+            );
+            if rc == 0 {
+                return Err("tims_read_pasef_msms_for_frame_v2 returned 0".into());
+            }
+        }
+        let out = unsafe { PASEF_BUF_DATA.take() }.unwrap_or_default();
+        Ok(out)
+    }
 }
+
+// Globals for the C-callback trampolines. Locked on each extract call so
+// only one thread runs the SDK at a time per process — same restriction
+// pyTDFSDK + alphatims live with.
+static EXTRACT_BUF: Mutex<()> = Mutex::new(());
+static mut EXTRACT_BUF_DATA: Option<(Vec<f64>, Vec<f32>)> = None;
+
+extern "C" fn centroid_trampoline(
+    _precursor_id: i64,
+    n_peaks: u32,
+    mzs: *const f64,
+    intensities: *const f32,
+) {
+    if n_peaks == 0 || mzs.is_null() || intensities.is_null() { return; }
+    let mz_slice = unsafe { std::slice::from_raw_parts(mzs, n_peaks as usize) };
+    let in_slice = unsafe { std::slice::from_raw_parts(intensities, n_peaks as usize) };
+    unsafe {
+        if let Some((ref mut mz_acc, ref mut in_acc)) = EXTRACT_BUF_DATA {
+            mz_acc.extend_from_slice(mz_slice);
+            in_acc.extend_from_slice(in_slice);
+        }
+    }
+}
+
+static PASEF_BUF: Mutex<()> = Mutex::new(());
+static mut PASEF_BUF_DATA: Option<Vec<(i64, Vec<f64>, Vec<f32>)>> = None;
+
+extern "C" fn pasef_trampoline(
+    precursor_id: i64,
+    n_peaks: u32,
+    mzs: *const f64,
+    intensities: *const f32,
+    _user_data: *mut *mut std::ffi::c_void,
+) {
+    if n_peaks == 0 || mzs.is_null() || intensities.is_null() { return; }
+    let mz_slice = unsafe { std::slice::from_raw_parts(mzs, n_peaks as usize) };
+    let in_slice = unsafe { std::slice::from_raw_parts(intensities, n_peaks as usize) };
+    unsafe {
+        if let Some(ref mut acc) = PASEF_BUF_DATA {
+            acc.push((precursor_id, mz_slice.to_vec(), in_slice.to_vec()));
+        }
+    }
+}
+
+// Silence the unused `c_float` warning on platforms where it's only
+// touched by callbacks above.
+#[allow(dead_code)]
+const _: fn() = || { let _: c_float = 0.0; };
 
 impl Drop for BrukerTimsDataLibrary {
     fn drop(&mut self) {


### PR DESCRIPTION
Brings `feature/predictor-finetune` onto `main` so the native **Chronologer RT adapter** (`imspy_predictors/rt/chronologer.py`) and the per-task RT/CCS/intensity fine-tune work land alongside the `calibrate_nce` NCE calibration already on main.

Why: `feature/predictor-finetune` branched from `488a8305` (before PR #395), so no branch currently has *both* Chronologer and `calibrate_nce`. `sagepy-rescore` pins imspy-predictors at a branch == main, so it cannot reach Chronologer until this lands.

**Conflict resolution:** `intensity/predictors.py` auto-merged cleanly -- `calibrate_nce` is preserved. The only conflict was a one-hunk cosmetic difference in `ccs/predictors.py` (IM fine-tune verbose-logging cadence); took the feature-branch version (`epoch % 5`, `im` label) which matches the RT/intensity report cadence. Fine-tune history tracking is present on both sides and merged cleanly.

After merge: repin `sagepy-rescore` pyproject to `main` and reinstall.