### PR TITLE
imspy_predictors RT: default to Chronologer

### DIFF
--- a/packages/imspy-predictors/src/imspy_predictors/pretrained/hub.py
+++ b/packages/imspy-predictors/src/imspy_predictors/pretrained/hub.py
@@ -29,7 +29,9 @@ _RELEASE_BASE = (
 )
 
 # Maps the *package-relative* path (as used by callers of get_model_path)
-# to its download URL and expected SHA-256 hash.
+# to its download URL and expected SHA-256 hash. Entries default to the
+# rustims models GitHub Release; an explicit "url" overrides that for
+# vendor-free upstream redistributions (e.g. Chronologer).
 MODELS = {
     "ccs/best_model.pt": {
         "filename": "ccs-best_model.pt",
@@ -50,6 +52,15 @@ MODELS = {
     "pretrained_encoder.pt": {
         "filename": "pretrained_encoder.pt",
         "sha256": "43ccc2f836bf3d81943ddce353ade9628e7d036421ba5b5c182bf163e496385e",
+    },
+    # Chronologer base weights — fetched directly from upstream Searle Lab
+    # (Apache-2.0, attribution preserved in imspy_predictors.rt.chronologer).
+    # We deliberately do not re-host: pulls from the upstream repo so any
+    # future fix or retraining propagates automatically.
+    "rt/chronologer_base.pt": {
+        "filename": "chronologer_base.pt",
+        "url": "https://github.com/searlelab/chronologer/raw/main/models/Chronologer_20220601193755.pt",
+        "sha256": "1a500c246b49a1a23643bce7f2df86d5a107359bf0ec34365531c73431b6c0b3",
     },
 }
 
@@ -153,7 +164,7 @@ def ensure_model(model_name: str) -> Path:
 
     # 3. Download into a temp file in the same filesystem, then atomic-rename.
     cached_path.parent.mkdir(parents=True, exist_ok=True)
-    url = f"{_RELEASE_BASE}/{meta['filename']}"
+    url = meta.get("url") or f"{_RELEASE_BASE}/{meta['filename']}"
     logger.info("Downloading model '%s' from %s ...", model_name, url)
 
     tmp_fd, tmp_path = tempfile.mkstemp(

--- a/packages/imspy-predictors/src/imspy_predictors/rt/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/rt/predictors.py
@@ -228,11 +228,19 @@ def load_deep_retention_time_predictor(backend: Optional[str] = None):
     """
     Load a pretrained retention time predictor model.
 
+    Defaults to **Chronologer** (Searle Lab, Apache-2.0) — a residual-CNN that
+    reaches roughly 4× tighter median residual than the imspy transformer
+    baseline on timsTOF data. Pass ``backend="transformer"`` to opt back into
+    the legacy imspy ``UnifiedPeptideModel`` RT predictor.
+
     Args:
-        backend: Kept for backward compatibility, ignored (always uses PyTorch)
+        backend: ``"chronologer"`` (default, or pass ``None``) loads the
+            Chronologer wrapper. ``"transformer"`` loads the legacy imspy
+            transformer RT model. Any other value is treated as the default.
 
     Returns:
-        Loaded PyTorch model
+        Either a :class:`Chronologer` wrapper or the legacy transformer
+        PyTorch model, depending on ``backend``.
     """
     if not TORCH_AVAILABLE:
         raise ImportError(
@@ -240,6 +248,25 @@ def load_deep_retention_time_predictor(backend: Optional[str] = None):
             "Install with: pip install torch"
         )
 
+    backend = (backend or "chronologer").lower()
+
+    if backend == "chronologer":
+        # Default: Chronologer is the goto RT predictor on timsTOF data.
+        # Falls back to the transformer path only if Chronologer can't be
+        # constructed (e.g. upstream `chronologer` package not installed, or
+        # the base-weights download is unreachable).
+        try:
+            from imspy_predictors.rt.chronologer import Chronologer
+            base_path = get_model_path('rt/chronologer_base.pt')
+            return Chronologer.from_base(str(base_path))
+        except (ImportError, FileNotFoundError, RuntimeError) as e:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Chronologer load failed (%s); falling back to transformer.", e,
+            )
+            backend = "transformer"
+
+    # Transformer path (legacy / fallback).
     # Try to load UnifiedPeptideModel first (new architecture)
     try:
         from imspy_predictors.models import UnifiedPeptideModel


### PR DESCRIPTION
## Summary

- `load_deep_retention_time_predictor()` now defaults to **Chronologer** (Searle Lab residual-CNN, Apache-2.0) — roughly 4× tighter median residual than the imspy transformer on timsTOF data, per `rt_im_exploration.ipynb` benchmarks
- Legacy transformer still reachable via `load_deep_retention_time_predictor(backend="transformer")`
- `pretrained/hub.py` gains a per-model `"url"` override; the new `rt/chronologer_base.pt` entry pulls `Chronologer_20220601193755.pt` directly from the upstream Searle Lab repo — no re-hosting, so upstream fixes propagate automatically. SHA-256 locked (`1a500c24…`) so corruption surfaces immediately on download

## Why now

Cross-deposit reproducibility analysis on six modern timsTOF deposits showed the imspy transformer RT was the weakest of the three predictors we ship. Chronologer's residual-CNN architecture wins consistently. Now that the vendor-free Chronologer adapter is in `imspy_predictors.rt` (landed in PR #397), wiring it as the default is mechanical.

This is **Chunk A** of a three-chunk plan. Chunks B (CCS goto = fine-tuned) and C (intensity goto = fine-tuned) are deferred until the production fine-tune notebook (`claudius-proteomics/notebook/production_finetune.ipynb`) runs and produces weights on disk.

## Backward compatibility

- Existing `load_deep_retention_time_predictor()` and `load_deep_retention_time_predictor(backend=None)` calls now return Chronologer — *behavior change*, but the call signature is unchanged
- Existing `load_deep_retention_time_predictor(backend="transformer")` calls preserve the previous behavior exactly
- If the upstream `chronologer` Python package isn't installed, or the base-weights download is unreachable, the function logs a warning and falls back to the transformer path. No hard breakage

## Test plan

- [ ] Existing `tests/test_predictors.py::test_deep_chromatography_apex` still passes (the test only checks class importability, not loader defaults)
- [ ] Fresh-env smoke test: `python -c "from imspy_predictors.rt import load_deep_retention_time_predictor; m = load_deep_retention_time_predictor(); print(type(m).__name__)"` returns `Chronologer` (or, in a env without the upstream chronologer package, prints a warning and returns the transformer)
- [ ] `python -c "from imspy_predictors.rt import load_deep_retention_time_predictor; m = load_deep_retention_time_predictor(backend='transformer'); print(type(m).__name__)"` returns the legacy model