### PR TITLE
fix(rustdf): dedup+sort (scan,tof) in Rust tdf_bin writer to match Python

### DIFF
--- a/packages/imspy-simulation/src/imspy_simulation/tdf.py
+++ b/packages/imspy-simulation/src/imspy_simulation/tdf.py
@@ -47,7 +47,7 @@ def validate_frames_id_uniqueness(meta_df: pd.DataFrame) -> None:
 
 
 class TDFWriter:
-    def __init__(self, helper_handle: TimsDataset, path: str = "./", exp_name: str = "RAW.d", offset_bytes: int = 64, verbose: bool=False) -> None:
+    def __init__(self, helper_handle: TimsDataset, path: str = "./", exp_name: str = "RAW.d", offset_bytes: int = 64, verbose: bool=False, use_rust_compression: bool=False) -> None:
 
         self.path = Path(path)
         self.exp_name = exp_name
@@ -59,6 +59,17 @@ class TDFWriter:
         self.helper_handle = helper_handle
         self.offset_bytes = offset_bytes
         self.verbose = verbose
+        # When True, the per-frame tdf_bin realdata is produced by the Rust
+        # encoder (imspy_connector get_data_for_compression) instead of the
+        # NumPy/Numba get_compressible_data. The Python dedup+lexsort over
+        # (scan, tof) is kept either way so frame metadata stays correct; the
+        # Rust encoder reproduces it byte-for-byte (see scripts/parity_tof_writer.py).
+        # Also togglable globally via TIMSIM_RUST_COMPRESSION=1 so a stock
+        # `timsim` run can exercise the Rust writer without code changes.
+        import os
+        self.use_rust_compression = use_rust_compression or os.environ.get(
+            "TIMSIM_RUST_COMPRESSION", "0"
+        ) not in ("0", "", "false", "False")
 
         self.__conn_native = None
         self._setup_connections()
@@ -251,8 +262,16 @@ class TDFWriter:
         tof = unique_tof[sort_idx]
         intensity = summed_intensity[sort_idx].astype(np.uint32)
 
-        # get the real data as interleaved bytes
-        real_data = get_compressible_data(tof, scan, intensity, self.helper_handle.num_scans)
+        # get the real data as interleaved bytes (Rust encoder or NumPy/Numba)
+        if self.use_rust_compression:
+            real_data = ims.get_data_for_compression(
+                tof.astype(np.uint32).tolist(),
+                scan.astype(np.uint32).tolist(),
+                intensity.astype(np.uint32).tolist(),
+                int(self.helper_handle.num_scans),
+            )
+        else:
+            real_data = get_compressible_data(tof, scan, intensity, self.helper_handle.num_scans)
         # compress the data
         return intensity, zstd.ZSTD_compress(bytes(real_data), 0)
 

--- a/rustdf/src/data/utility.rs
+++ b/rustdf/src/data/utility.rs
@@ -40,9 +40,46 @@ pub fn zstd_compress(decompressed_data: &[u8], compression_level: i32) -> io::Re
     Ok(compressed_data)
 }
 
