### PR TITLE
DCA: request transformer backend explicitly post Chronologer-default

### DIFF
--- a/packages/imspy-predictors/src/imspy_predictors/rt/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/rt/predictors.py
@@ -340,7 +340,7 @@ class DeepChromatographyApex(PeptideChromatographyApex):
 
         # Load model
         if model is None:
-            self.model = load_deep_retention_time_predictor()
+            self.model = load_deep_retention_time_predictor(backend="transformer")
         else:
             self.model = model
 


### PR DESCRIPTION
## Summary

PR #398 made `load_deep_retention_time_predictor()` default to **Chronologer**, but `DeepChromatographyApex.__init__` was already calling that loader with no args and then running `self.model.to(self._device)`. Chronologer is a wrapper class with its own internal device handling and no `.to()` method, so DCA now raises `AttributeError: 'Chronologer' object has no attribute 'to'` on plain instantiation.

One-line fix: DCA explicitly requests `backend="transformer"` — it's the model class DCA was designed around. Other callers keep getting Chronologer by default (the PR #398 behavior we want).

## How it surfaced

End-to-end integration run on monster3's `primitives` DIA pipeline. Cell A (the baseline cell of the v4 production-weights comparison, which uses `--rt-model dca`) failed at the RT predictor instantiation step:

```
File "/.../imspy_predictors/rt/predictors.py", line 350, in __init__
    self.model = self.model.to(self._device)
AttributeError: 'Chronologer' object has no attribute 'to'
```

Cell A → DCA → broken. Comparison run was blocked until this was patched in the editable install on monster3; PR brings the same fix to main so it doesn't bite anyone else.

## Backward compatibility

- DCA users: behavior is restored to pre-PR-#398 (the transformer model)
- Direct `load_deep_retention_time_predictor()` callers: unchanged — still returns Chronologer by default
- `load_deep_retention_time_predictor(backend="transformer")`: unchanged
- No new dependencies

## Test plan

- [x] Editable install on monster3 patched; `DeepChromatographyApex(verbose=False)` instantiates cleanly and re-launched `cell_A` rescore (in progress)
- [ ] No existing test in `tests/test_predictors.py::test_deep_chromatography_apex` failed before the fix (the test only checked class importability, not instantiation). Worth adding a one-liner that actually instantiates DCA — separate PR