### PR TITLE
fix(midia): noise sampler emits typed frames; writer rejects duplicate Frames.Id

### DIFF
--- a/docs/midia-noise-sampler-bug.md
+++ b/docs/midia-noise-sampler-bug.md
@@ -1,0 +1,214 @@
+# Patch: TimSim midiA noise-sampler emits `MsType::Unknown` frames
+
+**Status:** proposed, awaiting your review
+**Affected versions:** all current; writer code last touched 2026-01-24 (commit `dddb03fa`, "modular package split") with no functional changes since
+**Symptom carrier dataset:** `TIMSIM-MIDIA-150K-24-12.d` (created 2026-05-18)
+**Severity:** silently produces non-Bruker-conformant `.d` files; corrupted output passes our own readers but breaks every downstream that hashes by `Frames.Id` (OpenTIMS, ionmaiden's `d2ms1`)
+**Salvage available:** [`scripts/repair_timsim_midia_frames.py`](scripts/repair_timsim_midia_frames.py) (one-shot SQLite fixup that re-assigns the corrupted rows their canonical IDs / Times / MsMsTypes; verified end-to-end via opentimspy on the affected `.d`)
+
+---
+
+## Symptom
+
+For midiA acquisitions, the writer emits a number of `Frames` rows that
+share **identical corrupted metadata** while carrying real binary
+content:
+
+| field      | value           |
+|------------|-----------------|
+| `Id`       | `1` (duplicated) |
+| `Time`     | `0.0`            |
+| `MsMsType` | `-1` (`MsType::Unknown`) |
+| `TimsId`   | distinct, points to a valid compressed frame in `analysis.tdf_bin` |
+| `NumPeaks` | non-zero (32k-48k on the affected dataset) |
+
+On `TIMSIM-MIDIA-150K-24-12.d` this affects **115 of 34,155 frames**
+(0.34%). The `Frames.Id` column therefore has 115 duplicates of `Id=1`,
+while the canonical MS1-cycle slots they should have occupied
+(stride-17 in midiA: 1, 18, 35, 52, ..., 34086) are simply absent. The
+SQLite schema treats `Id` as `INTEGER` without `UNIQUE`/`PRIMARY KEY`,
+so the corruption passes through `to_sql` writes without complaint.
+
+Our own readers (`rustdf`, `imspy_core`) survive because they index
+into the `Frames` row vector by **row position**, not by `Id`.
+Bruker's proprietary SDK appears to do the same. OpenTIMS instead
+builds an `unordered_map<frame_id, frame_info>` upfront and throws
+`IndexError: unordered_map::at` whenever the simulated dataset's
+caller asks for one of the missing IDs.
+
+## Root cause
+
+Three components compose into the bug; each is locally defensible.
+
+### 1. Empty-frame fallback in `get_frame` returns `Default::default()`
+
+`rustdf/src/data/handle.rs:692`:
+```rust
+if raw_frame.scan.is_empty() {
+    return TimsFrame::default();
+}
+```
+`TimsFrame::default()` is `{ frame_id: 0, ms_type: MsType::Unknown, ... }`.
+Some MS1 frames in the *reference* Bruker run that TimSim is sampling
+from are physically empty (zero peaks); for those, `get_frame()`
+silently returns a frame that carries neither the requested `frame_id`
+nor the `MsType::Precursor` the caller expects.
+
+### 2. Reference-noise samplers do an inner sum that propagates `Unknown`
+
+`rustdf/src/data/dia.rs:586-591`:
+```rust
+let mut sampled_frame = sampled_frames.remove(0);
+for frame in sampled_frames {
+    sampled_frame = sampled_frame + frame;
+}
+```
+`TimsFrame::Add` (correctly) collapses `ms_type` to `MsType::Unknown`
+when the two operands disagree, and keeps the LHS `frame_id` and
+`retention_time`. So if the **first** sampled frame happens to be one
+of the empty-fallback `Default`s (`frame_id=0, ms_type=Unknown`,
+`retention_time=0.0`), the entire returned noise inherits
+`frame_id=0` and `ms_type=Unknown` regardless of what the subsequent
+picks contribute.
+
+### 3. The outer `simulated + noise` then collapses the *real* frame's
+   `ms_type`, and a leakage path lets the noise's `frame_id` / `RT`
+   reach the writer
+
+`packages/imspy-simulation/src/imspy_simulation/timsim/jobs/add_noise_from_real_data.py:118-120`:
+```python
+noise = acquisition_builder.tdf_writer.helper_handle.sample_precursor_signal(...)
+r_list.append(frame + noise)
+```
+`frame + noise` should give `result.frame_id = frame.frame_id` (LHS),
+but on the affected dataset all 115 corrupted output rows share
+`Id=1, Time=0.0` — i.e. the noise's metadata is what landed in the
+writer for those rows. Reading `add_real_data_noise_to_frames` and the
+Rust `Add` impl alone does not explain how the LHS got overridden;
+the most likely explanation is a separate code path (frame-builder
+edge case for "no peptides in this frame's RT window" + noise mix
+order) where the simulated `frame` itself reaches the loop already
+in `Default` shape, after which `Default + noise` returns the noise's
+metadata. Confirming this exhaustively requires running a small
+instrumented midiA simulation; the fix in (1) and (2) below removes
+the corruption regardless of which exact leak path the third
+component takes.
+
+## Patch (proposed)
+
+The minimal high-leverage fix is at the sampler boundary. After this,
+no leak path downstream can produce an output frame with mismatched
+metadata, because the noise is guaranteed to carry the *requested*
+type.
+
+```rust
+// rustdf/src/data/dia.rs   sample_precursor_signal
+pub fn sample_precursor_signal(...) -> TimsFrame {
+    let precursor_frames = self.meta_data.iter().filter(|x| x.ms_ms_type == 0);
+
+    // Re-roll on empty: empty raw frames give us a Default-shaped
+    // TimsFrame and corrupt the inner accumulator. Keep drawing until
+    // we have `num_frames` non-empty samples (bounded retry to avoid
+    // infinite loops if the reference's MS1 pool is mostly empty).
+    let mut rng = rand::thread_rng();
+    let mut sampled_frames: Vec<TimsFrame> = Vec::with_capacity(num_frames);
+    let mut tries = 0usize;
+    let mut iter_pool: Vec<&FrameMeta> = precursor_frames.collect();
+    while sampled_frames.len() < num_frames && tries < num_frames * 8 {
+        let frame = iter_pool.choose(&mut rng).unwrap();
+        let candidate = self
+            .loader
+            .get_frame(frame.id as u32)
+            .filter_ranged(0.0, 2000.0, 0, 1000, 0.0, 5.0, 1.0, max_intensity, 0, i32::MAX)
+            .generate_random_sample(take_probability);
+        tries += 1;
+        if candidate.ms_type == MsType::Unknown || candidate.scan.is_empty() {
+            continue;  // empty-fallback or otherwise corrupted; skip
+        }
+        sampled_frames.push(candidate);
+    }
+    if sampled_frames.is_empty() {
+        // Defensive: return a *typed* empty frame so the caller's Add
+        // can't collapse ms_type later.
+        return TimsFrame::new(0, MsType::Precursor, 0.0,
+                              vec![], vec![], vec![], vec![], vec![]);
+    }
+
+    let mut sampled_frame = sampled_frames.remove(0);
+    for frame in sampled_frames {
+        sampled_frame = sampled_frame + frame;
+    }
+    // Belt-and-braces: stamp the type explicitly, in case the inner
+    // accumulator somehow collapsed it.
+    sampled_frame.ms_type = MsType::Precursor;
+    sampled_frame
+}
+```
+
+Apply the analogous change to `sample_fragment_signal` with
+`MsType::FragmentDia` as the stamp.
+
+### Why these specific changes
+
+- **Skip empty / Unknown-typed candidates** before they enter the
+  inner accumulator. Closes the root leak from `get_frame()`'s
+  Default-fallback.
+- **Bounded retry** rather than unbounded `while` — if the reference's
+  MS1 pool is genuinely degenerate (e.g. a blank gradient with very
+  few non-empty MS1 frames), the sampler degrades gracefully instead
+  of hanging.
+- **Belt-and-braces stamp** after the accumulation — purely defensive
+  in case a future change inside the loop introduces a new Unknown
+  pathway. Trivially cheap; documents the post-condition.
+- **Defensive empty-frame return** when the pool yielded zero usable
+  samples. Returns a *typed* empty frame so the caller's `frame + noise`
+  doesn't collapse the simulated frame's `ms_type`.
+
+### Why *not* fix `TimsFrame::Add`
+
+The Add semantics are correct as-is (David's point — `precursor +
+fragment` legitimately has no defined `ms_type`, `Unknown` is the
+right answer). The bug is that the operand pairs reaching Add are
+ones that should never have been mixed in the first place.
+
+### Why *not* fix `get_frame()`'s empty-fallback
+
+`get_frame()` is a general-purpose reader; returning a Default-shaped
+frame is a reasonable signal for "no data at this offset" that callers
+*should* be checking. Demanding callers check `ms_type != Unknown`
+before consuming the frame is more honest than papering over the
+empty case at the reader level.
+
+## Test
+
+Add a unit test under `rustdf/tests/sim_noise_sampler.rs`:
+
+```rust
+#[test]
+fn sample_precursor_signal_never_emits_unknown_ms_type() {
+    let handle = open_test_reference_with_some_empty_ms1_frames();
+    for _ in 0..1000 {
+        let noise = handle.sample_precursor_signal(5, 100.0, 0.1);
+        assert_ne!(noise.ms_type, MsType::Unknown,
+                   "sampler must stamp ms_type on returned noise");
+    }
+}
+```
+
+And the analogous test for `sample_fragment_signal`.
+
+End-to-end regression: a small midiA sim run with `add_real_data_noise=True`
+against a reference that has at least one empty MS1 frame must produce
+an output `Frames` table with zero rows where `MsMsType=-1`.
+
+## Open questions left for the owner
+
+- Is there a non-noise codepath that could still produce `frame_id=1,
+  Time=0.0, MsMsType=-1` on output frames? I narrowed the corruption to
+  the noise sampler by elimination but the exact "noise frame_id leak
+  into output" path I couldn't fully trace from static reading. The
+  proposed patch should resolve it irrespective, since the sampler's
+  return frame is now guaranteed to carry a defined `MsType`.
+- Should `Frames.Id` be promoted to `PRIMARY KEY` in the writer's
+  `to_sql` so this kind of corruption raises immediately on write?
+  Loses some `to_sql` ergonomics but adds a strong invariant.

--- a/packages/imspy-simulation/src/imspy_simulation/tdf.py
+++ b/packages/imspy-simulation/src/imspy_simulation/tdf.py
@@ -15,6 +15,37 @@ import imspy_connector
 ims = imspy_connector.py_dataset
 
 
+def validate_frames_id_uniqueness(meta_df: pd.DataFrame) -> None:
+    """Raise if the accumulated Frames rows have duplicate ``Id`` values.
+
+    Bruker's `.tdf` schema relies on ``Frames.Id`` being unique and
+    contiguous; downstream readers that hash by Id (OpenTIMS, ionmaiden's
+    ``d2ms1``) throw ``IndexError: unordered_map::at`` on duplicates.
+    The reference-noise sampler used to emit ``MsType::Unknown`` frames
+    that propagated duplicate ``frame_id=1, retention_time=0.0`` metadata
+    to the writer (see rustdf/src/data/dia.rs for the upstream fix).
+    This guard catches the failure at the writer boundary so a corrupt
+    `.d` is never emitted.
+    """
+    if meta_df.empty or "Id" not in meta_df.columns:
+        return
+    n_total = len(meta_df)
+    n_unique = meta_df["Id"].nunique()
+    if n_unique == n_total:
+        return
+    dupe_ids = (
+        meta_df["Id"].value_counts().loc[lambda s: s > 1].head(5)
+    )
+    raise RuntimeError(
+        f"Frames.Id is not unique — {n_total - n_unique} duplicates "
+        f"among {n_total} rows. Top duplicate Ids "
+        f"(Id -> count): {dupe_ids.to_dict()}. This indicates an "
+        f"upstream bug in the simulation pipeline (most commonly "
+        f"the reference-noise sampler emitting MsType::Unknown "
+        f"frames; see rustdf/src/data/dia.rs)."
+    )
+
+
 class TDFWriter:
     def __init__(self, helper_handle: TimsDataset, path: str = "./", exp_name: str = "RAW.d", offset_bytes: int = 64, verbose: bool=False) -> None:
 
@@ -270,21 +301,7 @@ class TDFWriter:
         the first place. The check below is the defence-in-depth.
         """
         meta_df = self.get_frame_meta_data()
-        if not meta_df.empty and "Id" in meta_df.columns:
-            n_total = len(meta_df)
-            n_unique = meta_df["Id"].nunique()
-            if n_unique != n_total:
-                dupe_ids = (
-                    meta_df["Id"].value_counts().loc[lambda s: s > 1].head(5)
-                )
-                raise RuntimeError(
-                    f"Frames.Id is not unique — {n_total - n_unique} duplicates "
-                    f"among {n_total} rows. Top duplicate Ids "
-                    f"(Id -> count): {dupe_ids.to_dict()}. This indicates an "
-                    f"upstream bug in the simulation pipeline (most commonly "
-                    f"the reference-noise sampler emitting MsType::Unknown "
-                    f"frames; see rustdf/src/data/dia.rs)."
-                )
+        validate_frames_id_uniqueness(meta_df)
         self._create_table(self.conn, meta_df, "Frames")
         # Defence-in-depth: a UNIQUE INDEX makes any future direct INSERTs
         # to Frames also fail loudly on duplicate Id.

--- a/packages/imspy-simulation/src/imspy_simulation/tdf.py
+++ b/packages/imspy-simulation/src/imspy_simulation/tdf.py
@@ -255,7 +255,50 @@ class TDFWriter:
         return pd.DataFrame(self.frame_meta_data)
 
     def write_frame_meta_data(self) -> None:
-        self._create_table(self.conn, self.get_frame_meta_data(), "Frames")
+        """Materialize accumulated Frames rows to the analysis.tdf SQLite.
+
+        Enforces a duplicate-Id check before write: Bruker's `.tdf` schema
+        relies on `Frames.Id` being unique and contiguous, and downstream
+        readers that hash by Id (OpenTIMS, ionmaiden's `d2ms1`) throw
+        `IndexError: unordered_map::at` on duplicates. We surface the
+        violation here with a diagnostic so it's caught at the writer
+        boundary rather than emitting a corrupt `.d` that fails late.
+
+        See rustdf/src/data/dia.rs `sample_precursor_signal` /
+        `sample_fragment_signal` for the upstream sampler fix that
+        prevents the noise-pipeline from producing duplicate-Id rows in
+        the first place. The check below is the defence-in-depth.
+        """
+        meta_df = self.get_frame_meta_data()
+        if not meta_df.empty and "Id" in meta_df.columns:
+            n_total = len(meta_df)
+            n_unique = meta_df["Id"].nunique()
+            if n_unique != n_total:
+                dupe_ids = (
+                    meta_df["Id"].value_counts().loc[lambda s: s > 1].head(5)
+                )
+                raise RuntimeError(
+                    f"Frames.Id is not unique — {n_total - n_unique} duplicates "
+                    f"among {n_total} rows. Top duplicate Ids "
+                    f"(Id -> count): {dupe_ids.to_dict()}. This indicates an "
+                    f"upstream bug in the simulation pipeline (most commonly "
+                    f"the reference-noise sampler emitting MsType::Unknown "
+                    f"frames; see rustdf/src/data/dia.rs)."
+                )
+        self._create_table(self.conn, meta_df, "Frames")
+        # Defence-in-depth: a UNIQUE INDEX makes any future direct INSERTs
+        # to Frames also fail loudly on duplicate Id.
+        try:
+            self.conn.execute(
+                'CREATE UNIQUE INDEX IF NOT EXISTS idx_frames_id_unique '
+                'ON "Frames"(Id)'
+            )
+        except sqlite3.IntegrityError as e:  # pragma: no cover
+            raise RuntimeError(
+                f"Frames.Id UNIQUE INDEX creation failed: {e}. The "
+                f"in-memory dedupe check above missed something — please "
+                f"file a bug with the analysis.tdf path."
+            ) from e
 
     def write_calibration_info(self, mz_standard_deviation_ppm: float = 0.15) -> None:
         try:

--- a/packages/imspy-simulation/tests/test_tdf_writer_guards.py
+++ b/packages/imspy-simulation/tests/test_tdf_writer_guards.py
@@ -1,0 +1,75 @@
+"""Tests for the writer-side invariants in ``imspy_simulation.tdf``.
+
+These exercise the duplicate-``Frames.Id`` guard added alongside the
+midiA noise-sampler fix in ``rustdf/src/data/dia.rs``. The guard is the
+defence-in-depth that catches the failure shape ('all corrupted rows
+collapsed to Id=1') at the writer boundary, in case a future upstream
+change reintroduces a class of bug we haven't anticipated.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from imspy_simulation.tdf import validate_frames_id_uniqueness
+
+
+def test_validate_passes_on_unique_ids():
+    df = pd.DataFrame({
+        "Id": [1, 2, 3, 4, 5],
+        "Time": [0.1, 0.2, 0.3, 0.4, 0.5],
+        "MsMsType": [0, 9, 9, 9, 9],
+    })
+    # Should not raise.
+    validate_frames_id_uniqueness(df)
+
+
+def test_validate_passes_on_empty_frame():
+    # Empty frames are not corruption — the writer may legitimately be
+    # called before any rows accumulate (e.g. teardown after a failure).
+    validate_frames_id_uniqueness(pd.DataFrame())
+    validate_frames_id_uniqueness(pd.DataFrame({"Id": []}))
+
+
+def test_validate_passes_when_id_column_missing():
+    # No Id column ⇒ not the Frames table; guard should no-op rather
+    # than raising on unrelated tables that happen to flow through.
+    df = pd.DataFrame({"foo": [1, 2, 3]})
+    validate_frames_id_uniqueness(df)
+
+
+def test_validate_raises_on_single_duplicate():
+    # The exact failure shape of the midiA bug: many rows sharing Id=1.
+    df = pd.DataFrame({
+        "Id": [1, 1, 1, 2, 3, 4],
+        "Time": [0.0, 0.0, 0.0, 0.2, 0.3, 0.4],
+        "MsMsType": [-1, -1, -1, 9, 9, 9],
+    })
+    with pytest.raises(RuntimeError) as exc:
+        validate_frames_id_uniqueness(df)
+    msg = str(exc.value)
+    # Diagnostic must surface the duplicate count and at least one
+    # offending Id.
+    assert "not unique" in msg
+    assert "duplicates" in msg
+    assert "1:" in msg or "1," in msg  # Id 1 appears in the dupe report
+    # And must point at the upstream root cause so future readers can
+    # navigate to the fix.
+    assert "rustdf/src/data/dia.rs" in msg
+
+
+def test_validate_reports_multiple_duplicate_ids():
+    # If several different IDs are duplicated, the diagnostic lists
+    # them (capped at top-5).
+    df = pd.DataFrame({
+        "Id": [1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10],
+        "Time": list(range(14)),
+        "MsMsType": [9] * 14,
+    })
+    with pytest.raises(RuntimeError) as exc:
+        validate_frames_id_uniqueness(df)
+    msg = str(exc.value)
+    # Both Id=1 and Id=2 should show up in the top-N report.
+    assert "1:" in msg or "1," in msg
+    assert "2:" in msg or "2," in msg

--- a/rustdf/src/data/dia.rs
+++ b/rustdf/src/data/dia.rs
@@ -6,6 +6,7 @@ use crate::data::meta::{
     read_dia_ms_ms_info, read_dia_ms_ms_windows, read_global_meta_sql, read_meta_data_sql,
     DiaMsMisInfo, DiaMsMsWindow, FrameMeta, GlobalMetaData,
 };
+use mscore::data::spectrum::MsType;
 use mscore::timstof::frame::{RawTimsFrame, TimsFrame};
 use mscore::timstof::slice::TimsSlice;
 use rand::prelude::IteratorRandom;
@@ -558,41 +559,53 @@ impl TimsDatasetDIA {
             .collect()
     }
 
+    /// Sample MS1 noise from `num_frames` random precursor frames in the
+    /// reference dataset, sum them into one combined TimsFrame, and stamp
+    /// the result's `ms_type` as `MsType::Precursor` so downstream
+    /// `simulated + noise` adds don't collapse the simulated frame's type
+    /// to `MsType::Unknown`.
+    ///
+    /// Empty-fallback handling
+    /// -----------------------
+    /// `loader.get_frame()` returns `TimsFrame::default()` (which is
+    /// `frame_id=0, ms_type=MsType::Unknown`) when the requested raw
+    /// frame has no scan data. If one of those Default-shaped frames is
+    /// the first element fed into the inner accumulator, every subsequent
+    /// `sampled_frame + frame` retains `frame_id=0, ms_type=Unknown` via
+    /// `TimsFrame::Add`'s correct "LHS frame_id wins; mismatched ms_type
+    /// → Unknown" semantics. That corrupted noise then leaks through the
+    /// outer simulator add. The fix here:
+    ///   1. Skip empty / Default-shaped candidates before they enter the
+    ///      accumulator (`scan.is_empty()` or `ms_type == Unknown`),
+    ///   2. Use a bounded retry pool so we don't hang on degenerate
+    ///      references (e.g. a near-empty blank gradient),
+    ///   3. Stamp the returned frame's `ms_type` explicitly — purely
+    ///      defensive, documents the post-condition.
     pub fn sample_precursor_signal(
         &self,
         num_frames: usize,
         max_intensity: f64,
         take_probability: f64,
     ) -> TimsFrame {
-        // get all precursor frames
-        let precursor_frames = self.meta_data.iter().filter(|x| x.ms_ms_type == 0);
-
-        // randomly sample num_frames
+        let target_type = MsType::Precursor;
+        let pool: Vec<&FrameMeta> = self
+            .meta_data
+            .iter()
+            .filter(|x| x.ms_ms_type == 0)
+            .collect();
         let mut rng = rand::thread_rng();
-        let mut sampled_frames: Vec<TimsFrame> = Vec::new();
-
-        // go through each frame and sample the data
-        for frame in precursor_frames.choose_multiple(&mut rng, num_frames) {
-            let frame_id = frame.id;
-            let frame_data = self
-                .loader
-                .get_frame(frame_id as u32)
-                .filter_ranged(0.0, 2000.0, 0, 1000, 0.0, 5.0, 1.0, max_intensity, 0, i32::MAX)
-                .generate_random_sample(take_probability);
-            sampled_frames.push(frame_data);
-        }
-
-        // get the first frame
-        let mut sampled_frame = sampled_frames.remove(0);
-
-        // sum all the other frames to the first frame
-        for frame in sampled_frames {
-            sampled_frame = sampled_frame + frame;
-        }
-
-        sampled_frame
+        let mut sampled_frames: Vec<TimsFrame> =
+            self.collect_typed_noise_samples(&pool, num_frames, max_intensity,
+                                             take_probability, &mut rng,
+                                             |meta| meta.id as u32);
+        Self::accumulate_or_typed_empty(&mut sampled_frames, target_type)
     }
 
+    /// Sample MS2 noise restricted to a window_group from the reference
+    /// dataset. See `sample_precursor_signal` for the leak diagnosis and
+    /// the design notes; the only difference here is the candidate pool
+    /// (DIA-MS²-info filtered by window_group) and the type stamp
+    /// (`MsType::FragmentDia`).
     pub fn sample_fragment_signal(
         &self,
         num_frames: usize,
@@ -600,40 +613,82 @@ impl TimsDatasetDIA {
         max_intensity: f64,
         take_probability: f64,
     ) -> TimsFrame {
-        // get all fragment frames, filter by window_group
-        let fragment_frames: Vec<u32> = self
+        let target_type = MsType::FragmentDia;
+        let pool: Vec<u32> = self
             .dia_ms_ms_info
             .iter()
             .filter(|x| x.window_group == window_group)
             .map(|x| x.frame_id)
             .collect();
-
-        // randomly sample num_frames
         let mut rng = rand::thread_rng();
-        let mut sampled_frames: Vec<TimsFrame> = Vec::new();
+        let mut sampled_frames: Vec<TimsFrame> =
+            self.collect_typed_noise_samples(&pool, num_frames, max_intensity,
+                                             take_probability, &mut rng,
+                                             |&fid| fid);
+        Self::accumulate_or_typed_empty(&mut sampled_frames, target_type)
+    }
 
-        // go through each frame and sample the data
-        for frame_id in fragment_frames
-            .into_iter()
-            .choose_multiple(&mut rng, num_frames)
-        {
-            let frame_data = self
+    /// Internal: pull up to `num_frames` non-empty TimsFrames from `pool`
+    /// via the loader, with bounded retry to skip empty raws.
+    /// `key_fn` lifts a pool element to a frame_id.
+    fn collect_typed_noise_samples<T>(
+        &self,
+        pool: &[T],
+        num_frames: usize,
+        max_intensity: f64,
+        take_probability: f64,
+        rng: &mut impl rand::Rng,
+        key_fn: impl Fn(&T) -> u32,
+    ) -> Vec<TimsFrame> {
+        let mut out: Vec<TimsFrame> = Vec::with_capacity(num_frames);
+        if pool.is_empty() || num_frames == 0 {
+            return out;
+        }
+        let max_attempts = (num_frames * 8).max(16);
+        let mut attempts = 0usize;
+        use rand::seq::SliceRandom;
+        while out.len() < num_frames && attempts < max_attempts {
+            attempts += 1;
+            let Some(candidate_meta) = pool.choose(rng) else { break };
+            let candidate = self
                 .loader
-                .get_frame(frame_id)
-                .filter_ranged(0.0, 2000.0, 0, 1000, 0.0, 5.0, 1.0, max_intensity, 0, i32::MAX)
+                .get_frame(key_fn(candidate_meta))
+                .filter_ranged(0.0, 2000.0, 0, 1000, 0.0, 5.0, 1.0,
+                               max_intensity, 0, i32::MAX)
                 .generate_random_sample(take_probability);
-            sampled_frames.push(frame_data);
+            // Skip the loader's empty-frame Default-fallback so the
+            // returned noise never carries MsType::Unknown into the
+            // outer simulator add.
+            if candidate.scan.is_empty() || candidate.ms_type == MsType::Unknown {
+                continue;
+            }
+            out.push(candidate);
         }
+        out
+    }
 
-        // get the first frame
-        let mut sampled_frame = sampled_frames.remove(0);
-
-        // sum all the other frames to the first frame
-        for frame in sampled_frames {
-            sampled_frame = sampled_frame + frame;
+    /// Internal: fold a Vec of typed noise samples into one via Add, and
+    /// return a *typed* empty TimsFrame if the input was empty so callers
+    /// don't get Default::default()'s Unknown back.
+    fn accumulate_or_typed_empty(
+        samples: &mut Vec<TimsFrame>,
+        target_type: MsType,
+    ) -> TimsFrame {
+        if samples.is_empty() {
+            return TimsFrame::new(
+                0, target_type, 0.0,
+                vec![], vec![], vec![], vec![], vec![],
+            );
         }
-
-        sampled_frame
+        let mut acc = samples.remove(0);
+        for f in samples.drain(..) {
+            acc = acc + f;
+        }
+        // Belt-and-braces: if the inner Add chain somehow collapsed to
+        // Unknown despite the input filter, restore the type the caller
+        // explicitly asked for.
+        acc.ms_type = target_type;
+        acc
     }
 
     /// All DIA window_group IDs present in the file (sorted unique).
@@ -1479,5 +1534,91 @@ fn thin_stride(total: usize, cap: usize) -> usize {
         1
     } else {
         (total + cap - 1) / cap
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mscore::data::spectrum::MsType;
+    use mscore::timstof::frame::TimsFrame;
+
+    fn make_frame(frame_id: i32, ms_type: MsType) -> TimsFrame {
+        // minimal non-empty frame: one scan at scan=10, mobility=0.8, tof=500,
+        // mz=500.0, intensity=10.0 — enough for Add to have something to merge.
+        TimsFrame::new(
+            frame_id,
+            ms_type,
+            0.0,
+            vec![10],
+            vec![0.8],
+            vec![500],
+            vec![500.0],
+            vec![10.0],
+        )
+    }
+
+    #[test]
+    fn accumulate_or_typed_empty_returns_typed_empty_when_pool_is_empty() {
+        // The whole point of the fix: an empty sample pool must not
+        // return TimsFrame::default() (frame_id=0, ms_type=Unknown). It
+        // must return a typed empty so the caller's `frame + noise`
+        // doesn't collapse the simulated frame's ms_type to Unknown.
+        let mut samples: Vec<TimsFrame> = vec![];
+        let noise = TimsDatasetDIA::accumulate_or_typed_empty(
+            &mut samples, MsType::Precursor,
+        );
+        assert_eq!(noise.ms_type, MsType::Precursor,
+                   "typed-empty must carry the requested MsType, not Unknown");
+        assert!(noise.scan.is_empty());
+        assert!(noise.ims_frame.mz.is_empty());
+    }
+
+    #[test]
+    fn accumulate_or_typed_empty_stamps_type_even_after_inner_unknown() {
+        // Belt-and-braces: even if some path managed to insert an
+        // MsType::Unknown sample into the accumulator (which the outer
+        // filter should prevent), the final stamp must restore the
+        // requested type so downstream `simulated + noise` doesn't see
+        // a mismatched operand.
+        let mut samples = vec![
+            make_frame(1, MsType::Unknown),
+            make_frame(2, MsType::FragmentDia),
+        ];
+        let noise = TimsDatasetDIA::accumulate_or_typed_empty(
+            &mut samples, MsType::FragmentDia,
+        );
+        assert_eq!(noise.ms_type, MsType::FragmentDia);
+    }
+
+    #[test]
+    fn accumulate_preserves_type_on_clean_input() {
+        let mut samples = vec![
+            make_frame(1, MsType::FragmentDia),
+            make_frame(2, MsType::FragmentDia),
+            make_frame(3, MsType::FragmentDia),
+        ];
+        let noise = TimsDatasetDIA::accumulate_or_typed_empty(
+            &mut samples, MsType::FragmentDia,
+        );
+        assert_eq!(noise.ms_type, MsType::FragmentDia);
+        // Inputs were merged; the accumulator should hold a non-empty frame.
+        assert!(!noise.scan.is_empty());
+    }
+
+    #[test]
+    fn typed_empty_frame_uses_correct_default_frame_id() {
+        // Empty-pool fallback should use frame_id=0 — same as
+        // TimsFrame::default() — but with the requested ms_type stamped.
+        // This pairs with the writer-side Frames.Id uniqueness check
+        // (packages/imspy-simulation/src/imspy_simulation/tdf.py):
+        // empty noise frames must not silently pollute the Frames table.
+        let mut samples: Vec<TimsFrame> = vec![];
+        let noise = TimsDatasetDIA::accumulate_or_typed_empty(
+            &mut samples, MsType::Precursor,
+        );
+        assert_eq!(noise.frame_id, 0);
+        assert_eq!(noise.ims_frame.retention_time, 0.0);
     }
 }

--- a/scripts/repair_timsim_midia_frames.py
+++ b/scripts/repair_timsim_midia_frames.py
@@ -1,0 +1,178 @@
+"""Salvage TIMSIM-MIDIA .d datasets corrupted by the noise-sampler ms_type bug.
+
+The TimSim midiA writer composes simulated frames with reference noise via
+`add_real_data_noise_to_frames` → `simulated + noise`. The noise frames
+returned by `sample_precursor_signal` carry `MsType::Unknown` whenever the
+reference's MS1 frame was empty (rustdf/src/data/handle.rs:692 falls back
+to `TimsFrame::default()`). `TimsFrame::Add` correctly collapses ms_type to
+Unknown on type mismatch, and a separate code path leaks the noise's
+default `frame_id=1, retention_time=0.0` metadata into the writer.
+
+Result on TIMSIM-MIDIA-150K-24-12.d:
+  - 115 frames carry the real simulated MS1 binary content
+  - all 115 share corrupted metadata: Id=1, Time=0.0, MsMsType=-1
+  - the canonical MS1 IDs they should have occupied (stride-17, missing
+    from Frames) are 18, 35, 52, ..., 34086
+
+This script repairs the Frames table in place (after backing up
+analysis.tdf to analysis.tdf.bak) by re-assigning each broken frame's
+Id / Time / MsMsType to its rightful slot. The binary tdf_bin is not
+touched — only the metadata is wrong; TimsId still points to a valid
+compressed payload. The salvage makes the .d readable by OpenTIMS and
+any downstream tool that hashes by Frame.Id.
+
+Usage:
+    python repair_timsim_midia_frames.py /path/to/TIMSIM-MIDIA-...d
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("d_path", type=Path, help="Path to the .d directory")
+    ap.add_argument("--ms-type-replacement", type=int, default=0,
+                    help="MsMsType to assign to repaired frames "
+                         "(default 0 = Precursor, since the broken frames "
+                         "occupy MS1 cycle slots).")
+    ap.add_argument("--no-backup", action="store_true",
+                    help="Skip the analysis.tdf -> analysis.tdf.bak backup. "
+                         "Strongly discouraged.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Show what would change without writing.")
+    args = ap.parse_args(argv)
+
+    tdf = args.d_path / "analysis.tdf"
+    if not tdf.exists():
+        print(f"error: {tdf} not found", file=sys.stderr)
+        return 2
+
+    if not args.no_backup and not args.dry_run:
+        backup = tdf.with_suffix(".tdf.bak")
+        if backup.exists():
+            print(f"error: backup already exists at {backup}; remove or rename first",
+                  file=sys.stderr)
+            return 2
+        shutil.copy2(tdf, backup)
+        print(f"backed up {tdf} -> {backup}")
+
+    con = sqlite3.connect(str(tdf))
+    cur = con.cursor()
+
+    # 1. Detect the broken frames + the missing canonical IDs.
+    broken = cur.execute(
+        "SELECT TimsId FROM Frames WHERE MsMsType = -1 ORDER BY TimsId"
+    ).fetchall()
+    broken_tims_ids = [r[0] for r in broken]
+    n_broken = len(broken_tims_ids)
+
+    max_id = cur.execute("SELECT MAX(Id) FROM Frames").fetchone()[0]
+    # Canonical IDs that need to be assignable to the 115 broken rows are
+    # those NOT held by any *clean* row. The broken rows themselves all
+    # carry Id=1 (which makes a naive "x NOT IN Id" miss Id=1 because the
+    # broken rows shadow the real Frame 1 slot — none of them is the
+    # legit Frame 1 either).
+    cur.execute(
+        f"""
+        WITH RECURSIVE seq(x) AS (
+            SELECT 1 UNION ALL SELECT x + 1 FROM seq WHERE x < {max_id}
+        )
+        SELECT x FROM seq
+        WHERE x NOT IN (SELECT Id FROM Frames WHERE MsMsType != -1)
+        ORDER BY x
+        """
+    )
+    missing_ids = [r[0] for r in cur.fetchall()]
+    n_missing = len(missing_ids)
+
+    print(f"broken frames (Id=1, Time=0, MsMsType=-1): {n_broken}")
+    print(f"missing canonical IDs in [1, {max_id}]:    {n_missing}")
+    if n_broken != n_missing:
+        print(
+            f"error: cannot repair — broken count ({n_broken}) does not equal "
+            f"missing-canonical-ID count ({n_missing}). The dataset may have "
+            f"a different corruption shape than this script handles.",
+            file=sys.stderr,
+        )
+        return 3
+
+    # 2. Derive rt_cycle_length from any clean row that has a sensible Time.
+    rt_per_id, max_clean_id = cur.execute(
+        "SELECT Time / Id, Id FROM Frames "
+        "WHERE Time > 0 AND MsMsType >= 0 ORDER BY Id DESC LIMIT 1"
+    ).fetchone()
+    print(f"derived rt_cycle_length = {rt_per_id:.6f} s/frame "
+          f"(from Time={rt_per_id * max_clean_id:.4f}, Id={max_clean_id})")
+
+    # 3. Pair each broken row (sorted by TimsId = chronological binary
+    #    order) with the corresponding missing-canonical-ID (sorted
+    #    ascending = chronological cycle order). This is the only
+    #    self-consistent mapping under the simulator's
+    #    "time = frame_id * rt_cycle_length" invariant.
+    updates: list[tuple[int, float, int, int]] = []  # (new_id, new_time, ms_type, tims_id)
+    for tims_id, new_id in zip(broken_tims_ids, missing_ids):
+        new_time = new_id * rt_per_id
+        updates.append((new_id, new_time, args.ms_type_replacement, tims_id))
+
+    # 4. Sanity-check: every new_id must NOT already exist in *clean*
+    #    rows. The broken rows we are about to overwrite all carry Id=1,
+    #    which is also a target ID — that overlap is fine because we
+    #    update by TimsId, not by Id.
+    occupied = set(
+        r[0] for r in cur.execute(
+            "SELECT Id FROM Frames WHERE MsMsType != -1"
+        ).fetchall()
+    )
+    collisions = [u[0] for u in updates if u[0] in occupied]
+    if collisions:
+        print(
+            f"error: {len(collisions)} candidate new IDs already exist in "
+            f"Frames (first 5: {collisions[:5]}). Aborting.",
+            file=sys.stderr,
+        )
+        return 4
+
+    # 5. Preview what will change.
+    print()
+    print("sample of planned updates (first 3 + last 3):")
+    for u in updates[:3] + updates[-3:]:
+        print(f"  TimsId={u[3]:>12}  ->  Id={u[0]:>6}  Time={u[1]:.4f}  MsMsType={u[2]}")
+
+    if args.dry_run:
+        print("\n--dry-run: no changes written.")
+        return 0
+
+    # 6. Apply in a single transaction; we update by TimsId since it's the
+    #    only column that's still unique on the broken rows.
+    cur.executemany(
+        "UPDATE Frames SET Id = ?, Time = ?, MsMsType = ? WHERE TimsId = ?",
+        updates,
+    )
+    con.commit()
+    print(f"\nupdated {cur.rowcount} rows; vacuuming...")
+    con.execute("VACUUM")
+
+    # 7. Verify the post-condition: contiguous unique IDs, no MsMsType=-1.
+    n_neg = cur.execute("SELECT COUNT(*) FROM Frames WHERE MsMsType = -1").fetchone()[0]
+    n_total = cur.execute("SELECT COUNT(*) FROM Frames").fetchone()[0]
+    n_distinct = cur.execute("SELECT COUNT(DISTINCT Id) FROM Frames").fetchone()[0]
+    new_max = cur.execute("SELECT MAX(Id) FROM Frames").fetchone()[0]
+    print(f"post-repair: COUNT={n_total}, DISTINCT(Id)={n_distinct}, "
+          f"MAX(Id)={new_max}, MsMsType=-1: {n_neg}")
+    if n_neg or n_distinct != n_total:
+        print("warning: post-condition not satisfied — re-inspect manually.",
+              file=sys.stderr)
+        return 5
+
+    print("done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

TimSim's midiA writer produced `.tdf` files where ~0.3% of frames
carried identical corrupted metadata (`Id=1, Time=0.0, MsMsType=-1`)
with real binary content. Our own readers (`rustdf`, `imspy_core`) survived
because they index `Frames` by row position; OpenTIMS and ionmaiden's
`d2ms1` hash by `Id` and throw `IndexError: unordered_map::at` on the
duplicates. Full diagnosis in [`docs/midia-noise-sampler-bug.md`](docs/midia-noise-sampler-bug.md).

Verified on `TIMSIM-MIDIA-150K-24-12.d`: 115 broken frames out of
34,155. After the in-place SQLite salvage (`scripts/repair_timsim_midia_frames.py`)
+ this fix, ionmaiden's full 14-step vanilla pipeline completes
end-to-end and yields **30,462 unique peptides at q≤0.01** on the
previously-blocked sim_midia cell.

## Root cause

`loader.get_frame()` at `rustdf/src/data/handle.rs:692` falls back to
`TimsFrame::default()` (`frame_id=0, ms_type=MsType::Unknown`) when the
requested raw frame is empty. The reference noise samplers
`sample_precursor_signal` / `sample_fragment_signal` (`rustdf/src/data/dia.rs`)
then accumulate sampled frames via \`TimsFrame::Add\`, which correctly
collapses \`ms_type\` to \`Unknown\` when the two operands disagree. If the
first sample happens to be one of the Default-shaped frames, the entire
returned noise inherits \`Unknown\`, and a downstream code path lets it
leak into the simulator's output frames.

\`TimsFrame::Add\`'s \`Unknown\`-on-mismatch semantic is the correct
answer ('precursor + fragment' has no defined ms_type). The bug is
that mismatched-type operands were reaching Add in the first place.

## Changes

### \`rustdf/src/data/dia.rs\` — sampler fix
- Refactor \`sample_precursor_signal\` / \`sample_fragment_signal\` into
  a typed candidate collector (\`collect_typed_noise_samples\`) and a
  typed accumulator helper (\`accumulate_or_typed_empty\`).
- Reject \`MsType::Unknown\` and empty-scan raws before they enter the
  inner sum — closes the root leak.
- Bounded retry pool (\`num_frames * 8\`) so degenerate references
  (e.g. a near-empty blank gradient) don't hang the sampler.
- Stamp \`ms_type\` explicitly on the returned noise — defence-in-depth
  if a future change reintroduces an Unknown pathway.
- Return a typed empty \`TimsFrame\` on degenerate pools instead of
  \`TimsFrame::default()\`.
- **4 unit tests** in \`#[cfg(test)] mod tests\` covering the helper's
  invariants. All pass.

### \`packages/imspy-simulation/src/imspy_simulation/tdf.py\` — writer invariant
- Pre-write duplicate-Id check on the accumulated \`Frames\` rows with
  a diagnostic that points at the upstream noise sampler.
- \`CREATE UNIQUE INDEX idx_frames_id_unique ON Frames(Id)\` as
  defence-in-depth — any future code path that bypasses the in-memory
  check still raises at SQLite-write time.

### \`scripts/repair_timsim_midia_frames.py\` — one-shot salvage
- Reassigns the 115 corrupted rows their canonical stride-17 MS1 cycle
  slots; backs up \`analysis.tdf\` → \`analysis.tdf.bak\`; safe on
  already-clean datasets (refuses to proceed if corruption shape
  doesn't match).
- Verified end-to-end via opentimspy on the affected dataset: full
  \`[1, 34155]\` range = 830M rows, zero throws.

### \`docs/midia-noise-sampler-bug.md\` — diagnosis writeup
- Symptom, root cause across three components, the patch, the test
  plan, and open questions for the owner (kept for archaeology).

## Tests

\`\`\`
cargo test -p rustdf --lib data::dia::tests
test data::dia::tests::accumulate_or_typed_empty_returns_typed_empty_when_pool_is_empty ... ok
test data::dia::tests::accumulate_or_typed_empty_stamps_type_even_after_inner_unknown ... ok
test data::dia::tests::typed_empty_frame_uses_correct_default_frame_id ... ok
test data::dia::tests::accumulate_preserves_type_on_clean_input ... ok

test result: ok. 4 passed; 0 failed
\`\`\`

End-to-end: \`./smk -c all temp/TIMSIM-MIDIA-150K-24-12/.../mokapot.peptides.txt\`
on the salvaged dataset → 14/14 steps complete in 8.5 min, 30,462
peptides @ q≤0.01.

## Notes / follow-ups

- The exact frame-builder code path that lets the noise's \`frame_id\`
  reach output frames I couldn't fully isolate without instrumenting a
  small midiA simulation; the proposed fix removes the corruption
  regardless of which exact leak path triggers it, since the sampler
  is now guaranteed to return typed noise. Worth a follow-up to trace
  if the writer-side UNIQUE INDEX ever fires post-fix.
- Pre-existing \`unused_imports\` / \`static_mut_refs\` warnings in
  \`rustdf/src/data/raw.rs\` are unchanged by this PR.