+/// Deduplicate `(scan, tof)` pairs (summing their intensities) and return the
+/// arrays sorted ascending by `(scan, tof)`.
+///
+/// The Bruker `tdf_bin` layout requires this ordering: [`modify_tofs`] delta-
+/// encodes TOF within each scan (so TOFs must ascend within a scan) and
+/// [`get_peak_cnts`] walks scans assuming they ascend. The Python writer
+/// enforces the same invariant via an `np.unique` dedup + `np.lexsort((tof,
+/// scan))` before encoding; the Rust write path previously fed raw, unsorted
+/// frame data straight into the encoder, producing negative/garbage TOF deltas
+/// that vendor readers (e.g. DiaNN) reject. Mirroring the Python preprocessing
+/// here keeps the two writers byte-for-byte identical.
+fn sort_dedup_scan_tof(
+    scans: &[u32],
+    tofs: &[u32],
+    intensities: &[u32],
+) -> (Vec<u32>, Vec<u32>, Vec<u32>) {
+    use std::collections::HashMap;
+    let mut acc: HashMap<(u32, u32), u64> = HashMap::with_capacity(scans.len());
+    for i in 0..scans.len() {
+        *acc.entry((scans[i], tofs[i])).or_insert(0) += intensities[i] as u64;
+    }
+    let mut pairs: Vec<((u32, u32), u64)> = acc.into_iter().collect();
+    // Sort by scan, then tof — matches numpy's lexsort((tof, scan)).
+    pairs.sort_unstable_by_key(|&((s, t), _)| (s, t));
+
+    let n = pairs.len();
+    let mut out_scan = Vec::with_capacity(n);
+    let mut out_tof = Vec::with_capacity(n);
+    let mut out_int = Vec::with_capacity(n);
+    for ((s, t), inten) in pairs {
+        out_scan.push(s);
+        out_tof.push(t);
+        out_int.push(inten.min(u32::MAX as u64) as u32);
+    }
+    (out_scan, out_tof, out_int)
+}
+
 pub fn reconstruct_compressed_data(
     scans: Vec<u32>,
-    mut tofs: Vec<u32>,
+    tofs: Vec<u32>,
     intensities: Vec<u32>,
     total_scans: u32,
     compression_level: i32,
@@ -50,6 +87,9 @@ pub fn reconstruct_compressed_data(
     // Ensuring all vectors have the same length
     assert_eq!(scans.len(), tofs.len());
     assert_eq!(scans.len(), intensities.len());
+
+    // Dedup + sort by (scan, tof) so TOF delta-encoding stays monotonic.
+    let (scans, mut tofs, intensities) = sort_dedup_scan_tof(&scans, &tofs, &intensities);
 
     // Modify TOFs based on scans
     modify_tofs(&mut tofs, &scans);
@@ -269,10 +309,14 @@ pub fn get_data_for_compression(
     intensities: &Vec<u32>,
     max_scans: u32,
 ) -> Vec<u8> {
+    // Dedup + sort by (scan, tof) so TOF delta-encoding stays monotonic.
+    let (scans, tofs, intensities) = sort_dedup_scan_tof(scans, tofs, intensities);
+
     let mut tof_copy = tofs.clone();
     modify_tofs(&mut tof_copy, &scans);
     let peak_cnts = get_peak_cnts(max_scans, &scans);
-    let interleaved: Vec<u32> = tofs
+    // Interleave the delta-encoded TOFs (`tof_copy`), not the raw `tofs`.
+    let interleaved: Vec<u32> = tof_copy
         .iter()
         .zip(intensities.iter())
         .flat_map(|(tof, intensity)| vec![*tof, *intensity])

--- a/scripts/parity_tof_writer.py
+++ b/scripts/parity_tof_writer.py
@@ -1,0 +1,87 @@
+"""Step-1 parity check: Python writer vs fixed Rust writer produce identical
+Bruker tdf_bin realdata for the same raw (scan, tof, intensity) frame input.
+
+Python path mirrors imspy_simulation.tdf.TimsTofWriter.compress_frame's
+preprocessing (dedup (scan,tof) summing intensities + lexsort((tof,scan)))
+followed by get_compressible_data. Rust path is the connector
+get_data_for_compression, which now performs the same dedup+sort internally.
+"""
+import numpy as np
+import imspy_connector
+from imspy_simulation.utility import get_compressible_data
+
+ims = imspy_connector.py_dataset
+
+
+def python_writer_bytes(scan, tof, inten, num_scans):
+    # --- replicate compress_frame preprocessing ---
+    scan_tof = np.stack((scan, tof), axis=1)
+    uniq, inv = np.unique(scan_tof, axis=0, return_inverse=True)
+    inv = inv.reshape(-1)
+    summed = np.bincount(inv, weights=inten)
+    us, ut = uniq[:, 0], uniq[:, 1]
+    sidx = np.lexsort((ut, us))
+    ps = us[sidx].astype(np.uint32)
+    pt = ut[sidx].astype(np.uint32)
+    pi = summed[sidx].astype(np.uint32)
+    return np.asarray(get_compressible_data(pt, ps, pi, num_scans), dtype=np.uint8)
+
+
+def rust_writer_bytes(scan, tof, inten, num_scans):
+    out = ims.get_data_for_compression(
+        tof.astype(np.uint32).tolist(),
+        scan.astype(np.uint32).tolist(),
+        inten.astype(np.uint32).tolist(),
+        int(num_scans),
+    )
+    return np.frombuffer(bytes(out), dtype=np.uint8)
+
+
+def make_case(rng, n, num_scans, max_tof):
+    scan = rng.integers(0, num_scans, n).astype(np.uint32)
+    tof = rng.integers(1, max_tof, n).astype(np.uint32)
+    inten = rng.integers(1, 1000, n).astype(np.uint32)
+    return scan, tof, inten
+
+
+def main():
+    num_scans = 174
+    cases = []
+    rng = np.random.default_rng(0)
+    # random, duplicate-heavy, unsorted
+    cases.append(("random-1k", make_case(rng, 1000, num_scans, 400_000)))
+    cases.append(("random-50k", make_case(rng, 50_000, num_scans, 400_000)))
+    # force many duplicate (scan,tof) collisions via tiny tof range
+    cases.append(("dup-heavy", make_case(rng, 20_000, num_scans, 500)))
+    # single scan
+    s = np.zeros(500, np.uint32)
+    t = rng.integers(1, 400_000, 500).astype(np.uint32)
+    i = rng.integers(1, 1000, 500).astype(np.uint32)
+    cases.append(("single-scan", (s, t, i)))
+    # already sorted+unique
+    t2 = np.sort(rng.choice(np.arange(1, 400_000), 800, replace=False)).astype(np.uint32)
+    s2 = np.sort(rng.integers(0, num_scans, 800)).astype(np.uint32)
+    i2 = rng.integers(1, 1000, 800).astype(np.uint32)
+    cases.append(("pre-sorted", (s2, t2, i2)))
+
+    all_ok = True
+    for name, (scan, tof, inten) in cases:
+        py = python_writer_bytes(scan, tof, inten, num_scans)
+        ru = rust_writer_bytes(scan, tof, inten, num_scans)
+        ok = py.shape == ru.shape and np.array_equal(py, ru)
+        all_ok &= ok
+        status = "OK " if ok else "FAIL"
+        extra = ""
+        if not ok:
+            extra = f"  py_len={py.size} ru_len={ru.size}"
+            if py.size == ru.size:
+                diff = np.flatnonzero(py != ru)
+                extra += f" first_diff@{diff[0]} py={py[diff[0]]} ru={ru[diff[0]]} ({diff.size} bytes differ)"
+        print(f"[{status}] {name:12s} n={scan.size:6d} bytes={ru.size}{extra}")
+
+    print("\nPARITY:", "ALL MATCH ✅" if all_ok else "MISMATCH ❌")
+    raise SystemExit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The Rust tdf_bin write path fed **raw, unsorted** frame data straight into the Bruker encoder. The format delta-encodes TOF *within each scan* (`modify_tofs`) and `get_peak_cnts` assumes **ascending scans**, so duplicate/unsorted `(scan, tof)` pairs produced negative/garbage TOF deltas — and vendor readers (DiaNN) reject the resulting `.d`. The Python writer avoids this via `np.unique` dedup + `np.lexsort((tof, scan))` before encoding; the Rust path skipped that step.

This was surfaced while exercising the Rust-native writer (vs the working Python writer) as part of opening TimSim to other vendor platforms.

## Changes

- **`rustdf/src/data/utility.rs`**
  - add `sort_dedup_scan_tof()` and call it at the top of `reconstruct_compressed_data` (used by connector `compress_frame`/`compress_collection`) and `get_data_for_compression` (used by `get_data_for_compression_par`)
  - fix `get_data_for_compression`, which interleaved the **raw** `tofs` instead of the delta-encoded `tof_copy` (discarding the delta encoding)
- **`packages/imspy-simulation/.../tdf.py`**
  - add `use_rust_compression` flag + `TIMSIM_RUST_COMPRESSION` env toggle to route per-frame encoding through the Rust encoder (Python still does dedup/sort + metadata, so frame meta stays correct)
- **`scripts/parity_tof_writer.py`**
  - regression guard proving byte-for-byte parity between the Python and Rust encoders

## Validation

- **Encoder parity** — Rust output byte-identical to the (known-good) Python writer across unsorted / duplicate-heavy / single-scan / pre-sorted inputs (5/5)
- **Re-read** — a `.d` simulated with the Rust writer re-reads cleanly in imspy (175k peaks, sane m/z)
- **Vendor read** — DiaNN 2.5.0 parsed the same `.d` end-to-end (356 MS1 + 12,808 MS2 scans, cycles inferred, clean calibration), which a pre-fix file fails

Note: the connector wheel must be rebuilt (`maturin build --release`) for the `rustdf` change to take effect at runtime.