### PR TITLE
feat(rustdf): vendor-neutral AcquisitionWriter + Thermo .raw writer

### DIFF
--- a/ACQUISITION_SCHEME_IMPL.codex-review.md
+++ b/ACQUISITION_SCHEME_IMPL.codex-review.md
@@ -1,3 +1,23 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019ea811-037b-7470-9546-c0956400e2ce
+--------
+user
+Review this Rust module: a vendor-neutral DIA acquisition SCHEME for a mass-spec simulator (TimSim). It is the INPUT/design side (what acquisition to simulate); a separate AcquisitionWriter is the output side. The model was already design-reviewed (converged on: ordered cycle of events, DiaMs2Frame as the explicit physical unit holding Vec<DiaWindow>, DiaGeometry to split mobility off the m/z-only IsolationWindow, CollisionEnergyPolicy enum incl. Unknown, Ms1Event first-class, version+Provenance+validate). This review is of the IMPLEMENTATION.
+
+Context to trust: thermorawfile::scan_event(scan) returns {ms_order(1=MS1,2=MS2), analyzer(4=FTMS,7=ASTMS,0=ITMS), isolation_center, isolation_width, collision_energy} and works per-scan (uniform stride); RawFile exposes pub first_scan/last_scan/data_addr/bytes/index, and ScanIndexEntry has pub time/offset; packet profile_size is u32 at packet+4. from_thermo_raw is verified to extract 1 MS1 + 15 MS2 windows from a real Astral file.
+
+Focus: 1) from_thermo_raw correctness — the first-cycle boundary detection (first MS1 .. next MS1), RT/cycle_time computation, mz_range derivation from window edges, analyzer/data_mode mapping, and edge cases (no MS2 before first MS1, only one cycle in the file so cycle_time stays 0, MS2 before any MS1, scan_event returning None mid-cycle, instrument detection via any_astms). 2) validate() completeness and correctness vs the model's invariants — anything it should reject but doesn't (e.g. overlapping/duplicate windows, MS1-only cycle, non-finite mz centers vs range membership, Linear CE finiteness, num_cycles with start>gradient). 3) the windows() iterator and num_cycles() arithmetic (truncation, negatives). 4) API/model soundness for the two consumers (extraction vs injection) and for the deferred Bruker/SCIEX extractors. 5) any correctness/robustness bug. Concrete, ranked by severity, cap ~750 words.
+
+<stdin>
 //! Vendor-neutral DIA acquisition **scheme** (input/design side).
 //!
 //! An [`AcquisitionScheme`] describes one DIA cycle as an *ordered sequence of
@@ -12,7 +32,6 @@
 //! Astral/SCIEX MS2 scan (one window) are both represented without overloading a
 //! `window_group` id to imply simultaneity.
 
-#[cfg(feature = "thermo")]
 use std::io;
 
 /// Current scheme schema version.
@@ -108,10 +127,7 @@ pub struct DiaWindow {
 pub struct Ms1Event {
     pub analyzer: Analyzer,
     pub data_mode: DataMode,
-    /// The MS1 acquisition m/z range, if known. `None` when not recoverable
-    /// (e.g. Thermo `scan_event` does not carry it — it must not be confused
-    /// with the DIA window coverage in [`AcquisitionScheme::mz_range`]).
-    pub mz_range: Option<(f64, f64)>,
+    pub mz_range: (f64, f64),
     pub duration_s: Option<f64>,
 }
 
@@ -199,11 +215,7 @@ impl AcquisitionScheme {
                 cycle_time_s,
                 gradient_length_s,
                 start_time_s,
-            } if cycle_time_s.is_finite()
-                && cycle_time_s > 0.0
-                && gradient_length_s.is_finite()
-                && start_time_s.is_finite() =>
-            {
+            } if cycle_time_s > 0.0 => {
                 Some(((gradient_length_s - start_time_s).max(0.0) / cycle_time_s) as u64)
             }
             _ => None,
@@ -253,146 +265,51 @@ impl AcquisitionScheme {
         if self.cycle.is_empty() {
             return Err("empty cycle".into());
         }
+        if self.ms1_count() == 0 {
+            return Err("cycle has no MS1 event".into());
+        }
         let (lo, hi) = self.mz_range;
         if !(lo.is_finite() && hi.is_finite()) || lo >= hi {
             return Err(format!("invalid mz_range ({lo}, {hi})"));
         }
-        // Structure: exactly one MS1, as the first event, then >= 1 MS2 frame.
-        if !matches!(self.cycle.first(), Some(AcquisitionEvent::Ms1(_))) {
-            return Err("cycle must begin with an MS1 event".into());
-        }
-        if self.ms1_count() != 1 {
-            return Err(format!(
-                "cycle must contain exactly one MS1 event (has {})",
-                self.ms1_count()
-            ));
-        }
-        if !self
-            .cycle
-            .iter()
-            .any(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
-        {
-            return Err("cycle has no MS2 frames".into());
-        }
-
-        let check_dur = |d: Option<f64>, what: &str| -> Result<(), String> {
-            match d {
-                Some(v) if !(v.is_finite() && v > 0.0) => {
-                    Err(format!("{what} duration must be finite and > 0"))
-                }
-                _ => Ok(()),
-            }
-        };
-
         for ev in &self.cycle {
-            match ev {
-                AcquisitionEvent::Ms1(m) => {
-                    check_dur(m.duration_s, "MS1")?;
-                    if let Some((a, b)) = m.mz_range {
-                        if !(a.is_finite() && b.is_finite()) || a >= b {
-                            return Err(format!("invalid MS1 mz_range ({a}, {b})"));
-                        }
-                    }
+            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+                if frame.windows.is_empty() {
+                    return Err("MS2 frame has no windows".into());
                 }
-                AcquisitionEvent::DiaMs2Frame(frame) => {
-                    check_dur(frame.duration_s, "MS2 frame")?;
-                    if frame.windows.is_empty() {
-                        return Err("MS2 frame has no windows".into());
+                if frame.windows.len() > 1 && self.instrument != InstrumentKind::TimsTofDia {
+                    return Err(
+                        "multi-window MS2 frame is only valid for timsTOF (mobility-partitioned)"
+                            .into(),
+                    );
+                }
+                for w in &frame.windows {
+                    if !(w.isolation.width_mz.is_finite() && w.isolation.width_mz > 0.0) {
+                        return Err("window width must be finite and > 0".into());
                     }
-                    let multi = frame.windows.len() > 1;
-                    if multi && self.instrument != InstrumentKind::TimsTofDia {
-                        return Err(
-                            "multi-window MS2 frame is only valid for timsTOF (mobility-partitioned)"
-                                .into(),
-                        );
+                    if !w.isolation.center_mz.is_finite() {
+                        return Err("window center m/z is not finite".into());
                     }
-                    for (i, w) in frame.windows.iter().enumerate() {
-                        if !(w.isolation.width_mz.is_finite() && w.isolation.width_mz > 0.0) {
-                            return Err("window width must be finite and > 0".into());
+                    if let CollisionEnergyPolicy::Value(v) = w.collision_energy {
+                        if !v.is_finite() {
+                            return Err("non-finite collision energy".into());
                         }
-                        if !w.isolation.center_mz.is_finite()
-                            || !w.isolation.lower().is_finite()
-                            || !w.isolation.upper().is_finite()
-                        {
-                            return Err("window m/z is not finite".into());
-                        }
-                        if w.isolation.lower() < lo - 1e-6 || w.isolation.upper() > hi + 1e-6 {
-                            return Err(format!(
-                                "window [{:.4}, {:.4}] outside mz_range [{lo:.4}, {hi:.4}]",
-                                w.isolation.lower(),
-                                w.isolation.upper()
-                            ));
-                        }
-                        match w.collision_energy {
-                            CollisionEnergyPolicy::Value(v) => {
-                                if !v.is_finite() || v < 0.0 {
-                                    return Err("collision energy must be finite and >= 0".into());
-                                }
-                            }
-                            CollisionEnergyPolicy::Linear {
-                                intercept,
-                                slope_per_mz,
-                            } => {
-                                if !intercept.is_finite() || !slope_per_mz.is_finite() {
-                                    return Err("non-finite linear CE coefficients".into());
-                                }
-                                match w.collision_energy.at(w.isolation.center_mz) {
-                                    Some(ce) if ce.is_finite() && ce >= 0.0 => {}
-                                    _ => {
-                                        return Err(
-                                            "linear CE resolves to non-finite or negative".into()
-                                        )
-                                    }
-                                }
-                            }
-                            CollisionEnergyPolicy::Unknown => {}
-                        }
-                        match w.geometry {
-                            DiaGeometry::TimsMobility {
-                                scan_start,
-                                scan_end,
-                            } => {
-                                if self.instrument != InstrumentKind::TimsTofDia {
-                                    return Err("mobility geometry is only valid for timsTOF".into());
-                                }
-                                if scan_start > scan_end {
-                                    return Err("mobility scan_start > scan_end".into());
-                                }
-                            }
-                            DiaGeometry::MzOnly => {
-                                if multi {
-                                    return Err(
-                                        "multi-window timsTOF frame requires mobility geometry on every window"
-                                            .into(),
-                                    );
-                                }
-                            }
-                        }
-                        // Within one frame, windows must not overlap in BOTH m/z
-                        // and mobility (overlap across sequential frames is fine).
-                        for w2 in &frame.windows[..i] {
-                            let mz_overlap = w.isolation.lower() < w2.isolation.upper()
-                                && w2.isolation.lower() < w.isolation.upper();
-                            let im_overlap = match (w.geometry, w2.geometry) {
-                                (
-                                    DiaGeometry::TimsMobility {
-                                        scan_start: a0,
-                                        scan_end: a1,
-                                    },
-                                    DiaGeometry::TimsMobility {
-                                        scan_start: b0,
-                                        scan_end: b1,
-                                    },
-                                ) => a0 <= b1 && b0 <= a1,
-                                _ => true, // m/z-only windows share all mobility
-                            };
-                            if mz_overlap && im_overlap {
+                    }
+                    match w.geometry {
+                        DiaGeometry::TimsMobility {
+                            scan_start,
+                            scan_end,
+                        } => {
+                            if self.instrument != InstrumentKind::TimsTofDia {
                                 return Err(
-                                    "windows within one frame overlap in both m/z and mobility"
-                                        .into(),
+                                    "mobility geometry is only valid for timsTOF".into()
                                 );
                             }
+                            if scan_start > scan_end {
+                                return Err("mobility scan_start > scan_end".into());
+                            }
                         }
+                        DiaGeometry::MzOnly => {}
                     }
                 }
             }
@@ -411,9 +328,6 @@ impl AcquisitionScheme {
                 }
                 if !start_time_s.is_finite() || start_time_s < 0.0 {
                     return Err("start_time_s must be finite and >= 0".into());
-                }
-                if start_time_s > gradient_length_s {
-                    return Err("start_time_s must be <= gradient_length_s".into());
                 }
             }
         }
@@ -455,32 +369,24 @@ impl AcquisitionScheme {
 
         let mut cycle: Vec<AcquisitionEvent> = Vec::new();
         let mut seen_ms1 = false;
-        let mut closed = false;
         let mut start_rt = 0.0f64;
         let mut cycle_time_s = 0.0f64;
         let mut win_lo = f64::INFINITY;
         let mut win_hi = f64::NEG_INFINITY;
+        let mut any_astms = false;
 
         for scan in raw.first_scan..=raw.last_scan {
             let ev = match raw.scan_event(scan) {
                 Some(e) => e,
-                None => {
-                    // A missing event *inside* the selected cycle would silently
-                    // drop a window — reject it. Before the first MS1 it's ignorable.
-                    if seen_ms1 {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            format!("missing scan event for scan {scan} inside the first cycle"),
-                        ));
-                    }
-                    continue;
-                }
+                None => continue,
             };
+            if ev.analyzer == 7 {
+                any_astms = true;
+            }
             if ev.ms_order <= 1 {
                 if seen_ms1 {
                     // start of the next cycle -> close this one
                     cycle_time_s = (rt_of(scan) - start_rt).max(0.0);
-                    closed = true;
                     break;
                 }
                 seen_ms1 = true;
@@ -488,7 +394,7 @@ impl AcquisitionScheme {
                 cycle.push(AcquisitionEvent::Ms1(Ms1Event {
                     analyzer: analyzer_of(ev.analyzer),
                     data_mode: data_mode_of(scan),
-                    mz_range: None, // scan_event does not carry the MS1 range
+                    mz_range: (0.0, 0.0), // filled below
                     duration_s: None,
                 }));
             } else if seen_ms1 {
@@ -511,36 +417,27 @@ impl AcquisitionScheme {
             }
         }
 
-        if !seen_ms1 {
+        if cycle.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "template has no MS1 scan",
-            ));
-        }
-        if !closed {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "template has only one cycle (no second MS1 to bound it); cannot determine cycle time",
+                "no scan events found in template",
             ));
         }
         let mz_range = if win_lo.is_finite() && win_hi > win_lo {
             (win_lo, win_hi)
         } else {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "first cycle has no usable MS2 isolation windows",
-            ));
+            (0.0, 0.0)
         };
+        for ev in &mut cycle {
+            if let AcquisitionEvent::Ms1(m) = ev {
+                m.mz_range = mz_range;
+            }
+        }
         let gradient_length_s = raw.index.last().map(|e| e.time).unwrap_or(0.0);
         let n_ms2 = cycle
             .iter()
             .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
             .count();
-        // Instrument from the analyzers of events actually in the cycle (an ASTMS
-        // MS2 frame ⇒ Orbitrap Astral), not from incidental scans elsewhere.
-        let any_astms = cycle.iter().any(|e| {
-            matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.analyzer == Analyzer::Astms)
-        });
 
         Ok(AcquisitionScheme {
             version: SCHEME_VERSION,
@@ -588,7 +485,7 @@ mod tests {
             Ms1Event {
                 analyzer: Analyzer::Ftms,
                 data_mode: DataMode::Profile,
-                mz_range: Some((390.0, 900.0)),
+                mz_range: (390.0, 900.0),
                 duration_s: None,
             },
             linear_windows(5),
@@ -620,7 +517,7 @@ mod tests {
                 AcquisitionEvent::Ms1(Ms1Event {
                     analyzer: Analyzer::Ftms,
                     data_mode: DataMode::Profile,
-                    mz_range: Some((390.0, 900.0)),
+                    mz_range: (390.0, 900.0),
                     duration_s: None,
                 }),
                 AcquisitionEvent::DiaMs2Frame(frame),
@@ -637,73 +534,6 @@ mod tests {
             },
         };
         assert!(s.validate().is_err());
-    }
-
-    #[test]
-    fn validate_rejects_bad_schemes() {
-        let repeat = RepeatPolicy::FixedCycleTime {
-            cycle_time_s: 1.0,
-            gradient_length_s: 600.0,
-            start_time_s: 0.0,
-        };
-        let ms1 = || Ms1Event {
-            analyzer: Analyzer::Ftms,
-            data_mode: DataMode::Profile,
-            mz_range: Some((390.0, 900.0)),
-            duration_s: None,
-        };
-        let win = || DiaWindow {
-            isolation: IsolationWindow {
-                center_mz: 500.0,
-                width_mz: 10.0,
-            },
-            collision_energy: CollisionEnergyPolicy::Value(25.0),
-            geometry: DiaGeometry::MzOnly,
-        };
-        let frame = |w: DiaWindow| {
-            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
-                windows: vec![w],
-                analyzer: Analyzer::Astms,
-                data_mode: DataMode::Centroid,
-                duration_s: None,
-            })
-        };
-        let mk = |cycle: Vec<AcquisitionEvent>| AcquisitionScheme {
-            version: SCHEME_VERSION,
-            instrument: InstrumentKind::OrbitrapAstral,
-            cycle,
-            repeat,
-            mz_range: (390.0, 900.0),
-            provenance: Provenance {
-                source: SchemeSource::Programmatic,
-                notes: String::new(),
-            },
-        };
-
-        // valid baseline
-        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_ok());
-        // MS2 first (no leading MS1)
-        assert!(mk(vec![frame(win()), AcquisitionEvent::Ms1(ms1())]).validate().is_err());
-        // two MS1 in a cycle
-        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_err());
-        // MS1 with no MS2 frame
-        assert!(mk(vec![AcquisitionEvent::Ms1(ms1())]).validate().is_err());
-        // window outside mz_range
-        let mut oob = win();
-        oob.isolation.center_mz = 2000.0;
-        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(oob)]).validate().is_err());
-        // negative collision energy
-        let mut neg = win();
-        neg.collision_energy = CollisionEnergyPolicy::Value(-5.0);
-        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(neg)]).validate().is_err());
-        // bad event duration
-        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
-            windows: vec![win()],
-            analyzer: Analyzer::Astms,
-            data_mode: DataMode::Centroid,
-            duration_s: Some(-1.0),
-        });
-        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), bad_dur]).validate().is_err());
     }
 
     #[cfg(feature = "thermo")]
@@ -738,3 +568,95 @@ mod tests {
         );
     }
 }
+</stdin>
+codex
+**Findings**
+
+1. **High: single-cycle files produce an unusable scheme.**  
+   `from_thermo_raw()` returns `cycle_time_s = 0.0` when no second MS1 exists, while `validate()` rejects it. Extraction should return `InvalidData`, or derive cycle time using a documented method. Returning an object guaranteed to fail validation is misleading.
+
+2. **High: missing scan metadata silently corrupts the extracted cycle.**  
+   `scan_event(scan) == None` is always skipped. Once the opening MS1 has been found, a missing event can silently remove an MS2 window while still yielding a valid-looking scheme. Missing events inside the selected cycle should be an extraction error. Skipping them before the first MS1 is reasonable.
+
+3. **High: `validate()` permits MS1-only and incorrectly ordered cycles.**  
+   It only requires at least one MS1. It accepts:
+   - an MS1-only cycle,
+   - cycles beginning with MS2,
+   - multiple MS1 events inside one cycle.
+
+   Given the cycle definition, validation should require exactly one MS1, as the first event, followed by at least one MS2 frame. The extractor currently returns an MS1-only object when two MS1 scans are consecutive; its `(0, 0)` range merely causes an indirect validation failure.
+
+4. **High: event durations are completely unchecked.**  
+   `Some(NaN)`, negative, zero, or infinite durations pass validation. Because durations control RT placement, require finite positive values. If the consumer schedules events consecutively, also reject a total known duration exceeding `cycle_time_s`.
+
+5. **Medium: isolation edges and range membership are not validated.**  
+   A finite center and width can still overflow to infinite `lower()`/`upper()`. Windows can also lie partially or entirely outside `AcquisitionScheme::mz_range`. Validate finite edges and containment. MS1 `mz_range` values likewise receive no validation.
+
+6. **Medium: Thermo extraction conflates DIA coverage with the MS1 scan range.**  
+   The extractor assigns window-edge coverage to `Ms1Event::mz_range`, despite the supplied `scan_event` data not containing the MS1 acquisition range. Those concepts need not match. This should either be extracted from other Thermo metadata or represented as unknown/optional rather than invented.
+
+7. **Medium: `CollisionEnergyPolicy::Linear` is unchecked.**  
+   Both coefficients may be non-finite, and evaluation can overflow at a window center. Validate coefficients and resolved CE for each applicable window. `Value` should probably also reject negative CE if the model treats CE as physical energy.
+
+8. **Medium: `any_astms` can misclassify the instrument.**  
+   It is updated before checking the cycle boundary and for scans preceding the first MS1. Thus an unrelated ASTMS scan, including the next cycle’s boundary MS1, can classify the extracted scheme as Astral. Determine instrument from analyzers of events actually inserted into the cycle, preferably its MS2 frames.
+
+9. **Medium: multi-window tims frames are under-constrained.**  
+   Validation allows a timsTOF frame containing multiple `MzOnly` windows, despite the stated model that simultaneous windows are mobility-partitioned. Require `TimsMobility` for multi-window frames. Within one frame, reject duplicate or physically intersecting windows where both m/z and mobility intervals overlap. Do not reject overlap globally across sequential frames: overlapping DIA schemes can be intentional.
+
+10. **Medium: repeat validation omits `start_time_s <= gradient_length_s`.**  
+    Such a scheme currently validates and `num_cycles()` silently returns zero. This is better treated as contradictory input.
+
+11. **Low: `num_cycles()` is unsafe on unvalidated values.**  
+    It checks only `cycle_time_s > 0`; infinity and non-finite gradient/start values can reach float-to-integer casts and produce saturated or surprising results. Check all operands for finiteness. Flooring/truncation is otherwise correct for “full cycles,” and clamping negative spans is unnecessary once validation rejects them.
+
+12. **Low: `windows()` is correct.**  
+    It preserves cycle/frame/window ordering and borrows without allocation, which suits both extraction and injection consumers.
+
+Tests should directly cover missing mid-cycle metadata, consecutive MS1 scans, a one-cycle file, ASTMS scans outside the selected cycle, invalid durations/linear CE, out-of-range edges, cycle ordering, and non-finite `num_cycles()` inputs.
+tokens used
+9,071
+**Findings**
+
+1. **High: single-cycle files produce an unusable scheme.**  
+   `from_thermo_raw()` returns `cycle_time_s = 0.0` when no second MS1 exists, while `validate()` rejects it. Extraction should return `InvalidData`, or derive cycle time using a documented method. Returning an object guaranteed to fail validation is misleading.
+
+2. **High: missing scan metadata silently corrupts the extracted cycle.**  
+   `scan_event(scan) == None` is always skipped. Once the opening MS1 has been found, a missing event can silently remove an MS2 window while still yielding a valid-looking scheme. Missing events inside the selected cycle should be an extraction error. Skipping them before the first MS1 is reasonable.
+
+3. **High: `validate()` permits MS1-only and incorrectly ordered cycles.**  
+   It only requires at least one MS1. It accepts:
+   - an MS1-only cycle,
+   - cycles beginning with MS2,
+   - multiple MS1 events inside one cycle.
+
+   Given the cycle definition, validation should require exactly one MS1, as the first event, followed by at least one MS2 frame. The extractor currently returns an MS1-only object when two MS1 scans are consecutive; its `(0, 0)` range merely causes an indirect validation failure.
+
+4. **High: event durations are completely unchecked.**  
+   `Some(NaN)`, negative, zero, or infinite durations pass validation. Because durations control RT placement, require finite positive values. If the consumer schedules events consecutively, also reject a total known duration exceeding `cycle_time_s`.
+
+5. **Medium: isolation edges and range membership are not validated.**  
+   A finite center and width can still overflow to infinite `lower()`/`upper()`. Windows can also lie partially or entirely outside `AcquisitionScheme::mz_range`. Validate finite edges and containment. MS1 `mz_range` values likewise receive no validation.
+
+6. **Medium: Thermo extraction conflates DIA coverage with the MS1 scan range.**  
+   The extractor assigns window-edge coverage to `Ms1Event::mz_range`, despite the supplied `scan_event` data not containing the MS1 acquisition range. Those concepts need not match. This should either be extracted from other Thermo metadata or represented as unknown/optional rather than invented.
+
+7. **Medium: `CollisionEnergyPolicy::Linear` is unchecked.**  
+   Both coefficients may be non-finite, and evaluation can overflow at a window center. Validate coefficients and resolved CE for each applicable window. `Value` should probably also reject negative CE if the model treats CE as physical energy.
+
+8. **Medium: `any_astms` can misclassify the instrument.**  
+   It is updated before checking the cycle boundary and for scans preceding the first MS1. Thus an unrelated ASTMS scan, including the next cycle’s boundary MS1, can classify the extracted scheme as Astral. Determine instrument from analyzers of events actually inserted into the cycle, preferably its MS2 frames.
+
+9. **Medium: multi-window tims frames are under-constrained.**  
+   Validation allows a timsTOF frame containing multiple `MzOnly` windows, despite the stated model that simultaneous windows are mobility-partitioned. Require `TimsMobility` for multi-window frames. Within one frame, reject duplicate or physically intersecting windows where both m/z and mobility intervals overlap. Do not reject overlap globally across sequential frames: overlapping DIA schemes can be intentional.
+
+10. **Medium: repeat validation omits `start_time_s <= gradient_length_s`.**  
+    Such a scheme currently validates and `num_cycles()` silently returns zero. This is better treated as contradictory input.
+
+11. **Low: `num_cycles()` is unsafe on unvalidated values.**  
+    It checks only `cycle_time_s > 0`; infinity and non-finite gradient/start values can reach float-to-integer casts and produce saturated or surprising results. Check all operands for finiteness. Flooring/truncation is otherwise correct for “full cycles,” and clamping negative spans is unnecessary once validation rejects them.
+
+12. **Low: `windows()` is correct.**  
+    It preserves cycle/frame/window ordering and borrows without allocation, which suits both extraction and injection consumers.
+
+Tests should directly cover missing mid-cycle metadata, consecutive MS1 scans, a one-cycle file, ASTMS scans outside the selected cycle, invalid durations/linear CE, out-of-range edges, cycle ordering, and non-finite `num_cycles()` inputs.

--- a/ACQUISITION_SCHEME_PLAN.codex-review-v2.md
+++ b/ACQUISITION_SCHEME_PLAN.codex-review-v2.md
@@ -1,0 +1,379 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019ea7ef-4649-7ed0-bd1c-e13f500a0128
+--------
+user
+This is v2 of a vendor-neutral AcquisitionScheme design for a DIA mass-spec simulator (TimSim: Bruker timsTOF today, extending to Thermo Orbitrap Astral + SCIEX ZenoTOF). You reviewed v1; v2 applied your feedback: ordered cycle of events (Ms1Event/DiaMs2Event) instead of flat windows; DiaGeometry splits mobility out of the m/z IsolationWindow; CollisionEnergyPolicy enum (incl. Unknown) instead of scalar CE; MS1 promoted to a first-class event; scheme version + Provenance; an explicit to_bruker_tables() adapter + golden tests; and two usage modes (reference-derived layout+noise, and injected/user schemes). Context to trust: the Thermo/SCIEX Rust readers exist and are oracle-verified; thermorawfile::scan_event works per-scan on Astral (uniform 280-byte stride) so from_thermo_raw is NOT blocked; the ThermoRawWriter now authors MS2 isolation/CE via set_isolation (review item #6, fixed).
+
+Review focused: 1) does v2's cycle-of-events model now correctly capture the timsTOF frame↔(mobility window group) relationship AND the linear Astral/SCIEX sequence — any remaining representational gap? 2) is the RepeatPolicy/RT-modeling sufficient or under-specified? 3) the overlay (real⊕sim) writer mode is called the biggest remaining piece — is the design pointing at the right primitive, and what are the concrete hazards (recomputing stats, packet budget, profile vs centroid)? 4) the Bruker to_bruker_tables() + golden-test migration — anything that will still break backward compat? 5) any NEW problems v2 introduced, or v1 issues not fully resolved. Be concrete and specific; cap ~700 words.
+
+<stdin>
+# AcquisitionScheme — vendor-neutral DIA acquisition design for TimSim (v2)
+
+**Status:** design draft v2 (revised after Codex review of v1)
+**Scope:** the *input/design* side of multi-instrument TimSim — the acquisition
+schedule the simulator generates against — complementary to the already-built
+`AcquisitionWriter` (output side, `rustdf/src/sim/acquisition.rs`).
+
+> **Changes vs v1** (from review): model an explicit *ordered cycle of events*
+> instead of a flat window list; split ion-mobility geometry out of the generic
+> isolation window; make collision energy a *policy*, not a scalar; promote MS1
+> to a first-class event; add scheme versioning + provenance + validation; spell
+> out a Bruker backward-compat *adapter* with golden tests (not a parity claim);
+> and resolve several open questions (below). Also corrects v1's assumption that
+> Thermo MS2 scan events are hard to locate — they are not (see §2).
+
+---
+
+## 1. Problem & the two usage modes
+
+TimSim must generate scans for the **target instrument's acquisition schedule**
+— isolation windows, cycle structure, collision-energy plan, and (timsTOF only)
+ion-mobility partitioning. These differ per vendor (timsTOF DIA-PASEF: 2-D m/z×
+mobility; Orbitrap Astral: 1-D narrow m/z, no mobility; SCIEX ZenoTOF: 1-D
+variable SWATH, no mobility, Zeno).
+
+Two first-class usage modes (both must be supported):
+
+- **Reference-derived (timsim-style):** a real reference run supplies *both* the
+  acquisition layout *and* the real background for noise. The reference is used
+  twice — extract the scheme from it, and overlay simulated peaks onto its real
+  signal (real⊕sim). This is the established TimSim pattern
+  (`use_reference_ds_layout` + `add_real_data_noise`), generalized across vendors.
+- **Injected (user-authored):** a programmatic or CSV scheme with no reference
+  dependence — synthesize a custom window plan from scratch.
+
+## 2. Current state
+
+`TimsTofAcquisitionBuilderDIA` (`packages/imspy-simulation/.../acquisition.py`)
+is timsTOF-coupled: it holds a pandas `dia_ms_ms_windows` table
+(`window_group, scan_start, scan_end, isolation_mz, isolation_width,
+collision_energy`; `scan_start/end` are **mobility scan ranges**), sourced from a
+CSV or by copying a real Bruker reference `.d`'s `DiaFrameMsMsWindows`. It also
+derives `precursor_every`, builds `frame`/`scan` tables, and persists
+`dia_ms_ms_windows` + `dia_ms_ms_info` (frame→group) → the output `.d`.
+
+**Reader inventory (built + oracle-verified this session):**
+- **Bruker** — `reference_ds.dia_ms_ms_windows` (Python, today).
+- **Thermo** — `thermorawfile::scan_event(scan)` → `ScanEvent { ms_order,
+  analyzer, isolation_center, isolation_width, collision_energy }`. **Verified to
+  work per-scan on a real Astral file (uniform 280-byte event stride);** scan 2
+  reads center 490.473 / width 20.009 / CE 25.0, matching the RawFileReader
+  oracle. So walking one MS2 cycle recovers the exact Astral window schedule —
+  **not blocked** (corrects v1 open-Q6).
+- **SCIEX** — `sciexwiff` → `SWATHMethod` ~60 variable windows + TOF calibration.
+
+**Known existing bug to fix during migration:** in
+`TimsTofAcquisitionBuilderDIA`, `num_frames` is computed in the base `__init__`
+from the passed `gradient_length/rt_cycle_length` *before* `use_reference_ds_layout`
+overwrites `rt_cycle_length`, so the frame count can be stale.
+
+## 3. Model — an ordered cycle of events
+
+Lives in Rust (`rustdf/src/sim/scheme.rs`), exposed via `imspy_connector`.
+
+```rust
+pub struct AcquisitionScheme {
+    pub version: u16,                 // schema version for forward-compat
+    pub instrument: InstrumentKind,   // TimsTofDia | OrbitrapAstral | SciexZenoTof
+    pub cycle: Vec<AcquisitionEvent>, // one DIA cycle, in acquisition order
+    pub repeat: RepeatPolicy,         // how the cycle tiles the gradient
+    pub mz_range: (f64, f64),
+    pub provenance: Provenance,       // where each field came from
+}
+
+pub enum AcquisitionEvent {
+    Ms1(Ms1Event),
+    DiaMs2(DiaMs2Event),
+}
+
+pub struct Ms1Event {
+    pub analyzer: Analyzer,           // FTMS | ASTMS | TOF | ITMS
+    pub data_mode: DataMode,          // Profile | Centroid
+    pub mz_range: (f64, f64),
+    pub duration_s: Option<f64>,      // transient/dwell if known
+}
+
+pub struct DiaMs2Event {
+    pub window_group: u32,            // events sharing a group co-occur (timsTOF frame)
+    pub isolation: IsolationWindow,   // m/z ONLY
+    pub collision_energy: CollisionEnergyPolicy,
+    pub geometry: DiaGeometry,        // mobility partitioning (or none)
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub duration_s: Option<f64>,
+}
+
+pub struct IsolationWindow {          // m/z only; boundary convention is half-open [lo, hi)
+    pub center_mz: f64,
+    pub width_mz: f64,
+}
+
+pub enum DiaGeometry {
+    MzOnly,
+    TimsMobility { scan_start: u32, scan_end: u32 }, // Bruker-grid coords (need ref calibration)
+}
+
+pub enum CollisionEnergyPolicy {
+    Fixed(f64),
+    PerWindow(f64),
+    Linear { intercept: f64, slope_per_mz: f64 }, // CE = intercept + slope*center_mz
+    Unknown,                                       // extraction couldn't recover it
+}
+
+pub enum RepeatPolicy {
+    FixedCycleTime { cycle_time_s: f64, gradient_length_s: f64 },
+    // room for staggered / variable-cycle schemes later
+}
+
+pub struct Provenance {              // per-source attribution + free-form notes
+    pub source: SchemeSource,        // ExtractedBruker | ExtractedThermo | ExtractedSciex | UserCsv | Programmatic
+    pub notes: String,
+}
+```
+
+Why this shape (review points):
+- **Ordered events**, not a flat window list, so a timsTOF MS2 *frame* (several
+  mobility slices sharing a `window_group`) and a linear Astral/SCIEX MS1→MS2…
+  sequence are both representable, plus per-event timing/analyzer.
+- **Geometry split out**: `IsolationWindow` is strictly m/z; mobility lives in
+  `DiaGeometry::TimsMobility`, so "mobility on Astral" is unrepresentable.
+- **CE policy, not scalar**: never silently invent SCIEX rolling CE — extraction
+  yields `Unknown` and the caller must supply a model, unless an explicitly
+  labeled default-sim mode is chosen.
+- **MS1 is first-class** (analyzer/data_mode/mz_range/duration), since it drives
+  cadence and the writer's MS1 representation.
+
+## 4. Extractors (populate from a real run)
+
+```rust
+impl AcquisitionScheme {
+    pub fn from_bruker_d(path: &str) -> io::Result<Self>;      // DiaFrameMsMsWindows (+TimsMobility geometry)
+    #[cfg(feature = "thermo")]
+    pub fn from_thermo_raw(path: &str) -> io::Result<Self>;    // walk one MS2 cycle via scan_event()
+    #[cfg(feature = "sciex")]
+    pub fn from_sciex_wiff(path: &str) -> io::Result<Self>;    // SWATHMethod; CE => Unknown (rolling)
+    pub fn from_window_table(rows, instrument) -> Self;        // injected / CSV
+}
+```
+
+Each sets `provenance.source` accordingly. `from_thermo_raw` reads the first
+MS1→(MS2…)→nextMS1 span, one `DiaMs2Event` per MS2 scan event, CE = `Fixed`/
+`PerWindow` as observed, geometry `MzOnly`.
+
+## 5. Relationship to the writer (output)
+
+- `AcquisitionScheme` (in) and `AcquisitionWriter` (out) are the two halves. A
+  reference round trip: `from_thermo_raw(template)` → generate → `ThermoRawWriter`
+  (same template) → `.raw`.
+- **#6 (fixed):** `ThermoRawWriter` now authors a descriptor's MS2 isolation
+  center/width/CE into the scan event (`set_isolation`), not just the peaks.
+- **Replace vs overlay (open design):** the writer currently *replaces* template
+  signal. The reference-derived noise mode (§1) needs an **overlay** writer mode —
+  keep the real template profile/centroids and *add* simulated peaks — to realize
+  real⊕sim. This is the main remaining writer feature.
+- **Validation:** add `writer.validate_scheme(&scheme)` — for template-mutation
+  writers, reject a scheme whose event count/order/types don't fit the template
+  (e.g. more MS2 windows than the template cycle provides), with a clear error
+  rather than silent truncation.
+
+## 6. Bruker backward-compatibility (explicit adapter + golden tests)
+
+Migration must not change existing `.d` output. The existing code uses
+`window_group` to *assign frames* (not merely label windows), with specific
+column names/integer types, `scan_start/scan_end` inclusivity, CE rounding, and
+`dia_ms_ms_info` frame→group sequencing.
+
+- Add `scheme.to_bruker_tables() -> (dia_ms_ms_windows, dia_ms_ms_info)` that
+  reproduces those exact columns/types/ordering.
+- Keep the current Python `TimsTofAcquisitionBuilderDIA` constructors
+  (CSV + `use_reference_ds_layout`) as a compatibility wrapper over the scheme.
+- **Golden tests:** byte-for-value compare both SQLite tables against the current
+  path on a reference dataset. Fix the `num_frames`/`rt_cycle_length` ordering bug
+  as part of this (or pin it with a regression test).
+
+## 7. Boundary / location
+
+`AcquisitionScheme` + extractors in `rustdf/src/sim`, exposed as
+`PyAcquisitionScheme` via `imspy_connector`. Python `TimsTofAcquisitionBuilderDIA`
+consumes the scheme through the binding. Bruker extraction may *stay Python*
+initially (it works), provided it produces the same versioned scheme DTO and
+passes the golden tables (deferrable per review).
+
+## 8. Open questions (revised)
+
+- **Resolved since v1:** MS1 is scheme-level (now an `Ms1Event`); SCIEX rolling CE
+  → `CollisionEnergyPolicy::Unknown` + required user model; Thermo MS2 scan-event
+  location works (uniform stride) so `from_thermo_raw` is unblocked.
+- **Still open (blockers for full fidelity):**
+  1. **Overlay writer mode** (real⊕sim) — needed for reference-derived noise;
+     biggest remaining piece. (How to add sim peaks to a real profile/centroid
+     packet within budget, recompute stats.)
+  2. **RT / duty-cycle modeling** — is `RepeatPolicy::FixedCycleTime` enough, or do
+     we need per-event durations to model real cycle time / overlap in RT?
+  3. **SCIEX CE source** — confirm whether any per-window CE is recoverable from
+     the `.wiff` method beyond `SWATHMethod` (else require a user model).
+- **Specify-now, implement-later:** overlapping windows need only a documented
+  boundary convention (half-open `[lo, hi)`) + preserved acquisition order; no
+  special isolation algorithm.
+
+## 9. Test plan
+
+- `from_thermo_raw(astral_template)`: N MS2 windows, monotonic centers, CE policy
+  `Fixed(25)`, one `Ms1Event` per cycle, all geometry `MzOnly`.
+- `from_sciex_wiff(zenotof)`: ~60 windows covering 399.5–899.9, CE `Unknown`.
+- `from_bruker_d(ref)` → `to_bruker_tables()` golden-equal to today's Python path.
+- End-to-end: `from_thermo_raw(template)` → generate 1×MS1 + N×MS2 → `ThermoRawWriter`
+  → read back via thermorawfile + Thermo oracle (peaks, isolation, CE).
+- Overlay mode (once built): authored peaks present *and* template background
+  retained.
+</stdin>
+codex
+## Review Findings
+
+**1. The timsTOF grouping is still implicit, not structurally correct.**  
+Repeated `window_group` values on serial `DiaMs2Event`s do not express that several mobility windows belong to one physical frame. Consumers could incorrectly assign each event its own duration, timestamp, or output frame.
+
+Make the physical acquisition unit explicit:
+
+```rust
+AcquisitionEvent::DiaMs2Frame {
+    windows: Vec<DiaWindow>,
+    analyzer: Analyzer,
+    data_mode: DataMode,
+    duration_s: Option<f64>,
+}
+```
+
+For Astral/SCIEX, each frame/scan contains one window. For timsTOF, one event contains multiple mobility windows. `window_group` can remain as a compatibility identifier, but should not define simultaneity indirectly.
+
+**2. `RepeatPolicy::FixedCycleTime` is insufficiently specified.**  
+It does not define:
+
+- Cycle start/phase relative to gradient start.
+- Full-cycle count and treatment of a trailing partial cycle.
+- Whether `cycle_time_s` is authoritative or derived from event durations.
+- Dead time, inter-event gaps, or parallel timsTOF mobility windows.
+- Reference runs with cycle-time drift, skipped scans, calibration frames, or staggered cycles.
+
+At minimum, specify `start_time_s`, trailing-cycle policy, and timing precedence. Prefer an explicit event offset/duration schedule plus a repetition rule. Preserve observed timestamps or cycle durations during reference extraction; otherwise layout-derived simulation loses real RT sampling.
+
+**3. Overlay should operate on decoded spectrum/frame data, not raw packet concatenation.**  
+The correct primitive is approximately:
+
+```rust
+merge(template_signal, simulated_signal, data_mode, merge_policy)
+    -> rewritten_signal_and_statistics
+```
+
+It must run per matched physical scan/frame after scheme-to-template validation.
+
+Concrete hazards:
+
+- **Profile:** simulated peaks must be evaluated onto the native m/z grid or combined before profile encoding. Appending centroids to a profile packet is invalid.
+- **Centroid:** merge nearby peaks using a declared tolerance, sum intensities, sort, and potentially re-centroid. Blind concatenation creates duplicate centroids.
+- **Statistics:** recompute TIC, base-peak intensity/m/z, point count, m/z bounds, intensity bounds, and any vendor summary fields.
+- **Packet budget:** account for compressed size, offsets, alignment, indexes, and checksums. Define overflow behavior explicitly; silent peak truncation is unacceptable.
+- **Template consistency:** retain acquisition metadata but rewrite all size/count pointers atomically.
+- **Semantics:** real analyte signal is retained along with noise. Document that overlay is not a noise-only background model and may duplicate analytes represented by the simulation.
+
+**4. Bruker compatibility needs stronger invariants than table golden tests alone.**  
+Potential breakpoints remain:
+
+- `scan_end` is documented as half-open globally, while the existing Bruker table may use a different convention. The adapter must encode that conversion explicitly.
+- Frame grouping must derive from physical grouped events, not accidental adjacency or numeric equality alone.
+- Define deterministic ordering, SQLite affinities, integer widths, floating-point/CE rounding, and group-ID allocation.
+- `dia_ms_ms_info` depends on total frame count and cycle phase, so `to_bruker_tables()` needs run timing/frame context, not merely the scheme as currently shown.
+- Fixing the stale `num_frames` bug intentionally changes affected historical output. Golden tests should distinguish legacy compatibility from corrected behavior.
+
+Compare ordered rows and declared SQLite types; “byte-for-value” is ambiguous because SQLite physical bytes are not stable.
+
+**5. New and unresolved model issues.**
+
+- `Provenance` is described as per-field attribution but contains only one scheme-level source and notes.
+- `Fixed(f64)` and `PerWindow(f64)` are structurally indistinguishable. Use `Fixed` at scheme/group level or make `PerWindow` the event value.
+- `TimsMobility` requires calibration, but the scheme carries neither a calibration identity nor a requirement binding it to a reference.
+- Extracting only the first Thermo cycle can miss staggered windows or later method segments. Validate repeated cycles and report divergence.
+- Versioning needs defined serialization behavior for unknown versions/enum variants; a `u16` alone does not provide forward compatibility.
+- Validation should cover finite/positive widths, ranges, scan ordering, overlapping mobility intervals, analyzer/instrument compatibility, and consistency between cycle time and event timing.
+
+The main remaining representational correction is therefore explicit physical-event grouping. Once that is fixed, the same model can cleanly represent timsTOF frames and linear Astral/SCIEX scans.
+tokens used
+4,961
+## Review Findings
+
+**1. The timsTOF grouping is still implicit, not structurally correct.**  
+Repeated `window_group` values on serial `DiaMs2Event`s do not express that several mobility windows belong to one physical frame. Consumers could incorrectly assign each event its own duration, timestamp, or output frame.
+
+Make the physical acquisition unit explicit:
+
+```rust
+AcquisitionEvent::DiaMs2Frame {
+    windows: Vec<DiaWindow>,
+    analyzer: Analyzer,
+    data_mode: DataMode,
+    duration_s: Option<f64>,
+}
+```
+
+For Astral/SCIEX, each frame/scan contains one window. For timsTOF, one event contains multiple mobility windows. `window_group` can remain as a compatibility identifier, but should not define simultaneity indirectly.
+
+**2. `RepeatPolicy::FixedCycleTime` is insufficiently specified.**  
+It does not define:
+
+- Cycle start/phase relative to gradient start.
+- Full-cycle count and treatment of a trailing partial cycle.
+- Whether `cycle_time_s` is authoritative or derived from event durations.
+- Dead time, inter-event gaps, or parallel timsTOF mobility windows.
+- Reference runs with cycle-time drift, skipped scans, calibration frames, or staggered cycles.
+
+At minimum, specify `start_time_s`, trailing-cycle policy, and timing precedence. Prefer an explicit event offset/duration schedule plus a repetition rule. Preserve observed timestamps or cycle durations during reference extraction; otherwise layout-derived simulation loses real RT sampling.
+
+**3. Overlay should operate on decoded spectrum/frame data, not raw packet concatenation.**  
+The correct primitive is approximately:
+
+```rust
+merge(template_signal, simulated_signal, data_mode, merge_policy)
+    -> rewritten_signal_and_statistics
+```
+
+It must run per matched physical scan/frame after scheme-to-template validation.
+
+Concrete hazards:
+
+- **Profile:** simulated peaks must be evaluated onto the native m/z grid or combined before profile encoding. Appending centroids to a profile packet is invalid.
+- **Centroid:** merge nearby peaks using a declared tolerance, sum intensities, sort, and potentially re-centroid. Blind concatenation creates duplicate centroids.
+- **Statistics:** recompute TIC, base-peak intensity/m/z, point count, m/z bounds, intensity bounds, and any vendor summary fields.
+- **Packet budget:** account for compressed size, offsets, alignment, indexes, and checksums. Define overflow behavior explicitly; silent peak truncation is unacceptable.
+- **Template consistency:** retain acquisition metadata but rewrite all size/count pointers atomically.
+- **Semantics:** real analyte signal is retained along with noise. Document that overlay is not a noise-only background model and may duplicate analytes represented by the simulation.
+
+**4. Bruker compatibility needs stronger invariants than table golden tests alone.**  
+Potential breakpoints remain:
+
+- `scan_end` is documented as half-open globally, while the existing Bruker table may use a different convention. The adapter must encode that conversion explicitly.
+- Frame grouping must derive from physical grouped events, not accidental adjacency or numeric equality alone.
+- Define deterministic ordering, SQLite affinities, integer widths, floating-point/CE rounding, and group-ID allocation.
+- `dia_ms_ms_info` depends on total frame count and cycle phase, so `to_bruker_tables()` needs run timing/frame context, not merely the scheme as currently shown.
+- Fixing the stale `num_frames` bug intentionally changes affected historical output. Golden tests should distinguish legacy compatibility from corrected behavior.
+
+Compare ordered rows and declared SQLite types; “byte-for-value” is ambiguous because SQLite physical bytes are not stable.
+
+**5. New and unresolved model issues.**
+
+- `Provenance` is described as per-field attribution but contains only one scheme-level source and notes.
+- `Fixed(f64)` and `PerWindow(f64)` are structurally indistinguishable. Use `Fixed` at scheme/group level or make `PerWindow` the event value.
+- `TimsMobility` requires calibration, but the scheme carries neither a calibration identity nor a requirement binding it to a reference.
+- Extracting only the first Thermo cycle can miss staggered windows or later method segments. Validate repeated cycles and report divergence.
+- Versioning needs defined serialization behavior for unknown versions/enum variants; a `u16` alone does not provide forward compatibility.
+- Validation should cover finite/positive widths, ranges, scan ordering, overlapping mobility intervals, analyzer/instrument compatibility, and consistency between cycle time and event timing.
+
+The main remaining representational correction is therefore explicit physical-event grouping. Once that is fixed, the same model can cleanly represent timsTOF frames and linear Astral/SCIEX scans.

--- a/ACQUISITION_SCHEME_PLAN.codex-review.md
+++ b/ACQUISITION_SCHEME_PLAN.codex-review.md
@@ -1,0 +1,1251 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019ea7e0-5e0c-7b73-b4e0-9c20d7b61fd0
+--------
+user
+Review this design doc as an independent engineer. It proposes a vendor-neutral AcquisitionScheme for a DIA mass-spec simulator (TimSim) that already supports Bruker timsTOF and is being extended to Thermo Orbitrap Astral and SCIEX ZenoTOF. Context you can trust: the team has working, oracle-verified Rust readers/writers for Thermo .raw (thermorawfile: scan_event gives per-MS2 isolation center/width/CE; author_profile/author_centroids) and a SCIEX .wiff method reader (sciexwiff: SWATHMethod windows). The existing timsTOF acquisition layout is Python, mobility-coupled (windows carry mobility scan ranges), and sourced by copying a real Bruker reference .d.
+
+Focus on: 1) is the AcquisitionScheme data model right — does Option<mobility_scan_range> on DiaWindow cleanly capture the timsTOF-vs-(Thermo/SCIEX) difference, or should mobility be split out? 2) the Rust-vs-Python boundary decision (scheme in Rust/rustdf exposed via connector, Python builder migrates onto it) — risks to backward compatibility with the existing dia_ms_ms_windows table and the Bruker reference path; 3) the 6 open questions — which are real blockers vs deferrable, and any the doc should have answered already; 4) anything missing for a faithful per-instrument acquisition design (e.g. MS1 handling, overlapping windows, rolling CE, cycle/RT modeling); 5) is the input(AcquisitionScheme)/output(AcquisitionWriter) split the right factoring? Concrete, specific, cap ~800 words.
+
+<stdin>
+# AcquisitionScheme — vendor-neutral DIA acquisition design for TimSim
+
+**Status:** design draft (for review)
+**Author:** drafted for David Teschner
+**Scope:** the *input/design* side of multi-instrument TimSim — the DIA window
+schedule the simulator generates against — complementary to the already-built
+`AcquisitionWriter` (the *output* side, `rustdf/src/sim/acquisition.rs`).
+
+---
+
+## 1. Problem
+
+TimSim simulates DIA acquisitions. To extend it beyond Bruker timsTOF to Thermo
+(Orbitrap Astral) and SCIEX (ZenoTOF), the simulator must generate scans for the
+**target instrument's acquisition scheme** — its isolation-window layout, cycle
+structure, and collision-energy plan. Those differ materially per vendor:
+
+- **timsTOF DIA-PASEF**: 2-D windows — (m/z isolation) × (ion-mobility scan
+  range). Cycle = 1 precursor (MS1) frame every `precursor_every` frames.
+- **Orbitrap Astral**: 1-D narrow m/z windows, **no mobility**. Cycle = 1 MS1
+  (FTMS) every ~16 MS2 (ASTMS), precursor m/z stepping, fixed/rolling CE.
+- **SCIEX ZenoTOF**: 1-D variable-width SWATH windows (~60), **no mobility**,
+  Zeno pulsing.
+
+We want to be able to **inject a real instrument's window layout into the sim**
+(e.g. replicate a specific Astral method), not just hand-author windows.
+
+## 2. Current state (what exists today)
+
+The only acquisition abstraction is **`TimsTofAcquisitionBuilderDIA`**
+(`packages/imspy-simulation/src/imspy_simulation/acquisition.py`), which is
+**timsTOF-coupled**:
+
+- Holds the scheme as a pandas `dia_ms_ms_windows` table with columns
+  `window_group, scan_start, scan_end, isolation_mz, isolation_width,
+  collision_energy` — note `scan_start/scan_end` are **mobility scan ranges**.
+- Sources the layout either from a `window_group_file` CSV or (default,
+  `use_reference_ds_layout=True`) by **copying a real Bruker reference `.d`'s**
+  `DiaFrameMsMsWindows` (`reference_ds.dia_ms_ms_windows`).
+- Also derives `precursor_every` from the reference and builds `frame`/`scan`
+  tables; persists to `synthetic_data.db` (`dia_ms_ms_windows`, `dia_ms_ms_info`)
+  → written into the output `.d`'s `DiaFrameMsMsWindows` table.
+
+So the "inject the real layout" idea **already exists for Bruker** (copy the
+reference `.d`'s windows). The gap: it's mobility-shaped and Bruker-only.
+
+### Readers we already have (this session)
+
+We can already *extract* the window layout from each vendor's real files:
+
+- **Bruker** — `reference_ds.dia_ms_ms_windows` (Python, today).
+- **Thermo** — `thermorawfile::RawFile::scan_event(scan)` returns
+  `ScanEvent { ms_order, analyzer, isolation_center, isolation_width,
+  collision_energy }` per MS2 scan. Walking one template DIA cycle recovers the
+  exact Astral window schedule.
+- **SCIEX** — `sciexwiff` extracts `SWATHMethod` → ~60 variable windows
+  `[lower, upper]` + TOF calibration (CE per window is rolling / not in
+  `SWATHMethod`; trailer = 0).
+
+## 3. Proposed model
+
+A vendor-neutral **`AcquisitionScheme`** describing one DIA cycle and how it
+repeats. Lives in Rust (`rustdf/src/sim/scheme.rs`), next to `AcquisitionWriter`.
+
+```rust
+/// One DIA isolation window in a cycle.
+pub struct DiaWindow {
+    pub window_group: u32,
+    pub isolation_mz: f64,       // center
+    pub isolation_width: f64,
+    pub collision_energy: f64,
+    /// timsTOF only: the mobility scan range. None for Thermo/SCIEX.
+    pub mobility_scan_range: Option<(u32, u32)>,
+}
+
+pub enum InstrumentKind { TimsTofDia, OrbitrapAstral, SciexZenoTof }
+
+pub struct AcquisitionScheme {
+    pub instrument: InstrumentKind,
+    pub windows: Vec<DiaWindow>,
+    /// MS1 cadence: one precursor scan every `precursor_every` cycle positions.
+    pub precursor_every: u32,
+    /// Nominal cycle time (s) and gradient length (s) — drive RT sampling.
+    pub cycle_time_s: f64,
+    pub gradient_length_s: f64,
+    /// m/z acquisition range (low, high), for MS1 and window coverage checks.
+    pub mz_range: (f64, f64),
+}
+```
+
+### Extractors (populate the scheme from a real run)
+
+```rust
+impl AcquisitionScheme {
+    pub fn from_bruker_d(path: &str) -> io::Result<Self>;       // DiaFrameMsMsWindows
+    #[cfg(feature = "thermo")]
+    pub fn from_thermo_raw(path: &str) -> io::Result<Self>;     // walk MS2 scan_event()
+    #[cfg(feature = "sciex")]
+    pub fn from_sciex_wiff(path: &str) -> io::Result<Self>;     // SWATHMethod
+    pub fn from_window_table(...) -> Self;                       // hand-authored / CSV
+}
+```
+
+- `from_thermo_raw`: iterate the template's first full cycle of MS2 scans, read
+  `scan_event()` per scan → `DiaWindow { isolation_mz=center, width, CE,
+  mobility_scan_range=None }`; `precursor_every` = count of MS2 between MS1s;
+  `cycle_time_s` from scan RTs.
+- `from_sciex_wiff`: `SWATHMethod` windows → `DiaWindow` (center = (lo+hi)/2,
+  width = hi-lo). CE: rolling — derive from a default model or per-window if
+  recoverable (open question).
+
+## 4. How it plugs in
+
+- **Generation**: the per-vendor frame/scan builders consume the
+  `AcquisitionScheme` to decide which MS2 windows exist, their CE, and (for
+  timsTOF) the mobility ranges. The neutral `ScanDescriptor`s the sim emits feed
+  the matching `AcquisitionWriter`.
+- **Migration of `TimsTofAcquisitionBuilderDIA`**: it stops reading
+  `reference_ds.dia_ms_ms_windows` directly and instead consumes an
+  `AcquisitionScheme` (via the connector). For Bruker this is
+  `from_bruker_d(reference)` → identical behavior (the `mobility_scan_range`
+  carries `scan_start/scan_end`). Backwards-compatible: the existing
+  `dia_ms_ms_windows` table is produced from the scheme.
+- **Symmetry**: `AcquisitionScheme` (in) and `AcquisitionWriter` (out) are the
+  two halves. A round trip is: `from_thermo_raw(template)` → generate → author
+  via `ThermoRawWriter(template)` → `.raw`.
+
+## 5. Boundary / location decision
+
+The new readers are Rust (`thermorawfile`, `sciexwiff`); the existing builder is
+Python. Proposal: `AcquisitionScheme` lives in `rustdf/src/sim`, exposed through
+`imspy_connector` as a `PyAcquisitionScheme`. Python `TimsTofAcquisitionBuilderDIA`
+consumes it via the binding rather than reading the reference `.d` itself. The
+Bruker extractor can stay Python-side initially (it already works) and move to
+Rust later, as long as the neutral scheme is the contract.
+
+## 6. Open questions
+
+1. **CE model for SCIEX** rolling collision energy — derive from m/z (a linear
+   CE(m/z) model) when not stored, or require a user-provided CE table?
+2. **Mobility for timsTOF** — keep `mobility_scan_range` on `DiaWindow`, or split
+   into a `TimsTofExtras` side-struct so the neutral type stays 1-D?
+3. **Variable cycle / overlapping windows** — Astral/SCIEX windows can overlap
+   (1 Th overlap observed in SCIEX). Does the generator need explicit overlap
+   handling, or is per-window isolation sufficient?
+4. **Where Bruker extraction lives** (Rust vs Python) given mobility coupling.
+5. **MS1 representation** — Astral MS1 is FTMS *profile*; the scheme is about MS2
+   windows. Does MS1 need any scheme-level config (mass range only?), or is it
+   purely the writer's concern?
+6. **scan_event location for arbitrary scans** — `from_thermo_raw` needs to read
+   `scan_event()` for MS2 scans beyond the first; thermorawfile's event locator
+   currently relies on a uniform stride that may not hold for mixed MS1/MS2
+   (MS1 events are longer). Does `from_thermo_raw` need the variable-stride walk
+   first?
+
+## 7. Test plan
+
+- `from_thermo_raw(astral_template)` → assert N windows, monotonic centers,
+  fixed CE=25, `precursor_every` ≈ 16, all `mobility_scan_range == None`.
+- `from_sciex_wiff(zenotof_wiff)` → assert ~60 windows covering 399.5–899.9.
+- `from_bruker_d(ref)` round-trips the existing `dia_ms_ms_windows` columns
+  (parity vs today's Python path).
+- End-to-end: `from_thermo_raw(template)` → generate a 1-MS1 + N-MS2 cycle →
+  `ThermoRawWriter` → read back via thermorawfile + Thermo oracle.
+</stdin>
+codex
+I’ll verify the proposed boundary against the current Python builder and Rust writer interfaces, then give a findings-first review capped near 800 words.
+exec
+/bin/bash -lc "sed -n '1,280p' packages/imspy-simulation/src/imspy_simulation/acquisition.py" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from abc import abstractmethod, ABC
+
+from imspy_simulation.experiment import SyntheticExperimentDataHandle
+from imspy_core.timstof import TimsDatasetDIA, TimsDatasetDDA
+from imspy_core.timstof.data import AcquisitionMode, TimsDataset
+from imspy_simulation.utility import calculate_number_frames, get_ms_ms_window_layout_resource_path
+from imspy_simulation.tdf import TDFWriter
+
+
+class TimsTofAcquisitionBuilder:
+    def __init__(
+            self,
+            path: str,
+            reference_ds: TimsDataset,
+            gradient_length: float,
+            rt_cycle_length: float,
+            exp_name: str = "RAW.d",
+            verbose: bool = False,
+    ):
+        """ Base class for building TimsTOF experiments
+        Parameters
+        ----------
+        path : str
+            Path to the experiment directory
+        gradient_length : float
+            Length of the gradient in seconds
+        rt_cycle_length : float
+            Length of the RT cycle in seconds
+        exp_name : str
+            Name of the experiment
+        verbose : bool
+            Print verbose output
+        """
+
+        self.path = path
+        self.gradient_length = gradient_length
+        self.rt_cycle_length = rt_cycle_length
+        self.num_frames = calculate_number_frames(gradient_length, rt_cycle_length)
+        self.verbose = verbose
+        # Create the TDFWriter, used to deal with bruker binary format writing and metadata for libtimsdata.so
+        self.tdf_writer = TDFWriter(
+            path=self.path,
+            helper_handle=reference_ds,
+            exp_name=exp_name,
+            verbose=verbose,
+        )
+        # Create the SyntheticExperimentDataHandle, which is used to deal with the sqlite database of synthetic data
+        self.synthetics_handle = SyntheticExperimentDataHandle(database_path=self.path)
+        self.frame_table = None
+        self.scan_table = None
+
+    def generate_frame_table(self, verbose: bool = True) -> pd.DataFrame:
+        if verbose:
+            print('Generating frame layout.')
+        frames = []
+        for i in range(self.num_frames):
+            frame_id = i + 1
+            time = frame_id * self.rt_cycle_length
+            frames.append({'frame_id': frame_id, 'time': time})
+
+        return pd.DataFrame(frames)
+
+    def generate_scan_table(self, verbose: bool = True) -> pd.DataFrame:
+        if verbose:
+            print('Generating scan layout.')
+
+        scans = np.arange(self.tdf_writer.helper_handle.num_scans)[::-1]
+        mobilities = self.tdf_writer.scan_to_inv_mobility(1, scans)
+
+        return pd.DataFrame({'scan': scans, 'mobility': mobilities})
+
+    def __repr__(self):
+        return (f"TimsTofAcquisitionBuilder(path={self.path}, gradient_length={np.round(self.gradient_length / 60)} "
+                f"min, mobility_range: {self.tdf_writer.helper_handle.im_lower}-{self.tdf_writer.helper_handle.im_upper}, "
+                f"num_frames: {self.num_frames}, num_scans: {self.tdf_writer.helper_handle.num_scans})")
+
+    @abstractmethod
+    def calculate_frame_types(self, *args) -> NDArray:
+        pass
+
+    @classmethod
+    def from_existing(cls, path: str, reference_ds: TimsDataset) -> "TimsTofAcquisitionBuilder":
+        """ Create an instance from existing data without calling __init__.
+        """
+        # Create a new instance without calling __init__
+        instance = cls.__new__(cls)
+        instance.synthetics_handle = SyntheticExperimentDataHandle(database_path=path)
+
+        # Manually set fields from data dictionary
+        instance.path = path
+        instance.frame_table = instance.synthetics_handle.get_table('frames')
+        instance.scan_table = instance.synthetics_handle.get_table('scans')
+        instance.gradient_length = np.round(instance.frame_table.time.max())
+        instance.rt_cycle_length = np.mean(np.diff(instance.frame_table.time))
+        instance.num_frames = instance.frame_table.shape[0]
+
+        # extract experiment name from the path
+        exp_name = Path(path).name
+
+        # Set up the TDFWriter and SyntheticExperimentDataHandle
+        instance.tdf_writer = TDFWriter(
+            path=instance.path,
+            helper_handle=reference_ds,
+            exp_name=exp_name,
+        )
+
+        return instance
+
+
+class TimsTofAcquisitionBuilderDDA(TimsTofAcquisitionBuilder, ABC):
+    def __init__(self,
+                 path: str,
+                 reference_ds: TimsDatasetDDA,
+                 verbose: bool = False,
+                 gradient_length=60 * 60,
+                 rt_cycle_length=0.109,
+                 exp_name: str = "T001.d",
+                 ):
+        super().__init__(path, reference_ds, gradient_length, rt_cycle_length, exp_name=exp_name, verbose=verbose)
+
+        self.scan_table = None
+        self.frame_table = None
+        self.pasef_meta = None
+        self.selected_precursors = None
+        self.acquisition_mode = AcquisitionMode('DDA')
+        self.verbose = verbose
+        self._setup(verbose=verbose)
+
+    def _setup(self, verbose: bool = True):
+        self.frame_table = self.generate_frame_table(verbose=verbose)
+        self.scan_table = self.generate_scan_table(verbose=verbose)
+        self.synthetics_handle.create_table(
+            table_name='frames',
+            table=self.frame_table
+        )
+        self.synthetics_handle.create_table(
+            table_name='scans',
+            table=self.scan_table
+        )
+
+    def calculate_frame_types(self, frame_types: NDArray):
+        assert len(frame_types) == self.frame_table.shape[0], "frame_types must have the same length as the frame table."
+        # assert set(frame_types).issubset({0, 8}), f"frame_types must be a list of 0s and 8s, got {set(frame_types)}."
+        self.frame_table['ms_type'] = frame_types
+        self.synthetics_handle.create_table(
+            table_name='frames',
+            table=self.frame_table
+        )
+
+class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
+    def __init__(self,
+                 path: str,
+                 reference_ds: TimsDatasetDIA,
+                 window_group_file: str,
+                 acquisition_name: str = "dia",
+                 exp_name: str = "RAW",
+                 verbose: bool = True,
+                 precursor_every: int = 17,
+                 gradient_length=50 * 60,
+                 rt_cycle_length=0.1054,
+                 use_reference_ds_layout: bool = True,
+                 round_collision_energy: bool = True,
+                 collision_energy_decimals: int = 1
+                 ):
+
+        super().__init__(path, reference_ds, gradient_length, rt_cycle_length,
+                         exp_name=exp_name)
+        # TODO: check this, could be missing replacement of reference layout of windows
+        if use_reference_ds_layout:
+            rt_cycle_length = np.mean(np.diff(reference_ds.meta_data.Time))
+            if verbose:
+                print('Using reference dataset cycle length:', np.round(rt_cycle_length, 4))
+            self.rt_cycle_length = rt_cycle_length
+
+        self.acquisition_name = acquisition_name
+        self.scan_table = None
+        self.frame_table = None
+        self.frames_to_window_groups = None
+        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+        self.use_reference_ds_layout = use_reference_ds_layout
+        self.reference = reference_ds
+        self.round_collision_energy = round_collision_energy
+        self.collision_energy_decimals = collision_energy_decimals
+
+        # TODO: check if the number of scans in the window group file matches the number of scans in the experiment
+
+        self.acquisition_mode = AcquisitionMode('DIA')
+        self.verbose = verbose
+        self.precursor_every = precursor_every
+
+        self._setup(verbose=verbose)
+
+    def calculate_frame_types(self, verbose: bool = True) -> NDArray:
+        if verbose:
+            print(f'Calculating frame types, precursor frame will be taken every {self.precursor_every} rt cycles.')
+        return np.array([0 if (x - 1) % self.precursor_every == 0 else 9 for x in self.frame_table.frame_id])
+
+    def generate_frame_to_window_group_table(self, verbose: bool = True) -> pd.DataFrame:
+        if verbose:
+            print(f'generating frame to window group table, precursors every {self.precursor_every} frames.')
+
+        table_list = []
+        for index, row in self.frame_table.iterrows():
+            frame_id, ms_type = row.frame_id, row.ms_type
+            wg = index % self.precursor_every
+            if ms_type > 0:
+                table_list.append({'frame': int(frame_id), 'window_group': wg})
+
+        return pd.DataFrame(table_list)
+
+    def _setup(self, verbose: bool = True):
+        self.frame_table = self.generate_frame_table(verbose=verbose)
+        self.scan_table = self.generate_scan_table(verbose=verbose)
+
+        if self.use_reference_ds_layout:
+            self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
+            self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+                columns={
+                    'WindowGroup': 'window_group',
+                    'ScanNumBegin': 'scan_start',
+                    'ScanNumEnd': 'scan_end',
+                    'IsolationMz': 'isolation_mz',
+                    'IsolationWidth': 'isolation_width',
+                    'CollisionEnergy': 'collision_energy',
+                }
+            )
+
+        self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+        self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
+
+        if self.round_collision_energy:
+            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+                                                                  decimals=self.collision_energy_decimals)
+
+        self.synthetics_handle.create_table(
+            table_name='frames',
+            table=self.frame_table
+        )
+        self.synthetics_handle.create_table(
+            table_name='scans',
+            table=self.scan_table
+        )
+        self.synthetics_handle.create_table(
+            table_name='dia_ms_ms_info',
+            table=self.frames_to_window_groups
+        )
+        self.synthetics_handle.create_table(
+            table_name='dia_ms_ms_windows',
+            table=self.dia_ms_ms_windows
+        )
+
+    @staticmethod
+    def from_config(
+            path: str,
+            reference_ds: TimsDatasetDIA,
+            exp_name: str,
+            config: Dict[str, any],
+            verbose: bool = True,
+            use_reference_layout: bool = True,
+            round_collision_energy: bool = True,
+            collision_energy_decimals: int = 1
+    ) -> 'TimsTofAcquisitionBuilderDIA':
+
+        acquisition_name = config['name'].lower().replace('pasef', '')
+        window_group_file = get_ms_ms_window_layout_resource_path(acquisition_name)
+
+        return TimsTofAcquisitionBuilderDIA(
+            path=str(Path(path) / exp_name),
+            reference_ds=reference_ds,
+            window_group_file=str(window_group_file),
+            exp_name=exp_name + ".d",
+            verbose=verbose,
+            acquisition_name=acquisition_name,
+            precursor_every=config['precursor_every'],
+
+exec
+/bin/bash -lc "sed -n '1,280p' rustdf/src/sim/acquisition.rs" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+//! Vendor-neutral acquisition-writer abstraction.
+//!
+//! [`AcquisitionWriter`] turns vendor-neutral [`ScanDescriptor`]s into a vendor
+//! raw file. The first implementation is [`ThermoRawWriter`] (Thermo `.raw`, via
+//! the `thermo` feature + the `thermorawfile` crate); a Bruker `.d` adapter over
+//! the existing write path is a planned follow-up.
+
+use std::io;
+
+/// MS2 quadrupole isolation window.
+#[derive(Clone, Copy, Debug)]
+pub struct IsolationWindow {
+    pub center_mz: f64,
+    pub width_mz: f64,
+    pub collision_energy: f64,
+}
+
+/// One vendor-neutral scan: a peak list plus acquisition metadata.
+///
+/// Intentionally has **no ion-mobility dimension** — it is the
+/// Bruker∩Thermo∩SCIEX common denominator. IMS-bearing Bruker frames are handled
+/// by the Bruker writer, which can flatten or carry mobility separately.
+#[derive(Clone, Debug)]
+pub struct ScanDescriptor {
+    pub ms_level: u8,
+    pub retention_time: f64,
+    /// Present for MS2 (the precursor isolation window).
+    pub isolation: Option<IsolationWindow>,
+    /// `(m/z, intensity)` pairs; need not be sorted (writers sort).
+    pub peaks: Vec<(f64, f32)>,
+}
+
+/// A sink that writes vendor-neutral scans into a vendor raw file. Scans are
+/// written in acquisition order; `finalize` flushes the file (and fixes any
+/// integrity checksum).
+pub trait AcquisitionWriter {
+    fn write_scan(&mut self, scan: &ScanDescriptor) -> io::Result<()>;
+    fn finalize(&mut self) -> io::Result<()>;
+}
+
+#[cfg(feature = "thermo")]
+pub use thermo::ThermoRawWriter;
+
+#[cfg(feature = "thermo")]
+mod thermo {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use thermorawfile::{Calibration, RawFile};
+
+    /// Authors scans into a Thermo `.raw` by **template-mutation**: open a real
+    /// `.raw`, overwrite template scans of matching type in acquisition order
+    /// (MS1 → profile via `author_profile`, MS2 → centroids via
+    /// `author_centroids`), and save on [`AcquisitionWriter::finalize`].
+    ///
+    /// The template supplies the frequency grid + calibration; synthetic peaks
+    /// are placed at their exact m/z within each packet's byte budget. The
+    /// calibration is read once from the first scan (it is ≈constant across a
+    /// run); each scan's own frequency grid is taken from its profile.
+    pub struct ThermoRawWriter {
+        raw: RawFile,
+        out_path: PathBuf,
+        calib: Calibration,
+        /// Template scans that carry a profile (treated as MS1 targets).
+        profile_scans: Vec<u32>,
+        /// Centroid-only template scans (treated as MS2 targets).
+        centroid_scans: Vec<u32>,
+        prof_cur: usize,
+        cent_cur: usize,
+    }
+
+    impl ThermoRawWriter {
+        /// Open `template` and prepare to author into `out`.
+        pub fn from_template<P: AsRef<Path>, Q: AsRef<Path>>(
+            template: P,
+            out: Q,
+        ) -> io::Result<Self> {
+            let raw = RawFile::open(template)?;
+            let calib = raw
+                .calibration_at_event(raw.scantrailer_addr as usize + 4)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "no MS1 calibration in template")
+                })?;
+
+            // Classify template scans by packet type: a non-zero profile section
+            // marks an MS1-style (FTMS profile) scan; centroid-only is MS2 (ASTMS).
+            let mut profile_scans = Vec::new();
+            let mut centroid_scans = Vec::new();
+            for (i, e) in raw.index.iter().enumerate() {
+                let pkt = (raw.data_addr + e.offset) as usize;
+                if pkt + 8 > raw.bytes.len() {
+                    continue;
+                }
+                let profile_size =
+                    u32::from_le_bytes(raw.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+                let scan = raw.first_scan + i as u32;
+                if profile_size > 0 {
+                    profile_scans.push(scan);
+                } else {
+                    centroid_scans.push(scan);
+                }
+            }
+            Ok(Self {
+                raw,
+                out_path: out.as_ref().to_path_buf(),
+                calib,
+                profile_scans,
+                centroid_scans,
+                prof_cur: 0,
+                cent_cur: 0,
+            })
+        }
+
+        /// Template MS1/MS2 capacity, so callers can check a run fits.
+        pub fn capacity(&self) -> (usize, usize) {
+            (self.profile_scans.len(), self.centroid_scans.len())
+        }
+    }
+
+    impl AcquisitionWriter for ThermoRawWriter {
+        fn write_scan(&mut self, scan: &ScanDescriptor) -> io::Result<()> {
+            if scan.ms_level <= 1 {
+                let t = *self.profile_scans.get(self.prof_cur).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "template exhausted of MS1 (profile) scans",
+                    )
+                })?;
+                self.prof_cur += 1;
+                self.raw.author_profile(t, &scan.peaks, &self.calib)
+            } else {
+                let t = *self.centroid_scans.get(self.cent_cur).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "template exhausted of MS2 (centroid) scans",
+                    )
+                })?;
+                self.cent_cur += 1;
+                self.raw.author_centroids(t, &scan.peaks)
+            }
+        }
+
+        fn finalize(&mut self) -> io::Result<()> {
+            let path = self.out_path.clone();
+            self.raw.save(path)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "thermo"))]
+mod tests {
+    use super::*;
+
+    // Gated: set TIMSIM_ASTRAL_TEMPLATE to a real Orbitrap Astral .raw to run.
+    // `cargo test --features thermo -- --nocapture thermo_roundtrip`
+    #[test]
+    fn thermo_roundtrip() {
+        let template = match std::env::var("TIMSIM_ASTRAL_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP thermo_roundtrip: set TIMSIM_ASTRAL_TEMPLATE=<astral .raw>");
+                return;
+            }
+        };
+        let out = std::env::temp_dir().join("rustdf_thermo_roundtrip.raw");
+
+        let mut w = ThermoRawWriter::from_template(&template, &out).expect("open template");
+        let (n_ms1, n_ms2) = w.capacity();
+        assert!(n_ms1 > 0 && n_ms2 > 0, "template has no MS1/MS2 scans");
+
+        let ms1 = ScanDescriptor {
+            ms_level: 1,
+            retention_time: 0.0,
+            isolation: None,
+            peaks: vec![(500.0, 1.0e6), (700.0, 5.0e5)],
+        };
+        let ms2 = ScanDescriptor {
+            ms_level: 2,
+            retention_time: 0.01,
+            isolation: Some(IsolationWindow {
+                center_mz: 500.0,
+                width_mz: 2.0,
+                collision_energy: 25.0,
+            }),
+            peaks: vec![(150.1, 3.0e4), (420.2, 8.0e4), (610.3, 5.0e4)],
+        };
+        w.write_scan(&ms1).expect("write MS1");
+        w.write_scan(&ms2).expect("write MS2");
+        w.finalize().expect("finalize");
+
+        // Read back through thermorawfile and confirm the authored peaks.
+        let rf = thermorawfile::RawFile::open(&out).expect("reopen");
+        assert!(rf.checksum_valid(), "checksum invalid");
+
+        // The writer used the first profile scan for MS1 and first centroid scan for MS2.
+        let cal = rf
+            .calibration_at_event(rf.scantrailer_addr as usize + 4)
+            .unwrap();
+        let mut prof_scan = None;
+        let mut cent_scan = None;
+        for i in 0..rf.index.len() {
+            let scan = rf.first_scan + i as u32;
+            let pkt = (rf.data_addr + rf.index[i].offset) as usize;
+            let psize = u32::from_le_bytes(rf.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+            if psize > 0 && prof_scan.is_none() {
+                prof_scan = Some(scan);
+            }
+            if psize == 0 && cent_scan.is_none() {
+                cent_scan = Some(scan);
+            }
+        }
+        let prof = rf.profile(prof_scan.unwrap()).expect("ms1 profile");
+        assert_eq!(prof.chunks.len(), 2, "MS1 peak count");
+        let ms1_mz: Vec<f64> = prof
+            .chunks
+            .iter()
+            .map(|c| prof.mz_of_bin(c.first_bin, &cal))
+            .collect();
+        assert!((ms1_mz[0] - 500.0).abs() < 0.01 && (ms1_mz[1] - 700.0).abs() < 0.01);
+
+        let cents = rf.centroid_peaks(cent_scan.unwrap());
+        assert_eq!(cents.len(), 3, "MS2 peak count");
+        assert!((cents[0].mz - 150.1).abs() < 0.01);
+        assert!((cents[2].mz - 610.3).abs() < 0.01);
+
+        eprintln!("thermo_roundtrip OK: MS1 {:?}, MS2 {} peaks", ms1_mz, cents.len());
+    }
+}
+
+exec
+/bin/bash -lc "rg -n \"dia_ms_ms_windows|DiaFrameMsMsWindows|precursor_every|ScanDescriptor|AcquisitionWriter\" packages rustdf imspy_connector -g '*.py' -g '*.rs'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+rustdf/src/sim/acquisition.rs:3://! [`AcquisitionWriter`] turns vendor-neutral [`ScanDescriptor`]s into a vendor
+rustdf/src/sim/acquisition.rs:24:pub struct ScanDescriptor {
+rustdf/src/sim/acquisition.rs:36:pub trait AcquisitionWriter {
+rustdf/src/sim/acquisition.rs:37:    fn write_scan(&mut self, scan: &ScanDescriptor) -> io::Result<()>;
+rustdf/src/sim/acquisition.rs:53:    /// `author_centroids`), and save on [`AcquisitionWriter::finalize`].
+rustdf/src/sim/acquisition.rs:119:    impl AcquisitionWriter for ThermoRawWriter {
+rustdf/src/sim/acquisition.rs:120:        fn write_scan(&mut self, scan: &ScanDescriptor) -> io::Result<()> {
+rustdf/src/sim/acquisition.rs:170:        let ms1 = ScanDescriptor {
+rustdf/src/sim/acquisition.rs:176:        let ms2 = ScanDescriptor {
+rustdf/src/sim/handle.rs:182:        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_windows")?;
+rustdf/src/data/meta.rs:377:pub fn read_dia_ms_ms_windows(
+rustdf/src/data/meta.rs:393:    let query = format!("SELECT {} FROM DiaFrameMsMsWindows", rows.join(", "));
+rustdf/src/data/dia.rs:6:    read_dia_ms_ms_info, read_dia_ms_ms_windows, read_global_meta_sql, read_meta_data_sql,
+rustdf/src/data/dia.rs:428:    pub dia_ms_ms_windows: Vec<DiaMsMsWindow>,
+rustdf/src/data/dia.rs:443:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+rustdf/src/data/dia.rs:478:        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+rustdf/src/data/dia.rs:485:            dia_ms_ms_windows,
+rustdf/src/data/dia.rs:503:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+rustdf/src/data/dia.rs:528:        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+rustdf/src/data/dia.rs:535:            dia_ms_ms_windows,
+rustdf/src/data/dia.rs:544:    /// Collect all program slices for a window group from DiaFrameMsMsWindows.
+rustdf/src/data/dia.rs:547:        self.dia_ms_ms_windows
+rustdf/src/data/dia.rs:739:    /// Merged, sorted **global scan** unions for this DIA group, from DiaFrameMsMsWindows.
+rustdf/src/data/dia.rs:743:            .dia_ms_ms_windows
+rustdf/src/data/dia.rs:758:    /// m/z unions (min..max) for the group from DiaFrameMsMsWindows (wide clamp).
+rustdf/src/data/dia.rs:763:        for w in &self.dia_ms_ms_windows {
+rustdf/examples/build_bruker_pseudo_ms2_v3.rs:102:         FROM DiaFrameMsMsWindows ORDER BY WindowGroup, ScanNumBegin",
+rustdf/examples/dump_bruker_centroids.rs:13:// definitions from `dia_ms_ms_windows` and `dia_ms_ms_info`.
+rustdf/examples/dump_bruker_centroids.rs:44:         FROM DiaFrameMsMsWindows ORDER BY WindowGroup, ScanNumBegin",
+rustdf/examples/build_bruker_pseudo_ms2.rs:84:         FROM DiaFrameMsMsWindows ORDER BY WindowGroup, ScanNumBegin",
+packages/imspy-core/src/imspy_core/timstof/dia.py:21:    def dia_ms_ms_windows(self):
+packages/imspy-core/src/imspy_core/timstof/dia.py:27:        return pd.read_sql_query("SELECT * from DiaFrameMsMsWindows",
+packages/imspy-vis/src/imspy_vis/frame_rendering.py:289:        self.windows = self.handle.dia_ms_ms_windows.copy()
+packages/imspy-simulation/src/imspy_simulation/experiment.py:635:        self.dia_ms_ms_windows = None
+packages/imspy-simulation/src/imspy_simulation/experiment.py:641:        self.dia_ms_ms_windows = self.get_table('dia_ms_ms_windows')
+packages/imspy-simulation/src/imspy_simulation/experiment.py:649:        for _, row in self.dia_ms_ms_windows.iterrows():
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:164:                 precursor_every: int = 17,
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:185:        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:195:        self.precursor_every = precursor_every
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:201:            print(f'Calculating frame types, precursor frame will be taken every {self.precursor_every} rt cycles.')
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:202:        return np.array([0 if (x - 1) % self.precursor_every == 0 else 9 for x in self.frame_table.frame_id])
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:206:            print(f'generating frame to window group table, precursors every {self.precursor_every} frames.')
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:211:            wg = index % self.precursor_every
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:222:            self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:223:            self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:238:            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:254:            table_name='dia_ms_ms_windows',
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:255:            table=self.dia_ms_ms_windows
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:280:            precursor_every=config['precursor_every'],
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:321:        instance.precursor_every = int(np.diff(instance.reference.precursor_frames)[0])
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:328:        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:20:        config_name: Name of the config file (e.g., 'dia_ms_ms_windows.csv')
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:504:            # dia-PASEF: Load all windows from actual dia_ms_ms_windows.csv
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:506:            window_df = load_window_config("dia_ms_ms_windows.csv")
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:580:            # midia-PASEF: Load windows from actual midia_ms_ms_windows.csv
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:581:            window_df = load_window_config("midia_ms_ms_windows.csv")
+packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:179:        acquisition_builder.tdf_writer.write_dia_ms_ms_windows(
+packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:180:            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_windows'))
+packages/imspy-simulation/src/imspy_simulation/data/database.py:217:        dia_ms_ms_windows: Cached DIA MS/MS windows DataFrame.
+packages/imspy-simulation/src/imspy_simulation/data/database.py:235:        self.dia_ms_ms_windows: Optional[pd.DataFrame] = None
+packages/imspy-simulation/src/imspy_simulation/data/database.py:242:            self.dia_ms_ms_windows = self.get_table("dia_ms_ms_windows")
+packages/imspy-simulation/src/imspy_simulation/data/database.py:266:        if self.dia_ms_ms_windows is None:
+packages/imspy-simulation/src/imspy_simulation/data/database.py:269:        if self.dia_ms_ms_windows is None:
+packages/imspy-simulation/src/imspy_simulation/data/database.py:273:        for _, row in self.dia_ms_ms_windows.iterrows():
+packages/imspy-simulation/src/imspy_simulation/timsim/validate/runner.py:46:    Checks for presence of DIA-specific tables (DiaFrameMsMsInfo, DiaFrameMsMsWindows)
+packages/imspy-simulation/src/imspy_simulation/timsim/validate/runner.py:70:        has_dia_tables = "DiaFrameMsMsInfo" in tables or "DiaFrameMsMsWindows" in tables
+packages/imspy-simulation/src/imspy_simulation/tdf.py:496:    def write_dia_ms_ms_windows(self, dia_ms_ms_windows: pd.DataFrame) -> None:
+packages/imspy-simulation/src/imspy_simulation/tdf.py:497:        out = dia_ms_ms_windows.rename(columns={
+packages/imspy-simulation/src/imspy_simulation/tdf.py:506:        self._create_table(self.conn, out, "DiaFrameMsMsWindows")
+
+codex
+The current code confirms a key compatibility hazard: `window_group` is not merely metadata; it drives Bruker frame assignment, while the stored table is consumed row-wise with mandatory scan bounds. I’m checking those consumers before ranking the design issues.
+exec
+/bin/bash -lc "sed -n '620,680p' packages/imspy-simulation/src/imspy_simulation/experiment.py" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+            cursor.execute(f"PRAGMA table_info({table_name});")
+            columns = cursor.fetchall()
+            return [column[1] for column in columns]
+
+    def __repr__(self):
+        return f"SyntheticExperimentDataHandle(database_path={self.database_path})"
+
+
+class SyntheticExperimentDataHandleDIA(SyntheticExperimentDataHandle, ABC):
+    def __init__(self,
+                 database_path: str,
+                 database_name: str = 'synthetic_data.db',
+                 verbose: bool = True,):
+        super().__init__(database_path, database_name, verbose)
+        self.dia_ms_ms_info = None
+        self.dia_ms_ms_windows = None
+
+        self._additional_setup()
+
+    def _additional_setup(self):
+        self.dia_ms_ms_info = self.get_table('dia_ms_ms_info')
+        self.dia_ms_ms_windows = self.get_table('dia_ms_ms_windows')
+
+    def get_frame_to_window_group(self):
+        return dict(zip(self.dia_ms_ms_info.frame, self.dia_ms_ms_info.window_group))
+
+    def get_window_group_settings(self):
+        window_group_settings = {}
+
+        for _, row in self.dia_ms_ms_windows.iterrows():
+            key = (row.window_group, row.scan_start)
+            value = (row.mz_mid, row.mz_width)
+            window_group_settings[key] = value
+
+        return window_group_settings
+
+
+if __name__ == '__main__':
+
+    # Example usage
+    path = '/path/to/directory'
+    db_name = 'experiment_data.db'
+    handle = SyntheticExperimentDataHandle(path, db_name)
+
+    # Create a table, for example
+    sql_create_peptides_table = '''
+    CREATE TABLE IF NOT EXISTS peptides (
+        peptide_id INTEGER PRIMARY KEY,
+        sequence TEXT NOT NULL,
+        monoisotopic_mass REAL)
+    '''
+    handle.create_table(sql_create_peptides_table)
+
+    # Close the connection when done
+    handle.close()
+
+exec
+/bin/bash -lc "sed -n '280,350p' packages/imspy-simulation/src/imspy_simulation/acquisition.py" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+            precursor_every=config['precursor_every'],
+            gradient_length=config['gradient_length'],
+            rt_cycle_length=config['rt_cycle_length'],
+            use_reference_ds_layout=use_reference_layout,
+            round_collision_energy=round_collision_energy,
+            collision_energy_decimals=collision_energy_decimals
+        )
+
+    @classmethod
+    def from_existing(cls,
+                      path: str,
+                      reference_ds: TimsDatasetDIA,
+                      use_reference_ds_layout: bool = True,
+                      verbose: bool = True) -> "TimsTofAcquisitionBuilderDIA":
+        """ Create an instance from existing data for DIA without calling __init__."""
+
+        # Create an instance without calling __init__
+        instance = cls.__new__(cls)
+
+        # Initialize shared attributes as done in the parent’s from_existing
+        instance.synthetics_handle = SyntheticExperimentDataHandle(database_path=path)
+        instance.path = path
+        instance.frame_table = instance.synthetics_handle.get_table('frames')
+        instance.scan_table = instance.synthetics_handle.get_table('scans')
+        instance.gradient_length = np.round(instance.frame_table.time.max())
+        instance.rt_cycle_length = np.mean(np.diff(instance.frame_table.time))
+        instance.num_frames = instance.frame_table.shape[0]
+        exp_name = Path(path).name
+        instance.tdf_writer = TDFWriter(
+            path=instance.path,
+            helper_handle=reference_ds,
+            exp_name=exp_name,
+        )
+
+        # Ensure use_reference_ds_layout is supported
+        assert use_reference_ds_layout, "Only use_reference_ds_layout=True is supported for existing DIA acquisitions"
+
+        # Set DIA-specific fields
+        instance.reference = reference_ds
+        instance.verbose = verbose
+        instance.window_group_file = None
+        instance.precursor_every = int(np.diff(instance.reference.precursor_frames)[0])
+        instance.round_collision_energy = True
+        instance.collision_energy_decimals = 1
+        instance.use_reference_ds_layout = use_reference_ds_layout
+
+        # Load additional tables for DIA-specific data
+        instance.frames_to_window_groups = instance.synthetics_handle.get_table('dia_ms_ms_info')
+        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+
+        return instance
+
+    def __repr__(self):
+        return (f"TimsTofAcquisitionBuilderDIA(name={self.acquisition_name}, path={self.path}, "
+                f"gradient_length={np.round(self.gradient_length / 60)} min, mobility_range: "
+                f"{self.tdf_writer.helper_handle.im_lower}-{self.tdf_writer.helper_handle.im_upper}, "
+                f"num_frames: {self.num_frames}, num_scans: {self.tdf_writer.helper_handle.num_scans})")
+
+exec
+/bin/bash -lc "sed -n '350,420p' rustdf/src/data/meta.rs && sed -n '160,210p' rustdf/src/sim/handle.rs" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+
+pub fn read_dia_ms_ms_info(
+    bruker_d_folder_name: &str,
+) -> Result<Vec<DiaMsMisInfo>, Box<dyn std::error::Error>> {
+    // Connect to the database
+    let db_path = Path::new(bruker_d_folder_name).join("analysis.tdf");
+    let conn = Connection::open(db_path)?;
+
+    // prepare the query
+    let rows: Vec<&str> = vec!["Frame", "WindowGroup"];
+    let query = format!("SELECT {} FROM DiaFrameMsMsInfo", rows.join(", "));
+
+    // execute the query
+    let frames_rows: Result<Vec<DiaMsMisInfo>, _> = conn
+        .prepare(&query)?
+        .query_map([], |row| {
+            Ok(DiaMsMisInfo {
+                frame_id: row.get(0)?,
+                window_group: row.get(1)?,
+            })
+        })?
+        .collect();
+
+    // return the frames
+    Ok(frames_rows?)
+}
+
+pub fn read_dia_ms_ms_windows(
+    bruker_d_folder_name: &str,
+) -> Result<Vec<DiaMsMsWindow>, Box<dyn std::error::Error>> {
+    // Connect to the database
+    let db_path = Path::new(bruker_d_folder_name).join("analysis.tdf");
+    let conn = Connection::open(db_path)?;
+
+    // prepare the query
+    let rows: Vec<&str> = vec![
+        "WindowGroup",
+        "ScanNumBegin",
+        "ScanNumEnd",
+        "IsolationMz",
+        "IsolationWidth",
+        "CollisionEnergy",
+    ];
+    let query = format!("SELECT {} FROM DiaFrameMsMsWindows", rows.join(", "));
+
+    // execute the query
+    let frames_rows: Result<Vec<DiaMsMsWindow>, _> = conn
+        .prepare(&query)?
+        .query_map([], |row| {
+            Ok(DiaMsMsWindow {
+                window_group: row.get(0)?,
+                scan_num_begin: row.get(1)?,
+                scan_num_end: row.get(2)?,
+                isolation_mz: row.get(3)?,
+                isolation_width: row.get(4)?,
+                collision_energy: row.get(5)?,
+            })
+        })?
+        .collect();
+
+    // return the frames
+    Ok(frames_rows?)
+}
+
+/// Read m/z calibration data from the MzCalibration table.
+/// This provides the coefficients needed for accurate TOF to m/z conversion
+/// without requiring the Bruker SDK.
+///
+/// The calibration formula is:
+///   tof_time = (tof_index + 0.5) * digitizer_timebase + digitizer_delay
+///   sqrt(mz) = c0 + c1*tof_time + c2*tof_time^2 + ...
+
+        Ok(FragmentIonSim::new(
+            row.get("peptide_id")?,
+            row.get("ion_id")?,
+            row.get("collision_energy")?,
+            row.get("charge")?,
+            indices,
+            values,
+        ))
+    }
+
+    pub fn read_ions(&self) -> rusqlite::Result<Vec<IonSim>> {
+        let mut stmt = self.connection.prepare("SELECT * FROM ions")?;
+        let ions_iter = stmt.query_map([], |row| Self::ion_from_row(row))?;
+        let mut ions = Vec::new();
+        for ion in ions_iter {
+            ions.push(ion?);
+        }
+        Ok(ions)
+    }
+
+    pub fn read_window_group_settings(&self) -> rusqlite::Result<Vec<WindowGroupSettingsSim>> {
+        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_windows")?;
+        let window_group_settings_iter = stmt.query_map([], |row| {
+            Ok(WindowGroupSettingsSim::new(
+                row.get("window_group")?,
+                row.get("scan_start")?,
+                row.get("scan_end")?,
+                row.get("isolation_mz")?,
+                row.get("isolation_width")?,
+                row.get("collision_energy")?,
+            ))
+        })?;
+        let mut window_group_settings = Vec::new();
+        for window_group_setting in window_group_settings_iter {
+            window_group_settings.push(window_group_setting?);
+        }
+        Ok(window_group_settings)
+    }
+
+    pub fn read_frame_to_window_group(&self) -> rusqlite::Result<Vec<FrameToWindowGroupSim>> {
+        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_info")?;
+        let frame_to_window_group_iter = stmt.query_map([], |row| {
+            Ok(FrameToWindowGroupSim::new(
+                row.get("frame")?,
+                row.get("window_group")?,
+            ))
+        })?;
+
+        let mut frame_to_window_groups: Vec<FrameToWindowGroupSim> = Vec::new();
+        for frame_to_window_group in frame_to_window_group_iter {
+
+exec
+/bin/bash -lc "sed -n '470,520p' packages/imspy-simulation/src/imspy_simulation/tdf.py && sed -n '160,195p' packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+                FOREIGN KEY(Frame) REFERENCES Frames(Id),
+                FOREIGN KEY(Precursor) REFERENCES Precursors(Id)
+            ) WITHOUT ROWID
+        """)
+        cursor.execute("CREATE INDEX IF NOT EXISTS PasefFrameMsMsInfoPrecursorIndex ON PasefFrameMsMsInfo (Precursor)")
+
+        # Insert data with remapped precursor IDs if mapping provided
+        for _, row in out.iterrows():
+            precursor_id = int(row['Precursor']) if pd.notna(row['Precursor']) else None
+            if id_mapping is not None and precursor_id is not None:
+                precursor_id = id_mapping.get(precursor_id, precursor_id)
+
+            cursor.execute("""
+                INSERT INTO PasefFrameMsMsInfo (Frame, ScanNumBegin, ScanNumEnd, IsolationMz, IsolationWidth, CollisionEnergy, Precursor)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, (
+                int(row['Frame']),
+                int(row['ScanNumBegin']),
+                int(row['ScanNumEnd']),
+                float(row['IsolationMz']),
+                float(row['IsolationWidth']),
+                float(row['CollisionEnergy']),
+                precursor_id
+            ))
+        self.conn.commit()
+
+    def write_dia_ms_ms_windows(self, dia_ms_ms_windows: pd.DataFrame) -> None:
+        out = dia_ms_ms_windows.rename(columns={
+            'window_group': 'WindowGroup',
+            'scan_start': 'ScanNumBegin',
+            'scan_end': 'ScanNumEnd',
+            'isolation_mz': 'IsolationMz',
+            'isolation_width': 'IsolationWidth',
+            'collision_energy': 'CollisionEnergy',
+        })
+
+        self._create_table(self.conn, out, "DiaFrameMsMsWindows")
+
+        # TODO: these methods needs to be debugged
+        """
+        def compress_frames(self, frames: List[TimsFrame], only_frame_one: bool = False, num_threads: int = 4) -> List[bytes]:
+            # same as compress_frame but for multiple frames
+            tofs, scans, intensities = [], [], []
+            for frame in frames:
+                i = 1 if only_frame_one else frame.frame_id
+                tofs.append(self.mz_to_tof(i, frame.mz).astype(np.uint32))
+                scans.append(self.inv_mobility_to_scan(i, frame.mobility).astype(np.uint32))
+                intensities.append(frame.intensity.astype(np.uint32))
+
+            real_data = ims.get_data_for_compression_par(tofs, scans, intensities, self.helper_handle.num_scans, num_threads)
+            return [zstd.ZSTD_compress(bytes(data), 1) for data in real_data]
+            )
+
+        for frame in built_frames:
+            if acquisition_builder.acquisition_mode.mode == 'DDA':
+                acquisition_builder.tdf_writer.write_frame(frame, scan_mode=8)
+            else:
+                acquisition_builder.tdf_writer.write_frame(frame, scan_mode=9)
+
+    logger.info('Writing frame meta data to database ...')
+
+    # write frame meta data to database
+    acquisition_builder.tdf_writer.write_frame_meta_data()
+
+    if acquisition_builder.acquisition_mode.mode == 'DIA':
+        logger.info("Writing DIA specific meta data to database ...")
+        # write frame ms/ms info to database
+        acquisition_builder.tdf_writer.write_dia_ms_ms_info(
+            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_info'))
+        # write frame ms/ms windows to database
+        acquisition_builder.tdf_writer.write_dia_ms_ms_windows(
+            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_windows'))
+        # write prm frame ms ms info
+        acquisition_builder.tdf_writer.write_prm_frame_ms_ms_info()
+        # write pasef frame ms ms info
+        acquisition_builder.tdf_writer.write_pasef_frame_ms_ms_info()
+        # write calibration info to database
+
+        if mz_noise_precursor:
+            acquisition_builder.tdf_writer.write_calibration_info(
+                mz_standard_deviation_ppm=precursor_noise_ppm)
+
+        elif mz_noise_fragment:
+            acquisition_builder.tdf_writer.write_calibration_info(
+                mz_standard_deviation_ppm=fragment_noise_ppm)
+
+        else:
+
+codex
+**Key Findings**
+
+1. **The proposed model is too window-centric.** A flat `Vec<DiaWindow>` plus `precursor_every` cannot unambiguously represent:
+   - timsTOF: one frame containing several mobility-partitioned windows sharing a `window_group`.
+   - Astral/SCIEX: an ordered sequence of individual MS1/MS2 scans.
+   - Variable cycles, staggered schemes, multiple MS1 types, calibration scans, or per-event timing.
+
+   Model an ordered cycle explicitly:
+
+   ```rust
+   struct AcquisitionScheme {
+       cycle: Vec<AcquisitionEvent>,
+       repeat: RepeatPolicy,
+       run_duration_s: f64,
+   }
+
+   enum AcquisitionEvent {
+       Ms1(Ms1Event),
+       DiaMs2(DiaMs2Event),
+   }
+   ```
+
+   Each event should carry relative timing or duration, analyzer/type, m/z range, isolation, and CE policy. For timsTOF, an MS2 event can contain multiple mobility slices belonging to one frame.
+
+2. **Split mobility from the common isolation window.** `Option<(u32,u32)>` is mechanically workable but semantically weak. Scan numbers are Bruker-grid coordinates requiring the reference dataset’s calibration and scan count; they are not a physical mobility range. It also permits invalid states such as mobility on Astral.
+
+   Prefer:
+
+   ```rust
+   enum DiaGeometry {
+       MzOnly,
+       TimsMobility {
+           scan_start: u32,
+           scan_end: u32,
+           // optionally inverse-mobility bounds
+       },
+   }
+   ```
+
+   Better still, put geometry on a timsTOF frame/event rather than every generic window. Keep `IsolationWindow` strictly m/z-based.
+
+3. **Backward compatibility needs an explicit adapter, not an assertion of parity.** Existing code requires six concrete columns and uses `window_group` to assign frames, not merely identify windows ([acquisition.py](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:199), [handle.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/handle.rs:181)). The migration must preserve:
+   - Exact group IDs and row order.
+   - Inclusive/exclusive meaning of `scan_start`/`scan_end`.
+   - Integer types and column names.
+   - CE rounding behavior.
+   - Existing CSV and `use_reference_ds_layout` constructor paths.
+   - `dia_ms_ms_info` frame-to-group sequencing.
+
+   Add `scheme.to_bruker_tables()`, and retain the existing Python API as a compatibility wrapper. Golden-test both SQLite tables byte-for-value against the current path. Also fix or test the current ordering bug where `num_frames` is calculated before reference-derived `rt_cycle_length` replaces it.
+
+4. **MS1 is part of acquisition design, not purely writer behavior.** It determines cadence, analyzer, resolution/transient time, profile/centroid representation, mass range, and cycle duration. At minimum, add `Ms1Event { analyzer, mz_range, duration_s, data_mode }`. “One precursor every N positions” is unsuitable terminology outside Bruker and becomes redundant with an explicit event sequence.
+
+5. **CE must be a policy, not mandatory `f64`.** Represent `CollisionEnergyPolicy::{Fixed, PerWindow, Linear{...}, VendorModel{...}, Unknown}`. Silently inventing SCIEX CE would make “real-method replication” misleading. Require a user model/table when extraction cannot recover it, unless an explicitly labeled default simulation mode is selected.
+
+6. **The input/output split is correct, but the current writer contract is incomplete.** `AcquisitionScheme` describes intended events; `AcquisitionWriter` materializes scans. However, the existing Thermo writer ignores descriptor RT, isolation, and CE and only replaces peak packets ([acquisition.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/acquisition.rs:119)). Therefore the claimed arbitrary round trip is only valid when the generated scheme exactly matches the template schedule. Writers need either:
+   - Metadata-authoring support, or
+   - `validate_scheme(&scheme)` that rejects incompatible event count/order/metadata.
+
+**Open Questions**
+
+- **Blockers now:** 2 (core representation), 5 (MS1/cycle semantics), 6 (correct Thermo extraction), and 1 for faithful SCIEX output.
+- **Must be specified now but implementation can follow:** 3. Overlap needs no special isolation algorithm; windows should independently include ions in their bounds, including duplicated coverage. Define boundary conventions and preserve acquisition order.
+- **Deferrable:** 4. Bruker extraction may remain Python, provided both paths produce the same versioned Rust DTO and golden tables.
+
+**Missing Design Elements**
+
+Add event-level timing, cycle ordering, CE policy, analyzer/data mode, isolation boundary conventions, optional dwell/transient time, validation rules, scheme versioning, and provenance indicating whether values were extracted, inferred, or user-supplied. `cycle_time_s` alone cannot faithfully model RT sampling or instrument duty cycle.
+tokens used
+17,539
+**Key Findings**
+
+1. **The proposed model is too window-centric.** A flat `Vec<DiaWindow>` plus `precursor_every` cannot unambiguously represent:
+   - timsTOF: one frame containing several mobility-partitioned windows sharing a `window_group`.
+   - Astral/SCIEX: an ordered sequence of individual MS1/MS2 scans.
+   - Variable cycles, staggered schemes, multiple MS1 types, calibration scans, or per-event timing.
+
+   Model an ordered cycle explicitly:
+
+   ```rust
+   struct AcquisitionScheme {
+       cycle: Vec<AcquisitionEvent>,
+       repeat: RepeatPolicy,
+       run_duration_s: f64,
+   }
+
+   enum AcquisitionEvent {
+       Ms1(Ms1Event),
+       DiaMs2(DiaMs2Event),
+   }
+   ```
+
+   Each event should carry relative timing or duration, analyzer/type, m/z range, isolation, and CE policy. For timsTOF, an MS2 event can contain multiple mobility slices belonging to one frame.
+
+2. **Split mobility from the common isolation window.** `Option<(u32,u32)>` is mechanically workable but semantically weak. Scan numbers are Bruker-grid coordinates requiring the reference dataset’s calibration and scan count; they are not a physical mobility range. It also permits invalid states such as mobility on Astral.
+
+   Prefer:
+
+   ```rust
+   enum DiaGeometry {
+       MzOnly,
+       TimsMobility {
+           scan_start: u32,
+           scan_end: u32,
+           // optionally inverse-mobility bounds
+       },
+   }
+   ```
+
+   Better still, put geometry on a timsTOF frame/event rather than every generic window. Keep `IsolationWindow` strictly m/z-based.
+
+3. **Backward compatibility needs an explicit adapter, not an assertion of parity.** Existing code requires six concrete columns and uses `window_group` to assign frames, not merely identify windows ([acquisition.py](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:199), [handle.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/handle.rs:181)). The migration must preserve:
+   - Exact group IDs and row order.
+   - Inclusive/exclusive meaning of `scan_start`/`scan_end`.
+   - Integer types and column names.
+   - CE rounding behavior.
+   - Existing CSV and `use_reference_ds_layout` constructor paths.
+   - `dia_ms_ms_info` frame-to-group sequencing.
+
+   Add `scheme.to_bruker_tables()`, and retain the existing Python API as a compatibility wrapper. Golden-test both SQLite tables byte-for-value against the current path. Also fix or test the current ordering bug where `num_frames` is calculated before reference-derived `rt_cycle_length` replaces it.
+
+4. **MS1 is part of acquisition design, not purely writer behavior.** It determines cadence, analyzer, resolution/transient time, profile/centroid representation, mass range, and cycle duration. At minimum, add `Ms1Event { analyzer, mz_range, duration_s, data_mode }`. “One precursor every N positions” is unsuitable terminology outside Bruker and becomes redundant with an explicit event sequence.
+
+5. **CE must be a policy, not mandatory `f64`.** Represent `CollisionEnergyPolicy::{Fixed, PerWindow, Linear{...}, VendorModel{...}, Unknown}`. Silently inventing SCIEX CE would make “real-method replication” misleading. Require a user model/table when extraction cannot recover it, unless an explicitly labeled default simulation mode is selected.
+
+6. **The input/output split is correct, but the current writer contract is incomplete.** `AcquisitionScheme` describes intended events; `AcquisitionWriter` materializes scans. However, the existing Thermo writer ignores descriptor RT, isolation, and CE and only replaces peak packets ([acquisition.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/acquisition.rs:119)). Therefore the claimed arbitrary round trip is only valid when the generated scheme exactly matches the template schedule. Writers need either:
+   - Metadata-authoring support, or
+   - `validate_scheme(&scheme)` that rejects incompatible event count/order/metadata.
+
+**Open Questions**
+
+- **Blockers now:** 2 (core representation), 5 (MS1/cycle semantics), 6 (correct Thermo extraction), and 1 for faithful SCIEX output.
+- **Must be specified now but implementation can follow:** 3. Overlap needs no special isolation algorithm; windows should independently include ions in their bounds, including duplicated coverage. Define boundary conventions and preserve acquisition order.
+- **Deferrable:** 4. Bruker extraction may remain Python, provided both paths produce the same versioned Rust DTO and golden tables.
+
+**Missing Design Elements**
+
+Add event-level timing, cycle ordering, CE policy, analyzer/data mode, isolation boundary conventions, optional dwell/transient time, validation rules, scheme versioning, and provenance indicating whether values were extracted, inferred, or user-supplied. `cycle_time_s` alone cannot faithfully model RT sampling or instrument duty cycle.

--- a/ACQUISITION_SCHEME_PLAN.md
+++ b/ACQUISITION_SCHEME_PLAN.md
@@ -1,0 +1,219 @@
+# AcquisitionScheme — vendor-neutral DIA acquisition design for TimSim (v2)
+
+**Status:** design draft v2 (revised after Codex review of v1)
+**Scope:** the *input/design* side of multi-instrument TimSim — the acquisition
+schedule the simulator generates against — complementary to the already-built
+`AcquisitionWriter` (output side, `rustdf/src/sim/acquisition.rs`).
+
+> **Changes vs v1** (from review): model an explicit *ordered cycle of events*
+> instead of a flat window list; split ion-mobility geometry out of the generic
+> isolation window; make collision energy a *policy*, not a scalar; promote MS1
+> to a first-class event; add scheme versioning + provenance + validation; spell
+> out a Bruker backward-compat *adapter* with golden tests (not a parity claim);
+> and resolve several open questions (below). Also corrects v1's assumption that
+> Thermo MS2 scan events are hard to locate — they are not (see §2).
+
+---
+
+## 1. Problem & the two usage modes
+
+TimSim must generate scans for the **target instrument's acquisition schedule**
+— isolation windows, cycle structure, collision-energy plan, and (timsTOF only)
+ion-mobility partitioning. These differ per vendor (timsTOF DIA-PASEF: 2-D m/z×
+mobility; Orbitrap Astral: 1-D narrow m/z, no mobility; SCIEX ZenoTOF: 1-D
+variable SWATH, no mobility, Zeno).
+
+Two first-class usage modes (both must be supported):
+
+- **Reference-derived (timsim-style):** a real reference run supplies *both* the
+  acquisition layout *and* the real background for noise. The reference is used
+  twice — extract the scheme from it, and overlay simulated peaks onto its real
+  signal (real⊕sim). This is the established TimSim pattern
+  (`use_reference_ds_layout` + `add_real_data_noise`), generalized across vendors.
+- **Injected (user-authored):** a programmatic or CSV scheme with no reference
+  dependence — synthesize a custom window plan from scratch.
+
+## 2. Current state
+
+`TimsTofAcquisitionBuilderDIA` (`packages/imspy-simulation/.../acquisition.py`)
+is timsTOF-coupled: it holds a pandas `dia_ms_ms_windows` table
+(`window_group, scan_start, scan_end, isolation_mz, isolation_width,
+collision_energy`; `scan_start/end` are **mobility scan ranges**), sourced from a
+CSV or by copying a real Bruker reference `.d`'s `DiaFrameMsMsWindows`. It also
+derives `precursor_every`, builds `frame`/`scan` tables, and persists
+`dia_ms_ms_windows` + `dia_ms_ms_info` (frame→group) → the output `.d`.
+
+**Reader inventory (built + oracle-verified this session):**
+- **Bruker** — `reference_ds.dia_ms_ms_windows` (Python, today).
+- **Thermo** — `thermorawfile::scan_event(scan)` → `ScanEvent { ms_order,
+  analyzer, isolation_center, isolation_width, collision_energy }`. **Verified to
+  work per-scan on a real Astral file (uniform 280-byte event stride);** scan 2
+  reads center 490.473 / width 20.009 / CE 25.0, matching the RawFileReader
+  oracle. So walking one MS2 cycle recovers the exact Astral window schedule —
+  **not blocked** (corrects v1 open-Q6).
+- **SCIEX** — `sciexwiff` → `SWATHMethod` ~60 variable windows + TOF calibration.
+
+**Known existing bug to fix during migration:** in
+`TimsTofAcquisitionBuilderDIA`, `num_frames` is computed in the base `__init__`
+from the passed `gradient_length/rt_cycle_length` *before* `use_reference_ds_layout`
+overwrites `rt_cycle_length`, so the frame count can be stale.
+
+## 3. Model — an ordered cycle of events
+
+Lives in Rust (`rustdf/src/sim/scheme.rs`), exposed via `imspy_connector`.
+
+```rust
+pub struct AcquisitionScheme {
+    pub version: u16,                 // schema version for forward-compat
+    pub instrument: InstrumentKind,   // TimsTofDia | OrbitrapAstral | SciexZenoTof
+    pub cycle: Vec<AcquisitionEvent>, // one DIA cycle, in acquisition order
+    pub repeat: RepeatPolicy,         // how the cycle tiles the gradient
+    pub mz_range: (f64, f64),
+    pub provenance: Provenance,       // where each field came from
+}
+
+pub enum AcquisitionEvent {
+    Ms1(Ms1Event),
+    DiaMs2(DiaMs2Event),
+}
+
+pub struct Ms1Event {
+    pub analyzer: Analyzer,           // FTMS | ASTMS | TOF | ITMS
+    pub data_mode: DataMode,          // Profile | Centroid
+    pub mz_range: (f64, f64),
+    pub duration_s: Option<f64>,      // transient/dwell if known
+}
+
+pub struct DiaMs2Event {
+    pub window_group: u32,            // events sharing a group co-occur (timsTOF frame)
+    pub isolation: IsolationWindow,   // m/z ONLY
+    pub collision_energy: CollisionEnergyPolicy,
+    pub geometry: DiaGeometry,        // mobility partitioning (or none)
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub duration_s: Option<f64>,
+}
+
+pub struct IsolationWindow {          // m/z only; boundary convention is half-open [lo, hi)
+    pub center_mz: f64,
+    pub width_mz: f64,
+}
+
+pub enum DiaGeometry {
+    MzOnly,
+    TimsMobility { scan_start: u32, scan_end: u32 }, // Bruker-grid coords (need ref calibration)
+}
+
+pub enum CollisionEnergyPolicy {
+    Fixed(f64),
+    PerWindow(f64),
+    Linear { intercept: f64, slope_per_mz: f64 }, // CE = intercept + slope*center_mz
+    Unknown,                                       // extraction couldn't recover it
+}
+
+pub enum RepeatPolicy {
+    FixedCycleTime { cycle_time_s: f64, gradient_length_s: f64 },
+    // room for staggered / variable-cycle schemes later
+}
+
+pub struct Provenance {              // per-source attribution + free-form notes
+    pub source: SchemeSource,        // ExtractedBruker | ExtractedThermo | ExtractedSciex | UserCsv | Programmatic
+    pub notes: String,
+}
+```
+
+Why this shape (review points):
+- **Ordered events**, not a flat window list, so a timsTOF MS2 *frame* (several
+  mobility slices sharing a `window_group`) and a linear Astral/SCIEX MS1→MS2…
+  sequence are both representable, plus per-event timing/analyzer.
+- **Geometry split out**: `IsolationWindow` is strictly m/z; mobility lives in
+  `DiaGeometry::TimsMobility`, so "mobility on Astral" is unrepresentable.
+- **CE policy, not scalar**: never silently invent SCIEX rolling CE — extraction
+  yields `Unknown` and the caller must supply a model, unless an explicitly
+  labeled default-sim mode is chosen.
+- **MS1 is first-class** (analyzer/data_mode/mz_range/duration), since it drives
+  cadence and the writer's MS1 representation.
+
+## 4. Extractors (populate from a real run)
+
+```rust
+impl AcquisitionScheme {
+    pub fn from_bruker_d(path: &str) -> io::Result<Self>;      // DiaFrameMsMsWindows (+TimsMobility geometry)
+    #[cfg(feature = "thermo")]
+    pub fn from_thermo_raw(path: &str) -> io::Result<Self>;    // walk one MS2 cycle via scan_event()
+    #[cfg(feature = "sciex")]
+    pub fn from_sciex_wiff(path: &str) -> io::Result<Self>;    // SWATHMethod; CE => Unknown (rolling)
+    pub fn from_window_table(rows, instrument) -> Self;        // injected / CSV
+}
+```
+
+Each sets `provenance.source` accordingly. `from_thermo_raw` reads the first
+MS1→(MS2…)→nextMS1 span, one `DiaMs2Event` per MS2 scan event, CE = `Fixed`/
+`PerWindow` as observed, geometry `MzOnly`.
+
+## 5. Relationship to the writer (output)
+
+- `AcquisitionScheme` (in) and `AcquisitionWriter` (out) are the two halves. A
+  reference round trip: `from_thermo_raw(template)` → generate → `ThermoRawWriter`
+  (same template) → `.raw`.
+- **#6 (fixed):** `ThermoRawWriter` now authors a descriptor's MS2 isolation
+  center/width/CE into the scan event (`set_isolation`), not just the peaks.
+- **Replace vs overlay (open design):** the writer currently *replaces* template
+  signal. The reference-derived noise mode (§1) needs an **overlay** writer mode —
+  keep the real template profile/centroids and *add* simulated peaks — to realize
+  real⊕sim. This is the main remaining writer feature.
+- **Validation:** add `writer.validate_scheme(&scheme)` — for template-mutation
+  writers, reject a scheme whose event count/order/types don't fit the template
+  (e.g. more MS2 windows than the template cycle provides), with a clear error
+  rather than silent truncation.
+
+## 6. Bruker backward-compatibility (explicit adapter + golden tests)
+
+Migration must not change existing `.d` output. The existing code uses
+`window_group` to *assign frames* (not merely label windows), with specific
+column names/integer types, `scan_start/scan_end` inclusivity, CE rounding, and
+`dia_ms_ms_info` frame→group sequencing.
+
+- Add `scheme.to_bruker_tables() -> (dia_ms_ms_windows, dia_ms_ms_info)` that
+  reproduces those exact columns/types/ordering.
+- Keep the current Python `TimsTofAcquisitionBuilderDIA` constructors
+  (CSV + `use_reference_ds_layout`) as a compatibility wrapper over the scheme.
+- **Golden tests:** byte-for-value compare both SQLite tables against the current
+  path on a reference dataset. Fix the `num_frames`/`rt_cycle_length` ordering bug
+  as part of this (or pin it with a regression test).
+
+## 7. Boundary / location
+
+`AcquisitionScheme` + extractors in `rustdf/src/sim`, exposed as
+`PyAcquisitionScheme` via `imspy_connector`. Python `TimsTofAcquisitionBuilderDIA`
+consumes the scheme through the binding. Bruker extraction may *stay Python*
+initially (it works), provided it produces the same versioned scheme DTO and
+passes the golden tables (deferrable per review).
+
+## 8. Open questions (revised)
+
+- **Resolved since v1:** MS1 is scheme-level (now an `Ms1Event`); SCIEX rolling CE
+  → `CollisionEnergyPolicy::Unknown` + required user model; Thermo MS2 scan-event
+  location works (uniform stride) so `from_thermo_raw` is unblocked.
+- **Still open (blockers for full fidelity):**
+  1. **Overlay writer mode** (real⊕sim) — needed for reference-derived noise;
+     biggest remaining piece. (How to add sim peaks to a real profile/centroid
+     packet within budget, recompute stats.)
+  2. **RT / duty-cycle modeling** — is `RepeatPolicy::FixedCycleTime` enough, or do
+     we need per-event durations to model real cycle time / overlap in RT?
+  3. **SCIEX CE source** — confirm whether any per-window CE is recoverable from
+     the `.wiff` method beyond `SWATHMethod` (else require a user model).
+- **Specify-now, implement-later:** overlapping windows need only a documented
+  boundary convention (half-open `[lo, hi)`) + preserved acquisition order; no
+  special isolation algorithm.
+
+## 9. Test plan
+
+- `from_thermo_raw(astral_template)`: N MS2 windows, monotonic centers, CE policy
+  `Fixed(25)`, one `Ms1Event` per cycle, all geometry `MzOnly`.
+- `from_sciex_wiff(zenotof)`: ~60 windows covering 399.5–899.9, CE `Unknown`.
+- `from_bruker_d(ref)` → `to_bruker_tables()` golden-equal to today's Python path.
+- End-to-end: `from_thermo_raw(template)` → generate 1×MS1 + N×MS2 → `ThermoRawWriter`
+  → read back via thermorawfile + Thermo oracle (peaks, isolation, CE).
+- Overlay mode (once built): authored peaks present *and* template background
+  retained.

--- a/BRUKER_INFO.codex-review.md
+++ b/BRUKER_INFO.codex-review.md
@@ -1,3 +1,23 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019eab49-6901-7170-b02b-4b220a0e8c61
+--------
+user
+Review ONLY the newly added code (rest already reviewed): the private bruker_group_layout(), to_bruker_info(num_frames), to_bruker_tables(num_frames), and the refactor of to_bruker_windows onto bruker_group_layout. Plus their tests to_bruker_info_tiling (unconditional) and bruker_info_round_trip (gated).
+
+Trusted context: this is the Bruker backward-compat adapter for a DIA mass-spec simulator. The scheme's cycle is an ordered Vec<AcquisitionEvent> = Ms1 | DiaMs2Frame(windows, vendor_group_id:Option<u32>). For real Bruker DIA-PASEF the cycle is [Ms1, then N DiaMs2Frames], frames_per_cycle = cycle.len(). bruker_group_layout returns Vec<Option<u32>> indexed by cycle position (None=MS1, Some=MS2 group id), reserving explicit vendor_group_ids (rejecting duplicates) and drawing collision-free positional fallbacks for None frames. to_bruker_info tiles: for frame_id in 1..=num_frames, pos=(frame_id-1)%cycle_len, emit (frame_id, group) when layout[pos] is Some. Verified on a real .d: regenerates DiaFrameMsMsWindows (36 rows) and DiaFrameMsMsInfo (16543 rows over 17646 frames, incl a partial last cycle) bit-exact.
+
+Focus: 1) to_bruker_info tiling correctness — the (frame_id-1)%cycle_len mapping vs how Bruker actually numbers frames (is frame 1 always the first MS1 of cycle 0? what if the scheme cycle doesn't start with MS1, or has interleaved/multiple MS1 — does pos mapping still hold? note validate() requires exactly one MS1 first). 2) the assumption that cycle order == real acquisition frame order (the doc flags ascending-WindowGroup ordering; does to_bruker_info inherit/compound that, and could it silently produce a wrong frame→group map that the bit-exact test only validates because this particular .d's acquisition order matches ascending group?). 3) num_frames edge cases: 0, not a multiple of cycle_len (partial cycle — verified ok), huge values (perf/overflow of frame_id:u32 and (frame_id-1)). 4) consistency guarantee between to_bruker_windows and to_bruker_info via the shared layout — any path where they diverge. 5) the gated round-trip test: does matching THIS .d actually prove generality, and what's NOT covered (e.g. non-ascending groups, multi-window timsTOF frames in the info tiling). 6) any panic/overflow/correctness bug. Concrete, ranked, ~550 words.
+
+<stdin>
 //! Vendor-neutral DIA acquisition **scheme** (input/design side).
 //!
 //! An [`AcquisitionScheme`] describes one DIA cycle as an *ordered sequence of
@@ -531,25 +551,15 @@ impl AcquisitionScheme {
     }
 
     /// Generate the Bruker `DiaFrameMsMsInfo` (frame → window group) rows for a run
-    /// of `num_frames` total frames, tiling the scheme's cycle. Cycle position
-    /// `(frame_id - 1) % cycle_len` selects the event (1-based frame ids), MS1
+    /// of `num_frames` total frames, tiling the scheme's cycle. Frame ids are
+    /// 1-based; cycle position `(frame_id - 1) % cycle_len` selects the event, MS1
     /// frames produce no row, and each MS2 frame maps to its window-group id (the
-    /// same ids `to_bruker_windows` emits, so the two tables reference the same
-    /// groups). The final cycle may be partial.
-    ///
-    /// Precondition: this models a **clean generated run** — frame 1 is the
-    /// cycle's leading MS1 and frame ids are contiguous (as TimSim produces). It
-    /// is not a reproducer for arbitrary real files with prefix/calibration
-    /// frames, gaps, or acquisition starting mid-cycle.
+    /// same ids `to_bruker_windows` emits, so the two tables are consistent). The
+    /// final cycle may be partial.
     pub fn to_bruker_info(
         &self,
         num_frames: u32,
     ) -> Result<Vec<crate::data::meta::DiaMsMisInfo>, String> {
-        // Bound the work so an absurd frame count errors cleanly instead of OOM.
-        const MAX_FRAMES: u32 = 100_000_000;
-        if num_frames > MAX_FRAMES {
-            return Err(format!("num_frames {num_frames} exceeds the {MAX_FRAMES} limit"));
-        }
         let layout = self.bruker_group_layout()?;
         let fpc = layout.len() as u32;
         if fpc == 0 {
@@ -592,13 +602,12 @@ impl AcquisitionScheme {
     /// preceded by a single MS1 event. Cycle timing comes from the spacing of
     /// the precursor (MS1) frames. The returned scheme is validated.
     ///
-    /// Window groups (frames) are ordered by their **first occurrence in
-    /// `DiaFrameMsMsInfo`** (ascending frame id), i.e. the real acquisition order
-    /// within a cycle — not merely ascending `WindowGroup` id — so the cycle
-    /// faithfully represents permuted/reused group numbering. (If the info table
-    /// is absent, falls back to ascending group id.)
+    /// Note: window groups are ordered by ascending `WindowGroup` id, which is
+    /// the DIA-PASEF acquisition order in practice; a file that reuses or
+    /// permutes group numbering would need ordering by first MS2-frame
+    /// occurrence (via `DiaFrameMsMsInfo`) instead.
     pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
-        use crate::data::meta::{read_dia_ms_ms_info, read_dia_ms_ms_windows, read_meta_data_sql};
+        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
         use std::collections::BTreeMap;
 
         let folder = path.as_ref().to_string_lossy().into_owned();
@@ -634,34 +643,14 @@ impl AcquisitionScheme {
             by_group.entry(w.window_group).or_default().push(dw);
         }
 
-        // Order groups by first occurrence (ascending frame id) in DiaFrameMsMsInfo
-        // = real intra-cycle acquisition order. Missing info -> ascending group id.
-        let info = read_dia_ms_ms_info(&folder).unwrap_or_default();
-        let mut first_frame: BTreeMap<u32, u32> = BTreeMap::new();
-        for r in &info {
-            first_frame
-                .entry(r.window_group)
-                .and_modify(|f| {
-                    if r.frame_id < *f {
-                        *f = r.frame_id
-                    }
-                })
-                .or_insert(r.frame_id);
-        }
-        let mut ordered_groups: Vec<u32> = by_group.keys().copied().collect();
-        // Stable sort by first-occurrence frame; groups absent from the info table
-        // (key u32::MAX) keep their ascending-id relative order.
-        ordered_groups.sort_by_key(|g| first_frame.get(g).copied().unwrap_or(u32::MAX));
-
         let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
             analyzer: Analyzer::Tof,
             data_mode: DataMode::Centroid,
             mz_range: None,
             duration_s: None,
         })];
-        let n_groups = ordered_groups.len();
-        for group in ordered_groups {
-            let ws = by_group.remove(&group).expect("group present");
+        let n_groups = by_group.len();
+        for (group, ws) in by_group {
             cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
                 windows: ws,
                 analyzer: Analyzer::Tof,
@@ -1288,56 +1277,6 @@ mod tests {
         let wg: std::collections::BTreeSet<u32> = windows.iter().map(|w| w.window_group).collect();
         let ig: std::collections::BTreeSet<u32> = info2.iter().map(|r| r.window_group).collect();
         assert_eq!(wg, ig, "windows/info group ids disagree");
-
-        // Non-ascending explicit ids + a multi-window (mobility-partitioned) frame:
-        // info must follow CYCLE order (not sorted id) and emit ONE row per frame.
-        let win = |center: f64, s0: u32, s1: u32| DiaWindow {
-            isolation: IsolationWindow { center_mz: center, width_mz: 10.0 },
-            collision_energy: CollisionEnergyPolicy::Value(20.0),
-            geometry: DiaGeometry::TimsMobility { scan_start: s0, scan_end: s1 },
-        };
-        let dia = |gid: u32, ws: Vec<DiaWindow>| {
-            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
-                windows: ws,
-                analyzer: Analyzer::Tof,
-                data_mode: DataMode::Centroid,
-                duration_s: None,
-                vendor_group_id: Some(gid),
-            })
-        };
-        let s2 = AcquisitionScheme {
-            version: SCHEME_VERSION,
-            instrument: InstrumentKind::TimsTofDia,
-            cycle: vec![
-                AcquisitionEvent::Ms1(Ms1Event {
-                    analyzer: Analyzer::Tof,
-                    data_mode: DataMode::Centroid,
-                    mz_range: None,
-                    duration_s: None,
-                }),
-                dia(7, vec![win(500.0, 0, 50), win(500.0, 51, 100)]), // 2 mobility windows
-                dia(2, vec![win(600.0, 0, 100)]),
-            ],
-            repeat: RepeatPolicy::FixedCycleTime {
-                cycle_time_s: 1.0,
-                gradient_length_s: 600.0,
-                start_time_s: 0.0,
-            },
-            mz_range: (300.0, 900.0),
-            provenance: Provenance { source: SchemeSource::Programmatic, notes: String::new() },
-        };
-        // cycle len 3; frame2->g7 (first), frame3->g2 — acquisition order, NOT sorted.
-        let info3: Vec<(u32, u32)> = s2
-            .to_bruker_info(3)
-            .unwrap()
-            .iter()
-            .map(|r| (r.frame_id, r.window_group))
-            .collect();
-        assert_eq!(info3, vec![(2, 7), (3, 2)], "info must follow cycle order, one row/frame");
-        // windows: the 2-window frame emits 2 rows (group 7), the other 1 (group 2).
-        let w3 = s2.to_bruker_windows().unwrap();
-        assert_eq!(w3.iter().filter(|w| w.window_group == 7).count(), 2);
-        assert_eq!(w3.iter().filter(|w| w.window_group == 2).count(), 1);
     }
 
     // Gated: regenerate DiaFrameMsMsInfo for the .d's full frame count and match.
@@ -1433,3 +1372,39 @@ mod tests {
         );
     }
 }
+</stdin>
+codex
+1. **High: `to_bruker_info` assumes frame 1 is exactly the cycle’s leading MS1.**  
+   `(frame_id - 1) % cycle_len` is correct only when the run starts at cycle position zero and frame IDs are contiguous physical acquisition events. `validate()` proves the modeled cycle begins with exactly one MS1, but it cannot prove that an existing Bruker run’s frame 1 corresponds to that event. Prefix/calibration frames, missing IDs, or acquisition beginning mid-cycle would silently shift every mapping. The API needs either an explicitly documented/generated-run precondition or a starting frame/cycle offset derived from actual frame metadata.
+
+2. **High: extraction order can silently corrupt the frame-to-group schedule.**  
+   `to_bruker_info` correctly treats `cycle` order as authoritative, but `from_bruker_d` constructs that order by ascending `WindowGroup`, not first occurrence in `DiaFrameMsMsInfo`. Consequently, a valid file acquired in order `[7, 2, 9]` becomes `[2, 7, 9]`, and `to_bruker_info` emits a plausible but wrong schedule. The new round-trip passes precisely when acquisition order happens to equal ascending group order, so it does not establish general correctness. This should ideally be prevented at extraction by ordering groups from the info table; otherwise the adapter should reject extracted schemes whose ordering provenance is uncertain.
+
+3. **Medium: `num_frames` permits impractically large work and possible process abort.**  
+   `u32::MAX` causes roughly four billion loop iterations and potentially billions of rows. Rust arithmetic in `frame_id - 1` is safe because iteration starts at 1, and a standard inclusive range handles its terminal value, but memory exhaustion can abort rather than return `Err`. Consider checked conversion/allocation and an application-level maximum, or an iterator/streaming API. `num_frames == 0` is handled correctly and returns an empty vector; partial cycles are also correct.
+
+4. **Low: the shared-layout consistency guarantee is narrower than the documentation suggests.**  
+   Group-ID assignment cannot diverge: both methods deterministically call the same validated layout, and `to_bruker_tables` returns nothing if window materialization fails. However, standalone `to_bruker_info` can succeed for schemes whose windows later fail `to_bruker_windows` because of `MzOnly` geometry or unknown CE. Thus “always agree” means assigned IDs agree, not that every successful info table has a materializable windows table. `to_bruker_tables` also computes and validates the layout twice; not incorrect, but passing one layout to both renderers would make the guarantee structural and avoid duplicate work.
+
+5. **Low: tests cover one canonical schedule only.**  
+   `to_bruker_info_tiling` verifies the basic `[MS1, g1, g2]` mapping and a complete two-cycle run, but not `0`, partial cycles, explicit/non-ascending IDs, mixed explicit/fallback IDs, or a multi-window MS2 frame producing exactly one info row. The gated test proves exact compatibility with this particular `.d`, including its partial final cycle, but not permuted group IDs, unusual frame prefixes/gaps, or other timsTOF schedules.
+
+No immediate arithmetic panic exists in `to_bruker_info`. `next_seq += 1` is theoretically overflowable, but reaching it requires essentially exhausting the `u32` ID space and is not a practical input size.
+tokens used
+22,140
+1. **High: `to_bruker_info` assumes frame 1 is exactly the cycle’s leading MS1.**  
+   `(frame_id - 1) % cycle_len` is correct only when the run starts at cycle position zero and frame IDs are contiguous physical acquisition events. `validate()` proves the modeled cycle begins with exactly one MS1, but it cannot prove that an existing Bruker run’s frame 1 corresponds to that event. Prefix/calibration frames, missing IDs, or acquisition beginning mid-cycle would silently shift every mapping. The API needs either an explicitly documented/generated-run precondition or a starting frame/cycle offset derived from actual frame metadata.
+
+2. **High: extraction order can silently corrupt the frame-to-group schedule.**  
+   `to_bruker_info` correctly treats `cycle` order as authoritative, but `from_bruker_d` constructs that order by ascending `WindowGroup`, not first occurrence in `DiaFrameMsMsInfo`. Consequently, a valid file acquired in order `[7, 2, 9]` becomes `[2, 7, 9]`, and `to_bruker_info` emits a plausible but wrong schedule. The new round-trip passes precisely when acquisition order happens to equal ascending group order, so it does not establish general correctness. This should ideally be prevented at extraction by ordering groups from the info table; otherwise the adapter should reject extracted schemes whose ordering provenance is uncertain.
+
+3. **Medium: `num_frames` permits impractically large work and possible process abort.**  
+   `u32::MAX` causes roughly four billion loop iterations and potentially billions of rows. Rust arithmetic in `frame_id - 1` is safe because iteration starts at 1, and a standard inclusive range handles its terminal value, but memory exhaustion can abort rather than return `Err`. Consider checked conversion/allocation and an application-level maximum, or an iterator/streaming API. `num_frames == 0` is handled correctly and returns an empty vector; partial cycles are also correct.
+
+4. **Low: the shared-layout consistency guarantee is narrower than the documentation suggests.**  
+   Group-ID assignment cannot diverge: both methods deterministically call the same validated layout, and `to_bruker_tables` returns nothing if window materialization fails. However, standalone `to_bruker_info` can succeed for schemes whose windows later fail `to_bruker_windows` because of `MzOnly` geometry or unknown CE. Thus “always agree” means assigned IDs agree, not that every successful info table has a materializable windows table. `to_bruker_tables` also computes and validates the layout twice; not incorrect, but passing one layout to both renderers would make the guarantee structural and avoid duplicate work.
+
+5. **Low: tests cover one canonical schedule only.**  
+   `to_bruker_info_tiling` verifies the basic `[MS1, g1, g2]` mapping and a complete two-cycle run, but not `0`, partial cycles, explicit/non-ascending IDs, mixed explicit/fallback IDs, or a multi-window MS2 frame producing exactly one info row. The gated test proves exact compatibility with this particular `.d`, including its partial final cycle, but not permuted group IDs, unusual frame prefixes/gaps, or other timsTOF schedules.
+
+No immediate arithmetic panic exists in `to_bruker_info`. `next_seq += 1` is theoretically overflowable, but reaching it requires essentially exhausting the `u32` ID space and is not a practical input size.

--- a/EXTRACTORS.codex-review.md
+++ b/EXTRACTORS.codex-review.md
@@ -1,0 +1,2169 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019eab08-de8e-7470-b5f1-79100a6009db
+--------
+user
+Review the NEW code added to these two Rust files for a mass-spec simulator (TimSim): in scheme.rs, the extractors AcquisitionScheme::from_bruker_d and AcquisitionScheme::from_sciex_wiff (the data model, validate(), num_cycles, windows(), from_window_table, and from_thermo_raw were ALREADY reviewed — only skim them for interaction bugs). The second file is sciexwiff's new library API (read_method).
+
+Trusted context: rustdf reads Bruker TDF natively — read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow{window_group,scan_num_begin,scan_num_end,isolation_mz,isolation_width,collision_energy}> and read_meta_data_sql(folder)->Vec<FrameMeta{id,time:f64,ms_ms_type:i64,...}> (MsMsType==0 = MS1/precursor frame). from_bruker_d groups windows by window_group into DiaMs2Frame{TimsMobility windows} and derives cycle time from precursor-frame spacing; verified to extract 15 frames/36 windows from a real DIA-PASEF .d. from_sciex_wiff maps SWATH windows to single MzOnly frames with CE Unknown (SCIEX rolling CE not in the method) and caller-supplied timing; verified 60 windows on a real ZenoTOF .wiff. validate() (already reviewed) requires exactly one MS1 first then >=1 MS2 frame, finite/positive widths, window edges within mz_range, CE finite>=0 for Value/resolved-Linear, multi-window frames need TimsMobility on every window and no within-frame m/z+mobility overlap, start<=gradient. sciexwiff::read_method opens a .wiff OLE2 (cfb crate) and parses SWATHMethod (20B records from off 40) + TOFCalibrationData.
+
+Focus: 1) from_bruker_d correctness — window-group grouping, cycle-time from precursor spacing (sorted; what if precursor times equal/unsorted/duplicated, or DIA uses a different MsMsType for MS1?), start/gradient via fold over f64 (NaN handling), whether the produced scheme always passes validate() (e.g. within-frame overlap on real PASEF groups; windows-within-mz_range by construction), empty/edge frames. 2) from_sciex_wiff — caller-supplied timing validation, window mapping, the Unknown-CE contract, mz_range. 3) sciexwiff read_method — bounds/stride safety on untrusted .wiff bytes, partial/short streams, the SWATHMethod record count derivation, calibration optionality. 4) any panic on malformed vendor files, and any case where an extractor returns a scheme that then fails validate() (surprising for a caller). Concrete, ranked by severity, cap ~700 words.
+
+<stdin>
+===== FILE: rustdf/src/sim/scheme.rs =====
+//! Vendor-neutral DIA acquisition **scheme** (input/design side).
+//!
+//! An [`AcquisitionScheme`] describes one DIA cycle as an *ordered sequence of
+//! physical events* ([`AcquisitionEvent`]) and how that cycle tiles the
+//! gradient ([`RepeatPolicy`]). It is the design counterpart to the
+//! [`crate::sim::acquisition::AcquisitionWriter`] (output side): the simulator
+//! generates scans for the scheme, and a writer materializes them.
+//!
+//! The key modelling choice (per review) is that a *physical acquisition unit*
+//! is explicit: [`AcquisitionEvent::DiaMs2Frame`] carries a `Vec<DiaWindow>`, so
+//! a timsTOF MS2 frame holding several mobility-partitioned windows and a linear
+//! Astral/SCIEX MS2 scan (one window) are both represented without overloading a
+//! `window_group` id to imply simultaneity.
+
+use std::io;
+
+/// Current scheme schema version.
+pub const SCHEME_VERSION: u16 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstrumentKind {
+    TimsTofDia,
+    OrbitrapAstral,
+    SciexZenoTof,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Analyzer {
+    Ftms,
+    Astms,
+    Tof,
+    Itms,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataMode {
+    Profile,
+    Centroid,
+}
+
+/// An m/z isolation window (no ion mobility — see [`DiaGeometry`]).
+#[derive(Clone, Copy, Debug)]
+pub struct IsolationWindow {
+    pub center_mz: f64,
+    pub width_mz: f64,
+}
+
+impl IsolationWindow {
+    pub fn lower(&self) -> f64 {
+        self.center_mz - self.width_mz / 2.0
+    }
+    pub fn upper(&self) -> f64 {
+        self.center_mz + self.width_mz / 2.0
+    }
+}
+
+/// How a window's collision energy is determined.
+///
+/// `Value` covers both a per-window CE and a scheme-wide fixed CE (every window
+/// carries the same value) — there is intentionally no separate `Fixed` variant
+/// (they were structurally identical). `Unknown` means extraction could not
+/// recover it (e.g. SCIEX rolling CE) and a model must be supplied downstream —
+/// it is never silently invented.
+#[derive(Clone, Copy, Debug)]
+pub enum CollisionEnergyPolicy {
+    Value(f64),
+    Linear { intercept: f64, slope_per_mz: f64 },
+    Unknown,
+}
+
+impl CollisionEnergyPolicy {
+    /// Resolve the CE for a window centered at `center_mz`, if determinable.
+    pub fn at(&self, center_mz: f64) -> Option<f64> {
+        match *self {
+            CollisionEnergyPolicy::Value(v) => Some(v),
+            CollisionEnergyPolicy::Linear {
+                intercept,
+                slope_per_mz,
+            } => Some(intercept + slope_per_mz * center_mz),
+            CollisionEnergyPolicy::Unknown => None,
+        }
+    }
+}
+
+/// Window geometry: m/z only, or (timsTOF) an additional ion-mobility partition.
+/// Mobility is kept off [`IsolationWindow`] so "mobility on a non-IMS instrument"
+/// is unrepresentable. Scan numbers are Bruker-grid coordinates (they require the
+/// reference dataset's calibration to map to physical mobility).
+#[derive(Clone, Copy, Debug)]
+pub enum DiaGeometry {
+    MzOnly,
+    TimsMobility { scan_start: u32, scan_end: u32 },
+}
+
+/// One DIA isolation window within a frame.
+#[derive(Clone, Copy, Debug)]
+pub struct DiaWindow {
+    pub isolation: IsolationWindow,
+    pub collision_energy: CollisionEnergyPolicy,
+    pub geometry: DiaGeometry,
+}
+
+/// An MS1 (precursor) acquisition.
+#[derive(Clone, Debug)]
+pub struct Ms1Event {
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    /// The MS1 acquisition m/z range, if known. `None` when not recoverable
+    /// (e.g. Thermo `scan_event` does not carry it — it must not be confused
+    /// with the DIA window coverage in [`AcquisitionScheme::mz_range`]).
+    pub mz_range: Option<(f64, f64)>,
+    pub duration_s: Option<f64>,
+}
+
+/// One physical MS2 acquisition unit. Holds one window for Astral/SCIEX; several
+/// mobility-partitioned windows (sharing the frame) for timsTOF.
+#[derive(Clone, Debug)]
+pub struct DiaMs2Frame {
+    pub windows: Vec<DiaWindow>,
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub duration_s: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AcquisitionEvent {
+    Ms1(Ms1Event),
+    DiaMs2Frame(DiaMs2Frame),
+}
+
+/// How the cycle repeats over the gradient.
+#[derive(Clone, Copy, Debug)]
+pub enum RepeatPolicy {
+    /// The cycle repeats every `cycle_time_s`, starting at `start_time_s`, until
+    /// `gradient_length_s`. Per-event `duration_s` (when present) takes
+    /// precedence for fine RT placement; otherwise events are spread across the
+    /// cycle uniformly.
+    FixedCycleTime {
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+        start_time_s: f64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SchemeSource {
+    ExtractedBruker,
+    ExtractedThermo,
+    ExtractedSciex,
+    UserTable,
+    Programmatic,
+}
+
+/// Where the scheme came from (scheme-level attribution; not per-field).
+#[derive(Clone, Debug)]
+pub struct Provenance {
+    pub source: SchemeSource,
+    pub notes: String,
+}
+
+/// A vendor-neutral DIA acquisition design.
+#[derive(Clone, Debug)]
+pub struct AcquisitionScheme {
+    pub version: u16,
+    pub instrument: InstrumentKind,
+    pub cycle: Vec<AcquisitionEvent>,
+    pub repeat: RepeatPolicy,
+    pub mz_range: (f64, f64),
+    pub provenance: Provenance,
+}
+
+impl AcquisitionScheme {
+    /// Iterate every DIA window across all MS2 frames in the cycle.
+    pub fn windows(&self) -> impl Iterator<Item = &DiaWindow> {
+        self.cycle
+            .iter()
+            .flat_map(|e| match e {
+                AcquisitionEvent::DiaMs2Frame(f) => f.windows.as_slice(),
+                AcquisitionEvent::Ms1(_) => &[][..],
+            }
+            .iter())
+    }
+
+    /// Number of MS1 events in one cycle.
+    pub fn ms1_count(&self) -> usize {
+        self.cycle
+            .iter()
+            .filter(|e| matches!(e, AcquisitionEvent::Ms1(_)))
+            .count()
+    }
+
+    /// Number of full cycles that fit the gradient (if derivable).
+    pub fn num_cycles(&self) -> Option<u64> {
+        match self.repeat {
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s,
+            } if cycle_time_s.is_finite()
+                && cycle_time_s > 0.0
+                && gradient_length_s.is_finite()
+                && start_time_s.is_finite() =>
+            {
+                Some(((gradient_length_s - start_time_s).max(0.0) / cycle_time_s) as u64)
+            }
+            _ => None,
+        }
+    }
+
+    /// Build a scheme from an explicit window list (injected / CSV). One MS1
+    /// followed by one single-window MS2 frame per window.
+    pub fn from_window_table(
+        instrument: InstrumentKind,
+        ms1: Ms1Event,
+        windows: Vec<DiaWindow>,
+        repeat: RepeatPolicy,
+        mz_range: (f64, f64),
+    ) -> Self {
+        let mut cycle = vec![AcquisitionEvent::Ms1(ms1.clone())];
+        for w in windows {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![w],
+                analyzer: ms1.analyzer,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            }));
+        }
+        AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument,
+            cycle,
+            repeat,
+            mz_range,
+            provenance: Provenance {
+                source: SchemeSource::UserTable,
+                notes: "built from explicit window table".to_string(),
+            },
+        }
+    }
+
+    /// Validate internal consistency. Returns a human-readable error on the first
+    /// problem found.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.version != SCHEME_VERSION {
+            return Err(format!(
+                "unsupported scheme version {} (this build supports {})",
+                self.version, SCHEME_VERSION
+            ));
+        }
+        if self.cycle.is_empty() {
+            return Err("empty cycle".into());
+        }
+        let (lo, hi) = self.mz_range;
+        if !(lo.is_finite() && hi.is_finite()) || lo >= hi {
+            return Err(format!("invalid mz_range ({lo}, {hi})"));
+        }
+        // Structure: exactly one MS1, as the first event, then >= 1 MS2 frame.
+        if !matches!(self.cycle.first(), Some(AcquisitionEvent::Ms1(_))) {
+            return Err("cycle must begin with an MS1 event".into());
+        }
+        if self.ms1_count() != 1 {
+            return Err(format!(
+                "cycle must contain exactly one MS1 event (has {})",
+                self.ms1_count()
+            ));
+        }
+        if !self
+            .cycle
+            .iter()
+            .any(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+        {
+            return Err("cycle has no MS2 frames".into());
+        }
+
+        let check_dur = |d: Option<f64>, what: &str| -> Result<(), String> {
+            match d {
+                Some(v) if !(v.is_finite() && v > 0.0) => {
+                    Err(format!("{what} duration must be finite and > 0"))
+                }
+                _ => Ok(()),
+            }
+        };
+
+        for ev in &self.cycle {
+            match ev {
+                AcquisitionEvent::Ms1(m) => {
+                    check_dur(m.duration_s, "MS1")?;
+                    if let Some((a, b)) = m.mz_range {
+                        if !(a.is_finite() && b.is_finite()) || a >= b {
+                            return Err(format!("invalid MS1 mz_range ({a}, {b})"));
+                        }
+                    }
+                }
+                AcquisitionEvent::DiaMs2Frame(frame) => {
+                    check_dur(frame.duration_s, "MS2 frame")?;
+                    if frame.windows.is_empty() {
+                        return Err("MS2 frame has no windows".into());
+                    }
+                    let multi = frame.windows.len() > 1;
+                    if multi && self.instrument != InstrumentKind::TimsTofDia {
+                        return Err(
+                            "multi-window MS2 frame is only valid for timsTOF (mobility-partitioned)"
+                                .into(),
+                        );
+                    }
+                    for (i, w) in frame.windows.iter().enumerate() {
+                        if !(w.isolation.width_mz.is_finite() && w.isolation.width_mz > 0.0) {
+                            return Err("window width must be finite and > 0".into());
+                        }
+                        if !w.isolation.center_mz.is_finite()
+                            || !w.isolation.lower().is_finite()
+                            || !w.isolation.upper().is_finite()
+                        {
+                            return Err("window m/z is not finite".into());
+                        }
+                        if w.isolation.lower() < lo - 1e-6 || w.isolation.upper() > hi + 1e-6 {
+                            return Err(format!(
+                                "window [{:.4}, {:.4}] outside mz_range [{lo:.4}, {hi:.4}]",
+                                w.isolation.lower(),
+                                w.isolation.upper()
+                            ));
+                        }
+                        match w.collision_energy {
+                            CollisionEnergyPolicy::Value(v) => {
+                                if !v.is_finite() || v < 0.0 {
+                                    return Err("collision energy must be finite and >= 0".into());
+                                }
+                            }
+                            CollisionEnergyPolicy::Linear {
+                                intercept,
+                                slope_per_mz,
+                            } => {
+                                if !intercept.is_finite() || !slope_per_mz.is_finite() {
+                                    return Err("non-finite linear CE coefficients".into());
+                                }
+                                match w.collision_energy.at(w.isolation.center_mz) {
+                                    Some(ce) if ce.is_finite() && ce >= 0.0 => {}
+                                    _ => {
+                                        return Err(
+                                            "linear CE resolves to non-finite or negative".into()
+                                        )
+                                    }
+                                }
+                            }
+                            CollisionEnergyPolicy::Unknown => {}
+                        }
+                        match w.geometry {
+                            DiaGeometry::TimsMobility {
+                                scan_start,
+                                scan_end,
+                            } => {
+                                if self.instrument != InstrumentKind::TimsTofDia {
+                                    return Err("mobility geometry is only valid for timsTOF".into());
+                                }
+                                if scan_start > scan_end {
+                                    return Err("mobility scan_start > scan_end".into());
+                                }
+                            }
+                            DiaGeometry::MzOnly => {
+                                if multi {
+                                    return Err(
+                                        "multi-window timsTOF frame requires mobility geometry on every window"
+                                            .into(),
+                                    );
+                                }
+                            }
+                        }
+                        // Within one frame, windows must not overlap in BOTH m/z
+                        // and mobility (overlap across sequential frames is fine).
+                        for w2 in &frame.windows[..i] {
+                            let mz_overlap = w.isolation.lower() < w2.isolation.upper()
+                                && w2.isolation.lower() < w.isolation.upper();
+                            let im_overlap = match (w.geometry, w2.geometry) {
+                                (
+                                    DiaGeometry::TimsMobility {
+                                        scan_start: a0,
+                                        scan_end: a1,
+                                    },
+                                    DiaGeometry::TimsMobility {
+                                        scan_start: b0,
+                                        scan_end: b1,
+                                    },
+                                ) => a0 <= b1 && b0 <= a1,
+                                _ => true, // m/z-only windows share all mobility
+                            };
+                            if mz_overlap && im_overlap {
+                                return Err(
+                                    "windows within one frame overlap in both m/z and mobility"
+                                        .into(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        match self.repeat {
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s,
+            } => {
+                if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+                    return Err("cycle_time_s must be finite and > 0".into());
+                }
+                if !(gradient_length_s.is_finite() && gradient_length_s > 0.0) {
+                    return Err("gradient_length_s must be finite and > 0".into());
+                }
+                if !start_time_s.is_finite() || start_time_s < 0.0 {
+                    return Err("start_time_s must be finite and >= 0".into());
+                }
+                if start_time_s > gradient_length_s {
+                    return Err("start_time_s must be <= gradient_length_s".into());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl AcquisitionScheme {
+    /// Extract the acquisition scheme from a real Bruker timsTOF DIA `.d`.
+    ///
+    /// Reads `DiaFrameMsMsWindows` and the frame table. Each **window group**
+    /// becomes one [`DiaMs2Frame`] holding its mobility-partitioned windows
+    /// (`TimsMobility` geometry — the scan ranges are Bruker-grid coordinates),
+    /// preceded by a single MS1 event. Cycle timing comes from the spacing of
+    /// the precursor (MS1) frames.
+    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+        use std::collections::BTreeMap;
+
+        let folder = path.as_ref().to_string_lossy().into_owned();
+        let to_io =
+            |e: Box<dyn std::error::Error>| io::Error::new(io::ErrorKind::InvalidData, e.to_string());
+        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+        let frames = read_meta_data_sql(&folder).map_err(to_io)?;
+        if windows.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no DiaFrameMsMsWindows rows (not a DIA .d?)",
+            ));
+        }
+
+        // Group windows by window group (ascending); each group is a frame.
+        let mut by_group: BTreeMap<u32, Vec<DiaWindow>> = BTreeMap::new();
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        for w in &windows {
+            let dw = DiaWindow {
+                isolation: IsolationWindow {
+                    center_mz: w.isolation_mz,
+                    width_mz: w.isolation_width,
+                },
+                collision_energy: CollisionEnergyPolicy::Value(w.collision_energy),
+                geometry: DiaGeometry::TimsMobility {
+                    scan_start: w.scan_num_begin,
+                    scan_end: w.scan_num_end,
+                },
+            };
+            lo = lo.min(dw.isolation.lower());
+            hi = hi.max(dw.isolation.upper());
+            by_group.entry(w.window_group).or_default().push(dw);
+        }
+
+        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        })];
+        let n_groups = by_group.len();
+        for (_group, ws) in by_group {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: ws,
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            }));
+        }
+
+        // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+        let mut prec_times: Vec<f64> = frames
+            .iter()
+            .filter(|f| f.ms_ms_type == 0)
+            .map(|f| f.time)
+            .collect();
+        prec_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let cycle_time_s = if prec_times.len() >= 2 {
+            (prec_times[1] - prec_times[0]).max(0.0)
+        } else {
+            0.0
+        };
+        if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "could not determine cycle time (need >= 2 precursor frames)",
+            ));
+        }
+        let start_time_s = frames
+            .iter()
+            .map(|f| f.time)
+            .fold(f64::INFINITY, f64::min);
+        let gradient_length_s = frames
+            .iter()
+            .map(|f| f.time)
+            .fold(f64::NEG_INFINITY, f64::max);
+
+        Ok(AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::TimsTofDia,
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: if start_time_s.is_finite() {
+                    start_time_s
+                } else {
+                    0.0
+                },
+            },
+            mz_range: (lo, hi),
+            provenance: Provenance {
+                source: SchemeSource::ExtractedBruker,
+                notes: format!("extracted from Bruker .d ({n_groups} window groups)"),
+            },
+        })
+    }
+}
+
+#[cfg(feature = "sciex")]
+impl AcquisitionScheme {
+    /// Extract the SWATH scheme from a real SCIEX ZenoTOF `.wiff` method.
+    ///
+    /// Each SWATH window becomes a single-window [`DiaMs2Frame`] (no ion
+    /// mobility) preceded by an MS1. SCIEX uses **rolling collision energy**,
+    /// which is not stored in the `.wiff` SWATH method, so CE is
+    /// [`CollisionEnergyPolicy::Unknown`] (a model must be supplied downstream;
+    /// it is never invented). The `.wiff` method also does not carry run timing,
+    /// so `cycle_time_s` and `gradient_length_s` are caller-supplied.
+    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+        path: P,
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+    ) -> io::Result<Self> {
+        let method = sciexwiff::read_method(path)?;
+        if method.swath_windows.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no SWATH windows in the .wiff method",
+            ));
+        }
+        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        })];
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        let n = method.swath_windows.len();
+        for w in &method.swath_windows {
+            let iso = IsolationWindow {
+                center_mz: w.center_mz(),
+                width_mz: w.width_mz(),
+            };
+            lo = lo.min(iso.lower());
+            hi = hi.max(iso.upper());
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![DiaWindow {
+                    isolation: iso,
+                    collision_energy: CollisionEnergyPolicy::Unknown,
+                    geometry: DiaGeometry::MzOnly,
+                }],
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            }));
+        }
+        Ok(AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::SciexZenoTof,
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: 0.0,
+            },
+            mz_range: (lo, hi),
+            provenance: Provenance {
+                source: SchemeSource::ExtractedSciex,
+                notes: format!(
+                    "extracted from SCIEX .wiff method ({n} SWATH windows; rolling CE unknown, timing caller-supplied)"
+                ),
+            },
+        })
+    }
+}
+
+#[cfg(feature = "thermo")]
+impl AcquisitionScheme {
+    /// Extract the acquisition scheme from a real Thermo `.raw` by walking the
+    /// first complete cycle (first MS1 up to the next MS1). Each MS2 scan becomes
+    /// a single-window [`DiaMs2Frame`] (Thermo has no mobility), with the
+    /// observed isolation center/width and CE.
+    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        use thermorawfile::RawFile;
+        let raw = RawFile::open(path)?;
+
+        let analyzer_of = |a: u8| match a {
+            4 => Analyzer::Ftms,
+            7 => Analyzer::Astms,
+            0 => Analyzer::Itms,
+            _ => Analyzer::Unknown,
+        };
+        let data_mode_of = |scan: u32| -> DataMode {
+            let i = (scan - raw.first_scan) as usize;
+            let pkt = (raw.data_addr + raw.index[i].offset) as usize;
+            if pkt + 8 <= raw.bytes.len() {
+                let ps = u32::from_le_bytes(raw.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+                if ps > 0 {
+                    DataMode::Profile
+                } else {
+                    DataMode::Centroid
+                }
+            } else {
+                DataMode::Centroid
+            }
+        };
+        let rt_of = |scan: u32| raw.index[(scan - raw.first_scan) as usize].time;
+
+        let mut cycle: Vec<AcquisitionEvent> = Vec::new();
+        let mut seen_ms1 = false;
+        let mut closed = false;
+        let mut start_rt = 0.0f64;
+        let mut cycle_time_s = 0.0f64;
+        let mut win_lo = f64::INFINITY;
+        let mut win_hi = f64::NEG_INFINITY;
+
+        for scan in raw.first_scan..=raw.last_scan {
+            let ev = match raw.scan_event(scan) {
+                Some(e) => e,
+                None => {
+                    // A missing event *inside* the selected cycle would silently
+                    // drop a window — reject it. Before the first MS1 it's ignorable.
+                    if seen_ms1 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("missing scan event for scan {scan} inside the first cycle"),
+                        ));
+                    }
+                    continue;
+                }
+            };
+            if ev.ms_order <= 1 {
+                if seen_ms1 {
+                    // start of the next cycle -> close this one
+                    cycle_time_s = (rt_of(scan) - start_rt).max(0.0);
+                    closed = true;
+                    break;
+                }
+                seen_ms1 = true;
+                start_rt = rt_of(scan);
+                cycle.push(AcquisitionEvent::Ms1(Ms1Event {
+                    analyzer: analyzer_of(ev.analyzer),
+                    data_mode: data_mode_of(scan),
+                    mz_range: None, // scan_event does not carry the MS1 range
+                    duration_s: None,
+                }));
+            } else if seen_ms1 {
+                let iso = IsolationWindow {
+                    center_mz: ev.isolation_center,
+                    width_mz: ev.isolation_width,
+                };
+                win_lo = win_lo.min(iso.lower());
+                win_hi = win_hi.max(iso.upper());
+                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                    windows: vec![DiaWindow {
+                        isolation: iso,
+                        collision_energy: CollisionEnergyPolicy::Value(ev.collision_energy),
+                        geometry: DiaGeometry::MzOnly,
+                    }],
+                    analyzer: analyzer_of(ev.analyzer),
+                    data_mode: data_mode_of(scan),
+                    duration_s: None,
+                }));
+            }
+        }
+
+        if !seen_ms1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "template has no MS1 scan",
+            ));
+        }
+        if !closed {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "template has only one cycle (no second MS1 to bound it); cannot determine cycle time",
+            ));
+        }
+        let mz_range = if win_lo.is_finite() && win_hi > win_lo {
+            (win_lo, win_hi)
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "first cycle has no usable MS2 isolation windows",
+            ));
+        };
+        let gradient_length_s = raw.index.last().map(|e| e.time).unwrap_or(0.0);
+        let n_ms2 = cycle
+            .iter()
+            .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+            .count();
+        // Instrument from the analyzers of events actually in the cycle (an ASTMS
+        // MS2 frame ⇒ Orbitrap Astral), not from incidental scans elsewhere.
+        let any_astms = cycle.iter().any(|e| {
+            matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.analyzer == Analyzer::Astms)
+        });
+
+        Ok(AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: if any_astms {
+                InstrumentKind::OrbitrapAstral
+            } else {
+                InstrumentKind::Other
+            },
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: start_rt,
+            },
+            mz_range,
+            provenance: Provenance {
+                source: SchemeSource::ExtractedThermo,
+                notes: format!("extracted from Thermo .raw (first cycle: 1 MS1 + {n_ms2} MS2)"),
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linear_windows(n: usize) -> Vec<DiaWindow> {
+        (0..n)
+            .map(|i| DiaWindow {
+                isolation: IsolationWindow {
+                    center_mz: 400.0 + i as f64 * 10.0,
+                    width_mz: 10.0,
+                },
+                collision_energy: CollisionEnergyPolicy::Value(25.0),
+                geometry: DiaGeometry::MzOnly,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn from_window_table_validates() {
+        let s = AcquisitionScheme::from_window_table(
+            InstrumentKind::OrbitrapAstral,
+            Ms1Event {
+                analyzer: Analyzer::Ftms,
+                data_mode: DataMode::Profile,
+                mz_range: Some((390.0, 900.0)),
+                duration_s: None,
+            },
+            linear_windows(5),
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s: 1.0,
+                gradient_length_s: 600.0,
+                start_time_s: 0.0,
+            },
+            (390.0, 900.0),
+        );
+        s.validate().unwrap();
+        assert_eq!(s.windows().count(), 5);
+        assert_eq!(s.ms1_count(), 1);
+        assert_eq!(s.num_cycles(), Some(600));
+    }
+
+    #[test]
+    fn multi_window_frame_only_tims() {
+        let frame = DiaMs2Frame {
+            windows: linear_windows(3),
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            duration_s: None,
+        };
+        let s = AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::OrbitrapAstral, // wrong: multi-window on non-tims
+            cycle: vec![
+                AcquisitionEvent::Ms1(Ms1Event {
+                    analyzer: Analyzer::Ftms,
+                    data_mode: DataMode::Profile,
+                    mz_range: Some((390.0, 900.0)),
+                    duration_s: None,
+                }),
+                AcquisitionEvent::DiaMs2Frame(frame),
+            ],
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s: 1.0,
+                gradient_length_s: 600.0,
+                start_time_s: 0.0,
+            },
+            mz_range: (390.0, 900.0),
+            provenance: Provenance {
+                source: SchemeSource::Programmatic,
+                notes: String::new(),
+            },
+        };
+        assert!(s.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_schemes() {
+        let repeat = RepeatPolicy::FixedCycleTime {
+            cycle_time_s: 1.0,
+            gradient_length_s: 600.0,
+            start_time_s: 0.0,
+        };
+        let ms1 = || Ms1Event {
+            analyzer: Analyzer::Ftms,
+            data_mode: DataMode::Profile,
+            mz_range: Some((390.0, 900.0)),
+            duration_s: None,
+        };
+        let win = || DiaWindow {
+            isolation: IsolationWindow {
+                center_mz: 500.0,
+                width_mz: 10.0,
+            },
+            collision_energy: CollisionEnergyPolicy::Value(25.0),
+            geometry: DiaGeometry::MzOnly,
+        };
+        let frame = |w: DiaWindow| {
+            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![w],
+                analyzer: Analyzer::Astms,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            })
+        };
+        let mk = |cycle: Vec<AcquisitionEvent>| AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::OrbitrapAstral,
+            cycle,
+            repeat,
+            mz_range: (390.0, 900.0),
+            provenance: Provenance {
+                source: SchemeSource::Programmatic,
+                notes: String::new(),
+            },
+        };
+
+        // valid baseline
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_ok());
+        // MS2 first (no leading MS1)
+        assert!(mk(vec![frame(win()), AcquisitionEvent::Ms1(ms1())]).validate().is_err());
+        // two MS1 in a cycle
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_err());
+        // MS1 with no MS2 frame
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1())]).validate().is_err());
+        // window outside mz_range
+        let mut oob = win();
+        oob.isolation.center_mz = 2000.0;
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(oob)]).validate().is_err());
+        // negative collision energy
+        let mut neg = win();
+        neg.collision_energy = CollisionEnergyPolicy::Value(-5.0);
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(neg)]).validate().is_err());
+        // bad event duration
+        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+            windows: vec![win()],
+            analyzer: Analyzer::Astms,
+            data_mode: DataMode::Centroid,
+            duration_s: Some(-1.0),
+        });
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), bad_dur]).validate().is_err());
+    }
+
+    // Gated: set TIMSIM_BRUKER_DIA_D to a real Bruker DIA-PASEF .d folder.
+    #[test]
+    fn from_bruker_d_extracts_cycle() {
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_bruker_d_extracts_cycle: set TIMSIM_BRUKER_DIA_D=<dia .d>");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::TimsTofDia);
+        assert_eq!(s.ms1_count(), 1);
+        let n_win = s.windows().count();
+        assert!(n_win > 1, "expected several windows, got {n_win}");
+        // timsTOF windows carry mobility geometry with a known CE.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::TimsMobility { .. }));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_some());
+        }
+        // At least one frame should be mobility-partitioned (>1 window).
+        let multi = s.cycle.iter().any(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.windows.len() > 1));
+        let n_frames = s.cycle.iter().filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_))).count();
+        eprintln!(
+            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+            n_frames, n_win, if multi { "mobility-partitioned" } else { "single-window" },
+            s.mz_range.0, s.mz_range.1
+        );
+    }
+
+    // Gated: set TIMSIM_SCIEX_WIFF to a real ZenoTOF .wiff (OLE2 method).
+    #[cfg(feature = "sciex")]
+    #[test]
+    fn from_sciex_wiff_extracts_windows() {
+        let wiff = match std::env::var("TIMSIM_SCIEX_WIFF") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::SciexZenoTof);
+        assert_eq!(s.ms1_count(), 1);
+        let n = s.windows().count();
+        assert!(n > 10, "expected many SWATH windows, got {n}");
+        // SCIEX: m/z-only windows, rolling CE not recoverable -> Unknown.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::MzOnly));
+            assert!(matches!(w.collision_energy, CollisionEnergyPolicy::Unknown));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_none());
+        }
+        eprintln!(
+            "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",
+            n, s.mz_range.0, s.mz_range.1
+        );
+    }
+
+    #[cfg(feature = "thermo")]
+    #[test]
+    fn from_thermo_raw_extracts_cycle() {
+        let template = match std::env::var("TIMSIM_ASTRAL_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::OrbitrapAstral);
+        assert_eq!(s.ms1_count(), 1, "one MS1 per cycle");
+        let n_win = s.windows().count();
+        assert!(n_win > 1, "expected several MS2 windows, got {n_win}");
+        // Thermo: every window is m/z-only with a known CE.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::MzOnly));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_some());
+            assert!(w.isolation.width_mz > 0.0);
+        }
+        // centers should be (weakly) increasing across the first cycle is not
+        // guaranteed by Astral, but coverage must be a sane m/z span.
+        assert!(s.mz_range.0 > 100.0 && s.mz_range.1 < 3000.0 && s.mz_range.0 < s.mz_range.1);
+        eprintln!(
+            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+            s.instrument, n_win, s.mz_range.0, s.mz_range.1,
+            match s.repeat { RepeatPolicy::FixedCycleTime { cycle_time_s, .. } => cycle_time_s }
+        );
+    }
+}
+
+===== FILE: sciexwiff/src/lib.rs (separate crate, the .wiff method reader) =====
+//! Minimal pure-Rust reader for the SCIEX `.wiff` acquisition **method**
+//! (SWATH isolation windows + TOF calibration). See `README.md` for the scope
+//! and legitimacy notes — this reads the open OLE2 method, not the proprietary
+//! `.wiff.scan` spectra.
+
+use std::io;
+use std::path::Path;
+
+/// A SWATH isolation window (m/z bounds).
+#[derive(Clone, Copy, Debug)]
+pub struct SwathWindow {
+    pub lower_mz: f64,
+    pub upper_mz: f64,
+}
+
+impl SwathWindow {
+    pub fn center_mz(&self) -> f64 {
+        (self.lower_mz + self.upper_mz) / 2.0
+    }
+    pub fn width_mz(&self) -> f64 {
+        self.upper_mz - self.lower_mz
+    }
+}
+
+/// TOF → m/z calibration, of the form `m/z = (coef1·tof + coef2)²`.
+#[derive(Clone, Copy, Debug)]
+pub struct TofCalibration {
+    pub coef1: f64,
+    pub coef2: f64,
+}
+
+/// The acquisition method decoded from a `.wiff`.
+#[derive(Clone, Debug)]
+pub struct WiffMethod {
+    pub swath_windows: Vec<SwathWindow>,
+    pub tof_calibration: Option<TofCalibration>,
+}
+
+fn f64le(b: &[u8], o: usize) -> Option<f64> {
+    b.get(o..o + 8)
+        .map(|s| f64::from_le_bytes(s.try_into().unwrap()))
+}
+
+fn read_stream(comp: &mut cfb::CompoundFile<std::fs::File>, name: &str) -> Option<Vec<u8>> {
+    use std::io::Read;
+    let mut s = comp.open_stream(name).ok()?;
+    let mut v = Vec::new();
+    s.read_to_end(&mut v).ok()?;
+    Some(v)
+}
+
+/// Open a `.wiff` (OLE2 compound file) and decode its SWATH method + TOF
+/// calibration. The SWATH windows live in
+/// `/MethodSubtree/Method1/DeviceMethod0/SWATHMethod` as 20-byte records
+/// `{ f64 lower, f64 upper, u32 }` starting at offset 40; the calibration in
+/// `/SampleSubtree/Sample1/TOFCalibrationData` (24-byte records from offset 32).
+pub fn read_method<P: AsRef<Path>>(path: P) -> io::Result<WiffMethod> {
+    let mut comp = cfb::open(path.as_ref())?;
+
+    let mut swath_windows = Vec::new();
+    if let Some(sw) = read_stream(&mut comp, "/MethodSubtree/Method1/DeviceMethod0/SWATHMethod") {
+        let (base, stride) = (40usize, 20usize);
+        if sw.len() > base {
+            let n = (sw.len() - base) / stride;
+            for k in 0..n {
+                let o = base + k * stride;
+                if let (Some(lo), Some(hi)) = (f64le(&sw, o), f64le(&sw, o + 8)) {
+                    if lo.is_finite() && hi.is_finite() && hi > lo {
+                        swath_windows.push(SwathWindow {
+                            lower_mz: lo,
+                            upper_mz: hi,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    let tof_calibration = read_stream(&mut comp, "/SampleSubtree/Sample1/TOFCalibrationData")
+        .and_then(|cal| {
+            let c1 = f64le(&cal, 32)?;
+            let c2 = f64le(&cal, 40)?;
+            (c1.is_finite() && c2.is_finite()).then_some(TofCalibration {
+                coef1: c1,
+                coef2: c2,
+            })
+        });
+
+    Ok(WiffMethod {
+        swath_windows,
+        tof_calibration,
+    })
+}
+</stdin>
+codex
+I’ll inspect the repository versions and surrounding APIs/tests, then return only ranked review findings with concrete file/line references.
+exec
+/bin/bash -lc "nl -ba rustdf/src/sim/scheme.rs | sed -n '280,570p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   280	                    Err(format!("{what} duration must be finite and > 0"))
+   281	                }
+   282	                _ => Ok(()),
+   283	            }
+   284	        };
+   285	
+   286	        for ev in &self.cycle {
+   287	            match ev {
+   288	                AcquisitionEvent::Ms1(m) => {
+   289	                    check_dur(m.duration_s, "MS1")?;
+   290	                    if let Some((a, b)) = m.mz_range {
+   291	                        if !(a.is_finite() && b.is_finite()) || a >= b {
+   292	                            return Err(format!("invalid MS1 mz_range ({a}, {b})"));
+   293	                        }
+   294	                    }
+   295	                }
+   296	                AcquisitionEvent::DiaMs2Frame(frame) => {
+   297	                    check_dur(frame.duration_s, "MS2 frame")?;
+   298	                    if frame.windows.is_empty() {
+   299	                        return Err("MS2 frame has no windows".into());
+   300	                    }
+   301	                    let multi = frame.windows.len() > 1;
+   302	                    if multi && self.instrument != InstrumentKind::TimsTofDia {
+   303	                        return Err(
+   304	                            "multi-window MS2 frame is only valid for timsTOF (mobility-partitioned)"
+   305	                                .into(),
+   306	                        );
+   307	                    }
+   308	                    for (i, w) in frame.windows.iter().enumerate() {
+   309	                        if !(w.isolation.width_mz.is_finite() && w.isolation.width_mz > 0.0) {
+   310	                            return Err("window width must be finite and > 0".into());
+   311	                        }
+   312	                        if !w.isolation.center_mz.is_finite()
+   313	                            || !w.isolation.lower().is_finite()
+   314	                            || !w.isolation.upper().is_finite()
+   315	                        {
+   316	                            return Err("window m/z is not finite".into());
+   317	                        }
+   318	                        if w.isolation.lower() < lo - 1e-6 || w.isolation.upper() > hi + 1e-6 {
+   319	                            return Err(format!(
+   320	                                "window [{:.4}, {:.4}] outside mz_range [{lo:.4}, {hi:.4}]",
+   321	                                w.isolation.lower(),
+   322	                                w.isolation.upper()
+   323	                            ));
+   324	                        }
+   325	                        match w.collision_energy {
+   326	                            CollisionEnergyPolicy::Value(v) => {
+   327	                                if !v.is_finite() || v < 0.0 {
+   328	                                    return Err("collision energy must be finite and >= 0".into());
+   329	                                }
+   330	                            }
+   331	                            CollisionEnergyPolicy::Linear {
+   332	                                intercept,
+   333	                                slope_per_mz,
+   334	                            } => {
+   335	                                if !intercept.is_finite() || !slope_per_mz.is_finite() {
+   336	                                    return Err("non-finite linear CE coefficients".into());
+   337	                                }
+   338	                                match w.collision_energy.at(w.isolation.center_mz) {
+   339	                                    Some(ce) if ce.is_finite() && ce >= 0.0 => {}
+   340	                                    _ => {
+   341	                                        return Err(
+   342	                                            "linear CE resolves to non-finite or negative".into()
+   343	                                        )
+   344	                                    }
+   345	                                }
+   346	                            }
+   347	                            CollisionEnergyPolicy::Unknown => {}
+   348	                        }
+   349	                        match w.geometry {
+   350	                            DiaGeometry::TimsMobility {
+   351	                                scan_start,
+   352	                                scan_end,
+   353	                            } => {
+   354	                                if self.instrument != InstrumentKind::TimsTofDia {
+   355	                                    return Err("mobility geometry is only valid for timsTOF".into());
+   356	                                }
+   357	                                if scan_start > scan_end {
+   358	                                    return Err("mobility scan_start > scan_end".into());
+   359	                                }
+   360	                            }
+   361	                            DiaGeometry::MzOnly => {
+   362	                                if multi {
+   363	                                    return Err(
+   364	                                        "multi-window timsTOF frame requires mobility geometry on every window"
+   365	                                            .into(),
+   366	                                    );
+   367	                                }
+   368	                            }
+   369	                        }
+   370	                        // Within one frame, windows must not overlap in BOTH m/z
+   371	                        // and mobility (overlap across sequential frames is fine).
+   372	                        for w2 in &frame.windows[..i] {
+   373	                            let mz_overlap = w.isolation.lower() < w2.isolation.upper()
+   374	                                && w2.isolation.lower() < w.isolation.upper();
+   375	                            let im_overlap = match (w.geometry, w2.geometry) {
+   376	                                (
+   377	                                    DiaGeometry::TimsMobility {
+   378	                                        scan_start: a0,
+   379	                                        scan_end: a1,
+   380	                                    },
+   381	                                    DiaGeometry::TimsMobility {
+   382	                                        scan_start: b0,
+   383	                                        scan_end: b1,
+   384	                                    },
+   385	                                ) => a0 <= b1 && b0 <= a1,
+   386	                                _ => true, // m/z-only windows share all mobility
+   387	                            };
+   388	                            if mz_overlap && im_overlap {
+   389	                                return Err(
+   390	                                    "windows within one frame overlap in both m/z and mobility"
+   391	                                        .into(),
+   392	                                );
+   393	                            }
+   394	                        }
+   395	                    }
+   396	                }
+   397	            }
+   398	        }
+   399	        match self.repeat {
+   400	            RepeatPolicy::FixedCycleTime {
+   401	                cycle_time_s,
+   402	                gradient_length_s,
+   403	                start_time_s,
+   404	            } => {
+   405	                if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+   406	                    return Err("cycle_time_s must be finite and > 0".into());
+   407	                }
+   408	                if !(gradient_length_s.is_finite() && gradient_length_s > 0.0) {
+   409	                    return Err("gradient_length_s must be finite and > 0".into());
+   410	                }
+   411	                if !start_time_s.is_finite() || start_time_s < 0.0 {
+   412	                    return Err("start_time_s must be finite and >= 0".into());
+   413	                }
+   414	                if start_time_s > gradient_length_s {
+   415	                    return Err("start_time_s must be <= gradient_length_s".into());
+   416	                }
+   417	            }
+   418	        }
+   419	        Ok(())
+   420	    }
+   421	}
+   422	
+   423	impl AcquisitionScheme {
+   424	    /// Extract the acquisition scheme from a real Bruker timsTOF DIA `.d`.
+   425	    ///
+   426	    /// Reads `DiaFrameMsMsWindows` and the frame table. Each **window group**
+   427	    /// becomes one [`DiaMs2Frame`] holding its mobility-partitioned windows
+   428	    /// (`TimsMobility` geometry — the scan ranges are Bruker-grid coordinates),
+   429	    /// preceded by a single MS1 event. Cycle timing comes from the spacing of
+   430	    /// the precursor (MS1) frames.
+   431	    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+   432	        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+   433	        use std::collections::BTreeMap;
+   434	
+   435	        let folder = path.as_ref().to_string_lossy().into_owned();
+   436	        let to_io =
+   437	            |e: Box<dyn std::error::Error>| io::Error::new(io::ErrorKind::InvalidData, e.to_string());
+   438	        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+   439	        let frames = read_meta_data_sql(&folder).map_err(to_io)?;
+   440	        if windows.is_empty() {
+   441	            return Err(io::Error::new(
+   442	                io::ErrorKind::InvalidData,
+   443	                "no DiaFrameMsMsWindows rows (not a DIA .d?)",
+   444	            ));
+   445	        }
+   446	
+   447	        // Group windows by window group (ascending); each group is a frame.
+   448	        let mut by_group: BTreeMap<u32, Vec<DiaWindow>> = BTreeMap::new();
+   449	        let mut lo = f64::INFINITY;
+   450	        let mut hi = f64::NEG_INFINITY;
+   451	        for w in &windows {
+   452	            let dw = DiaWindow {
+   453	                isolation: IsolationWindow {
+   454	                    center_mz: w.isolation_mz,
+   455	                    width_mz: w.isolation_width,
+   456	                },
+   457	                collision_energy: CollisionEnergyPolicy::Value(w.collision_energy),
+   458	                geometry: DiaGeometry::TimsMobility {
+   459	                    scan_start: w.scan_num_begin,
+   460	                    scan_end: w.scan_num_end,
+   461	                },
+   462	            };
+   463	            lo = lo.min(dw.isolation.lower());
+   464	            hi = hi.max(dw.isolation.upper());
+   465	            by_group.entry(w.window_group).or_default().push(dw);
+   466	        }
+   467	
+   468	        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+   469	            analyzer: Analyzer::Tof,
+   470	            data_mode: DataMode::Centroid,
+   471	            mz_range: None,
+   472	            duration_s: None,
+   473	        })];
+   474	        let n_groups = by_group.len();
+   475	        for (_group, ws) in by_group {
+   476	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   477	                windows: ws,
+   478	                analyzer: Analyzer::Tof,
+   479	                data_mode: DataMode::Centroid,
+   480	                duration_s: None,
+   481	            }));
+   482	        }
+   483	
+   484	        // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+   485	        let mut prec_times: Vec<f64> = frames
+   486	            .iter()
+   487	            .filter(|f| f.ms_ms_type == 0)
+   488	            .map(|f| f.time)
+   489	            .collect();
+   490	        prec_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+   491	        let cycle_time_s = if prec_times.len() >= 2 {
+   492	            (prec_times[1] - prec_times[0]).max(0.0)
+   493	        } else {
+   494	            0.0
+   495	        };
+   496	        if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+   497	            return Err(io::Error::new(
+   498	                io::ErrorKind::InvalidData,
+   499	                "could not determine cycle time (need >= 2 precursor frames)",
+   500	            ));
+   501	        }
+   502	        let start_time_s = frames
+   503	            .iter()
+   504	            .map(|f| f.time)
+   505	            .fold(f64::INFINITY, f64::min);
+   506	        let gradient_length_s = frames
+   507	            .iter()
+   508	            .map(|f| f.time)
+   509	            .fold(f64::NEG_INFINITY, f64::max);
+   510	
+   511	        Ok(AcquisitionScheme {
+   512	            version: SCHEME_VERSION,
+   513	            instrument: InstrumentKind::TimsTofDia,
+   514	            cycle,
+   515	            repeat: RepeatPolicy::FixedCycleTime {
+   516	                cycle_time_s,
+   517	                gradient_length_s,
+   518	                start_time_s: if start_time_s.is_finite() {
+   519	                    start_time_s
+   520	                } else {
+   521	                    0.0
+   522	                },
+   523	            },
+   524	            mz_range: (lo, hi),
+   525	            provenance: Provenance {
+   526	                source: SchemeSource::ExtractedBruker,
+   527	                notes: format!("extracted from Bruker .d ({n_groups} window groups)"),
+   528	            },
+   529	        })
+   530	    }
+   531	}
+   532	
+   533	#[cfg(feature = "sciex")]
+   534	impl AcquisitionScheme {
+   535	    /// Extract the SWATH scheme from a real SCIEX ZenoTOF `.wiff` method.
+   536	    ///
+   537	    /// Each SWATH window becomes a single-window [`DiaMs2Frame`] (no ion
+   538	    /// mobility) preceded by an MS1. SCIEX uses **rolling collision energy**,
+   539	    /// which is not stored in the `.wiff` SWATH method, so CE is
+   540	    /// [`CollisionEnergyPolicy::Unknown`] (a model must be supplied downstream;
+   541	    /// it is never invented). The `.wiff` method also does not carry run timing,
+   542	    /// so `cycle_time_s` and `gradient_length_s` are caller-supplied.
+   543	    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+   544	        path: P,
+   545	        cycle_time_s: f64,
+   546	        gradient_length_s: f64,
+   547	    ) -> io::Result<Self> {
+   548	        let method = sciexwiff::read_method(path)?;
+   549	        if method.swath_windows.is_empty() {
+   550	            return Err(io::Error::new(
+   551	                io::ErrorKind::InvalidData,
+   552	                "no SWATH windows in the .wiff method",
+   553	            ));
+   554	        }
+   555	        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+   556	            analyzer: Analyzer::Tof,
+   557	            data_mode: DataMode::Centroid,
+   558	            mz_range: None,
+   559	            duration_s: None,
+   560	        })];
+   561	        let mut lo = f64::INFINITY;
+   562	        let mut hi = f64::NEG_INFINITY;
+   563	        let n = method.swath_windows.len();
+   564	        for w in &method.swath_windows {
+   565	            let iso = IsolationWindow {
+   566	                center_mz: w.center_mz(),
+   567	                width_mz: w.width_mz(),
+   568	            };
+   569	            lo = lo.min(iso.lower());
+   570	            hi = hi.max(iso.upper());
+
+exec
+/bin/bash -lc 'git status --short && git diff -- rustdf/src/sim/scheme.rs sciexwiff/src/lib.rs' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+?? EXTRACTORS.codex-review.md
+?? packages/imspy-predictors/scripts/compare_libraries.py
+?? packages/imspy-predictors/scripts/generate_calibrated_library.py
+?? primitives/
+?? rustdf/examples/build_bruker_pseudo_ms2.rs
+?? rustdf/examples/build_bruker_pseudo_ms2_v3.rs
+?? rustdf/examples/dump_bruker_ms1_centroids.rs
+?? scripts/compare_diann_to_truth.py
+?? scripts/reread_rustw_smoke.py
+
+exec
+/bin/bash -lc 'nl -ba sciexwiff/src/lib.rs' in /scratch/timsim-demo/SUBMISSION/rustims
+ exited 1 in 0ms:
+nl: sciexwiff/src/lib.rs: No such file or directory
+
+exec
+/bin/bash -lc "rg -n \"struct FrameMeta|enum MsMsType|ms_ms_type|read_dia_ms_ms_windows|SWATHMethod|TOFCalibrationData|read_method\" rustdf sciexwiff -g '*.rs' -g '*.md'" in /scratch/timsim-demo/SUBMISSION/rustims
+ exited 2 in 0ms:
+rg: sciexwiff: No such file or directory (os error 2)
+rustdf/src/sim/scheme.rs:432:        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+rustdf/src/sim/scheme.rs:438:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+rustdf/src/sim/scheme.rs:487:            .filter(|f| f.ms_ms_type == 0)
+rustdf/src/sim/scheme.rs:548:        let method = sciexwiff::read_method(path)?;
+rustdf/src/data/meta.rs:110:pub struct FrameMeta {
+rustdf/src/data/meta.rs:115:    pub ms_ms_type: i64,
+rustdf/src/data/meta.rs:330:                ms_ms_type: row.get(4)?,
+rustdf/src/data/meta.rs:377:pub fn read_dia_ms_ms_windows(
+rustdf/src/data/dda.rs:345:        let precursor_frames = meta_data.iter().filter(|x| x.ms_ms_type == 0);
+rustdf/src/data/dda.rs:402:            .filter(|f| f.ms_ms_type == 0)
+rustdf/src/data/dda.rs:978:        let precursor_frames = meta_data.iter().filter(|x| x.ms_ms_type == 0);
+rustdf/src/data/handle.rs:435:            let ms_type_raw = self.raw_data_layout.frame_meta_data[frame_index].ms_ms_type;
+rustdf/src/data/handle.rs:548:                let ms_type_raw = self.raw_data_layout.frame_meta_data[frame_index].ms_ms_type;
+rustdf/src/data/handle.rs:588:                let ms_type_raw = self.raw_data_layout.frame_meta_data[frame_index].ms_ms_type;
+rustdf/src/data/handle.rs:662:                let ms_type_raw = self.raw_data_layout.frame_meta_data[frame_index].ms_ms_type;
+rustdf/src/data/handle.rs:771:        let ms_type_raw = self.raw_data_layout.frame_meta_data[frame_index].ms_ms_type;
+rustdf/src/data/dia.rs:6:    read_dia_ms_ms_info, read_dia_ms_ms_windows, read_global_meta_sql, read_meta_data_sql,
+rustdf/src/data/dia.rs:443:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+rustdf/src/data/dia.rs:503:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+rustdf/src/data/dia.rs:594:            .filter(|x| x.ms_ms_type == 0)
+rustdf/src/data/dia.rs:710:    /// Map frame_id -> (time, ms_ms_type) for quick lookups.
+rustdf/src/data/dia.rs:714:            m.insert(fm.id as u32, (fm.time as f32, fm.ms_ms_type));
+rustdf/src/data/dia.rs:731:        // Just in case: keep only MS2 frames (ms_ms_type != 0)
+rustdf/src/data/dia.rs:813:    /// RT-sorted PRECURSOR frames (ms_ms_type == 0) into FrameBinView rows.
+rustdf/src/data/dia.rs:820:            .filter(|m| m.ms_ms_type == 0)
+
+codex
+The SCIEX crate is not under the current repository root at the path shown in the prompt, so I’m locating its actual workspace path and checking the Bruker metadata semantics before finalizing findings.
+exec
+/bin/bash -lc "nl -ba rustdf/src/sim/scheme.rs | sed -n '533,620p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   533	#[cfg(feature = "sciex")]
+   534	impl AcquisitionScheme {
+   535	    /// Extract the SWATH scheme from a real SCIEX ZenoTOF `.wiff` method.
+   536	    ///
+   537	    /// Each SWATH window becomes a single-window [`DiaMs2Frame`] (no ion
+   538	    /// mobility) preceded by an MS1. SCIEX uses **rolling collision energy**,
+   539	    /// which is not stored in the `.wiff` SWATH method, so CE is
+   540	    /// [`CollisionEnergyPolicy::Unknown`] (a model must be supplied downstream;
+   541	    /// it is never invented). The `.wiff` method also does not carry run timing,
+   542	    /// so `cycle_time_s` and `gradient_length_s` are caller-supplied.
+   543	    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+   544	        path: P,
+   545	        cycle_time_s: f64,
+   546	        gradient_length_s: f64,
+   547	    ) -> io::Result<Self> {
+   548	        let method = sciexwiff::read_method(path)?;
+   549	        if method.swath_windows.is_empty() {
+   550	            return Err(io::Error::new(
+   551	                io::ErrorKind::InvalidData,
+   552	                "no SWATH windows in the .wiff method",
+   553	            ));
+   554	        }
+   555	        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+   556	            analyzer: Analyzer::Tof,
+   557	            data_mode: DataMode::Centroid,
+   558	            mz_range: None,
+   559	            duration_s: None,
+   560	        })];
+   561	        let mut lo = f64::INFINITY;
+   562	        let mut hi = f64::NEG_INFINITY;
+   563	        let n = method.swath_windows.len();
+   564	        for w in &method.swath_windows {
+   565	            let iso = IsolationWindow {
+   566	                center_mz: w.center_mz(),
+   567	                width_mz: w.width_mz(),
+   568	            };
+   569	            lo = lo.min(iso.lower());
+   570	            hi = hi.max(iso.upper());
+   571	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   572	                windows: vec![DiaWindow {
+   573	                    isolation: iso,
+   574	                    collision_energy: CollisionEnergyPolicy::Unknown,
+   575	                    geometry: DiaGeometry::MzOnly,
+   576	                }],
+   577	                analyzer: Analyzer::Tof,
+   578	                data_mode: DataMode::Centroid,
+   579	                duration_s: None,
+   580	            }));
+   581	        }
+   582	        Ok(AcquisitionScheme {
+   583	            version: SCHEME_VERSION,
+   584	            instrument: InstrumentKind::SciexZenoTof,
+   585	            cycle,
+   586	            repeat: RepeatPolicy::FixedCycleTime {
+   587	                cycle_time_s,
+   588	                gradient_length_s,
+   589	                start_time_s: 0.0,
+   590	            },
+   591	            mz_range: (lo, hi),
+   592	            provenance: Provenance {
+   593	                source: SchemeSource::ExtractedSciex,
+   594	                notes: format!(
+   595	                    "extracted from SCIEX .wiff method ({n} SWATH windows; rolling CE unknown, timing caller-supplied)"
+   596	                ),
+   597	            },
+   598	        })
+   599	    }
+   600	}
+   601	
+   602	#[cfg(feature = "thermo")]
+   603	impl AcquisitionScheme {
+   604	    /// Extract the acquisition scheme from a real Thermo `.raw` by walking the
+   605	    /// first complete cycle (first MS1 up to the next MS1). Each MS2 scan becomes
+   606	    /// a single-window [`DiaMs2Frame`] (Thermo has no mobility), with the
+   607	    /// observed isolation center/width and CE.
+   608	    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+   609	        use thermorawfile::RawFile;
+   610	        let raw = RawFile::open(path)?;
+   611	
+   612	        let analyzer_of = |a: u8| match a {
+   613	            4 => Analyzer::Ftms,
+   614	            7 => Analyzer::Astms,
+   615	            0 => Analyzer::Itms,
+   616	            _ => Analyzer::Unknown,
+   617	        };
+   618	        let data_mode_of = |scan: u32| -> DataMode {
+   619	            let i = (scan - raw.first_scan) as usize;
+   620	            let pkt = (raw.data_addr + raw.index[i].offset) as usize;
+
+exec
+/bin/bash -lc "nl -ba rustdf/src/data/meta.rs | sed -n '90,135p;360,420p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+    90	}
+    91	
+    92	#[derive(Debug)]
+    93	pub struct GlobalMetaData {
+    94	    pub schema_type: String,
+    95	    pub schema_version_major: i64,
+    96	    pub schema_version_minor: i64,
+    97	    pub acquisition_software_vendor: String,
+    98	    pub instrument_vendor: String,
+    99	    pub closed_property: i64,
+   100	    pub tims_compression_type: i64,
+   101	    pub max_num_peaks_per_scan: i64,
+   102	    pub mz_acquisition_range_lower: f64,
+   103	    pub mz_acquisition_range_upper: f64,
+   104	    pub one_over_k0_range_lower: f64,
+   105	    pub one_over_k0_range_upper: f64,
+   106	    pub tof_max_index: u32,
+   107	}
+   108	
+   109	#[derive(Debug)]
+   110	pub struct FrameMeta {
+   111	    pub id: i64,
+   112	    pub time: f64,
+   113	    pub polarity: String,
+   114	    pub scan_mode: i64,
+   115	    pub ms_ms_type: i64,
+   116	    pub tims_id: i64,
+   117	    pub max_intensity: f64,
+   118	    pub sum_intensity: f64,
+   119	    pub num_scans: i64,
+   120	    pub num_peaks: i64,
+   121	    pub mz_calibration: i64,
+   122	    pub t_1: f64,
+   123	    pub t_2: f64,
+   124	    pub tims_calibration: i64,
+   125	    pub property_group: i64,
+   126	    pub accumulation_time: f64,
+   127	    pub ramp_time: f64,
+   128	}
+   129	
+   130	struct GlobalMetaInternal {
+   131	    key: String,
+   132	    value: String,
+   133	}
+   134	
+   135	pub fn read_dda_precursor_meta(
+   360	    let query = format!("SELECT {} FROM DiaFrameMsMsInfo", rows.join(", "));
+   361	
+   362	    // execute the query
+   363	    let frames_rows: Result<Vec<DiaMsMisInfo>, _> = conn
+   364	        .prepare(&query)?
+   365	        .query_map([], |row| {
+   366	            Ok(DiaMsMisInfo {
+   367	                frame_id: row.get(0)?,
+   368	                window_group: row.get(1)?,
+   369	            })
+   370	        })?
+   371	        .collect();
+   372	
+   373	    // return the frames
+   374	    Ok(frames_rows?)
+   375	}
+   376	
+   377	pub fn read_dia_ms_ms_windows(
+   378	    bruker_d_folder_name: &str,
+   379	) -> Result<Vec<DiaMsMsWindow>, Box<dyn std::error::Error>> {
+   380	    // Connect to the database
+   381	    let db_path = Path::new(bruker_d_folder_name).join("analysis.tdf");
+   382	    let conn = Connection::open(db_path)?;
+   383	
+   384	    // prepare the query
+   385	    let rows: Vec<&str> = vec![
+   386	        "WindowGroup",
+   387	        "ScanNumBegin",
+   388	        "ScanNumEnd",
+   389	        "IsolationMz",
+   390	        "IsolationWidth",
+   391	        "CollisionEnergy",
+   392	    ];
+   393	    let query = format!("SELECT {} FROM DiaFrameMsMsWindows", rows.join(", "));
+   394	
+   395	    // execute the query
+   396	    let frames_rows: Result<Vec<DiaMsMsWindow>, _> = conn
+   397	        .prepare(&query)?
+   398	        .query_map([], |row| {
+   399	            Ok(DiaMsMsWindow {
+   400	                window_group: row.get(0)?,
+   401	                scan_num_begin: row.get(1)?,
+   402	                scan_num_end: row.get(2)?,
+   403	                isolation_mz: row.get(3)?,
+   404	                isolation_width: row.get(4)?,
+   405	                collision_energy: row.get(5)?,
+   406	            })
+   407	        })?
+   408	        .collect();
+   409	
+   410	    // return the frames
+   411	    Ok(frames_rows?)
+   412	}
+   413	
+   414	/// Read m/z calibration data from the MzCalibration table.
+   415	/// This provides the coefficients needed for accurate TOF to m/z conversion
+   416	/// without requiring the Bruker SDK.
+   417	///
+   418	/// The calibration formula is:
+   419	///   tof_time = (tof_index + 0.5) * digitizer_timebase + digitizer_delay
+   420	///   sqrt(mz) = c0 + c1*tof_time + c2*tof_time^2 + ...
+
+exec
+/bin/bash -lc "rg -n \"sciexwiff\" Cargo.toml '**/Cargo.toml' Cargo.lock 2>/dev/null" in /scratch/timsim-demo/SUBMISSION/rustims
+ exited 2 in 0ms:
+Cargo.lock:2156: "sciexwiff",
+Cargo.lock:2210:name = "sciexwiff"
+Cargo.lock:2212:source = "git+https://github.com/theGreatHerrLebert/sciexwiff?rev=4e8ff07842bb52a0bd9fe601cc61fd95a68b9080#4e8ff07842bb52a0bd9fe601cc61fd95a68b9080"
+
+exec
+/bin/bash -lc "find .. -path '*/sciexwiff/src/lib.rs' -o -path '*/sciexwiff/Cargo.toml'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 1303ms:
+codex
+A key interaction risk is emerging around malformed numeric data and extractor postconditions. I’m checking how Bruker scan bounds are interpreted elsewhere, because `validate()` currently treats touching mobility intervals as overlapping.
+exec
+/bin/bash -lc "git show 4e8ff07842bb52a0bd9fe601cc61fd95a68b9080:src/lib.rs 2>/dev/null | nl -ba | sed -n '1,180p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+exec
+/bin/bash -lc 'rg -n "scan_num_begin|scan_num_end|scan_start|scan_end" rustdf/src | head -120' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+rustdf/src/sim/dda.rs:572:                if scan_i32 < meta.scan_start || scan_i32 > meta.scan_end {
+rustdf/src/sim/dda.rs:870:                if scan_i32 < meta.scan_start || scan_i32 > meta.scan_end {
+rustdf/src/sim/containers.rs:128:    pub scan_start: u32,
+rustdf/src/sim/containers.rs:129:    pub scan_end: u32,
+rustdf/src/sim/containers.rs:138:        scan_start: u32,
+rustdf/src/sim/containers.rs:139:        scan_end: u32,
+rustdf/src/sim/containers.rs:146:            scan_start,
+rustdf/src/sim/containers.rs:147:            scan_end,
+rustdf/src/data/raw.rs:216:    //       uint32_t scan_end,
+rustdf/src/data/raw.rs:237:        scan_end: u32,
+rustdf/src/data/raw.rs:261:                scan_end,
+rustdf/src/sim/scheme.rs:94:    TimsMobility { scan_start: u32, scan_end: u32 },
+rustdf/src/sim/scheme.rs:351:                                scan_start,
+rustdf/src/sim/scheme.rs:352:                                scan_end,
+rustdf/src/sim/scheme.rs:357:                                if scan_start > scan_end {
+rustdf/src/sim/scheme.rs:358:                                    return Err("mobility scan_start > scan_end".into());
+rustdf/src/sim/scheme.rs:378:                                        scan_start: a0,
+rustdf/src/sim/scheme.rs:379:                                        scan_end: a1,
+rustdf/src/sim/scheme.rs:382:                                        scan_start: b0,
+rustdf/src/sim/scheme.rs:383:                                        scan_end: b1,
+rustdf/src/sim/scheme.rs:459:                    scan_start: w.scan_num_begin,
+rustdf/src/sim/scheme.rs:460:                    scan_end: w.scan_num_end,
+rustdf/src/sim/lazy_builder.rs:952:                        .find(|scan_meta| scan_meta.scan_start <= *scan as i32 && scan_meta.scan_end >= *scan as i32)
+rustdf/src/data/meta.rs:15:    pub scan_num_begin: u32,
+rustdf/src/data/meta.rs:16:    pub scan_num_end: u32,
+rustdf/src/data/meta.rs:25:    pub scan_num_begin: i64,
+rustdf/src/data/meta.rs:26:    pub scan_num_end: i64,
+rustdf/src/data/meta.rs:64:    pub scan_end: i64,
+rustdf/src/data/meta.rs:201:                scan_num_begin: row.get(1)?,
+rustdf/src/data/meta.rs:202:                scan_num_end: row.get(2)?,
+rustdf/src/data/meta.rs:401:                scan_num_begin: row.get(1)?,
+rustdf/src/data/meta.rs:402:                scan_num_end: row.get(2)?,
+rustdf/src/data/dia.rs:209:            if let Some(p) = norm_u32_pair(w.scan_num_begin, w.scan_num_end) {
+rustdf/src/data/dia.rs:555:                    scan_lo: w.scan_num_begin,
+rustdf/src/data/dia.rs:556:                    scan_hi: w.scan_num_end,
+rustdf/src/data/dia.rs:747:                let l = w.scan_num_begin as usize;
+rustdf/src/data/dia.rs:748:                let r = w.scan_num_end as usize;
+rustdf/src/data/handle.rs:133:    scan_start: usize,
+rustdf/src/data/handle.rs:143:    let mut current_index = scan_start;
+rustdf/src/data/handle.rs:162:    let scan_size = current_index - scan_start;
+rustdf/src/data/handle.rs:502:                let mut scan_start = 0usize;
+rustdf/src/data/handle.rs:517:                    scan_start += parse_decompressed_bruker_binary_type1(
+rustdf/src/data/handle.rs:522:                        scan_start,
+rustdf/src/data/dda.rs:671:            let scan_margin = (pasef_info.scan_num_end - pasef_info.scan_num_begin) / 20;
+rustdf/src/data/dda.rs:677:                (pasef_info.scan_num_begin - scan_margin) as i32,
+rustdf/src/data/dda.rs:678:                (pasef_info.scan_num_end + scan_margin) as i32,
+rustdf/src/data/dda.rs:774:            let scan_start_time = frame_time_map.get(&first_pasef.frame_id).copied().unwrap_or(0.0);
+rustdf/src/data/dda.rs:788:                let scan_margin = (pasef_info.scan_num_end - pasef_info.scan_num_begin) / 20;
+rustdf/src/data/dda.rs:794:                    (pasef_info.scan_num_begin - scan_margin) as i32,
+rustdf/src/data/dda.rs:795:                    (pasef_info.scan_num_end + scan_margin) as i32,
+rustdf/src/data/dda.rs:824:                scan_start_time,
+rustdf/src/data/dda.rs:876:        let scan_margin = (pasef_info.scan_num_end - pasef_info.scan_num_begin) / 20;
+rustdf/src/data/dda.rs:882:            (pasef_info.scan_num_begin - scan_margin) as i32,
+rustdf/src/data/dda.rs:883:            (pasef_info.scan_num_end + scan_margin) as i32,
+rustdf/src/sim/handle.rs:186:                row.get("scan_start")?,
+rustdf/src/sim/handle.rs:187:                row.get("scan_end")?,
+rustdf/src/sim/handle.rs:219:            "SELECT frame, scan_start, scan_end, isolation_mz, isolation_width, collision_energy, precursor FROM pasef_meta"
+rustdf/src/sim/handle.rs:224:                row.get("scan_start")?,
+rustdf/src/sim/handle.rs:225:                row.get("scan_end")?,
+rustdf/src/sim/handle.rs:374:                .map(|x| x.scan_start as i32)
+rustdf/src/sim/handle.rs:378:                .map(|x| x.scan_end as i32)
+rustdf/src/sim/handle.rs:419:                .map(|x| x.scan_start as i32)
+rustdf/src/sim/handle.rs:423:                .map(|x| x.scan_end as i32)
+
+exec
+/bin/bash -lc "find ~/.cargo/git/checkouts -path '*/sciexwiff-*/src/lib.rs' -print 2>/dev/null | head -10" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs
+
+exec
+/bin/bash -lc "nl -ba rustdf/src/data/dia.rs | sed -n '430,530p;700,750p;805,840p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   430	}
+   431	
+   432	impl TimsDatasetDIA {
+   433	    pub fn new(
+   434	        bruker_lib_path: &str,
+   435	        data_path: &str,
+   436	        in_memory: bool,
+   437	        use_bruker_sdk: bool,
+   438	    ) -> Self {
+   439	        // TODO: error handling
+   440	        let global_meta_data = read_global_meta_sql(data_path).unwrap();
+   441	        let meta_data = read_meta_data_sql(data_path).unwrap();
+   442	        let dia_ms_mis_info = read_dia_ms_ms_info(data_path).unwrap();
+   443	        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+   444	
+   445	        let scan_max_index = meta_data.iter().map(|x| x.num_scans).max().unwrap() as u32;
+   446	        let im_lower = global_meta_data.one_over_k0_range_lower;
+   447	        let im_upper = global_meta_data.one_over_k0_range_upper;
+   448	
+   449	        let tof_max_index = global_meta_data.tof_max_index;
+   450	        let mz_lower = global_meta_data.mz_acquisition_range_lower;
+   451	        let mz_upper = global_meta_data.mz_acquisition_range_upper;
+   452	
+   453	        let loader = match in_memory {
+   454	            true => TimsDataLoader::new_in_memory(
+   455	                bruker_lib_path,
+   456	                data_path,
+   457	                use_bruker_sdk,
+   458	                scan_max_index,
+   459	                im_lower,
+   460	                im_upper,
+   461	                tof_max_index,
+   462	                mz_lower,
+   463	                mz_upper,
+   464	            ),
+   465	            false => TimsDataLoader::new_lazy(
+   466	                bruker_lib_path,
+   467	                data_path,
+   468	                use_bruker_sdk,
+   469	                scan_max_index,
+   470	                im_lower,
+   471	                im_upper,
+   472	                tof_max_index,
+   473	                mz_lower,
+   474	                mz_upper,
+   475	            ),
+   476	        };
+   477	
+   478	        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+   479	
+   480	        TimsDatasetDIA {
+   481	            loader,
+   482	            global_meta_data,
+   483	            meta_data,
+   484	            dia_ms_ms_info: dia_ms_mis_info,
+   485	            dia_ms_ms_windows,
+   486	            dia_index,
+   487	        }
+   488	    }
+   489	
+   490	    /// Create a DIA dataset with regression-derived m/z calibration.
+   491	    ///
+   492	    /// This method uses externally-provided m/z calibration coefficients (e.g., from
+   493	    /// linear regression on SDK data) instead of the simple boundary model.
+   494	    pub fn new_with_mz_calibration(
+   495	        data_path: &str,
+   496	        in_memory: bool,
+   497	        tof_intercept: f64,
+   498	        tof_slope: f64,
+   499	    ) -> Self {
+   500	        let meta_data = read_meta_data_sql(data_path).unwrap();
+   501	        let global_meta_data = read_global_meta_sql(data_path).unwrap();
+   502	        let dia_ms_mis_info = read_dia_ms_ms_info(data_path).unwrap();
+   503	        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+   504	
+   505	        let scan_max_index = meta_data.iter().map(|x| x.num_scans).max().unwrap() as u32;
+   506	        let im_lower = global_meta_data.one_over_k0_range_lower;
+   507	        let im_upper = global_meta_data.one_over_k0_range_upper;
+   508	
+   509	        let loader = match in_memory {
+   510	            true => TimsDataLoader::new_in_memory_with_mz_calibration(
+   511	                data_path,
+   512	                tof_intercept,
+   513	                tof_slope,
+   514	                im_lower,
+   515	                im_upper,
+   516	                scan_max_index,
+   517	            ),
+   518	            false => TimsDataLoader::new_lazy_with_mz_calibration(
+   519	                data_path,
+   520	                tof_intercept,
+   521	                tof_slope,
+   522	                im_lower,
+   523	                im_upper,
+   524	                scan_max_index,
+   525	            ),
+   526	        };
+   527	
+   528	        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+   529	
+   530	        TimsDatasetDIA {
+   700	            .collect();
+   701	        gs.sort_unstable();
+   702	        gs.dedup();
+   703	        gs
+   704	    }
+   705	
+   706	    pub fn window_groups_for_precursor(&self, prec_mz: f32, im_apex: f32) -> Vec<u32> {
+   707	        self.dia_index.groups_for_precursor(prec_mz, im_apex)
+   708	    }
+   709	
+   710	    /// Map frame_id -> (time, ms_ms_type) for quick lookups.
+   711	    fn frame_time_map(&self) -> FxHashMap<u32, (f32, i64)> {
+   712	        let mut m = FxHashMap::default();
+   713	        for fm in &self.meta_data {
+   714	            m.insert(fm.id as u32, (fm.time as f32, fm.ms_ms_type));
+   715	        }
+   716	        m
+   717	    }
+   718	
+   719	    /// RT-sorted **fragment** frames for a given DIA group.
+   720	    pub fn fragment_frame_ids_and_times_for_group_core(&self, window_group: u32) -> (Vec<u32>, Vec<f32>) {
+   721	        let time_map = self.frame_time_map();
+   722	        let mut rows: Vec<(u32, f32)> = self
+   723	            .dia_ms_ms_info
+   724	            .iter()
+   725	            .filter(|x| x.window_group == window_group)
+   726	            .filter_map(|x| {
+   727	                time_map.get(&(x.frame_id)).map(|(t, _ms2)| (x.frame_id, *t))
+   728	            })
+   729	            .collect();
+   730	
+   731	        // Just in case: keep only MS2 frames (ms_ms_type != 0)
+   732	        rows.retain(|(fid, _)| time_map.get(fid).map(|(_, ty)| *ty != 0).unwrap_or(false));
+   733	
+   734	        rows.sort_by(|a,b| a.1.partial_cmp(&b.1).unwrap());
+   735	        let (ids, times): (Vec<_>, Vec<_>) = rows.into_iter().unzip();
+   736	        (ids, times)
+   737	    }
+   738	
+   739	    /// Merged, sorted **global scan** unions for this DIA group, from DiaFrameMsMsWindows.
+   740	    /// Returns None if there are no window rows for this group.
+   741	    pub fn scan_unions_for_window_group_core(&self, window_group: u32) -> Option<Vec<(usize, usize)>> {
+   742	        let ranges: Vec<(usize, usize)> = self
+   743	            .dia_ms_ms_windows
+   744	            .iter()
+   745	            .filter(|w| w.window_group == window_group)
+   746	            .map(|w| {
+   747	                let l = w.scan_num_begin as usize;
+   748	                let r = w.scan_num_end as usize;
+   749	                if l <= r { (l, r) } else { (r, l) }
+   750	            })
+   805	        RtFrames {
+   806	            frames,
+   807	            frame_ids: ids,
+   808	            rt_times: times,
+   809	            scale: Arc::new(scale),
+   810	        }
+   811	    }
+   812	
+   813	    /// RT-sorted PRECURSOR frames (ms_ms_type == 0) into FrameBinView rows.
+   814	    /// `tof_step` controls TOF granularity of CSR binning.
+   815	    pub fn make_rt_frames_for_precursor(&self, tof_step: i32) -> RtFrames {
+   816	        assert!(tof_step > 0);
+   817	
+   818	        let mut rows: Vec<(u32, f32, usize)> = self.meta_data
+   819	            .iter()
+   820	            .filter(|m| m.ms_ms_type == 0)
+   821	            .map(|m| (m.id as u32, m.time as f32, m.num_scans as usize))
+   822	            .collect();
+   823	
+   824	        assert!(!rows.is_empty(), "No precursor (MS1) frames found");
+   825	        rows.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+   826	
+   827	        let frame_ids: Vec<u32> = rows.iter().map(|r| r.0).collect();
+   828	        let rt_times:  Vec<f32> = rows.iter().map(|r| r.1).collect();
+   829	        let global_num_scans = rows.iter().map(|r| r.2).max().unwrap_or(1);
+   830	
+   831	        // Build TOF scale from precursor frames
+   832	        let frames_for_scale: Vec<_> = frame_ids.iter().map(|&fid| self.get_frame(fid)).collect();
+   833	        let scale = TofScale::build_from_tof(&frames_for_scale, tof_step)
+   834	            .expect("make_rt_frames_for_precursor: failed to build TOF scale");
+   835	
+   836	        let frames: Vec<FrameBinView> = frame_ids.par_iter()
+   837	            .map(|&fid| build_frame_bin_view(self.get_frame(fid), &scale, global_num_scans))
+   838	            .collect();
+   839	
+   840	        RtFrames {
+
+exec
+/bin/bash -lc 'nl -ba /home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+     1	//! Minimal pure-Rust reader for the SCIEX `.wiff` acquisition **method**
+     2	//! (SWATH isolation windows + TOF calibration). See `README.md` for the scope
+     3	//! and legitimacy notes — this reads the open OLE2 method, not the proprietary
+     4	//! `.wiff.scan` spectra.
+     5	
+     6	use std::io;
+     7	use std::path::Path;
+     8	
+     9	/// A SWATH isolation window (m/z bounds).
+    10	#[derive(Clone, Copy, Debug)]
+    11	pub struct SwathWindow {
+    12	    pub lower_mz: f64,
+    13	    pub upper_mz: f64,
+    14	}
+    15	
+    16	impl SwathWindow {
+    17	    pub fn center_mz(&self) -> f64 {
+    18	        (self.lower_mz + self.upper_mz) / 2.0
+    19	    }
+    20	    pub fn width_mz(&self) -> f64 {
+    21	        self.upper_mz - self.lower_mz
+    22	    }
+    23	}
+    24	
+    25	/// TOF → m/z calibration, of the form `m/z = (coef1·tof + coef2)²`.
+    26	#[derive(Clone, Copy, Debug)]
+    27	pub struct TofCalibration {
+    28	    pub coef1: f64,
+    29	    pub coef2: f64,
+    30	}
+    31	
+    32	/// The acquisition method decoded from a `.wiff`.
+    33	#[derive(Clone, Debug)]
+    34	pub struct WiffMethod {
+    35	    pub swath_windows: Vec<SwathWindow>,
+    36	    pub tof_calibration: Option<TofCalibration>,
+    37	}
+    38	
+    39	fn f64le(b: &[u8], o: usize) -> Option<f64> {
+    40	    b.get(o..o + 8)
+    41	        .map(|s| f64::from_le_bytes(s.try_into().unwrap()))
+    42	}
+    43	
+    44	fn read_stream(comp: &mut cfb::CompoundFile<std::fs::File>, name: &str) -> Option<Vec<u8>> {
+    45	    use std::io::Read;
+    46	    let mut s = comp.open_stream(name).ok()?;
+    47	    let mut v = Vec::new();
+    48	    s.read_to_end(&mut v).ok()?;
+    49	    Some(v)
+    50	}
+    51	
+    52	/// Open a `.wiff` (OLE2 compound file) and decode its SWATH method + TOF
+    53	/// calibration. The SWATH windows live in
+    54	/// `/MethodSubtree/Method1/DeviceMethod0/SWATHMethod` as 20-byte records
+    55	/// `{ f64 lower, f64 upper, u32 }` starting at offset 40; the calibration in
+    56	/// `/SampleSubtree/Sample1/TOFCalibrationData` (24-byte records from offset 32).
+    57	pub fn read_method<P: AsRef<Path>>(path: P) -> io::Result<WiffMethod> {
+    58	    let mut comp = cfb::open(path.as_ref())?;
+    59	
+    60	    let mut swath_windows = Vec::new();
+    61	    if let Some(sw) = read_stream(&mut comp, "/MethodSubtree/Method1/DeviceMethod0/SWATHMethod") {
+    62	        let (base, stride) = (40usize, 20usize);
+    63	        if sw.len() > base {
+    64	            let n = (sw.len() - base) / stride;
+    65	            for k in 0..n {
+    66	                let o = base + k * stride;
+    67	                if let (Some(lo), Some(hi)) = (f64le(&sw, o), f64le(&sw, o + 8)) {
+    68	                    if lo.is_finite() && hi.is_finite() && hi > lo {
+    69	                        swath_windows.push(SwathWindow {
+    70	                            lower_mz: lo,
+    71	                            upper_mz: hi,
+    72	                        });
+    73	                    }
+    74	                }
+    75	            }
+    76	        }
+    77	    }
+    78	
+    79	    let tof_calibration = read_stream(&mut comp, "/SampleSubtree/Sample1/TOFCalibrationData")
+    80	        .and_then(|cal| {
+    81	            let c1 = f64le(&cal, 32)?;
+    82	            let c2 = f64le(&cal, 40)?;
+    83	            (c1.is_finite() && c2.is_finite()).then_some(TofCalibration {
+    84	                coef1: c1,
+    85	                coef2: c2,
+    86	            })
+    87	        });
+    88	
+    89	    Ok(WiffMethod {
+    90	        swath_windows,
+    91	        tof_calibration,
+    92	    })
+    93	}
+
+exec
+/bin/bash -lc "nl -ba rustdf/src/data/dia.rs | sed -n '185,225p;739,775p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   185	            frame_time.insert(m.id as u32, m.time);
+   186	        }
+   187	
+   188	        // frame_id -> group; group -> frames
+   189	        let mut frame_to_group: HashMap<u32, u32> = HashMap::new();
+   190	        let mut group_to_frames: HashMap<u32, Vec<u32>> = HashMap::new();
+   191	        for r in info {
+   192	            let fid = r.frame_id;
+   193	            frame_to_group.insert(fid, r.window_group);
+   194	            group_to_frames.entry(r.window_group).or_default().push(fid);
+   195	        }
+   196	
+   197	        // raw program rows
+   198	        let mut group_to_isolation: HashMap<u32, Vec<(f64, f64)>> = HashMap::new();
+   199	        let mut group_to_scan_ranges: HashMap<u32, Vec<(u32, u32)>> = HashMap::new();
+   200	        for w in wins {
+   201	            let half = 0.5 * w.isolation_width;
+   202	            if half.is_finite() && half > 0.0 && w.isolation_mz.is_finite() {
+   203	                let lo = w.isolation_mz - half;
+   204	                let hi = w.isolation_mz + half;
+   205	                if let Some(p) = norm_f64_pair(lo, hi) {
+   206	                    group_to_isolation.entry(w.window_group).or_default().push(p);
+   207	                }
+   208	            }
+   209	            if let Some(p) = norm_u32_pair(w.scan_num_begin, w.scan_num_end) {
+   210	                group_to_scan_ranges.entry(w.window_group).or_default().push(p);
+   211	            }
+   212	        }
+   213	
+   214	        // unions + sort frames by time
+   215	        let mut group_to_mz_union: HashMap<u32, (f64, f64)> = HashMap::new();
+   216	        let mut group_to_scan_unions: HashMap<u32, Vec<(u32, u32)>> = HashMap::new();
+   217	
+   218	        for (g, frames) in group_to_frames.iter_mut() {
+   219	            frames.sort_unstable_by(|&a, &b| {
+   220	                let ta = frame_time.get(&a).copied().unwrap_or(f64::NAN);
+   221	                let tb = frame_time.get(&b).copied().unwrap_or(f64::NAN);
+   222	                ta.partial_cmp(&tb).unwrap_or(std::cmp::Ordering::Equal)
+   223	            });
+   224	
+   225	            if let Some(v) = group_to_isolation.get(g) {
+   739	    /// Merged, sorted **global scan** unions for this DIA group, from DiaFrameMsMsWindows.
+   740	    /// Returns None if there are no window rows for this group.
+   741	    pub fn scan_unions_for_window_group_core(&self, window_group: u32) -> Option<Vec<(usize, usize)>> {
+   742	        let ranges: Vec<(usize, usize)> = self
+   743	            .dia_ms_ms_windows
+   744	            .iter()
+   745	            .filter(|w| w.window_group == window_group)
+   746	            .map(|w| {
+   747	                let l = w.scan_num_begin as usize;
+   748	                let r = w.scan_num_end as usize;
+   749	                if l <= r { (l, r) } else { (r, l) }
+   750	            })
+   751	            .collect();
+   752	        if ranges.is_empty() {
+   753	            return None;
+   754	        }
+   755	        Some(merge_ranges(ranges))
+   756	    }
+   757	
+   758	    /// m/z unions (min..max) for the group from DiaFrameMsMsWindows (wide clamp).
+   759	    pub fn mz_bounds_for_window_group_core(&self, window_group: u32) -> Option<(f32, f32)> {
+   760	        let mut lo = f32::INFINITY;
+   761	        let mut hi = f32::NEG_INFINITY;
+   762	        let mut hit = false;
+   763	        for w in &self.dia_ms_ms_windows {
+   764	            if w.window_group == window_group {
+   765	                let c = w.isolation_mz as f32;
+   766	                let half = 0.5f32 * (w.isolation_width as f32);
+   767	                lo = lo.min(c - half);
+   768	                hi = hi.max(c + half);
+   769	                hit = true;
+   770	            }
+   771	        }
+   772	        if hit && hi > lo && lo.is_finite() && hi.is_finite() {
+   773	            Some((lo, hi))
+   774	        } else {
+   775	            None
+
+exec
+/bin/bash -lc "rg -n \"SWATHMethod|offset 40|20-byte|record|calibration\" /home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07 -g '*.md' -g '*.rs'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/README.md:11:  (`/MethodSubtree/Method1/DeviceMethod0/SWATHMethod`).
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/README.md:12:- **TOF → m/z calibration** coefficients
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/README.md:25:  61-window SWATH, Zeno attributes, TOF calibration).
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/README.md:29:the windows + calibration that let the simulator reproduce a real run's
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/README.md:54:SWATH windows (399.5–899.9 m/z) and TOF calibration (4.898e-4 / -12.90).
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/main.rs:1://! `sciexwiff <file.wiff>` — dump the SWATH window scheme + TOF calibration.
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/main.rs:27:    if let Some(c) = m.tof_calibration {
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:2://! (SWATH isolation windows + TOF calibration). See `README.md` for the scope
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:25:/// TOF → m/z calibration, of the form `m/z = (coef1·tof + coef2)²`.
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:36:    pub tof_calibration: Option<TofCalibration>,
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:53:/// calibration. The SWATH windows live in
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:54:/// `/MethodSubtree/Method1/DeviceMethod0/SWATHMethod` as 20-byte records
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:55:/// `{ f64 lower, f64 upper, u32 }` starting at offset 40; the calibration in
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:56:/// `/SampleSubtree/Sample1/TOFCalibrationData` (24-byte records from offset 32).
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:61:    if let Some(sw) = read_stream(&mut comp, "/MethodSubtree/Method1/DeviceMethod0/SWATHMethod") {
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:79:    let tof_calibration = read_stream(&mut comp, "/SampleSubtree/Sample1/TOFCalibrationData")
+/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:91:        tof_calibration,
+
+codex
+**Findings**
+
+1. **High: `read_method` silently accepts truncated/corrupt SWATH streams and can return a partial acquisition method.**  
+   [lib.rs](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:61) derives record count solely from `(len - 40) / 20`, ignores trailing partial bytes, and silently drops malformed/non-finite records. A truncated 60-window method may therefore become a valid-looking 59-window method. Require `len >= 40`, `(len - 40) % 20 == 0`, validate any encoded header count if available, and return `InvalidData` when any expected record is malformed.
+
+2. **High: both extractors can return `Ok` with a scheme that immediately fails `validate()`.**  
+   Bruker fields are copied without checking widths, centers, CE, scan ordering, or within-group overlap at [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:451). SCIEX caller timing is copied unchecked at [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:586). Consequently malformed vendor rows, `cycle_time_s <= 0`, non-finite timing, or non-positive gradient produce successful extraction followed by validation failure. Construct, call `validate()`, and convert failure to `io::ErrorKind::InvalidData` before returning.
+
+3. **Medium: Bruker cycle-time inference is fragile in the presence of duplicate, non-finite, or anomalous precursor times.**  
+   [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:485) sorts using a comparator that treats NaN as equal, then uses only the first two entries. Duplicate earliest times cause rejection even when later distinct precursor frames exist; one anomalous first interval determines the entire cycle. Filter finite times, sort with `total_cmp`, deduplicate, calculate all positive consecutive gaps, and choose a robust representative such as the median. `MsMsType == 0` is consistent with the supplied rustdf/Bruker contract, so that predicate itself is not a defect.
+
+4. **Medium: Bruker event order is inferred from numeric window-group IDs rather than observed frame order.**  
+   The `BTreeMap` iteration at [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:475) assumes ascending `WindowGroup` equals physical acquisition order. The scheme model explicitly represents an ordered cycle, but `DiaFrameMsMsInfo`/frame times are not consulted. Files with arbitrary or reused group numbering will produce the wrong event order. Order groups by their first MS2-frame occurrence in the first bounded cycle.
+
+5. **Medium: stream I/O and structural errors are collapsed into “optional/missing.”**  
+   [lib.rs](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:44) converts both `open_stream` and `read_to_end` errors to `None`. This is defensible for a genuinely optional calibration stream, but not for the required SWATH stream, and it hides CFB corruption or short reads. Return `io::Result<Option<Vec<u8>>>`; treat missing calibration as `None`, malformed calibration as `InvalidData`, and missing/unreadable SWATH as an error.
+
+6. **Low: accepted finite SCIEX bounds can overflow during conversion.**  
+   `read_method` accepts any finite `lo < hi`, but [center_mz](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:17) and [width_mz](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:20) can overflow to infinity for adversarial values, again yielding an invalid successful extraction. Validate finite center/width or retain lower/upper bounds directly.
+
+I found no direct panic from short record slices: `get()` protects those accesses, and the subsequent `try_into().unwrap()` receives exactly eight bytes.
+tokens used
+57,439
+**Findings**
+
+1. **High: `read_method` silently accepts truncated/corrupt SWATH streams and can return a partial acquisition method.**  
+   [lib.rs](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:61) derives record count solely from `(len - 40) / 20`, ignores trailing partial bytes, and silently drops malformed/non-finite records. A truncated 60-window method may therefore become a valid-looking 59-window method. Require `len >= 40`, `(len - 40) % 20 == 0`, validate any encoded header count if available, and return `InvalidData` when any expected record is malformed.
+
+2. **High: both extractors can return `Ok` with a scheme that immediately fails `validate()`.**  
+   Bruker fields are copied without checking widths, centers, CE, scan ordering, or within-group overlap at [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:451). SCIEX caller timing is copied unchecked at [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:586). Consequently malformed vendor rows, `cycle_time_s <= 0`, non-finite timing, or non-positive gradient produce successful extraction followed by validation failure. Construct, call `validate()`, and convert failure to `io::ErrorKind::InvalidData` before returning.
+
+3. **Medium: Bruker cycle-time inference is fragile in the presence of duplicate, non-finite, or anomalous precursor times.**  
+   [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:485) sorts using a comparator that treats NaN as equal, then uses only the first two entries. Duplicate earliest times cause rejection even when later distinct precursor frames exist; one anomalous first interval determines the entire cycle. Filter finite times, sort with `total_cmp`, deduplicate, calculate all positive consecutive gaps, and choose a robust representative such as the median. `MsMsType == 0` is consistent with the supplied rustdf/Bruker contract, so that predicate itself is not a defect.
+
+4. **Medium: Bruker event order is inferred from numeric window-group IDs rather than observed frame order.**  
+   The `BTreeMap` iteration at [scheme.rs](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:475) assumes ascending `WindowGroup` equals physical acquisition order. The scheme model explicitly represents an ordered cycle, but `DiaFrameMsMsInfo`/frame times are not consulted. Files with arbitrary or reused group numbering will produce the wrong event order. Order groups by their first MS2-frame occurrence in the first bounded cycle.
+
+5. **Medium: stream I/O and structural errors are collapsed into “optional/missing.”**  
+   [lib.rs](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:44) converts both `open_stream` and `read_to_end` errors to `None`. This is defensible for a genuinely optional calibration stream, but not for the required SWATH stream, and it hides CFB corruption or short reads. Return `io::Result<Option<Vec<u8>>>`; treat missing calibration as `None`, malformed calibration as `InvalidData`, and missing/unreadable SWATH as an error.
+
+6. **Low: accepted finite SCIEX bounds can overflow during conversion.**  
+   `read_method` accepts any finite `lo < hi`, but [center_mz](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:17) and [width_mz](/home/administrator/.cargo/git/checkouts/sciexwiff-765fdc7711006f90/4e8ff07/src/lib.rs:20) can overflow to infinity for adversarial values, again yielding an invalid successful extraction. Validate finite center/width or retain lower/upper bounds directly.
+
+I found no direct panic from short record slices: `get()` protects those accesses, and the subsequent `try_into().unwrap()` receives exactly eight bytes.

--- a/MIGRATION.codex-review.md
+++ b/MIGRATION.codex-review.md
@@ -1,0 +1,2335 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019eab6b-8a3f-7dc2-8f2a-1ddea8c9d30f
+--------
+user
+Review the NEWLY CHANGED code in this Python mass-spec simulator (rest is context): in TimsTofAcquisitionBuilderDIA — (a) the __init__ num_frames recompute under use_reference_ds_layout, (b) the new _layout_from_scheme() helper, (c) the rewired _setup() that uses the scheme layout (with legacy fallback), and (d) the parity test.
+
+Trusted context: imspy_connector.py_acquisition.PyAcquisitionScheme.from_bruker_d(path) wraps a Rust extractor; to_bruker_windows() returns a dict of numpy arrays {window_group, scan_start, scan_end, isolation_mz, isolation_width, collision_energy}; to_bruker_info(num_frames) returns {frame, window_group}; cycle_length() = frames per cycle (precursor_every). The Rust side is golden-tested to reproduce the reference .d's DiaFrameMsMsWindows/DiaFrameMsMsInfo exactly. The LEGACY path reads reference.dia_ms_ms_windows (renamed) and generate_frame_to_window_group_table uses wg = global_frame_index % precursor_every (emitting ms2 frames only). calculate_frame_types sets ms_type=0 when (frame_id-1)%precursor_every==0 else 9. CE is rounded to collision_energy_decimals after.
+
+Focus, ranked: 1) is the migrated _setup BEHAVIOR-EQUIVALENT to legacy for a real reference .d — same dia_ms_ms_windows (column names/dtypes/CE rounding) and same dia_ms_ms_info (frame ids, window_group values, row count, ordering), given scheme group ids vs the legacy POSITION-based wg=index%precursor_every (do they agree only when reference WindowGroups are 1..N contiguous in acquisition order, and is that now relied upon)? 2) the num_frames recompute fix — correct and sufficient? any other stale-state from rt_cycle_length changing (scan_table, frame_table already generated before _setup)? 3) dtype regressions from numpy uint32 columns vs the legacy int columns when written to SQLite (to_sql) and read back by the simulator — could downstream code break on uint32 / column order? 4) the fallback logic (connector without py_acquisition) — correctness and silent-degradation risk. 5) the parity test — does it actually prove backward-compat, what's NOT covered (CE rounding, dtypes, the full builder, non-1..N groups). 6) any bug. Concrete, ranked, ~550 words.
+
+<stdin>
+===== FILE: acquisition.py (focus: TimsTofAcquisitionBuilderDIA changes) =====
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+from abc import abstractmethod, ABC
+
+from imspy_simulation.experiment import SyntheticExperimentDataHandle
+from imspy_core.timstof import TimsDatasetDIA, TimsDatasetDDA
+from imspy_core.timstof.data import AcquisitionMode, TimsDataset
+from imspy_simulation.utility import calculate_number_frames, get_ms_ms_window_layout_resource_path
+from imspy_simulation.tdf import TDFWriter
+
+
+class TimsTofAcquisitionBuilder:
+    def __init__(
+            self,
+            path: str,
+            reference_ds: TimsDataset,
+            gradient_length: float,
+            rt_cycle_length: float,
+            exp_name: str = "RAW.d",
+            verbose: bool = False,
+    ):
+        """ Base class for building TimsTOF experiments
+        Parameters
+        ----------
+        path : str
+            Path to the experiment directory
+        gradient_length : float
+            Length of the gradient in seconds
+        rt_cycle_length : float
+            Length of the RT cycle in seconds
+        exp_name : str
+            Name of the experiment
+        verbose : bool
+            Print verbose output
+        """
+
+        self.path = path
+        self.gradient_length = gradient_length
+        self.rt_cycle_length = rt_cycle_length
+        self.num_frames = calculate_number_frames(gradient_length, rt_cycle_length)
+        self.verbose = verbose
+        # Create the TDFWriter, used to deal with bruker binary format writing and metadata for libtimsdata.so
+        self.tdf_writer = TDFWriter(
+            path=self.path,
+            helper_handle=reference_ds,
+            exp_name=exp_name,
+            verbose=verbose,
+        )
+        # Create the SyntheticExperimentDataHandle, which is used to deal with the sqlite database of synthetic data
+        self.synthetics_handle = SyntheticExperimentDataHandle(database_path=self.path)
+        self.frame_table = None
+        self.scan_table = None
+
+    def generate_frame_table(self, verbose: bool = True) -> pd.DataFrame:
+        if verbose:
+            print('Generating frame layout.')
+        frames = []
+        for i in range(self.num_frames):
+            frame_id = i + 1
+            time = frame_id * self.rt_cycle_length
+            frames.append({'frame_id': frame_id, 'time': time})
+
+        return pd.DataFrame(frames)
+
+    def generate_scan_table(self, verbose: bool = True) -> pd.DataFrame:
+        if verbose:
+            print('Generating scan layout.')
+
+        scans = np.arange(self.tdf_writer.helper_handle.num_scans)[::-1]
+        mobilities = self.tdf_writer.scan_to_inv_mobility(1, scans)
+
+        return pd.DataFrame({'scan': scans, 'mobility': mobilities})
+
+    def __repr__(self):
+        return (f"TimsTofAcquisitionBuilder(path={self.path}, gradient_length={np.round(self.gradient_length / 60)} "
+                f"min, mobility_range: {self.tdf_writer.helper_handle.im_lower}-{self.tdf_writer.helper_handle.im_upper}, "
+                f"num_frames: {self.num_frames}, num_scans: {self.tdf_writer.helper_handle.num_scans})")
+
+    @abstractmethod
+    def calculate_frame_types(self, *args) -> NDArray:
+        pass
+
+    @classmethod
+    def from_existing(cls, path: str, reference_ds: TimsDataset) -> "TimsTofAcquisitionBuilder":
+        """ Create an instance from existing data without calling __init__.
+        """
+        # Create a new instance without calling __init__
+        instance = cls.__new__(cls)
+        instance.synthetics_handle = SyntheticExperimentDataHandle(database_path=path)
+
+        # Manually set fields from data dictionary
+        instance.path = path
+        instance.frame_table = instance.synthetics_handle.get_table('frames')
+        instance.scan_table = instance.synthetics_handle.get_table('scans')
+        instance.gradient_length = np.round(instance.frame_table.time.max())
+        instance.rt_cycle_length = np.mean(np.diff(instance.frame_table.time))
+        instance.num_frames = instance.frame_table.shape[0]
+
+        # extract experiment name from the path
+        exp_name = Path(path).name
+
+        # Set up the TDFWriter and SyntheticExperimentDataHandle
+        instance.tdf_writer = TDFWriter(
+            path=instance.path,
+            helper_handle=reference_ds,
+            exp_name=exp_name,
+        )
+
+        return instance
+
+
+class TimsTofAcquisitionBuilderDDA(TimsTofAcquisitionBuilder, ABC):
+    def __init__(self,
+                 path: str,
+                 reference_ds: TimsDatasetDDA,
+                 verbose: bool = False,
+                 gradient_length=60 * 60,
+                 rt_cycle_length=0.109,
+                 exp_name: str = "T001.d",
+                 ):
+        super().__init__(path, reference_ds, gradient_length, rt_cycle_length, exp_name=exp_name, verbose=verbose)
+
+        self.scan_table = None
+        self.frame_table = None
+        self.pasef_meta = None
+        self.selected_precursors = None
+        self.acquisition_mode = AcquisitionMode('DDA')
+        self.verbose = verbose
+        self._setup(verbose=verbose)
+
+    def _setup(self, verbose: bool = True):
+        self.frame_table = self.generate_frame_table(verbose=verbose)
+        self.scan_table = self.generate_scan_table(verbose=verbose)
+        self.synthetics_handle.create_table(
+            table_name='frames',
+            table=self.frame_table
+        )
+        self.synthetics_handle.create_table(
+            table_name='scans',
+            table=self.scan_table
+        )
+
+    def calculate_frame_types(self, frame_types: NDArray):
+        assert len(frame_types) == self.frame_table.shape[0], "frame_types must have the same length as the frame table."
+        # assert set(frame_types).issubset({0, 8}), f"frame_types must be a list of 0s and 8s, got {set(frame_types)}."
+        self.frame_table['ms_type'] = frame_types
+        self.synthetics_handle.create_table(
+            table_name='frames',
+            table=self.frame_table
+        )
+
+class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
+    def __init__(self,
+                 path: str,
+                 reference_ds: TimsDatasetDIA,
+                 window_group_file: str,
+                 acquisition_name: str = "dia",
+                 exp_name: str = "RAW",
+                 verbose: bool = True,
+                 precursor_every: int = 17,
+                 gradient_length=50 * 60,
+                 rt_cycle_length=0.1054,
+                 use_reference_ds_layout: bool = True,
+                 round_collision_energy: bool = True,
+                 collision_energy_decimals: int = 1
+                 ):
+
+        super().__init__(path, reference_ds, gradient_length, rt_cycle_length,
+                         exp_name=exp_name)
+        # TODO: check this, could be missing replacement of reference layout of windows
+        if use_reference_ds_layout:
+            rt_cycle_length = np.mean(np.diff(reference_ds.meta_data.Time))
+            if verbose:
+                print('Using reference dataset cycle length:', np.round(rt_cycle_length, 4))
+            self.rt_cycle_length = rt_cycle_length
+            # Recompute the frame count: the base __init__ computed it from the
+            # passed rt_cycle_length before this reference-derived value replaced it.
+            self.num_frames = calculate_number_frames(self.gradient_length, rt_cycle_length)
+
+        self.acquisition_name = acquisition_name
+        self.scan_table = None
+        self.frame_table = None
+        self.frames_to_window_groups = None
+        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+        self.use_reference_ds_layout = use_reference_ds_layout
+        self.reference = reference_ds
+        self.round_collision_energy = round_collision_energy
+        self.collision_energy_decimals = collision_energy_decimals
+
+        # TODO: check if the number of scans in the window group file matches the number of scans in the experiment
+
+        self.acquisition_mode = AcquisitionMode('DIA')
+        self.verbose = verbose
+        self.precursor_every = precursor_every
+
+        self._setup(verbose=verbose)
+
+    def calculate_frame_types(self, verbose: bool = True) -> NDArray:
+        if verbose:
+            print(f'Calculating frame types, precursor frame will be taken every {self.precursor_every} rt cycles.')
+        return np.array([0 if (x - 1) % self.precursor_every == 0 else 9 for x in self.frame_table.frame_id])
+
+    def generate_frame_to_window_group_table(self, verbose: bool = True) -> pd.DataFrame:
+        if verbose:
+            print(f'generating frame to window group table, precursors every {self.precursor_every} frames.')
+
+        table_list = []
+        for index, row in self.frame_table.iterrows():
+            frame_id, ms_type = row.frame_id, row.ms_type
+            wg = index % self.precursor_every
+            if ms_type > 0:
+                table_list.append({'frame': int(frame_id), 'window_group': wg})
+
+        return pd.DataFrame(table_list)
+
+    def _layout_from_scheme(self, verbose: bool = True):
+        """Derive the DIA window + frame→group tables from the reference `.d` via
+        the vendor-neutral ``AcquisitionScheme`` (imspy_connector.py_acquisition).
+
+        Returns ``(dia_ms_ms_windows, frames_to_window_groups, precursor_every)``
+        or ``None`` if the connector lacks the scheme module (legacy fallback).
+        """
+        try:
+            import imspy_connector
+            acq = imspy_connector.py_acquisition
+        except (ImportError, AttributeError):
+            if verbose:
+                print('py_acquisition unavailable; using legacy reference layout')
+            return None
+
+        scheme = acq.PyAcquisitionScheme.from_bruker_d(self.reference.data_path)
+        precursor_every = scheme.cycle_length()
+        windows = pd.DataFrame(scheme.to_bruker_windows())
+        info = pd.DataFrame(scheme.to_bruker_info(int(self.num_frames)))
+        if verbose:
+            print(f'Using AcquisitionScheme layout: {len(windows)} windows, '
+                  f'{scheme.n_ms2_frames()} groups, precursor_every={precursor_every}')
+        return windows, info, precursor_every
+
+    def _setup(self, verbose: bool = True):
+        self.frame_table = self.generate_frame_table(verbose=verbose)
+        self.scan_table = self.generate_scan_table(verbose=verbose)
+
+        scheme_layout = self._layout_from_scheme(verbose=verbose) if self.use_reference_ds_layout else None
+
+        if scheme_layout is not None:
+            # Vendor-neutral path: windows + frame→group come from the scheme.
+            self.dia_ms_ms_windows, frames_to_window_groups, self.precursor_every = scheme_layout
+            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+            self.frames_to_window_groups = frames_to_window_groups
+        else:
+            # Legacy path: copy the reference .d's window table directly.
+            if self.use_reference_ds_layout:
+                self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
+                self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+                    columns={
+                        'WindowGroup': 'window_group',
+                        'ScanNumBegin': 'scan_start',
+                        'ScanNumEnd': 'scan_end',
+                        'IsolationMz': 'isolation_mz',
+                        'IsolationWidth': 'isolation_width',
+                        'CollisionEnergy': 'collision_energy',
+                    }
+                )
+            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+            self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
+
+        if self.round_collision_energy:
+            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+                                                                  decimals=self.collision_energy_decimals)
+
+        self.synthetics_handle.create_table(
+            table_name='frames',
+            table=self.frame_table
+        )
+        self.synthetics_handle.create_table(
+            table_name='scans',
+            table=self.scan_table
+        )
+        self.synthetics_handle.create_table(
+            table_name='dia_ms_ms_info',
+            table=self.frames_to_window_groups
+        )
+        self.synthetics_handle.create_table(
+            table_name='dia_ms_ms_windows',
+            table=self.dia_ms_ms_windows
+        )
+
+    @staticmethod
+    def from_config(
+            path: str,
+            reference_ds: TimsDatasetDIA,
+            exp_name: str,
+            config: Dict[str, any],
+            verbose: bool = True,
+            use_reference_layout: bool = True,
+            round_collision_energy: bool = True,
+            collision_energy_decimals: int = 1
+    ) -> 'TimsTofAcquisitionBuilderDIA':
+
+        acquisition_name = config['name'].lower().replace('pasef', '')
+        window_group_file = get_ms_ms_window_layout_resource_path(acquisition_name)
+
+        return TimsTofAcquisitionBuilderDIA(
+            path=str(Path(path) / exp_name),
+            reference_ds=reference_ds,
+            window_group_file=str(window_group_file),
+            exp_name=exp_name + ".d",
+            verbose=verbose,
+            acquisition_name=acquisition_name,
+            precursor_every=config['precursor_every'],
+            gradient_length=config['gradient_length'],
+            rt_cycle_length=config['rt_cycle_length'],
+            use_reference_ds_layout=use_reference_layout,
+            round_collision_energy=round_collision_energy,
+            collision_energy_decimals=collision_energy_decimals
+        )
+
+    @classmethod
+    def from_existing(cls,
+                      path: str,
+                      reference_ds: TimsDatasetDIA,
+                      use_reference_ds_layout: bool = True,
+                      verbose: bool = True) -> "TimsTofAcquisitionBuilderDIA":
+        """ Create an instance from existing data for DIA without calling __init__."""
+
+        # Create an instance without calling __init__
+        instance = cls.__new__(cls)
+
+        # Initialize shared attributes as done in the parent’s from_existing
+        instance.synthetics_handle = SyntheticExperimentDataHandle(database_path=path)
+        instance.path = path
+        instance.frame_table = instance.synthetics_handle.get_table('frames')
+        instance.scan_table = instance.synthetics_handle.get_table('scans')
+        instance.gradient_length = np.round(instance.frame_table.time.max())
+        instance.rt_cycle_length = np.mean(np.diff(instance.frame_table.time))
+        instance.num_frames = instance.frame_table.shape[0]
+        exp_name = Path(path).name
+        instance.tdf_writer = TDFWriter(
+            path=instance.path,
+            helper_handle=reference_ds,
+            exp_name=exp_name,
+        )
+
+        # Ensure use_reference_ds_layout is supported
+        assert use_reference_ds_layout, "Only use_reference_ds_layout=True is supported for existing DIA acquisitions"
+
+        # Set DIA-specific fields
+        instance.reference = reference_ds
+        instance.verbose = verbose
+        instance.window_group_file = None
+        instance.precursor_every = int(np.diff(instance.reference.precursor_frames)[0])
+        instance.round_collision_energy = True
+        instance.collision_energy_decimals = 1
+        instance.use_reference_ds_layout = use_reference_ds_layout
+
+        # Load additional tables for DIA-specific data
+        instance.frames_to_window_groups = instance.synthetics_handle.get_table('dia_ms_ms_info')
+        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+
+        return instance
+
+    def __repr__(self):
+        return (f"TimsTofAcquisitionBuilderDIA(name={self.acquisition_name}, path={self.path}, "
+                f"gradient_length={np.round(self.gradient_length / 60)} min, mobility_range: "
+                f"{self.tdf_writer.helper_handle.im_lower}-{self.tdf_writer.helper_handle.im_upper}, "
+                f"num_frames: {self.num_frames}, num_scans: {self.tdf_writer.helper_handle.num_scans})")
+
+===== FILE: tests/test_acquisition_scheme_parity.py =====
+"""Golden parity: the vendor-neutral AcquisitionScheme (via imspy_connector)
+must reproduce the Bruker DIA layout the legacy `use_reference_ds_layout` path
+copies from the reference `.d` — both the `DiaFrameMsMsWindows` window table and
+the per-frame `DiaFrameMsMsInfo` (frame→group) table.
+
+Gated on TIMSIM_BRUKER_DIA_D pointing at a real DIA-PASEF `.d`.
+"""
+import os
+import sqlite3
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import imspy_connector
+
+acq = imspy_connector.py_acquisition
+DIA_D = os.environ.get("TIMSIM_BRUKER_DIA_D")
+pytestmark = pytest.mark.skipif(
+    not DIA_D, reason="set TIMSIM_BRUKER_DIA_D to a real DIA-PASEF .d folder"
+)
+
+
+def _norm(df, cols):
+    return df[cols].astype(float).round(6).sort_values(cols).reset_index(drop=True)
+
+
+def test_scheme_windows_match_reference():
+    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
+    windows = pd.DataFrame(scheme.to_bruker_windows())
+
+    con = sqlite3.connect(DIA_D + "/analysis.tdf")
+    ref = pd.read_sql(
+        "SELECT WindowGroup window_group, ScanNumBegin scan_start, ScanNumEnd scan_end, "
+        "IsolationMz isolation_mz, IsolationWidth isolation_width, "
+        "CollisionEnergy collision_energy FROM DiaFrameMsMsWindows",
+        con,
+    )
+    cols = list(ref.columns)
+    assert len(windows) == len(ref)
+    pd.testing.assert_frame_equal(_norm(windows, cols), _norm(ref, cols))
+
+
+def test_scheme_info_matches_reference_and_legacy_formula():
+    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
+    con = sqlite3.connect(DIA_D + "/analysis.tdf")
+    num_frames = int(con.execute("SELECT MAX(Id) FROM Frames").fetchone()[0])
+
+    info = pd.DataFrame(scheme.to_bruker_info(num_frames))
+
+    # (a) matches the .d's own DiaFrameMsMsInfo exactly
+    ref = pd.read_sql("SELECT Frame frame, WindowGroup window_group FROM DiaFrameMsMsInfo", con)
+    pd.testing.assert_frame_equal(
+        _norm(info, ["frame", "window_group"]), _norm(ref, ["frame", "window_group"])
+    )
+
+    # (b) matches the legacy position formula (index % precursor_every, ms2 only)
+    pe = scheme.cycle_length()
+    legacy = pd.DataFrame(
+        [
+            {"frame": f, "window_group": (f - 1) % pe}
+            for f in range(1, num_frames + 1)
+            if (f - 1) % pe != 0
+        ]
+    )
+    pd.testing.assert_frame_equal(
+        _norm(info, ["frame", "window_group"]), _norm(legacy, ["frame", "window_group"])
+    )
+</stdin>
+codex
+I’ll inspect the actual diff and nearby persistence/read paths so the review distinguishes changed behavior from context. I’ll then rank concrete findings with file/line references and assess the test’s real coverage.
+exec
+/bin/bash -lc 'git diff -- acquisition.py tests/test_acquisition_scheme_parity.py' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+exec
+/bin/bash -lc "nl -ba acquisition.py | sed -n '120,360p'; nl -ba tests/test_acquisition_scheme_parity.py" in /scratch/timsim-demo/SUBMISSION/rustims
+ exited 1 in 0ms:
+nl: acquisition.py: No such file or directory
+nl: tests/test_acquisition_scheme_parity.py: No such file or directory
+
+exec
+/bin/bash -lc "rg -n \"dia_ms_ms_info|dia_ms_ms_windows|create_table\\(|get_table\\(\" -S ." in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+./MIGRATION.codex-review.md:16:Trusted context: imspy_connector.py_acquisition.PyAcquisitionScheme.from_bruker_d(path) wraps a Rust extractor; to_bruker_windows() returns a dict of numpy arrays {window_group, scan_start, scan_end, isolation_mz, isolation_width, collision_energy}; to_bruker_info(num_frames) returns {frame, window_group}; cycle_length() = frames per cycle (precursor_every). The Rust side is golden-tested to reproduce the reference .d's DiaFrameMsMsWindows/DiaFrameMsMsInfo exactly. The LEGACY path reads reference.dia_ms_ms_windows (renamed) and generate_frame_to_window_group_table uses wg = global_frame_index % precursor_every (emitting ms2 frames only). calculate_frame_types sets ms_type=0 when (frame_id-1)%precursor_every==0 else 9. CE is rounded to collision_energy_decimals after.
+./MIGRATION.codex-review.md:18:Focus, ranked: 1) is the migrated _setup BEHAVIOR-EQUIVALENT to legacy for a real reference .d — same dia_ms_ms_windows (column names/dtypes/CE rounding) and same dia_ms_ms_info (frame ids, window_group values, row count, ordering), given scheme group ids vs the legacy POSITION-based wg=index%precursor_every (do they agree only when reference WindowGroups are 1..N contiguous in acquisition order, and is that now relied upon)? 2) the num_frames recompute fix — correct and sufficient? any other stale-state from rt_cycle_length changing (scan_table, frame_table already generated before _setup)? 3) dtype regressions from numpy uint32 columns vs the legacy int columns when written to SQLite (to_sql) and read back by the simulator — could downstream code break on uint32 / column order? 4) the fallback logic (connector without py_acquisition) — correctness and silent-degradation risk. 5) the parity test — does it actually prove backward-compat, what's NOT covered (CE rounding, dtypes, the full builder, non-1..N groups). 6) any bug. Concrete, ranked, ~550 words.
+./MIGRATION.codex-review.md:118:        instance.frame_table = instance.synthetics_handle.get_table('frames')
+./MIGRATION.codex-review.md:119:        instance.scan_table = instance.synthetics_handle.get_table('scans')
+./MIGRATION.codex-review.md:159:        self.synthetics_handle.create_table(
+./MIGRATION.codex-review.md:163:        self.synthetics_handle.create_table(
+./MIGRATION.codex-review.md:172:        self.synthetics_handle.create_table(
+./MIGRATION.codex-review.md:209:        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+./MIGRATION.codex-review.md:245:        Returns ``(dia_ms_ms_windows, frames_to_window_groups, precursor_every)``
+./MIGRATION.codex-review.md:273:            self.dia_ms_ms_windows, frames_to_window_groups, self.precursor_every = scheme_layout
+./MIGRATION.codex-review.md:280:                self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+./MIGRATION.codex-review.md:294:            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+./MIGRATION.codex-review.md:297:        self.synthetics_handle.create_table(
+./MIGRATION.codex-review.md:301:        self.synthetics_handle.create_table(
+./MIGRATION.codex-review.md:305:        self.synthetics_handle.create_table(
+./MIGRATION.codex-review.md:306:            table_name='dia_ms_ms_info',
+./MIGRATION.codex-review.md:309:        self.synthetics_handle.create_table(
+./MIGRATION.codex-review.md:310:            table_name='dia_ms_ms_windows',
+./MIGRATION.codex-review.md:311:            table=self.dia_ms_ms_windows
+./MIGRATION.codex-review.md:358:        instance.frame_table = instance.synthetics_handle.get_table('frames')
+./MIGRATION.codex-review.md:359:        instance.scan_table = instance.synthetics_handle.get_table('scans')
+./MIGRATION.codex-review.md:383:        instance.frames_to_window_groups = instance.synthetics_handle.get_table('dia_ms_ms_info')
+./MIGRATION.codex-review.md:384:        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+./EXTRACTORS.codex-review.md:16:Trusted context: rustdf reads Bruker TDF natively — read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow{window_group,scan_num_begin,scan_num_end,isolation_mz,isolation_width,collision_energy}> and read_meta_data_sql(folder)->Vec<FrameMeta{id,time:f64,ms_ms_type:i64,...}> (MsMsType==0 = MS1/precursor frame). from_bruker_d groups windows by window_group into DiaMs2Frame{TimsMobility windows} and derives cycle time from precursor-frame spacing; verified to extract 15 frames/36 windows from a real DIA-PASEF .d. from_sciex_wiff maps SWATH windows to single MzOnly frames with CE Unknown (SCIEX rolling CE not in the method) and caller-supplied timing; verified 60 windows on a real ZenoTOF .wiff. validate() (already reviewed) requires exactly one MS1 first then >=1 MS2 frame, finite/positive widths, window edges within mz_range, CE finite>=0 for Value/resolved-Linear, multi-window frames need TimsMobility on every window and no within-frame m/z+mobility overlap, start<=gradient. sciexwiff::read_method opens a .wiff OLE2 (cfb crate) and parses SWATHMethod (20B records from off 40) + TOFCalibrationData.
+./EXTRACTORS.codex-review.md:453:        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+./EXTRACTORS.codex-review.md:459:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./EXTRACTORS.codex-review.md:1253:   432	        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+./EXTRACTORS.codex-review.md:1259:   438	        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./EXTRACTORS.codex-review.md:1412:/bin/bash -lc "rg -n \"struct FrameMeta|enum MsMsType|ms_ms_type|read_dia_ms_ms_windows|SWATHMethod|TOFCalibrationData|read_method\" rustdf sciexwiff -g '*.rs' -g '*.md'" in /scratch/timsim-demo/SUBMISSION/rustims
+./EXTRACTORS.codex-review.md:1415:rustdf/src/sim/scheme.rs:432:        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+./EXTRACTORS.codex-review.md:1416:rustdf/src/sim/scheme.rs:438:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./EXTRACTORS.codex-review.md:1422:rustdf/src/data/meta.rs:377:pub fn read_dia_ms_ms_windows(
+./EXTRACTORS.codex-review.md:1431:rustdf/src/data/dia.rs:6:    read_dia_ms_ms_info, read_dia_ms_ms_windows, read_global_meta_sql, read_meta_data_sql,
+./EXTRACTORS.codex-review.md:1432:rustdf/src/data/dia.rs:443:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./EXTRACTORS.codex-review.md:1433:rustdf/src/data/dia.rs:503:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./EXTRACTORS.codex-review.md:1601:   377	pub fn read_dia_ms_ms_windows(
+./EXTRACTORS.codex-review.md:1748:   442	        let dia_ms_mis_info = read_dia_ms_ms_info(data_path).unwrap();
+./EXTRACTORS.codex-review.md:1749:   443	        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./EXTRACTORS.codex-review.md:1784:   478	        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+./EXTRACTORS.codex-review.md:1790:   484	            dia_ms_ms_info: dia_ms_mis_info,
+./EXTRACTORS.codex-review.md:1791:   485	            dia_ms_ms_windows,
+./EXTRACTORS.codex-review.md:1808:   502	        let dia_ms_mis_info = read_dia_ms_ms_info(data_path).unwrap();
+./EXTRACTORS.codex-review.md:1809:   503	        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./EXTRACTORS.codex-review.md:1834:   528	        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+./EXTRACTORS.codex-review.md:1860:   723	            .dia_ms_ms_info
+./EXTRACTORS.codex-review.md:1880:   743	            .dia_ms_ms_windows
+./EXTRACTORS.codex-review.md:2070:   743	            .dia_ms_ms_windows
+./EXTRACTORS.codex-review.md:2090:   763	        for w in &self.dia_ms_ms_windows {
+./ACQUISITION_SCHEME_PLAN.md:39:is timsTOF-coupled: it holds a pandas `dia_ms_ms_windows` table
+./ACQUISITION_SCHEME_PLAN.md:44:`dia_ms_ms_windows` + `dia_ms_ms_info` (frame→group) → the output `.d`.
+./ACQUISITION_SCHEME_PLAN.md:47:- **Bruker** — `reference_ds.dia_ms_ms_windows` (Python, today).
+./ACQUISITION_SCHEME_PLAN.md:175:`dia_ms_ms_info` frame→group sequencing.
+./ACQUISITION_SCHEME_PLAN.md:177:- Add `scheme.to_bruker_tables() -> (dia_ms_ms_windows, dia_ms_ms_info)` that
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:57:is timsTOF-coupled: it holds a pandas `dia_ms_ms_windows` table
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:62:`dia_ms_ms_windows` + `dia_ms_ms_info` (frame→group) → the output `.d`.
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:65:- **Bruker** — `reference_ds.dia_ms_ms_windows` (Python, today).
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:193:`dia_ms_ms_info` frame→group sequencing.
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:195:- Add `scheme.to_bruker_tables() -> (dia_ms_ms_windows, dia_ms_ms_info)` that
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:294:- `dia_ms_ms_info` depends on total frame count and cycle phase, so `to_bruker_tables()` needs run timing/frame context, not merely the scheme as currently shown.
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:365:- `dia_ms_ms_info` depends on total frame count and cycle phase, so `to_bruker_tables()` needs run timing/frame context, not merely the scheme as currently shown.
+./BRUKER_INFO.codex-review.md:610:        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+./BRUKER_INFO.codex-review.md:616:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./BRUKER_INFO.codex-review.md:1189:        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./BRUKER_INFO.codex-review.md:1296:        let original = crate::data::meta::read_dia_ms_ms_info(&d).expect("read source");
+./TO_BRUKER_V2.codex-review.md:521:        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+./TO_BRUKER_V2.codex-review.md:527:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./TO_BRUKER_V2.codex-review.md:1046:        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./TO_BRUKER_V2.codex-review.md:1164:/bin/bash -lc 'rg -n "struct DiaMsMsWindow|read_dia_ms_ms_windows|DiaFrameMsMsInfo|WindowGroup|window_group" src tests crates 2>/dev/null' in /scratch/timsim-demo/SUBMISSION/rustims
+./TO_BRUKER_V2.codex-review.md:1167:./TO_BRUKER.codex-review.md:16:Trusted context: crate::data::meta::DiaMsMsWindow { window_group:u32, scan_num_begin:u32, scan_num_end:u32, isolation_mz:f64, isolation_width:f64, collision_energy:f64 } and read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow> read the Bruker SQLite DiaFrameMsMsWindows table (no ORDER BY). from_bruker_d builds the scheme by grouping those rows by window_group (BTreeMap ascending) into one DiaMs2Frame per group with TimsMobility geometry. The scheme model: cycle is an ordered Vec<AcquisitionEvent> = Ms1 | DiaMs2Frame(windows:Vec<DiaWindow{isolation:{center_mz,width_mz}, collision_energy:CollisionEnergyPolicy{Value|Linear|Unknown}, geometry:DiaGeometry{MzOnly|TimsMobility{scan_start,scan_end}}}>). to_bruker_windows numbers window groups 1..N in cycle (frame) order; the round-trip test normalizes window-group ids to canonical 1..N on both sides and compares sorted exact-bit field tuples.
+./TO_BRUKER_V2.codex-review.md:1221:./EXTRACTORS.codex-review.md:16:Trusted context: rustdf reads Bruker TDF natively — read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow{window_group,scan_num_begin,scan_num_end,isolation_mz,isolation_width,collision_energy}> and read_meta_data_sql(folder)->Vec<FrameMeta{id,time:f64,ms_ms_type:i64,...}> (MsMsType==0 = MS1/precursor frame). from_bruker_d groups windows by window_group into DiaMs2Frame{TimsMobility windows} and derives cycle time from precursor-frame spacing; verified to extract 15 frames/36 windows from a real DIA-PASEF .d. from_sciex_wiff maps SWATH windows to single MzOnly frames with CE Unknown (SCIEX rolling CE not in the method) and caller-supplied timing; verified 60 windows on a real ZenoTOF .wiff. validate() (already reviewed) requires exactly one MS1 first then >=1 MS2 frame, finite/positive widths, window edges within mz_range, CE finite>=0 for Value/resolved-Linear, multi-window frames need TimsMobility on every window and no within-frame m/z+mobility overlap, start<=gradient. sciexwiff::read_method opens a .wiff OLE2 (cfb crate) and parses SWATHMethod (20B records from off 40) + TOFCalibrationData.
+./TO_BRUKER_V2.codex-review.md:1312:./ACQUISITION_SCHEME_PLAN.codex-review.md:179:- `from_bruker_d(ref)` round-trips the existing `dia_ms_ms_windows` columns
+./TO_BRUKER_V2.codex-review.md:1551:        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+./TO_BRUKER_V2.codex-review.md:1557:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./TO_BRUKER_V2.codex-review.md:1632:        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./TO_BRUKER_V2.codex-review.md:1910:        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./TO_BRUKER_V2.codex-review.md:2104:         let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./TO_BRUKER_V2.codex-review.md:2507:  1028	        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./rustdf/src/sim/scheme.rs:601:        use crate::data::meta::{read_dia_ms_ms_info, read_dia_ms_ms_windows, read_meta_data_sql};
+./rustdf/src/sim/scheme.rs:607:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./rustdf/src/sim/scheme.rs:639:        let info = read_dia_ms_ms_info(&folder).unwrap_or_default();
+./rustdf/src/sim/scheme.rs:1200:        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./rustdf/src/sim/scheme.rs:1357:        let original = crate::data::meta::read_dia_ms_ms_info(&d).expect("read source");
+./rustdf/examples/dump_bruker_centroids.rs:13:// definitions from `dia_ms_ms_windows` and `dia_ms_ms_info`.
+./packages/imspy-dia/src/imspy_dia/clustering/helpers.py:93:    wg = getattr(ds, "dia_ms_ms_info", None)
+./packages/imspy-dia/src/imspy_dia/clustering/helpers.py:95:        raise ValueError("Dataset has no dia_ms_ms_info.WindowGroup")
+./packages/imspy-dia/src/imspy_dia/clustering/helpers.py:337:        if not hasattr(ds, "dia_ms_ms_info"):
+./packages/imspy-dia/src/imspy_dia/clustering/helpers.py:338:            raise AttributeError("Dataset missing 'dia_ms_ms_info'")
+./packages/imspy-dia/src/imspy_dia/clustering/helpers.py:339:        msms = ds.dia_ms_ms_info
+./packages/imspy-dia/src/imspy_dia/clustering/helpers.py:341:            raise AttributeError("dia_ms_ms_info must have 'WindowGroup' and 'Frame' columns")
+./ACQUISITION_SCHEME_PLAN.codex-review.md:16:Focus on: 1) is the AcquisitionScheme data model right — does Option<mobility_scan_range> on DiaWindow cleanly capture the timsTOF-vs-(Thermo/SCIEX) difference, or should mobility be split out? 2) the Rust-vs-Python boundary decision (scheme in Rust/rustdf exposed via connector, Python builder migrates onto it) — risks to backward compatibility with the existing dia_ms_ms_windows table and the Bruker reference path; 3) the 6 open questions — which are real blockers vs deferrable, and any the doc should have answered already; 4) anything missing for a faithful per-instrument acquisition design (e.g. MS1 handling, overlapping windows, rolling CE, cycle/RT modeling); 5) is the input(AcquisitionScheme)/output(AcquisitionWriter) split the right factoring? Concrete, specific, cap ~800 words.
+./ACQUISITION_SCHEME_PLAN.codex-review.md:52:- Holds the scheme as a pandas `dia_ms_ms_windows` table with columns
+./ACQUISITION_SCHEME_PLAN.codex-review.md:57:  `DiaFrameMsMsWindows` (`reference_ds.dia_ms_ms_windows`).
+./ACQUISITION_SCHEME_PLAN.codex-review.md:59:  tables; persists to `synthetic_data.db` (`dia_ms_ms_windows`, `dia_ms_ms_info`)
+./ACQUISITION_SCHEME_PLAN.codex-review.md:69:- **Bruker** — `reference_ds.dia_ms_ms_windows` (Python, today).
+./ACQUISITION_SCHEME_PLAN.codex-review.md:137:  `reference_ds.dia_ms_ms_windows` directly and instead consumes an
+./ACQUISITION_SCHEME_PLAN.codex-review.md:141:  `dia_ms_ms_windows` table is produced from the scheme.
+./ACQUISITION_SCHEME_PLAN.codex-review.md:179:- `from_bruker_d(ref)` round-trips the existing `dia_ms_ms_windows` columns
+./ACQUISITION_SCHEME_PLAN.codex-review.md:285:        instance.frame_table = instance.synthetics_handle.get_table('frames')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:286:        instance.scan_table = instance.synthetics_handle.get_table('scans')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:326:        self.synthetics_handle.create_table(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:330:        self.synthetics_handle.create_table(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:339:        self.synthetics_handle.create_table(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:373:        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+./ACQUISITION_SCHEME_PLAN.codex-review.md:411:            self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:426:            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:429:        self.synthetics_handle.create_table(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:433:        self.synthetics_handle.create_table(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:437:        self.synthetics_handle.create_table(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:438:            table_name='dia_ms_ms_info',
+./ACQUISITION_SCHEME_PLAN.codex-review.md:441:        self.synthetics_handle.create_table(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:442:            table_name='dia_ms_ms_windows',
+./ACQUISITION_SCHEME_PLAN.codex-review.md:443:            table=self.dia_ms_ms_windows
+./ACQUISITION_SCHEME_PLAN.codex-review.md:702:/bin/bash -lc "rg -n \"dia_ms_ms_windows|DiaFrameMsMsWindows|precursor_every|ScanDescriptor|AcquisitionWriter\" packages rustdf imspy_connector -g '*.py' -g '*.rs'" in /scratch/timsim-demo/SUBMISSION/rustims
+./ACQUISITION_SCHEME_PLAN.codex-review.md:713:rustdf/src/sim/handle.rs:182:        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_windows")?;
+./ACQUISITION_SCHEME_PLAN.codex-review.md:714:rustdf/src/data/meta.rs:377:pub fn read_dia_ms_ms_windows(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:716:rustdf/src/data/dia.rs:6:    read_dia_ms_ms_info, read_dia_ms_ms_windows, read_global_meta_sql, read_meta_data_sql,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:717:rustdf/src/data/dia.rs:428:    pub dia_ms_ms_windows: Vec<DiaMsMsWindow>,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:718:rustdf/src/data/dia.rs:443:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./ACQUISITION_SCHEME_PLAN.codex-review.md:719:rustdf/src/data/dia.rs:478:        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+./ACQUISITION_SCHEME_PLAN.codex-review.md:720:rustdf/src/data/dia.rs:485:            dia_ms_ms_windows,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:721:rustdf/src/data/dia.rs:503:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./ACQUISITION_SCHEME_PLAN.codex-review.md:722:rustdf/src/data/dia.rs:528:        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+./ACQUISITION_SCHEME_PLAN.codex-review.md:723:rustdf/src/data/dia.rs:535:            dia_ms_ms_windows,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:725:rustdf/src/data/dia.rs:547:        self.dia_ms_ms_windows
+./ACQUISITION_SCHEME_PLAN.codex-review.md:727:rustdf/src/data/dia.rs:743:            .dia_ms_ms_windows
+./ACQUISITION_SCHEME_PLAN.codex-review.md:729:rustdf/src/data/dia.rs:763:        for w in &self.dia_ms_ms_windows {
+./ACQUISITION_SCHEME_PLAN.codex-review.md:731:rustdf/examples/dump_bruker_centroids.rs:13:// definitions from `dia_ms_ms_windows` and `dia_ms_ms_info`.
+./ACQUISITION_SCHEME_PLAN.codex-review.md:734:packages/imspy-core/src/imspy_core/timstof/dia.py:21:    def dia_ms_ms_windows(self):
+./ACQUISITION_SCHEME_PLAN.codex-review.md:736:packages/imspy-vis/src/imspy_vis/frame_rendering.py:289:        self.windows = self.handle.dia_ms_ms_windows.copy()
+./ACQUISITION_SCHEME_PLAN.codex-review.md:737:packages/imspy-simulation/src/imspy_simulation/experiment.py:635:        self.dia_ms_ms_windows = None
+./ACQUISITION_SCHEME_PLAN.codex-review.md:738:packages/imspy-simulation/src/imspy_simulation/experiment.py:641:        self.dia_ms_ms_windows = self.get_table('dia_ms_ms_windows')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:739:packages/imspy-simulation/src/imspy_simulation/experiment.py:649:        for _, row in self.dia_ms_ms_windows.iterrows():
+./ACQUISITION_SCHEME_PLAN.codex-review.md:741:packages/imspy-simulation/src/imspy_simulation/acquisition.py:185:        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+./ACQUISITION_SCHEME_PLAN.codex-review.md:748:packages/imspy-simulation/src/imspy_simulation/acquisition.py:223:            self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:749:packages/imspy-simulation/src/imspy_simulation/acquisition.py:238:            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:750:packages/imspy-simulation/src/imspy_simulation/acquisition.py:254:            table_name='dia_ms_ms_windows',
+./ACQUISITION_SCHEME_PLAN.codex-review.md:751:packages/imspy-simulation/src/imspy_simulation/acquisition.py:255:            table=self.dia_ms_ms_windows
+./ACQUISITION_SCHEME_PLAN.codex-review.md:754:packages/imspy-simulation/src/imspy_simulation/acquisition.py:328:        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:755:packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:20:        config_name: Name of the config file (e.g., 'dia_ms_ms_windows.csv')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:756:packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:504:            # dia-PASEF: Load all windows from actual dia_ms_ms_windows.csv
+./ACQUISITION_SCHEME_PLAN.codex-review.md:757:packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:506:            window_df = load_window_config("dia_ms_ms_windows.csv")
+./ACQUISITION_SCHEME_PLAN.codex-review.md:758:packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:580:            # midia-PASEF: Load windows from actual midia_ms_ms_windows.csv
+./ACQUISITION_SCHEME_PLAN.codex-review.md:759:packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:581:            window_df = load_window_config("midia_ms_ms_windows.csv")
+./ACQUISITION_SCHEME_PLAN.codex-review.md:760:packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:179:        acquisition_builder.tdf_writer.write_dia_ms_ms_windows(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:761:packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:180:            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_windows'))
+./ACQUISITION_SCHEME_PLAN.codex-review.md:762:packages/imspy-simulation/src/imspy_simulation/data/database.py:217:        dia_ms_ms_windows: Cached DIA MS/MS windows DataFrame.
+./ACQUISITION_SCHEME_PLAN.codex-review.md:763:packages/imspy-simulation/src/imspy_simulation/data/database.py:235:        self.dia_ms_ms_windows: Optional[pd.DataFrame] = None
+./ACQUISITION_SCHEME_PLAN.codex-review.md:764:packages/imspy-simulation/src/imspy_simulation/data/database.py:242:            self.dia_ms_ms_windows = self.get_table("dia_ms_ms_windows")
+./ACQUISITION_SCHEME_PLAN.codex-review.md:765:packages/imspy-simulation/src/imspy_simulation/data/database.py:266:        if self.dia_ms_ms_windows is None:
+./ACQUISITION_SCHEME_PLAN.codex-review.md:766:packages/imspy-simulation/src/imspy_simulation/data/database.py:269:        if self.dia_ms_ms_windows is None:
+./ACQUISITION_SCHEME_PLAN.codex-review.md:767:packages/imspy-simulation/src/imspy_simulation/data/database.py:273:        for _, row in self.dia_ms_ms_windows.iterrows():
+./ACQUISITION_SCHEME_PLAN.codex-review.md:770:packages/imspy-simulation/src/imspy_simulation/tdf.py:496:    def write_dia_ms_ms_windows(self, dia_ms_ms_windows: pd.DataFrame) -> None:
+./ACQUISITION_SCHEME_PLAN.codex-review.md:771:packages/imspy-simulation/src/imspy_simulation/tdf.py:497:        out = dia_ms_ms_windows.rename(columns={
+./ACQUISITION_SCHEME_PLAN.codex-review.md:772:packages/imspy-simulation/src/imspy_simulation/tdf.py:506:        self._create_table(self.conn, out, "DiaFrameMsMsWindows")
+./ACQUISITION_SCHEME_PLAN.codex-review.md:793:        self.dia_ms_ms_info = None
+./ACQUISITION_SCHEME_PLAN.codex-review.md:794:        self.dia_ms_ms_windows = None
+./ACQUISITION_SCHEME_PLAN.codex-review.md:799:        self.dia_ms_ms_info = self.get_table('dia_ms_ms_info')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:800:        self.dia_ms_ms_windows = self.get_table('dia_ms_ms_windows')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:803:        return dict(zip(self.dia_ms_ms_info.frame, self.dia_ms_ms_info.window_group))
+./ACQUISITION_SCHEME_PLAN.codex-review.md:808:        for _, row in self.dia_ms_ms_windows.iterrows():
+./ACQUISITION_SCHEME_PLAN.codex-review.md:830:    handle.create_table(sql_create_peptides_table)
+./ACQUISITION_SCHEME_PLAN.codex-review.md:860:        instance.frame_table = instance.synthetics_handle.get_table('frames')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:861:        instance.scan_table = instance.synthetics_handle.get_table('scans')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:885:        instance.frames_to_window_groups = instance.synthetics_handle.get_table('dia_ms_ms_info')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:886:        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+./ACQUISITION_SCHEME_PLAN.codex-review.md:900:pub fn read_dia_ms_ms_info(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:926:pub fn read_dia_ms_ms_windows(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:992:        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_windows")?;
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1011:        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_info")?;
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1051:    def write_dia_ms_ms_windows(self, dia_ms_ms_windows: pd.DataFrame) -> None:
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1052:        out = dia_ms_ms_windows.rename(columns={
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1061:        self._create_table(self.conn, out, "DiaFrameMsMsWindows")
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1092:        acquisition_builder.tdf_writer.write_dia_ms_ms_info(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1093:            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_info'))
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1095:        acquisition_builder.tdf_writer.write_dia_ms_ms_windows(
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1096:            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_windows'))
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1161:   - `dia_ms_ms_info` frame-to-group sequencing.
+./ACQUISITION_SCHEME_PLAN.codex-review.md:1231:   - `dia_ms_ms_info` frame-to-group sequencing.
+./rustdf/src/sim/handle.rs:182:        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_windows")?;
+./rustdf/src/sim/handle.rs:201:        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_info")?;
+./packages/imspy-core/src/imspy_core/timstof/data.py:229:    def get_table(self, table_name: str) -> pd.DataFrame:
+./TO_BRUKER.codex-review.md:16:Trusted context: crate::data::meta::DiaMsMsWindow { window_group:u32, scan_num_begin:u32, scan_num_end:u32, isolation_mz:f64, isolation_width:f64, collision_energy:f64 } and read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow> read the Bruker SQLite DiaFrameMsMsWindows table (no ORDER BY). from_bruker_d builds the scheme by grouping those rows by window_group (BTreeMap ascending) into one DiaMs2Frame per group with TimsMobility geometry. The scheme model: cycle is an ordered Vec<AcquisitionEvent> = Ms1 | DiaMs2Frame(windows:Vec<DiaWindow{isolation:{center_mz,width_mz}, collision_energy:CollisionEnergyPolicy{Value|Linear|Unknown}, geometry:DiaGeometry{MzOnly|TimsMobility{scan_start,scan_end}}}>). to_bruker_windows numbers window groups 1..N in cycle (frame) order; the round-trip test normalizes window-group ids to canonical 1..N on both sides and compares sorted exact-bit field tuples.
+./TO_BRUKER.codex-review.md:510:        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+./TO_BRUKER.codex-review.md:516:        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+./TO_BRUKER.codex-review.md:1029:        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+./rustdf/src/data/meta.rs:351:pub fn read_dia_ms_ms_info(
+./rustdf/src/data/meta.rs:377:pub fn read_dia_ms_ms_windows(
+./rustdf/src/data/dia.rs:6:    read_dia_ms_ms_info, read_dia_ms_ms_windows, read_global_meta_sql, read_meta_data_sql,
+./rustdf/src/data/dia.rs:427:    pub dia_ms_ms_info: Vec<DiaMsMisInfo>,
+./rustdf/src/data/dia.rs:428:    pub dia_ms_ms_windows: Vec<DiaMsMsWindow>,
+./rustdf/src/data/dia.rs:442:        let dia_ms_mis_info = read_dia_ms_ms_info(data_path).unwrap();
+./rustdf/src/data/dia.rs:443:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./rustdf/src/data/dia.rs:478:        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+./rustdf/src/data/dia.rs:484:            dia_ms_ms_info: dia_ms_mis_info,
+./rustdf/src/data/dia.rs:485:            dia_ms_ms_windows,
+./rustdf/src/data/dia.rs:502:        let dia_ms_mis_info = read_dia_ms_ms_info(data_path).unwrap();
+./rustdf/src/data/dia.rs:503:        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+./rustdf/src/data/dia.rs:528:        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+./rustdf/src/data/dia.rs:534:            dia_ms_ms_info: dia_ms_mis_info,
+./rustdf/src/data/dia.rs:535:            dia_ms_ms_windows,
+./rustdf/src/data/dia.rs:547:        self.dia_ms_ms_windows
+./rustdf/src/data/dia.rs:618:            .dia_ms_ms_info
+./rustdf/src/data/dia.rs:697:            .dia_ms_ms_info
+./rustdf/src/data/dia.rs:723:            .dia_ms_ms_info
+./rustdf/src/data/dia.rs:743:            .dia_ms_ms_windows
+./rustdf/src/data/dia.rs:763:        for w in &self.dia_ms_ms_windows {
+./packages/imspy-core/src/imspy_core/timstof/dia.py:21:    def dia_ms_ms_windows(self):
+./packages/imspy-core/src/imspy_core/timstof/dia.py:31:    def dia_ms_ms_info(self):
+./packages/imspy-vis/src/imspy_vis/frame_rendering.py:289:        self.windows = self.handle.dia_ms_ms_windows.copy()
+./packages/imspy-vis/src/imspy_vis/frame_rendering.py:290:        self.frame_to_group = dict(zip(self.handle.dia_ms_ms_info.Frame, self.handle.dia_ms_ms_info.WindowGroup))
+./packages/imspy-dia/src/imspy_dia/pipeline/cluster_pipeline.py:559:    info = ds.dia_ms_ms_info
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:545:    def create_table(self, table_name: str, table: pd.DataFrame):
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:595:    def get_table(self, table_name: str) -> pd.DataFrame:
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:605:        return self.get_table("frames")
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:634:        self.dia_ms_ms_info = None
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:635:        self.dia_ms_ms_windows = None
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:640:        self.dia_ms_ms_info = self.get_table('dia_ms_ms_info')
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:641:        self.dia_ms_ms_windows = self.get_table('dia_ms_ms_windows')
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:644:        return dict(zip(self.dia_ms_ms_info.frame, self.dia_ms_ms_info.window_group))
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:649:        for _, row in self.dia_ms_ms_windows.iterrows():
+./packages/imspy-simulation/src/imspy_simulation/experiment.py:671:    handle.create_table(sql_create_peptides_table)
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:97:        instance.frame_table = instance.synthetics_handle.get_table('frames')
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:98:        instance.scan_table = instance.synthetics_handle.get_table('scans')
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:138:        self.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:142:        self.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:151:        self.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:188:        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:224:        Returns ``(dia_ms_ms_windows, frames_to_window_groups, precursor_every)``
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:252:            self.dia_ms_ms_windows, frames_to_window_groups, self.precursor_every = scheme_layout
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:259:                self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:273:            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:276:        self.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:280:        self.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:284:        self.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:285:            table_name='dia_ms_ms_info',
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:288:        self.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:289:            table_name='dia_ms_ms_windows',
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:290:            table=self.dia_ms_ms_windows
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:337:        instance.frame_table = instance.synthetics_handle.get_table('frames')
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:338:        instance.scan_table = instance.synthetics_handle.get_table('scans')
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:362:        instance.frames_to_window_groups = instance.synthetics_handle.get_table('dia_ms_ms_info')
+./packages/imspy-simulation/src/imspy_simulation/acquisition.py:363:        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:77:    def create_table(self, table_name: str, table: pd.DataFrame) -> None:
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:142:    def get_table(self, table_name: str) -> pd.DataFrame:
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:159:        return self.get_table("frames")
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:216:        dia_ms_ms_info: Cached DIA MS/MS info DataFrame.
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:217:        dia_ms_ms_windows: Cached DIA MS/MS windows DataFrame.
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:234:        self.dia_ms_ms_info: Optional[pd.DataFrame] = None
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:235:        self.dia_ms_ms_windows: Optional[pd.DataFrame] = None
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:241:            self.dia_ms_ms_info = self.get_table("dia_ms_ms_info")
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:242:            self.dia_ms_ms_windows = self.get_table("dia_ms_ms_windows")
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:252:        if self.dia_ms_ms_info is None:
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:255:        if self.dia_ms_ms_info is None:
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:258:        return dict(zip(self.dia_ms_ms_info.frame, self.dia_ms_ms_info.window_group))
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:266:        if self.dia_ms_ms_windows is None:
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:269:        if self.dia_ms_ms_windows is None:
+./packages/imspy-simulation/src/imspy_simulation/data/database.py:273:        for _, row in self.dia_ms_ms_windows.iterrows():
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/dda_selection_scheme.py:62:    scan_max = acquisition_builder.synthetics_handle.get_table("scans").scan.max()
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/dda_selection_scheme.py:75:    ms_1_frames = set(handle.get_table("frames")[handle.get_table("frames").ms_type == 0].frame_id.values)
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/dda_selection_scheme.py:78:    peptides = handle.get_table("peptides")
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/dda_selection_scheme.py:79:    ions = handle.get_table("ions")
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/dda_selection_scheme.py:129:    acquisition_builder.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:176:        acquisition_builder.tdf_writer.write_dia_ms_ms_info(
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:177:            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_info'))
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:179:        acquisition_builder.tdf_writer.write_dia_ms_ms_windows(
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:180:            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_windows'))
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:203:            id_mapping_table = acquisition_builder.synthetics_handle.get_table('precursor_id_mapping')
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:210:            acquisition_builder.synthetics_handle.get_table('precursors'),
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:216:            acquisition_builder.synthetics_handle.get_table('pasef_meta'),
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_fragment_intensities.py:396:            acquisition_builder.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_fragment_intensities.py:550:                acquisition_builder.synthetics_handle.create_table(
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:83:        frame_ms_ms_info = self.helper_handle.get_table("FrameMsmsInfo")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:84:        segments = self.helper_handle.get_table("Segments")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:94:        self._create_table(self.conn, self.helper_handle.mz_calibration, "MzCalibration")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:95:        self._create_table(self.conn, self.helper_handle.tims_calibration, "TimsCalibration")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:96:        self._create_table(self.conn, self.helper_handle.global_meta_data_pandas, "GlobalMetadata")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:97:        self._create_table(self.conn, frame_ms_ms_info, "FrameMsmsInfo")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:98:        self._create_table(self.conn, segments, "Segments")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:110:    def _get_table(conn, table_name: str) -> pd.DataFrame:
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:115:    def _create_table(conn, table, table_name: str) -> None:
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:324:        self._create_table(self.conn, meta_df, "Frames")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:341:            table = self.helper_handle.get_table("CalibrationInfo")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:343:            self._create_table(self.conn, table, "CalibrationInfo")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:350:            self._create_table(self.conn, self.helper_handle.get_table("PasefFrameMsMsInfo"), "PasefFrameMsMsInfo")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:356:            self._create_table(self.conn, self.helper_handle.get_table("PrmFrameMsMsInfo"), "PrmFrameMsMsInfo")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:360:    def write_dia_ms_ms_info(self, dia_ms_ms_info: pd.DataFrame) -> None:
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:361:        out = dia_ms_ms_info.rename(columns={
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:366:        self._create_table(self.conn, out, "DiaFrameMsMsInfo")
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:496:    def write_dia_ms_ms_windows(self, dia_ms_ms_windows: pd.DataFrame) -> None:
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:497:        out = dia_ms_ms_windows.rename(columns={
+./packages/imspy-simulation/src/imspy_simulation/tdf.py:506:        self._create_table(self.conn, out, "DiaFrameMsMsWindows")
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:906:        peptides = existing_sim_handle.get_table('peptides')
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:907:        proteins = existing_sim_handle.get_table('proteins')
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:908:        ions = existing_sim_handle.get_table('ions')
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1184:        acquisition_builder.synthetics_handle.create_table(table_name='proteins', table=proteins)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1198:        acquisition_builder.synthetics_handle.create_table(table_name='peptides', table=peptides)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1270:        acquisition_builder.synthetics_handle.create_table(table_name='ions', table=ions)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1283:            acquisition_builder.synthetics_handle.create_table(table_name='pasef_meta', table=pasef_meta)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1284:            acquisition_builder.synthetics_handle.create_table(table_name='precursors', table=precursors)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1298:        acquisition_builder.synthetics_handle.create_table(table_name='proteins', table=proteins)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1299:        acquisition_builder.synthetics_handle.create_table(table_name='peptides', table=peptides)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1300:        acquisition_builder.synthetics_handle.create_table(table_name='ions', table=ions)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1302:            acquisition_builder.synthetics_handle.create_table(table_name='pasef_meta', table=pasef_meta)
+./packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py:1304:            acquisition_builder.synthetics_handle.create_table(table_name='precursors', table=precursors)
+./packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:20:        config_name: Name of the config file (e.g., 'dia_ms_ms_windows.csv')
+./packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:504:            # dia-PASEF: Load all windows from actual dia_ms_ms_windows.csv
+./packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:506:            window_df = load_window_config("dia_ms_ms_windows.csv")
+./packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:580:            # midia-PASEF: Load windows from actual midia_ms_ms_windows.csv
+./packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:581:            window_df = load_window_config("midia_ms_ms_windows.csv")
+./packages/imspy-simulation/src/imspy_simulation/timsim/validate/comparison.py:48:    peptides = handle.get_table("peptides")
+./packages/imspy-simulation/src/imspy_simulation/timsim/validate/comparison.py:49:    ions = handle.get_table("ions")
+./packages/imspy-simulation/src/imspy_simulation/timsim/validate/comparison.py:54:        fragment_ions = handle.get_table("fragment_ions")
+
+codex
+The submitted paths are under `packages/imspy-simulation`, and the working tree diff is empty for the shorthand paths. I found the live implementation and am checking SQLite serialization plus the Rust/Python consumers, where dtype and ordering assumptions become observable.
+exec
+/bin/bash -lc 'git status --short; git log -1 --oneline -- packages/imspy-simulation/src/imspy_simulation/acquisition.py tests/test_acquisition_scheme_parity.py' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+ M imspy_connector/src/py_acquisition.rs
+?? MIGRATION.codex-review.md
+?? packages/imspy-predictors/scripts/compare_libraries.py
+?? packages/imspy-predictors/scripts/generate_calibrated_library.py
+?? primitives/
+?? rustdf/examples/build_bruker_pseudo_ms2.rs
+?? rustdf/examples/build_bruker_pseudo_ms2_v3.rs
+?? rustdf/examples/dump_bruker_ms1_centroids.rs
+?? scripts/compare_diann_to_truth.py
+?? scripts/reread_rustw_smoke.py
+ea07bcf1 feat(imspy-sim): migrate TimsTofAcquisitionBuilderDIA onto AcquisitionScheme
+
+exec
+/bin/bash -lc "nl -ba packages/imspy-simulation/src/imspy_simulation/acquisition.py | sed -n '160,310p'; nl -ba tests/test_acquisition_scheme_parity.py 2>/dev/null || true" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   160	                 window_group_file: str,
+   161	                 acquisition_name: str = "dia",
+   162	                 exp_name: str = "RAW",
+   163	                 verbose: bool = True,
+   164	                 precursor_every: int = 17,
+   165	                 gradient_length=50 * 60,
+   166	                 rt_cycle_length=0.1054,
+   167	                 use_reference_ds_layout: bool = True,
+   168	                 round_collision_energy: bool = True,
+   169	                 collision_energy_decimals: int = 1
+   170	                 ):
+   171	
+   172	        super().__init__(path, reference_ds, gradient_length, rt_cycle_length,
+   173	                         exp_name=exp_name)
+   174	        # TODO: check this, could be missing replacement of reference layout of windows
+   175	        if use_reference_ds_layout:
+   176	            rt_cycle_length = np.mean(np.diff(reference_ds.meta_data.Time))
+   177	            if verbose:
+   178	                print('Using reference dataset cycle length:', np.round(rt_cycle_length, 4))
+   179	            self.rt_cycle_length = rt_cycle_length
+   180	            # Recompute the frame count: the base __init__ computed it from the
+   181	            # passed rt_cycle_length before this reference-derived value replaced it.
+   182	            self.num_frames = calculate_number_frames(self.gradient_length, rt_cycle_length)
+   183	
+   184	        self.acquisition_name = acquisition_name
+   185	        self.scan_table = None
+   186	        self.frame_table = None
+   187	        self.frames_to_window_groups = None
+   188	        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+   189	        self.use_reference_ds_layout = use_reference_ds_layout
+   190	        self.reference = reference_ds
+   191	        self.round_collision_energy = round_collision_energy
+   192	        self.collision_energy_decimals = collision_energy_decimals
+   193	
+   194	        # TODO: check if the number of scans in the window group file matches the number of scans in the experiment
+   195	
+   196	        self.acquisition_mode = AcquisitionMode('DIA')
+   197	        self.verbose = verbose
+   198	        self.precursor_every = precursor_every
+   199	
+   200	        self._setup(verbose=verbose)
+   201	
+   202	    def calculate_frame_types(self, verbose: bool = True) -> NDArray:
+   203	        if verbose:
+   204	            print(f'Calculating frame types, precursor frame will be taken every {self.precursor_every} rt cycles.')
+   205	        return np.array([0 if (x - 1) % self.precursor_every == 0 else 9 for x in self.frame_table.frame_id])
+   206	
+   207	    def generate_frame_to_window_group_table(self, verbose: bool = True) -> pd.DataFrame:
+   208	        if verbose:
+   209	            print(f'generating frame to window group table, precursors every {self.precursor_every} frames.')
+   210	
+   211	        table_list = []
+   212	        for index, row in self.frame_table.iterrows():
+   213	            frame_id, ms_type = row.frame_id, row.ms_type
+   214	            wg = index % self.precursor_every
+   215	            if ms_type > 0:
+   216	                table_list.append({'frame': int(frame_id), 'window_group': wg})
+   217	
+   218	        return pd.DataFrame(table_list)
+   219	
+   220	    def _layout_from_scheme(self, verbose: bool = True):
+   221	        """Derive the DIA window + frame→group tables from the reference `.d` via
+   222	        the vendor-neutral ``AcquisitionScheme`` (imspy_connector.py_acquisition).
+   223	
+   224	        Returns ``(dia_ms_ms_windows, frames_to_window_groups, precursor_every)``
+   225	        or ``None`` if the connector lacks the scheme module (legacy fallback).
+   226	        """
+   227	        try:
+   228	            import imspy_connector
+   229	            acq = imspy_connector.py_acquisition
+   230	        except (ImportError, AttributeError):
+   231	            if verbose:
+   232	                print('py_acquisition unavailable; using legacy reference layout')
+   233	            return None
+   234	
+   235	        scheme = acq.PyAcquisitionScheme.from_bruker_d(self.reference.data_path)
+   236	        precursor_every = scheme.cycle_length()
+   237	        windows = pd.DataFrame(scheme.to_bruker_windows())
+   238	        info = pd.DataFrame(scheme.to_bruker_info(int(self.num_frames)))
+   239	        if verbose:
+   240	            print(f'Using AcquisitionScheme layout: {len(windows)} windows, '
+   241	                  f'{scheme.n_ms2_frames()} groups, precursor_every={precursor_every}')
+   242	        return windows, info, precursor_every
+   243	
+   244	    def _setup(self, verbose: bool = True):
+   245	        self.frame_table = self.generate_frame_table(verbose=verbose)
+   246	        self.scan_table = self.generate_scan_table(verbose=verbose)
+   247	
+   248	        scheme_layout = self._layout_from_scheme(verbose=verbose) if self.use_reference_ds_layout else None
+   249	
+   250	        if scheme_layout is not None:
+   251	            # Vendor-neutral path: windows + frame→group come from the scheme.
+   252	            self.dia_ms_ms_windows, frames_to_window_groups, self.precursor_every = scheme_layout
+   253	            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+   254	            self.frames_to_window_groups = frames_to_window_groups
+   255	        else:
+   256	            # Legacy path: copy the reference .d's window table directly.
+   257	            if self.use_reference_ds_layout:
+   258	                self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
+   259	                self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+   260	                    columns={
+   261	                        'WindowGroup': 'window_group',
+   262	                        'ScanNumBegin': 'scan_start',
+   263	                        'ScanNumEnd': 'scan_end',
+   264	                        'IsolationMz': 'isolation_mz',
+   265	                        'IsolationWidth': 'isolation_width',
+   266	                        'CollisionEnergy': 'collision_energy',
+   267	                    }
+   268	                )
+   269	            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+   270	            self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
+   271	
+   272	        if self.round_collision_energy:
+   273	            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+   274	                                                                  decimals=self.collision_energy_decimals)
+   275	
+   276	        self.synthetics_handle.create_table(
+   277	            table_name='frames',
+   278	            table=self.frame_table
+   279	        )
+   280	        self.synthetics_handle.create_table(
+   281	            table_name='scans',
+   282	            table=self.scan_table
+   283	        )
+   284	        self.synthetics_handle.create_table(
+   285	            table_name='dia_ms_ms_info',
+   286	            table=self.frames_to_window_groups
+   287	        )
+   288	        self.synthetics_handle.create_table(
+   289	            table_name='dia_ms_ms_windows',
+   290	            table=self.dia_ms_ms_windows
+   291	        )
+   292	
+   293	    @staticmethod
+   294	    def from_config(
+   295	            path: str,
+   296	            reference_ds: TimsDatasetDIA,
+   297	            exp_name: str,
+   298	            config: Dict[str, any],
+   299	            verbose: bool = True,
+   300	            use_reference_layout: bool = True,
+   301	            round_collision_energy: bool = True,
+   302	            collision_energy_decimals: int = 1
+   303	    ) -> 'TimsTofAcquisitionBuilderDIA':
+   304	
+   305	        acquisition_name = config['name'].lower().replace('pasef', '')
+   306	        window_group_file = get_ms_ms_window_layout_resource_path(acquisition_name)
+   307	
+   308	        return TimsTofAcquisitionBuilderDIA(
+   309	            path=str(Path(path) / exp_name),
+   310	            reference_ds=reference_ds,
+
+exec
+/bin/bash -lc "nl -ba packages/imspy-simulation/src/imspy_simulation/experiment.py | sed -n '530,665p'; nl -ba packages/imspy-simulation/src/imspy_simulation/tdf.py | sed -n '105,125p;350,375p;490,515p'; nl -ba rustdf/src/sim/handle.rs | sed -n '170,220p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   530	        self.base_path = database_path
+   531	        self.database_path = os.path.join(self.base_path, database_name)
+   532	        self.conn = None
+   533	
+   534	        self._setup()
+   535	
+   536	    def _setup(self):
+   537	        if not os.path.exists(self.base_path):
+   538	            if self.verbose:
+   539	                print(f"Creating data directory: {self.base_path}")
+   540	            os.makedirs(self.base_path)
+   541	        if self.verbose:
+   542	            print(f"Connecting to database: {self.database_path}")
+   543	        self.conn = sqlite3.connect(self.database_path)
+   544	
+   545	    def create_table(self, table_name: str, table: pd.DataFrame):
+   546	        # Create a table from a pandas DataFrame
+   547	        table.to_sql(table_name, self.conn, if_exists='replace', index=False)
+   548	        # Create indexes for efficient lazy loading queries
+   549	        self._create_indexes_for_table(table_name)
+   550	
+   551	    def _create_indexes_for_table(self, table_name: str):
+   552	        """Create indexes for efficient lazy loading queries based on table name."""
+   553	        indexes = {
+   554	            'peptides': [
+   555	                "CREATE INDEX IF NOT EXISTS idx_peptides_frame_range ON peptides(frame_occurrence_start, frame_occurrence_end)",
+   556	                "CREATE INDEX IF NOT EXISTS idx_peptides_peptide_id ON peptides(peptide_id)",
+   557	            ],
+   558	            'ions': [
+   559	                "CREATE INDEX IF NOT EXISTS idx_ions_peptide_id ON ions(peptide_id)",
+   560	            ],
+   561	            'fragment_ions': [
+   562	                "CREATE INDEX IF NOT EXISTS idx_fragment_ions_peptide_id ON fragment_ions(peptide_id)",
+   563	                "CREATE INDEX IF NOT EXISTS idx_fragment_ions_lookup ON fragment_ions(peptide_id, charge)",
+   564	            ],
+   565	        }
+   566	
+   567	        if table_name in indexes:
+   568	            cursor = self.conn.cursor()
+   569	            for sql in indexes[table_name]:
+   570	                try:
+   571	                    cursor.execute(sql)
+   572	                except sqlite3.Error as e:
+   573	                    if self.verbose:
+   574	                        print(f"Warning: Could not create index: {e}")
+   575	            self.conn.commit()
+   576	
+   577	    def append_table(self, table_name: str, table: pd.DataFrame):
+   578	        # Append a table to an existing table in the database
+   579	        table.to_sql(table_name, self.conn, if_exists='append', index=False)
+   580	
+   581	    def create_table_sql(self, sql):
+   582	        # Create a table as per the provided SQL statement
+   583	        try:
+   584	            cursor = self.conn.cursor()
+   585	            cursor.execute(sql)
+   586	            self.conn.commit()
+   587	        except sqlite3.Error as e:
+   588	            print(f"An error occurred: {e}")
+   589	
+   590	    def close(self):
+   591	        # Close the database connection
+   592	        if self.conn:
+   593	            self.conn.close()
+   594	
+   595	    def get_table(self, table_name: str) -> pd.DataFrame:
+   596	        # Get a table as a pandas DataFrame
+   597	        return pd.read_sql(f"SELECT * FROM {table_name}", self.conn)
+   598	
+   599	    def get_frame_meta_data(self) -> pd.DataFrame:
+   600	        """Get frame metadata table.
+   601	
+   602	        Returns:
+   603	            Frame metadata DataFrame.
+   604	        """
+   605	        return self.get_table("frames")
+   606	
+   607	    def list_tables(self):
+   608	        with self.conn:
+   609	            cursor = self.conn.cursor()
+   610	            cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+   611	            tables = cursor.fetchall()
+   612	            return [table[0] for table in tables]
+   613	
+   614	    def list_columns(self, table_name):
+   615	        if table_name not in self.list_tables():
+   616	            raise ValueError(f"Table '{table_name}' does not exist in the database.")
+   617	
+   618	        with self.conn:
+   619	            cursor = self.conn.cursor()
+   620	            cursor.execute(f"PRAGMA table_info({table_name});")
+   621	            columns = cursor.fetchall()
+   622	            return [column[1] for column in columns]
+   623	
+   624	    def __repr__(self):
+   625	        return f"SyntheticExperimentDataHandle(database_path={self.database_path})"
+   626	
+   627	
+   628	class SyntheticExperimentDataHandleDIA(SyntheticExperimentDataHandle, ABC):
+   629	    def __init__(self,
+   630	                 database_path: str,
+   631	                 database_name: str = 'synthetic_data.db',
+   632	                 verbose: bool = True,):
+   633	        super().__init__(database_path, database_name, verbose)
+   634	        self.dia_ms_ms_info = None
+   635	        self.dia_ms_ms_windows = None
+   636	
+   637	        self._additional_setup()
+   638	
+   639	    def _additional_setup(self):
+   640	        self.dia_ms_ms_info = self.get_table('dia_ms_ms_info')
+   641	        self.dia_ms_ms_windows = self.get_table('dia_ms_ms_windows')
+   642	
+   643	    def get_frame_to_window_group(self):
+   644	        return dict(zip(self.dia_ms_ms_info.frame, self.dia_ms_ms_info.window_group))
+   645	
+   646	    def get_window_group_settings(self):
+   647	        window_group_settings = {}
+   648	
+   649	        for _, row in self.dia_ms_ms_windows.iterrows():
+   650	            key = (row.window_group, row.scan_start)
+   651	            value = (row.mz_mid, row.mz_width)
+   652	            window_group_settings[key] = value
+   653	
+   654	        return window_group_settings
+   655	
+   656	
+   657	if __name__ == '__main__':
+   658	
+   659	    # Example usage
+   660	    path = '/path/to/directory'
+   661	    db_name = 'experiment_data.db'
+   662	    handle = SyntheticExperimentDataHandle(path, db_name)
+   663	
+   664	    # Create a table, for example
+   665	    sql_create_peptides_table = '''
+   105	
+   106	        if self.verbose:
+   107	            print(f"Setting up TDF file meta data, created: {self.full_path}/analysis.tdf and {self.full_path}/analysis.tdf_bin")
+   108	
+   109	    @staticmethod
+   110	    def _get_table(conn, table_name: str) -> pd.DataFrame:
+   111	        # Get a table as a pandas DataFrame
+   112	        return pd.read_sql(f"SELECT * FROM {table_name}", conn)
+   113	
+   114	    @staticmethod
+   115	    def _create_table(conn, table, table_name: str) -> None:
+   116	        # Create a table from a pandas DataFrame
+   117	        table.to_sql(table_name, conn, if_exists='replace', index=False)
+   118	
+   119	    def mz_to_tof(self, frame_id, mzs):
+   120	        """Convert m/z values to TOF values for a given frame using the helper handle.
+   121	        # CAUTION: This will use the calibration data from the reference handle.
+   122	        """
+   123	
+   124	        try:
+   125	            max_ref_frame_id = self.helper_handle.meta_data.Id.max()
+   350	            self._create_table(self.conn, self.helper_handle.get_table("PasefFrameMsMsInfo"), "PasefFrameMsMsInfo")
+   351	        except Exception as e:
+   352	            print(f"Error writing PasefFrameMsMsInfo table: {e}. In most cases, this is not a problem, since the table is empty in DIA mode.")
+   353	
+   354	    def write_prm_frame_ms_ms_info(self) -> None:
+   355	        try:
+   356	            self._create_table(self.conn, self.helper_handle.get_table("PrmFrameMsMsInfo"), "PrmFrameMsMsInfo")
+   357	        except Exception as e:
+   358	            print(f"Error writing PrmFrameMsMsInfo table: {e}")
+   359	
+   360	    def write_dia_ms_ms_info(self, dia_ms_ms_info: pd.DataFrame) -> None:
+   361	        out = dia_ms_ms_info.rename(columns={
+   362	            'frame': 'Frame',
+   363	            'window_group': 'WindowGroup',
+   364	        })
+   365	
+   366	        self._create_table(self.conn, out, "DiaFrameMsMsInfo")
+   367	
+   368	    def write_precursor_table(self, precursor_table: pd.DataFrame, id_mapping_table: pd.DataFrame = None) -> dict:
+   369	        """Write the Precursors table with proper vendor schema.
+   370	
+   371	        Args:
+   372	            precursor_table: DataFrame with precursor data
+   373	            id_mapping_table: Optional DataFrame with 'ion_id' and 'tdf_precursor_id' columns.
+   374	                             If None, creates sequential mapping from existing IDs.
+   375	
+   490	                float(row['IsolationWidth']),
+   491	                float(row['CollisionEnergy']),
+   492	                precursor_id
+   493	            ))
+   494	        self.conn.commit()
+   495	
+   496	    def write_dia_ms_ms_windows(self, dia_ms_ms_windows: pd.DataFrame) -> None:
+   497	        out = dia_ms_ms_windows.rename(columns={
+   498	            'window_group': 'WindowGroup',
+   499	            'scan_start': 'ScanNumBegin',
+   500	            'scan_end': 'ScanNumEnd',
+   501	            'isolation_mz': 'IsolationMz',
+   502	            'isolation_width': 'IsolationWidth',
+   503	            'collision_energy': 'CollisionEnergy',
+   504	        })
+   505	
+   506	        self._create_table(self.conn, out, "DiaFrameMsMsWindows")
+   507	
+   508	        # TODO: these methods needs to be debugged
+   509	        """
+   510	        def compress_frames(self, frames: List[TimsFrame], only_frame_one: bool = False, num_threads: int = 4) -> List[bytes]:
+   511	            # same as compress_frame but for multiple frames
+   512	            tofs, scans, intensities = [], [], []
+   513	            for frame in frames:
+   514	                i = 1 if only_frame_one else frame.frame_id
+   515	                tofs.append(self.mz_to_tof(i, frame.mz).astype(np.uint32))
+   170	
+   171	    pub fn read_ions(&self) -> rusqlite::Result<Vec<IonSim>> {
+   172	        let mut stmt = self.connection.prepare("SELECT * FROM ions")?;
+   173	        let ions_iter = stmt.query_map([], |row| Self::ion_from_row(row))?;
+   174	        let mut ions = Vec::new();
+   175	        for ion in ions_iter {
+   176	            ions.push(ion?);
+   177	        }
+   178	        Ok(ions)
+   179	    }
+   180	
+   181	    pub fn read_window_group_settings(&self) -> rusqlite::Result<Vec<WindowGroupSettingsSim>> {
+   182	        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_windows")?;
+   183	        let window_group_settings_iter = stmt.query_map([], |row| {
+   184	            Ok(WindowGroupSettingsSim::new(
+   185	                row.get("window_group")?,
+   186	                row.get("scan_start")?,
+   187	                row.get("scan_end")?,
+   188	                row.get("isolation_mz")?,
+   189	                row.get("isolation_width")?,
+   190	                row.get("collision_energy")?,
+   191	            ))
+   192	        })?;
+   193	        let mut window_group_settings = Vec::new();
+   194	        for window_group_setting in window_group_settings_iter {
+   195	            window_group_settings.push(window_group_setting?);
+   196	        }
+   197	        Ok(window_group_settings)
+   198	    }
+   199	
+   200	    pub fn read_frame_to_window_group(&self) -> rusqlite::Result<Vec<FrameToWindowGroupSim>> {
+   201	        let mut stmt = self.connection.prepare("SELECT * FROM dia_ms_ms_info")?;
+   202	        let frame_to_window_group_iter = stmt.query_map([], |row| {
+   203	            Ok(FrameToWindowGroupSim::new(
+   204	                row.get("frame")?,
+   205	                row.get("window_group")?,
+   206	            ))
+   207	        })?;
+   208	
+   209	        let mut frame_to_window_groups: Vec<FrameToWindowGroupSim> = Vec::new();
+   210	        for frame_to_window_group in frame_to_window_group_iter {
+   211	            frame_to_window_groups.push(frame_to_window_group?);
+   212	        }
+   213	
+   214	        Ok(frame_to_window_groups)
+   215	    }
+   216	
+   217	    pub fn read_pasef_meta(&self) -> rusqlite::Result<Vec<PASEFMeta>> {
+   218	        let mut stmt = self.connection.prepare(
+   219	            "SELECT frame, scan_start, scan_end, isolation_mz, isolation_width, collision_energy, precursor FROM pasef_meta"
+   220	        )?;
+
+exec
+/bin/bash -lc 'rg -n "def calculate_number_frames|calculate_number_frames" packages/imspy-simulation/src -S; rg -n "to_bruker_info|to_bruker_windows|cycle_length|n_ms2_frames" imspy_connector rustdf -S' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:12:from imspy_simulation.utility import calculate_number_frames, get_ms_ms_window_layout_resource_path
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:44:        self.num_frames = calculate_number_frames(gradient_length, rt_cycle_length)
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:182:            self.num_frames = calculate_number_frames(self.gradient_length, rt_cycle_length)
+packages/imspy-simulation/src/imspy_simulation/utility.py:325:def calculate_number_frames(gradient_length: float, rt_cycle_length: float) -> int:
+packages/imspy-simulation/src/imspy_simulation/__init__.py:67:    calculate_number_frames,
+packages/imspy-simulation/src/imspy_simulation/__init__.py:112:    "calculate_number_frames",
+rustdf/src/sim/scheme.rs:445:    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+rustdf/src/sim/scheme.rs:489:    /// scheme. This is the single source of truth shared by `to_bruker_windows`
+rustdf/src/sim/scheme.rs:490:    /// and `to_bruker_info`, so the two tables always agree.
+rustdf/src/sim/scheme.rs:537:    /// same ids `to_bruker_windows` emits, so the two tables reference the same
+rustdf/src/sim/scheme.rs:544:    pub fn to_bruker_info(
+rustdf/src/sim/scheme.rs:584:        Ok((self.to_bruker_windows()?, self.to_bruker_info(num_frames)?))
+rustdf/src/sim/scheme.rs:1133:    // Unconditional: to_bruker_windows must preserve explicit vendor_group_ids
+rustdf/src/sim/scheme.rs:1138:    fn to_bruker_windows_group_ids() {
+rustdf/src/sim/scheme.rs:1174:            s.to_bruker_windows().map(|r| r.iter().map(|w| w.window_group).collect::<Vec<_>>())
+rustdf/src/sim/scheme.rs:1199:        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+rustdf/src/sim/scheme.rs:1243:    fn to_bruker_info_tiling() {
+rustdf/src/sim/scheme.rs:1280:            .to_bruker_info(6)
+rustdf/src/sim/scheme.rs:1331:            .to_bruker_info(3)
+rustdf/src/sim/scheme.rs:1338:        let w3 = s2.to_bruker_windows().unwrap();
+rustdf/src/sim/scheme.rs:1356:        let regenerated = scheme.to_bruker_info(num_frames).expect("to_bruker_info");
+imspy_connector/src/py_acquisition.rs:117:    pub fn cycle_length(&self) -> usize {
+imspy_connector/src/py_acquisition.rs:122:    pub fn n_ms2_frames(&self) -> usize {
+imspy_connector/src/py_acquisition.rs:133:    pub fn to_bruker_windows<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+imspy_connector/src/py_acquisition.rs:134:        let rows = self.inner.to_bruker_windows().map_err(val_err)?;
+imspy_connector/src/py_acquisition.rs:158:    pub fn to_bruker_info<'py>(
+imspy_connector/src/py_acquisition.rs:163:        let rows = self.inner.to_bruker_info(num_frames).map_err(val_err)?;
+imspy_connector/src/py_utility.rs:43:#[pyo3(signature = (frame_ids, retention_times, frame_occurrences, rt, sigma, lambda_, rt_cycle_length, n_steps=None))]
+imspy_connector/src/py_utility.rs:44:pub fn calculate_frame_abundance_emg(frame_ids: Vec<i32>, retention_times: Vec<f64>, frame_occurrences: Vec<i32>, rt: f64, sigma: f64, lambda_: f64, rt_cycle_length: f64, n_steps: Option<usize>) -> Vec<f64> {
+imspy_connector/src/py_utility.rs:46:    mscore::algorithm::utility::calculate_frame_abundance_emg(&time_map, &frame_occurrences, rt, sigma, lambda_, rt_cycle_length, n_steps)
+imspy_connector/src/py_utility.rs:56:#[pyo3(signature = (frame_ids, retention_times, frame_occurrences, rts, sigmas, lambdas, rt_cycle_length, num_threads, n_steps=None))]
+imspy_connector/src/py_utility.rs:57:pub fn calculate_frame_abundances_emg_par(frame_ids: Vec<i32>, retention_times: Vec<f64>, frame_occurrences: Vec<Vec<i32>>, rts: Vec<f64>, sigmas: Vec<f64>, lambdas: Vec<f64>, rt_cycle_length: f64, num_threads: usize, n_steps: Option<usize>) -> Vec<Vec<f64>> {
+imspy_connector/src/py_utility.rs:59:    mscore::algorithm::utility::calculate_frame_abundances_emg_par(&time_map, frame_occurrences, rts, sigmas, lambdas, rt_cycle_length, num_threads, n_steps)
+imspy_connector/src/py_utility.rs:68:pub fn calculate_abundance_gaussian(indices: Vec<i32>, times: Vec<f64>, occurrences: Vec<i32>, mean: f64, sigma: f64, cycle_length: f64) -> Vec<f64> {
+imspy_connector/src/py_utility.rs:70:    mscore::algorithm::utility::calculate_abundance_gaussian(&time_map, &occurrences, mean, sigma, cycle_length)
+imspy_connector/src/py_utility.rs:79:pub fn calculate_scan_abundances_gaussian_par(indices: Vec<i32>, times: Vec<f64>, occurrences: Vec<Vec<i32>>, means: Vec<f64>, sigmas: Vec<f64>, cycle_length: f64, num_threads: usize) -> Vec<Vec<f64>> {
+imspy_connector/src/py_utility.rs:81:    mscore::algorithm::utility::calculate_scan_abundances_gaussian_par(&time_map, occurrences, means, sigmas, cycle_length, num_threads)
+
+codex
+A key distinction is emerging: direct scheme output can be internally correct while still not matching the legacy builder’s positional group formula. I’m tracing whether the extractor preserves vendor group IDs and whether the new test masks order/dtype differences before finalizing severity.
+exec
+/bin/bash -lc "nl -ba packages/imspy-simulation/src/imspy_simulation/utility.py | sed -n '315,340p'; rg --files | rg 'test_acquisition_scheme_parity\\.py"'$|acquisition.*test|test.*acquisition'"'" in /scratch/timsim-demo/SUBMISSION/rustims
+exec
+/bin/bash -lc 'git show --stat --oneline ea07bcf1; git show --format=fuller --find-renames ea07bcf1 -- packages/imspy-simulation/src/imspy_simulation/acquisition.py packages/imspy-simulation/tests/test_acquisition_scheme_parity.py tests/test_acquisition_scheme_parity.py' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   315	    NDArray
+   316	        Array of scaled values.
+   317	    """
+   318	    min_val = np.min(irt)
+   319	    max_val = np.max(irt)
+   320	    scaled_values = new_min + (irt - min_val) * (new_max - new_min) / (max_val - min_val)
+   321	    return scaled_values
+   322	
+   323	
+   324	@jit(nopython=True)
+   325	def calculate_number_frames(gradient_length: float, rt_cycle_length: float) -> int:
+   326	    """ Calculate the number of frames that will be taken during the acquisition
+   327	
+   328	    Parameters
+   329	    ----------
+   330	    gradient_length : float
+   331	        Length of the gradient in seconds
+   332	    rt_cycle_length : float
+   333	        Length of the RT cycle in seconds
+   334	
+   335	    Returns
+   336	    -------
+   337	    int
+   338	        Number of frames that will be taken during the acquisition
+   339	    """
+   340	    return int(gradient_length / rt_cycle_length)
+packages/imspy-simulation/tests/test_acquisition_scheme_parity.py
+
+ succeeded in 0ms:
+ea07bcf1 feat(imspy-sim): migrate TimsTofAcquisitionBuilderDIA onto AcquisitionScheme
+ .../src/imspy_simulation/acquisition.py            | 65 ++++++++++++++++-----
+ .../tests/test_acquisition_scheme_parity.py        | 68 ++++++++++++++++++++++
+ 2 files changed, 118 insertions(+), 15 deletions(-)
+commit ea07bcf18478fb4c502061d3f548bd6459dc3a24
+Author:     theGreatHerrLebert <davidteschner@googlemail.com>
+AuthorDate: Tue Jun 9 10:03:21 2026 +0200
+Commit:     theGreatHerrLebert <davidteschner@googlemail.com>
+CommitDate: Tue Jun 9 10:03:21 2026 +0200
+
+    feat(imspy-sim): migrate TimsTofAcquisitionBuilderDIA onto AcquisitionScheme
+    
+    use_reference_ds_layout now sources the DIA window table + frame->group table from
+    the vendor-neutral AcquisitionScheme via imspy_connector.py_acquisition
+    (PyAcquisitionScheme.from_bruker_d(reference.data_path) -> to_bruker_windows /
+    to_bruker_info), with precursor_every = scheme.cycle_length(). Falls back to the
+    legacy direct reference read if the connector lacks py_acquisition.
+    
+    Also fixes a latent bug (flagged in the scheme design review): num_frames was
+    computed in the base __init__ from the passed rt_cycle_length BEFORE the
+    reference-derived cycle length replaced it, leaving a stale frame count; now
+    recomputed.
+    
+    Golden parity test (TIMSIM_BRUKER_DIA_D): the scheme-derived DiaFrameMsMsWindows
+    and DiaFrameMsMsInfo match the reference .d's tables exactly AND the legacy
+    position formula. The Bruker layout now flows through the shared Rust scheme.
+
+diff --git a/packages/imspy-simulation/src/imspy_simulation/acquisition.py b/packages/imspy-simulation/src/imspy_simulation/acquisition.py
+index 1c9948cd..2e840c18 100644
+--- a/packages/imspy-simulation/src/imspy_simulation/acquisition.py
++++ b/packages/imspy-simulation/src/imspy_simulation/acquisition.py
+@@ -177,6 +177,9 @@ class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
+             if verbose:
+                 print('Using reference dataset cycle length:', np.round(rt_cycle_length, 4))
+             self.rt_cycle_length = rt_cycle_length
++            # Recompute the frame count: the base __init__ computed it from the
++            # passed rt_cycle_length before this reference-derived value replaced it.
++            self.num_frames = calculate_number_frames(self.gradient_length, rt_cycle_length)
+ 
+         self.acquisition_name = acquisition_name
+         self.scan_table = None
+@@ -214,25 +217,57 @@ class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
+ 
+         return pd.DataFrame(table_list)
+ 
++    def _layout_from_scheme(self, verbose: bool = True):
++        """Derive the DIA window + frame→group tables from the reference `.d` via
++        the vendor-neutral ``AcquisitionScheme`` (imspy_connector.py_acquisition).
++
++        Returns ``(dia_ms_ms_windows, frames_to_window_groups, precursor_every)``
++        or ``None`` if the connector lacks the scheme module (legacy fallback).
++        """
++        try:
++            import imspy_connector
++            acq = imspy_connector.py_acquisition
++        except (ImportError, AttributeError):
++            if verbose:
++                print('py_acquisition unavailable; using legacy reference layout')
++            return None
++
++        scheme = acq.PyAcquisitionScheme.from_bruker_d(self.reference.data_path)
++        precursor_every = scheme.cycle_length()
++        windows = pd.DataFrame(scheme.to_bruker_windows())
++        info = pd.DataFrame(scheme.to_bruker_info(int(self.num_frames)))
++        if verbose:
++            print(f'Using AcquisitionScheme layout: {len(windows)} windows, '
++                  f'{scheme.n_ms2_frames()} groups, precursor_every={precursor_every}')
++        return windows, info, precursor_every
++
+     def _setup(self, verbose: bool = True):
+         self.frame_table = self.generate_frame_table(verbose=verbose)
+         self.scan_table = self.generate_scan_table(verbose=verbose)
+ 
+-        if self.use_reference_ds_layout:
+-            self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
+-            self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+-                columns={
+-                    'WindowGroup': 'window_group',
+-                    'ScanNumBegin': 'scan_start',
+-                    'ScanNumEnd': 'scan_end',
+-                    'IsolationMz': 'isolation_mz',
+-                    'IsolationWidth': 'isolation_width',
+-                    'CollisionEnergy': 'collision_energy',
+-                }
+-            )
+-
+-        self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+-        self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
++        scheme_layout = self._layout_from_scheme(verbose=verbose) if self.use_reference_ds_layout else None
++
++        if scheme_layout is not None:
++            # Vendor-neutral path: windows + frame→group come from the scheme.
++            self.dia_ms_ms_windows, frames_to_window_groups, self.precursor_every = scheme_layout
++            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
++            self.frames_to_window_groups = frames_to_window_groups
++        else:
++            # Legacy path: copy the reference .d's window table directly.
++            if self.use_reference_ds_layout:
++                self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
++                self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
++                    columns={
++                        'WindowGroup': 'window_group',
++                        'ScanNumBegin': 'scan_start',
++                        'ScanNumEnd': 'scan_end',
++                        'IsolationMz': 'isolation_mz',
++                        'IsolationWidth': 'isolation_width',
++                        'CollisionEnergy': 'collision_energy',
++                    }
++                )
++            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
++            self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
+ 
+         if self.round_collision_energy:
+             self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+diff --git a/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py b/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py
+new file mode 100644
+index 00000000..98457c75
+--- /dev/null
++++ b/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py
+@@ -0,0 +1,68 @@
++"""Golden parity: the vendor-neutral AcquisitionScheme (via imspy_connector)
++must reproduce the Bruker DIA layout the legacy `use_reference_ds_layout` path
++copies from the reference `.d` — both the `DiaFrameMsMsWindows` window table and
++the per-frame `DiaFrameMsMsInfo` (frame→group) table.
++
++Gated on TIMSIM_BRUKER_DIA_D pointing at a real DIA-PASEF `.d`.
++"""
++import os
++import sqlite3
++
++import numpy as np
++import pandas as pd
++import pytest
++
++import imspy_connector
++
++acq = imspy_connector.py_acquisition
++DIA_D = os.environ.get("TIMSIM_BRUKER_DIA_D")
++pytestmark = pytest.mark.skipif(
++    not DIA_D, reason="set TIMSIM_BRUKER_DIA_D to a real DIA-PASEF .d folder"
++)
++
++
++def _norm(df, cols):
++    return df[cols].astype(float).round(6).sort_values(cols).reset_index(drop=True)
++
++
++def test_scheme_windows_match_reference():
++    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
++    windows = pd.DataFrame(scheme.to_bruker_windows())
++
++    con = sqlite3.connect(DIA_D + "/analysis.tdf")
++    ref = pd.read_sql(
++        "SELECT WindowGroup window_group, ScanNumBegin scan_start, ScanNumEnd scan_end, "
++        "IsolationMz isolation_mz, IsolationWidth isolation_width, "
++        "CollisionEnergy collision_energy FROM DiaFrameMsMsWindows",
++        con,
++    )
++    cols = list(ref.columns)
++    assert len(windows) == len(ref)
++    pd.testing.assert_frame_equal(_norm(windows, cols), _norm(ref, cols))
++
++
++def test_scheme_info_matches_reference_and_legacy_formula():
++    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
++    con = sqlite3.connect(DIA_D + "/analysis.tdf")
++    num_frames = int(con.execute("SELECT MAX(Id) FROM Frames").fetchone()[0])
++
++    info = pd.DataFrame(scheme.to_bruker_info(num_frames))
++
++    # (a) matches the .d's own DiaFrameMsMsInfo exactly
++    ref = pd.read_sql("SELECT Frame frame, WindowGroup window_group FROM DiaFrameMsMsInfo", con)
++    pd.testing.assert_frame_equal(
++        _norm(info, ["frame", "window_group"]), _norm(ref, ["frame", "window_group"])
++    )
++
++    # (b) matches the legacy position formula (index % precursor_every, ms2 only)
++    pe = scheme.cycle_length()
++    legacy = pd.DataFrame(
++        [
++            {"frame": f, "window_group": (f - 1) % pe}
++            for f in range(1, num_frames + 1)
++            if (f - 1) % pe != 0
++        ]
++    )
++    pd.testing.assert_frame_equal(
++        _norm(info, ["frame", "window_group"]), _norm(legacy, ["frame", "window_group"])
++    )
+
+exec
+/bin/bash -lc "nl -ba rustdf/src/sim/scheme.rs | sed -n '430,570p;590,670p;1120,1215p;1230,1375p'; nl -ba imspy_connector/src/py_acquisition.rs | sed -n '105,180p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   430	impl AcquisitionScheme {
+   431	    /// Render the scheme's MS2 windows as Bruker `DiaFrameMsMsWindows` rows — the
+   432	    /// backward-compatibility adapter for the existing timsTOF write path.
+   433	    ///
+   434	    /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
+   435	    /// geometry (the Bruker-grid scan ranges). The `WindowGroup` id is the frame's
+   436	    /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
+   437	    /// round-trip keeps the ids that `DiaFrameMsMsInfo` references), else a 1..N
+   438	    /// fallback in cycle order. A `Linear` CE policy is resolved at the window
+   439	    /// center (a lossy materialization, not an inverse); `Unknown` CE and
+   440	    /// non-timsTOF schemes are rejected. The scheme is validated first.
+   441	    ///
+   442	    /// Row order is not meaningful (the SQLite table has none); the companion
+   443	    /// frame→group table `DiaFrameMsMsInfo` needs the run frame schedule and is a
+   444	    /// separate step.
+   445	    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+   446	        let layout = self.bruker_group_layout()?;
+   447	        let mut rows = Vec::new();
+   448	        for (ev, slot) in self.cycle.iter().zip(&layout) {
+   449	            if let (AcquisitionEvent::DiaMs2Frame(frame), Some(group)) = (ev, slot) {
+   450	                for w in &frame.windows {
+   451	                    let (scan_num_begin, scan_num_end) = match w.geometry {
+   452	                        DiaGeometry::TimsMobility {
+   453	                            scan_start,
+   454	                            scan_end,
+   455	                        } => (scan_start, scan_end),
+   456	                        DiaGeometry::MzOnly => {
+   457	                            return Err("timsTOF window lacks mobility geometry".into())
+   458	                        }
+   459	                    };
+   460	                    let collision_energy = match w.collision_energy {
+   461	                        CollisionEnergyPolicy::Value(v) => v,
+   462	                        CollisionEnergyPolicy::Linear { .. } => w
+   463	                            .collision_energy
+   464	                            .at(w.isolation.center_mz)
+   465	                            .ok_or("could not resolve linear CE")?,
+   466	                        CollisionEnergyPolicy::Unknown => {
+   467	                            return Err("window has unknown collision energy".into())
+   468	                        }
+   469	                    };
+   470	                    rows.push(crate::data::meta::DiaMsMsWindow {
+   471	                        window_group: *group,
+   472	                        scan_num_begin,
+   473	                        scan_num_end,
+   474	                        isolation_mz: w.isolation.center_mz,
+   475	                        isolation_width: w.isolation.width_mz,
+   476	                        collision_energy,
+   477	                    });
+   478	                }
+   479	            }
+   480	        }
+   481	        Ok(rows)
+   482	    }
+   483	
+   484	    /// Per-cycle-position window-group id: `None` for an MS1 event, `Some(group)`
+   485	    /// for an MS2 frame. The group id is the frame's preserved `vendor_group_id`
+   486	    /// (Bruker `WindowGroup`) when set, else a collision-safe positional id drawn
+   487	    /// from the unused set (so preserved and fallback ids never collide).
+   488	    /// Duplicate explicit ids are rejected. Validates first; requires a timsTOF
+   489	    /// scheme. This is the single source of truth shared by `to_bruker_windows`
+   490	    /// and `to_bruker_info`, so the two tables always agree.
+   491	    fn bruker_group_layout(&self) -> Result<Vec<Option<u32>>, String> {
+   492	        self.validate()?;
+   493	        if self.instrument != InstrumentKind::TimsTofDia {
+   494	            return Err("Bruker tables require a timsTOF (TimsTofDia) scheme".into());
+   495	        }
+   496	        use std::collections::HashSet;
+   497	        let mut reserved: HashSet<u32> = HashSet::new();
+   498	        for ev in &self.cycle {
+   499	            if let AcquisitionEvent::DiaMs2Frame(f) = ev {
+   500	                if let Some(g) = f.vendor_group_id {
+   501	                    if !reserved.insert(g) {
+   502	                        return Err(format!("duplicate vendor window-group id {g}"));
+   503	                    }
+   504	                }
+   505	            }
+   506	        }
+   507	        let mut layout = Vec::with_capacity(self.cycle.len());
+   508	        let mut assigned: HashSet<u32> = HashSet::new();
+   509	        let mut next_seq: u32 = 1;
+   510	        for ev in &self.cycle {
+   511	            match ev {
+   512	                AcquisitionEvent::Ms1(_) => layout.push(None),
+   513	                AcquisitionEvent::DiaMs2Frame(frame) => {
+   514	                    let group = match frame.vendor_group_id {
+   515	                        Some(g) => g,
+   516	                        None => {
+   517	                            while reserved.contains(&next_seq) || assigned.contains(&next_seq) {
+   518	                                next_seq += 1;
+   519	                            }
+   520	                            next_seq
+   521	                        }
+   522	                    };
+   523	                    if !assigned.insert(group) {
+   524	                        return Err(format!("window-group id {group} collides"));
+   525	                    }
+   526	                    layout.push(Some(group));
+   527	                }
+   528	            }
+   529	        }
+   530	        Ok(layout)
+   531	    }
+   532	
+   533	    /// Generate the Bruker `DiaFrameMsMsInfo` (frame → window group) rows for a run
+   534	    /// of `num_frames` total frames, tiling the scheme's cycle. Cycle position
+   535	    /// `(frame_id - 1) % cycle_len` selects the event (1-based frame ids), MS1
+   536	    /// frames produce no row, and each MS2 frame maps to its window-group id (the
+   537	    /// same ids `to_bruker_windows` emits, so the two tables reference the same
+   538	    /// groups). The final cycle may be partial.
+   539	    ///
+   540	    /// Precondition: this models a **clean generated run** — frame 1 is the
+   541	    /// cycle's leading MS1 and frame ids are contiguous (as TimSim produces). It
+   542	    /// is not a reproducer for arbitrary real files with prefix/calibration
+   543	    /// frames, gaps, or acquisition starting mid-cycle.
+   544	    pub fn to_bruker_info(
+   545	        &self,
+   546	        num_frames: u32,
+   547	    ) -> Result<Vec<crate::data::meta::DiaMsMisInfo>, String> {
+   548	        // Bound the work so an absurd frame count errors cleanly instead of OOM.
+   549	        const MAX_FRAMES: u32 = 100_000_000;
+   550	        if num_frames > MAX_FRAMES {
+   551	            return Err(format!("num_frames {num_frames} exceeds the {MAX_FRAMES} limit"));
+   552	        }
+   553	        let layout = self.bruker_group_layout()?;
+   554	        let fpc = layout.len() as u32;
+   555	        if fpc == 0 {
+   556	            return Err("empty cycle".into());
+   557	        }
+   558	        let mut rows = Vec::new();
+   559	        for frame_id in 1..=num_frames {
+   560	            let pos = ((frame_id - 1) % fpc) as usize;
+   561	            if let Some(group) = layout[pos] {
+   562	                rows.push(crate::data::meta::DiaMsMisInfo {
+   563	                    frame_id,
+   564	                    window_group: group,
+   565	                });
+   566	            }
+   567	        }
+   568	        Ok(rows)
+   569	    }
+   570	
+   590	    /// becomes one [`DiaMs2Frame`] holding its mobility-partitioned windows
+   591	    /// (`TimsMobility` geometry — the scan ranges are Bruker-grid coordinates),
+   592	    /// preceded by a single MS1 event. Cycle timing comes from the spacing of
+   593	    /// the precursor (MS1) frames. The returned scheme is validated.
+   594	    ///
+   595	    /// Window groups (frames) are ordered by their **first occurrence in
+   596	    /// `DiaFrameMsMsInfo`** (ascending frame id), i.e. the real acquisition order
+   597	    /// within a cycle — not merely ascending `WindowGroup` id — so the cycle
+   598	    /// faithfully represents permuted/reused group numbering. (If the info table
+   599	    /// is absent, falls back to ascending group id.)
+   600	    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+   601	        use crate::data::meta::{read_dia_ms_ms_info, read_dia_ms_ms_windows, read_meta_data_sql};
+   602	        use std::collections::BTreeMap;
+   603	
+   604	        let folder = path.as_ref().to_string_lossy().into_owned();
+   605	        let to_io =
+   606	            |e: Box<dyn std::error::Error>| io::Error::new(io::ErrorKind::InvalidData, e.to_string());
+   607	        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+   608	        let frames = read_meta_data_sql(&folder).map_err(to_io)?;
+   609	        if windows.is_empty() {
+   610	            return Err(io::Error::new(
+   611	                io::ErrorKind::InvalidData,
+   612	                "no DiaFrameMsMsWindows rows (not a DIA .d?)",
+   613	            ));
+   614	        }
+   615	
+   616	        // Group windows by window group (ascending); each group is a frame.
+   617	        let mut by_group: BTreeMap<u32, Vec<DiaWindow>> = BTreeMap::new();
+   618	        let mut lo = f64::INFINITY;
+   619	        let mut hi = f64::NEG_INFINITY;
+   620	        for w in &windows {
+   621	            let dw = DiaWindow {
+   622	                isolation: IsolationWindow {
+   623	                    center_mz: w.isolation_mz,
+   624	                    width_mz: w.isolation_width,
+   625	                },
+   626	                collision_energy: CollisionEnergyPolicy::Value(w.collision_energy),
+   627	                geometry: DiaGeometry::TimsMobility {
+   628	                    scan_start: w.scan_num_begin,
+   629	                    scan_end: w.scan_num_end,
+   630	                },
+   631	            };
+   632	            lo = lo.min(dw.isolation.lower());
+   633	            hi = hi.max(dw.isolation.upper());
+   634	            by_group.entry(w.window_group).or_default().push(dw);
+   635	        }
+   636	
+   637	        // Order groups by first occurrence (ascending frame id) in DiaFrameMsMsInfo
+   638	        // = real intra-cycle acquisition order. Missing info -> ascending group id.
+   639	        let info = read_dia_ms_ms_info(&folder).unwrap_or_default();
+   640	        let mut first_frame: BTreeMap<u32, u32> = BTreeMap::new();
+   641	        for r in &info {
+   642	            first_frame
+   643	                .entry(r.window_group)
+   644	                .and_modify(|f| {
+   645	                    if r.frame_id < *f {
+   646	                        *f = r.frame_id
+   647	                    }
+   648	                })
+   649	                .or_insert(r.frame_id);
+   650	        }
+   651	        let mut ordered_groups: Vec<u32> = by_group.keys().copied().collect();
+   652	        // Stable sort by first-occurrence frame; groups absent from the info table
+   653	        // (key u32::MAX) keep their ascending-id relative order.
+   654	        ordered_groups.sort_by_key(|g| first_frame.get(g).copied().unwrap_or(u32::MAX));
+   655	
+   656	        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+   657	            analyzer: Analyzer::Tof,
+   658	            data_mode: DataMode::Centroid,
+   659	            mz_range: None,
+   660	            duration_s: None,
+   661	        })];
+   662	        let n_groups = ordered_groups.len();
+   663	        for group in ordered_groups {
+   664	            let ws = by_group.remove(&group).expect("group present");
+   665	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   666	                windows: ws,
+   667	                analyzer: Analyzer::Tof,
+   668	                data_mode: DataMode::Centroid,
+   669	                duration_s: None,
+   670	                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
+  1120	            assert!(w.collision_energy.at(w.isolation.center_mz).is_some());
+  1121	        }
+  1122	        // At least one frame should be mobility-partitioned (>1 window).
+  1123	        let multi = s.cycle.iter().any(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.windows.len() > 1));
+  1124	        let n_frames = s.cycle.iter().filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_))).count();
+  1125	        eprintln!(
+  1126	            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+  1127	            n_frames, n_win, if multi { "mobility-partitioned" } else { "single-window" },
+  1128	            s.mz_range.0, s.mz_range.1
+  1129	        );
+  1130	    }
+  1131	
+  1132	    // Gated: set TIMSIM_SCIEX_WIFF to a real ZenoTOF .wiff (OLE2 method).
+  1133	    // Unconditional: to_bruker_windows must preserve explicit vendor_group_ids
+  1134	    // (incl. non-canonical), allocate non-colliding ids for None frames, and
+  1135	    // reject duplicate explicit ids. (The gated round-trip uses a real .d whose
+  1136	    // ids are already 1..N, so it can't prove non-canonical preservation alone.)
+  1137	    #[test]
+  1138	    fn to_bruker_windows_group_ids() {
+  1139	        let frame = |gid: Option<u32>, center: f64| {
+  1140	            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+  1141	                windows: vec![DiaWindow {
+  1142	                    isolation: IsolationWindow { center_mz: center, width_mz: 10.0 },
+  1143	                    collision_energy: CollisionEnergyPolicy::Value(25.0),
+  1144	                    geometry: DiaGeometry::TimsMobility { scan_start: 0, scan_end: 100 },
+  1145	                }],
+  1146	                analyzer: Analyzer::Tof,
+  1147	                data_mode: DataMode::Centroid,
+  1148	                duration_s: None,
+  1149	                vendor_group_id: gid,
+  1150	            })
+  1151	        };
+  1152	        let mk = |frames: Vec<AcquisitionEvent>| {
+  1153	            let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+  1154	                analyzer: Analyzer::Tof,
+  1155	                data_mode: DataMode::Centroid,
+  1156	                mz_range: None,
+  1157	                duration_s: None,
+  1158	            })];
+  1159	            cycle.extend(frames);
+  1160	            AcquisitionScheme {
+  1161	                version: SCHEME_VERSION,
+  1162	                instrument: InstrumentKind::TimsTofDia,
+  1163	                cycle,
+  1164	                repeat: RepeatPolicy::FixedCycleTime {
+  1165	                    cycle_time_s: 1.0,
+  1166	                    gradient_length_s: 600.0,
+  1167	                    start_time_s: 0.0,
+  1168	                },
+  1169	                mz_range: (300.0, 900.0),
+  1170	                provenance: Provenance { source: SchemeSource::Programmatic, notes: String::new() },
+  1171	            }
+  1172	        };
+  1173	        let ids = |s: &AcquisitionScheme| {
+  1174	            s.to_bruker_windows().map(|r| r.iter().map(|w| w.window_group).collect::<Vec<_>>())
+  1175	        };
+  1176	
+  1177	        // preserved non-canonical ids
+  1178	        assert_eq!(ids(&mk(vec![frame(Some(7), 500.0), frame(Some(42), 600.0)])).unwrap(), vec![7, 42]);
+  1179	        // all-None -> sequential 1..N
+  1180	        assert_eq!(ids(&mk(vec![frame(None, 500.0), frame(None, 600.0)])).unwrap(), vec![1, 2]);
+  1181	        // mixed: None allocates a free id (1), avoiding the reserved 7
+  1182	        assert_eq!(ids(&mk(vec![frame(Some(7), 500.0), frame(None, 600.0)])).unwrap(), vec![7, 1]);
+  1183	        // duplicate explicit ids rejected
+  1184	        assert!(ids(&mk(vec![frame(Some(5), 500.0), frame(Some(5), 600.0)])).is_err());
+  1185	    }
+  1186	
+  1187	    // Gated: round-trip a real Bruker DIA .d through the scheme and back to the
+  1188	    // DiaFrameMsMsWindows rows; the regenerated table must match the source.
+  1189	    #[test]
+  1190	    fn bruker_windows_round_trip() {
+  1191	        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+  1192	            Ok(p) => p,
+  1193	            Err(_) => {
+  1194	                eprintln!("SKIP bruker_windows_round_trip: set TIMSIM_BRUKER_DIA_D");
+  1195	                return;
+  1196	            }
+  1197	        };
+  1198	        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+  1199	        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+  1200	        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+  1201	        assert_eq!(regenerated.len(), original.len(), "row count differs");
+  1202	
+  1203	        // Compare as a sorted multiset of EXACT field tuples, including the
+  1204	        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
+  1205	        // real id mismatch would fail. Row order in the table is not guaranteed.
+  1206	        fn tuples(
+  1207	            rows: &[crate::data::meta::DiaMsMsWindow],
+  1208	        ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+  1209	            let mut out: Vec<_> = rows
+  1210	                .iter()
+  1211	                .map(|r| {
+  1212	                    (
+  1213	                        r.window_group,
+  1214	                        r.scan_num_begin,
+  1215	                        r.scan_num_end,
+  1230	        eprintln!(
+  1231	            "bruker_windows_round_trip OK: {} rows match across {} groups",
+  1232	            original.len(),
+  1233	            scheme
+  1234	                .cycle
+  1235	                .iter()
+  1236	                .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+  1237	                .count()
+  1238	        );
+  1239	    }
+  1240	
+  1241	    // Unconditional: DiaFrameMsMsInfo tiling + windows/info group-id consistency.
+  1242	    #[test]
+  1243	    fn to_bruker_info_tiling() {
+  1244	        let frame = |c: f64| {
+  1245	            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+  1246	                windows: vec![DiaWindow {
+  1247	                    isolation: IsolationWindow { center_mz: c, width_mz: 10.0 },
+  1248	                    collision_energy: CollisionEnergyPolicy::Value(25.0),
+  1249	                    geometry: DiaGeometry::TimsMobility { scan_start: 0, scan_end: 100 },
+  1250	                }],
+  1251	                analyzer: Analyzer::Tof,
+  1252	                data_mode: DataMode::Centroid,
+  1253	                duration_s: None,
+  1254	                vendor_group_id: None,
+  1255	            })
+  1256	        };
+  1257	        let s = AcquisitionScheme {
+  1258	            version: SCHEME_VERSION,
+  1259	            instrument: InstrumentKind::TimsTofDia,
+  1260	            cycle: vec![
+  1261	                AcquisitionEvent::Ms1(Ms1Event {
+  1262	                    analyzer: Analyzer::Tof,
+  1263	                    data_mode: DataMode::Centroid,
+  1264	                    mz_range: None,
+  1265	                    duration_s: None,
+  1266	                }),
+  1267	                frame(500.0),
+  1268	                frame(600.0),
+  1269	            ],
+  1270	            repeat: RepeatPolicy::FixedCycleTime {
+  1271	                cycle_time_s: 1.0,
+  1272	                gradient_length_s: 600.0,
+  1273	                start_time_s: 0.0,
+  1274	            },
+  1275	            mz_range: (300.0, 900.0),
+  1276	            provenance: Provenance { source: SchemeSource::Programmatic, notes: String::new() },
+  1277	        };
+  1278	        // cycle = [MS1, g1, g2]; num_frames=6: 1->skip, 2->g1, 3->g2, 4->skip, 5->g1, 6->g2
+  1279	        let info: Vec<(u32, u32)> = s
+  1280	            .to_bruker_info(6)
+  1281	            .unwrap()
+  1282	            .iter()
+  1283	            .map(|r| (r.frame_id, r.window_group))
+  1284	            .collect();
+  1285	        assert_eq!(info, vec![(2, 1), (3, 2), (5, 1), (6, 2)]);
+  1286	        // The two tables must reference the same set of window-group ids.
+  1287	        let (windows, info2) = s.to_bruker_tables(6).unwrap();
+  1288	        let wg: std::collections::BTreeSet<u32> = windows.iter().map(|w| w.window_group).collect();
+  1289	        let ig: std::collections::BTreeSet<u32> = info2.iter().map(|r| r.window_group).collect();
+  1290	        assert_eq!(wg, ig, "windows/info group ids disagree");
+  1291	
+  1292	        // Non-ascending explicit ids + a multi-window (mobility-partitioned) frame:
+  1293	        // info must follow CYCLE order (not sorted id) and emit ONE row per frame.
+  1294	        let win = |center: f64, s0: u32, s1: u32| DiaWindow {
+  1295	            isolation: IsolationWindow { center_mz: center, width_mz: 10.0 },
+  1296	            collision_energy: CollisionEnergyPolicy::Value(20.0),
+  1297	            geometry: DiaGeometry::TimsMobility { scan_start: s0, scan_end: s1 },
+  1298	        };
+  1299	        let dia = |gid: u32, ws: Vec<DiaWindow>| {
+  1300	            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+  1301	                windows: ws,
+  1302	                analyzer: Analyzer::Tof,
+  1303	                data_mode: DataMode::Centroid,
+  1304	                duration_s: None,
+  1305	                vendor_group_id: Some(gid),
+  1306	            })
+  1307	        };
+  1308	        let s2 = AcquisitionScheme {
+  1309	            version: SCHEME_VERSION,
+  1310	            instrument: InstrumentKind::TimsTofDia,
+  1311	            cycle: vec![
+  1312	                AcquisitionEvent::Ms1(Ms1Event {
+  1313	                    analyzer: Analyzer::Tof,
+  1314	                    data_mode: DataMode::Centroid,
+  1315	                    mz_range: None,
+  1316	                    duration_s: None,
+  1317	                }),
+  1318	                dia(7, vec![win(500.0, 0, 50), win(500.0, 51, 100)]), // 2 mobility windows
+  1319	                dia(2, vec![win(600.0, 0, 100)]),
+  1320	            ],
+  1321	            repeat: RepeatPolicy::FixedCycleTime {
+  1322	                cycle_time_s: 1.0,
+  1323	                gradient_length_s: 600.0,
+  1324	                start_time_s: 0.0,
+  1325	            },
+  1326	            mz_range: (300.0, 900.0),
+  1327	            provenance: Provenance { source: SchemeSource::Programmatic, notes: String::new() },
+  1328	        };
+  1329	        // cycle len 3; frame2->g7 (first), frame3->g2 — acquisition order, NOT sorted.
+  1330	        let info3: Vec<(u32, u32)> = s2
+  1331	            .to_bruker_info(3)
+  1332	            .unwrap()
+  1333	            .iter()
+  1334	            .map(|r| (r.frame_id, r.window_group))
+  1335	            .collect();
+  1336	        assert_eq!(info3, vec![(2, 7), (3, 2)], "info must follow cycle order, one row/frame");
+  1337	        // windows: the 2-window frame emits 2 rows (group 7), the other 1 (group 2).
+  1338	        let w3 = s2.to_bruker_windows().unwrap();
+  1339	        assert_eq!(w3.iter().filter(|w| w.window_group == 7).count(), 2);
+  1340	        assert_eq!(w3.iter().filter(|w| w.window_group == 2).count(), 1);
+  1341	    }
+  1342	
+  1343	    // Gated: regenerate DiaFrameMsMsInfo for the .d's full frame count and match.
+  1344	    #[test]
+  1345	    fn bruker_info_round_trip() {
+  1346	        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+  1347	            Ok(p) => p,
+  1348	            Err(_) => {
+  1349	                eprintln!("SKIP bruker_info_round_trip: set TIMSIM_BRUKER_DIA_D");
+  1350	                return;
+  1351	            }
+  1352	        };
+  1353	        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+  1354	        let frames = crate::data::meta::read_meta_data_sql(&d).expect("frames");
+  1355	        let num_frames = frames.iter().map(|f| f.id).max().unwrap_or(0) as u32;
+  1356	        let regenerated = scheme.to_bruker_info(num_frames).expect("to_bruker_info");
+  1357	        let original = crate::data::meta::read_dia_ms_ms_info(&d).expect("read source");
+  1358	        let key = |r: &crate::data::meta::DiaMsMisInfo| (r.frame_id, r.window_group);
+  1359	        let mut a: Vec<_> = regenerated.iter().map(key).collect();
+  1360	        let mut b: Vec<_> = original.iter().map(key).collect();
+  1361	        a.sort_unstable();
+  1362	        b.sort_unstable();
+  1363	        assert_eq!(a, b, "DiaFrameMsMsInfo round-trip differs from source");
+  1364	        eprintln!("bruker_info_round_trip OK: {} (frame, group) rows over {num_frames} frames", a.len());
+  1365	    }
+  1366	
+  1367	    #[cfg(feature = "sciex")]
+  1368	    #[test]
+  1369	    fn from_sciex_wiff_extracts_windows() {
+  1370	        let wiff = match std::env::var("TIMSIM_SCIEX_WIFF") {
+  1371	            Ok(p) => p,
+  1372	            Err(_) => {
+  1373	                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+  1374	                return;
+  1375	            }
+   105	    }
+   106	
+   107	    pub fn n_windows(&self) -> usize {
+   108	        self.inner.windows().count()
+   109	    }
+   110	
+   111	    pub fn num_cycles(&self) -> Option<u64> {
+   112	        self.inner.num_cycles()
+   113	    }
+   114	
+   115	    /// Number of events in one cycle (1 MS1 + N MS2 frames) — the Bruker
+   116	    /// `precursor_every` (frames per cycle).
+   117	    pub fn cycle_length(&self) -> usize {
+   118	        self.inner.cycle.len()
+   119	    }
+   120	
+   121	    /// Number of MS2 frames (window groups) per cycle.
+   122	    pub fn n_ms2_frames(&self) -> usize {
+   123	        self.inner.cycle.len() - self.inner.ms1_count()
+   124	    }
+   125	
+   126	    pub fn validate(&self) -> PyResult<()> {
+   127	        self.inner.validate().map_err(val_err)
+   128	    }
+   129	
+   130	    /// Bruker `DiaFrameMsMsWindows` as a column dict of NumPy arrays, ready for
+   131	    /// `pandas.DataFrame(...)`: keys `window_group, scan_start, scan_end,
+   132	    /// isolation_mz, isolation_width, collision_energy`.
+   133	    pub fn to_bruker_windows<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+   134	        let rows = self.inner.to_bruker_windows().map_err(val_err)?;
+   135	        let n = rows.len();
+   136	        let (mut wg, mut ss, mut se) = (Vec::with_capacity(n), Vec::with_capacity(n), Vec::with_capacity(n));
+   137	        let (mut mz, mut wd, mut ce) = (Vec::with_capacity(n), Vec::with_capacity(n), Vec::with_capacity(n));
+   138	        for r in &rows {
+   139	            wg.push(r.window_group);
+   140	            ss.push(r.scan_num_begin);
+   141	            se.push(r.scan_num_end);
+   142	            mz.push(r.isolation_mz);
+   143	            wd.push(r.isolation_width);
+   144	            ce.push(r.collision_energy);
+   145	        }
+   146	        let d = PyDict::new(py);
+   147	        d.set_item("window_group", wg.into_pyarray(py))?;
+   148	        d.set_item("scan_start", ss.into_pyarray(py))?;
+   149	        d.set_item("scan_end", se.into_pyarray(py))?;
+   150	        d.set_item("isolation_mz", mz.into_pyarray(py))?;
+   151	        d.set_item("isolation_width", wd.into_pyarray(py))?;
+   152	        d.set_item("collision_energy", ce.into_pyarray(py))?;
+   153	        Ok(d)
+   154	    }
+   155	
+   156	    /// Bruker `DiaFrameMsMsInfo` as a column dict of NumPy arrays for a
+   157	    /// `num_frames`-frame run: keys `frame, window_group`.
+   158	    pub fn to_bruker_info<'py>(
+   159	        &self,
+   160	        py: Python<'py>,
+   161	        num_frames: u32,
+   162	    ) -> PyResult<Bound<'py, PyDict>> {
+   163	        let rows = self.inner.to_bruker_info(num_frames).map_err(val_err)?;
+   164	        let mut frame = Vec::with_capacity(rows.len());
+   165	        let mut wg = Vec::with_capacity(rows.len());
+   166	        for r in &rows {
+   167	            frame.push(r.frame_id);
+   168	            wg.push(r.window_group);
+   169	        }
+   170	        let d = PyDict::new(py);
+   171	        d.set_item("frame", frame.into_pyarray(py))?;
+   172	        d.set_item("window_group", wg.into_pyarray(py))?;
+   173	        Ok(d)
+   174	    }
+   175	}
+   176	
+   177	/// Whether this build includes the Thermo `.raw` extractor.
+   178	#[pyfunction]
+   179	pub fn has_thermo() -> bool {
+   180	    cfg!(feature = "thermo")
+
+exec
+/bin/bash -lc "nl -ba rustdf/src/sim/types.rs 2>/dev/null | sed -n '1,160p'; rg -n \"struct (WindowGroupSettingsSim|FrameToWindowGroupSim)|impl .*WindowGroupSettingsSim|window_group:\" rustdf/src/sim -S" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+rustdf/src/sim/containers.rs:126:pub struct WindowGroupSettingsSim {
+rustdf/src/sim/containers.rs:127:    pub window_group: u32,
+rustdf/src/sim/containers.rs:135:impl WindowGroupSettingsSim {
+rustdf/src/sim/containers.rs:137:        window_group: u32,
+rustdf/src/sim/containers.rs:156:pub struct FrameToWindowGroupSim {
+rustdf/src/sim/containers.rs:158:    pub window_group: u32,
+rustdf/src/sim/containers.rs:162:    pub fn new(frame_id: u32, window_group: u32) -> Self {
+rustdf/src/sim/scheme.rs:471:                        window_group: *group,
+rustdf/src/sim/scheme.rs:564:                    window_group: group,
+
+codex
+The frame-count recompute occurs before `_setup`, so `frame_table`, `scan_table`, and scheme info are generated from the updated value; I see no stale generated table. I’m doing one focused serialization check because NumPy unsigned integer handling differs by width in pandas/SQLite and should not be guessed.
+exec
+/bin/bash -lc "python - <<'PY'
+import sqlite3, pandas as pd, numpy as np
+for dt in [np.uint32, np.int64]:
+    con=sqlite3.connect(':memory:')
+    df=pd.DataFrame({'frame':np.array([2,3],dtype=dt),'window_group':np.array([1,2],dtype=dt)})
+    df.to_sql('x',con,index=False)
+    print(dt.__name__, con.execute('pragma table_info(x)').fetchall(), pd.read_sql('select * from x',con).dtypes.to_dict())
+PY" in /scratch/timsim-demo/SUBMISSION/rustims
+ exited 127 in 0ms:
+/bin/bash: line 1: python: command not found
+
+exec
+/bin/bash -lc "rg -n \"frames_to_window_groups|dia_ms_ms_windows\" packages/imspy-simulation/src/imspy_simulation -g '*.py' | head -80; nl -ba packages/imspy-simulation/tests/test_acquisition_scheme_parity.py" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+packages/imspy-simulation/src/imspy_simulation/experiment.py:635:        self.dia_ms_ms_windows = None
+packages/imspy-simulation/src/imspy_simulation/experiment.py:641:        self.dia_ms_ms_windows = self.get_table('dia_ms_ms_windows')
+packages/imspy-simulation/src/imspy_simulation/experiment.py:649:        for _, row in self.dia_ms_ms_windows.iterrows():
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:187:        self.frames_to_window_groups = None
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:188:        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:224:        Returns ``(dia_ms_ms_windows, frames_to_window_groups, precursor_every)``
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:252:            self.dia_ms_ms_windows, frames_to_window_groups, self.precursor_every = scheme_layout
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:254:            self.frames_to_window_groups = frames_to_window_groups
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:259:                self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:270:            self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:273:            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:286:            table=self.frames_to_window_groups
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:289:            table_name='dia_ms_ms_windows',
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:290:            table=self.dia_ms_ms_windows
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:362:        instance.frames_to_window_groups = instance.synthetics_handle.get_table('dia_ms_ms_info')
+packages/imspy-simulation/src/imspy_simulation/acquisition.py:363:        instance.dia_ms_ms_windows = instance.synthetics_handle.get_table('dia_ms_ms_windows')
+packages/imspy-simulation/src/imspy_simulation/data/database.py:217:        dia_ms_ms_windows: Cached DIA MS/MS windows DataFrame.
+packages/imspy-simulation/src/imspy_simulation/data/database.py:235:        self.dia_ms_ms_windows: Optional[pd.DataFrame] = None
+packages/imspy-simulation/src/imspy_simulation/data/database.py:242:            self.dia_ms_ms_windows = self.get_table("dia_ms_ms_windows")
+packages/imspy-simulation/src/imspy_simulation/data/database.py:266:        if self.dia_ms_ms_windows is None:
+packages/imspy-simulation/src/imspy_simulation/data/database.py:269:        if self.dia_ms_ms_windows is None:
+packages/imspy-simulation/src/imspy_simulation/data/database.py:273:        for _, row in self.dia_ms_ms_windows.iterrows():
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:20:        config_name: Name of the config file (e.g., 'dia_ms_ms_windows.csv')
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:504:            # dia-PASEF: Load all windows from actual dia_ms_ms_windows.csv
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:506:            window_df = load_window_config("dia_ms_ms_windows.csv")
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:580:            # midia-PASEF: Load windows from actual midia_ms_ms_windows.csv
+packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py:581:            window_df = load_window_config("midia_ms_ms_windows.csv")
+packages/imspy-simulation/src/imspy_simulation/tdf.py:496:    def write_dia_ms_ms_windows(self, dia_ms_ms_windows: pd.DataFrame) -> None:
+packages/imspy-simulation/src/imspy_simulation/tdf.py:497:        out = dia_ms_ms_windows.rename(columns={
+packages/imspy-simulation/src/imspy_simulation/timsim/jobs/add_noise_from_real_data.py:102:        d = acquisition_builder.frames_to_window_groups
+packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:179:        acquisition_builder.tdf_writer.write_dia_ms_ms_windows(
+packages/imspy-simulation/src/imspy_simulation/timsim/jobs/assemble_frames.py:180:            acquisition_builder.synthetics_handle.get_table('dia_ms_ms_windows'))
+     1	"""Golden parity: the vendor-neutral AcquisitionScheme (via imspy_connector)
+     2	must reproduce the Bruker DIA layout the legacy `use_reference_ds_layout` path
+     3	copies from the reference `.d` — both the `DiaFrameMsMsWindows` window table and
+     4	the per-frame `DiaFrameMsMsInfo` (frame→group) table.
+     5	
+     6	Gated on TIMSIM_BRUKER_DIA_D pointing at a real DIA-PASEF `.d`.
+     7	"""
+     8	import os
+     9	import sqlite3
+    10	
+    11	import numpy as np
+    12	import pandas as pd
+    13	import pytest
+    14	
+    15	import imspy_connector
+    16	
+    17	acq = imspy_connector.py_acquisition
+    18	DIA_D = os.environ.get("TIMSIM_BRUKER_DIA_D")
+    19	pytestmark = pytest.mark.skipif(
+    20	    not DIA_D, reason="set TIMSIM_BRUKER_DIA_D to a real DIA-PASEF .d folder"
+    21	)
+    22	
+    23	
+    24	def _norm(df, cols):
+    25	    return df[cols].astype(float).round(6).sort_values(cols).reset_index(drop=True)
+    26	
+    27	
+    28	def test_scheme_windows_match_reference():
+    29	    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
+    30	    windows = pd.DataFrame(scheme.to_bruker_windows())
+    31	
+    32	    con = sqlite3.connect(DIA_D + "/analysis.tdf")
+    33	    ref = pd.read_sql(
+    34	        "SELECT WindowGroup window_group, ScanNumBegin scan_start, ScanNumEnd scan_end, "
+    35	        "IsolationMz isolation_mz, IsolationWidth isolation_width, "
+    36	        "CollisionEnergy collision_energy FROM DiaFrameMsMsWindows",
+    37	        con,
+    38	    )
+    39	    cols = list(ref.columns)
+    40	    assert len(windows) == len(ref)
+    41	    pd.testing.assert_frame_equal(_norm(windows, cols), _norm(ref, cols))
+    42	
+    43	
+    44	def test_scheme_info_matches_reference_and_legacy_formula():
+    45	    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
+    46	    con = sqlite3.connect(DIA_D + "/analysis.tdf")
+    47	    num_frames = int(con.execute("SELECT MAX(Id) FROM Frames").fetchone()[0])
+    48	
+    49	    info = pd.DataFrame(scheme.to_bruker_info(num_frames))
+    50	
+    51	    # (a) matches the .d's own DiaFrameMsMsInfo exactly
+    52	    ref = pd.read_sql("SELECT Frame frame, WindowGroup window_group FROM DiaFrameMsMsInfo", con)
+    53	    pd.testing.assert_frame_equal(
+    54	        _norm(info, ["frame", "window_group"]), _norm(ref, ["frame", "window_group"])
+    55	    )
+    56	
+    57	    # (b) matches the legacy position formula (index % precursor_every, ms2 only)
+    58	    pe = scheme.cycle_length()
+    59	    legacy = pd.DataFrame(
+    60	        [
+    61	            {"frame": f, "window_group": (f - 1) % pe}
+    62	            for f in range(1, num_frames + 1)
+    63	            if (f - 1) % pe != 0
+    64	        ]
+    65	    )
+    66	    pd.testing.assert_frame_equal(
+    67	        _norm(info, ["frame", "window_group"]), _norm(legacy, ["frame", "window_group"])
+    68	    )
+
+exec
+/bin/bash -lc 'git show ea07bcf1''^:packages/imspy-simulation/src/imspy_simulation/acquisition.py | nl -ba | sed -n '"'165,260p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   165	                 gradient_length=50 * 60,
+   166	                 rt_cycle_length=0.1054,
+   167	                 use_reference_ds_layout: bool = True,
+   168	                 round_collision_energy: bool = True,
+   169	                 collision_energy_decimals: int = 1
+   170	                 ):
+   171	
+   172	        super().__init__(path, reference_ds, gradient_length, rt_cycle_length,
+   173	                         exp_name=exp_name)
+   174	        # TODO: check this, could be missing replacement of reference layout of windows
+   175	        if use_reference_ds_layout:
+   176	            rt_cycle_length = np.mean(np.diff(reference_ds.meta_data.Time))
+   177	            if verbose:
+   178	                print('Using reference dataset cycle length:', np.round(rt_cycle_length, 4))
+   179	            self.rt_cycle_length = rt_cycle_length
+   180	
+   181	        self.acquisition_name = acquisition_name
+   182	        self.scan_table = None
+   183	        self.frame_table = None
+   184	        self.frames_to_window_groups = None
+   185	        self.dia_ms_ms_windows = pd.read_csv(window_group_file)
+   186	        self.use_reference_ds_layout = use_reference_ds_layout
+   187	        self.reference = reference_ds
+   188	        self.round_collision_energy = round_collision_energy
+   189	        self.collision_energy_decimals = collision_energy_decimals
+   190	
+   191	        # TODO: check if the number of scans in the window group file matches the number of scans in the experiment
+   192	
+   193	        self.acquisition_mode = AcquisitionMode('DIA')
+   194	        self.verbose = verbose
+   195	        self.precursor_every = precursor_every
+   196	
+   197	        self._setup(verbose=verbose)
+   198	
+   199	    def calculate_frame_types(self, verbose: bool = True) -> NDArray:
+   200	        if verbose:
+   201	            print(f'Calculating frame types, precursor frame will be taken every {self.precursor_every} rt cycles.')
+   202	        return np.array([0 if (x - 1) % self.precursor_every == 0 else 9 for x in self.frame_table.frame_id])
+   203	
+   204	    def generate_frame_to_window_group_table(self, verbose: bool = True) -> pd.DataFrame:
+   205	        if verbose:
+   206	            print(f'generating frame to window group table, precursors every {self.precursor_every} frames.')
+   207	
+   208	        table_list = []
+   209	        for index, row in self.frame_table.iterrows():
+   210	            frame_id, ms_type = row.frame_id, row.ms_type
+   211	            wg = index % self.precursor_every
+   212	            if ms_type > 0:
+   213	                table_list.append({'frame': int(frame_id), 'window_group': wg})
+   214	
+   215	        return pd.DataFrame(table_list)
+   216	
+   217	    def _setup(self, verbose: bool = True):
+   218	        self.frame_table = self.generate_frame_table(verbose=verbose)
+   219	        self.scan_table = self.generate_scan_table(verbose=verbose)
+   220	
+   221	        if self.use_reference_ds_layout:
+   222	            self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
+   223	            self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+   224	                columns={
+   225	                    'WindowGroup': 'window_group',
+   226	                    'ScanNumBegin': 'scan_start',
+   227	                    'ScanNumEnd': 'scan_end',
+   228	                    'IsolationMz': 'isolation_mz',
+   229	                    'IsolationWidth': 'isolation_width',
+   230	                    'CollisionEnergy': 'collision_energy',
+   231	                }
+   232	            )
+   233	
+   234	        self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+   235	        self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
+   236	
+   237	        if self.round_collision_energy:
+   238	            self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,
+   239	                                                                  decimals=self.collision_energy_decimals)
+   240	
+   241	        self.synthetics_handle.create_table(
+   242	            table_name='frames',
+   243	            table=self.frame_table
+   244	        )
+   245	        self.synthetics_handle.create_table(
+   246	            table_name='scans',
+   247	            table=self.scan_table
+   248	        )
+   249	        self.synthetics_handle.create_table(
+   250	            table_name='dia_ms_ms_info',
+   251	            table=self.frames_to_window_groups
+   252	        )
+   253	        self.synthetics_handle.create_table(
+   254	            table_name='dia_ms_ms_windows',
+   255	            table=self.dia_ms_ms_windows
+   256	        )
+   257	
+   258	    @staticmethod
+   259	    def from_config(
+   260	            path: str,
+
+exec
+/bin/bash -lc "python3 - <<'PY'
+import sqlite3, pandas as pd, numpy as np
+for dt in [np.uint32, np.int64]:
+    con=sqlite3.connect(':memory:')
+    df=pd.DataFrame({'frame':np.array([2,3],dtype=dt),'window_group':np.array([1,2],dtype=dt)})
+    df.to_sql('x',con,index=False)
+    print(dt.__name__, con.execute('pragma table_info(x)').fetchall(), pd.read_sql('select * from x',con).dtypes.to_dict())
+PY" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 350ms:
+uint32 [(0, 'frame', 'INTEGER', 0, None, 0), (1, 'window_group', 'INTEGER', 0, None, 0)] {'frame': dtype('int64'), 'window_group': dtype('int64')}
+int64 [(0, 'frame', 'INTEGER', 0, None, 0), (1, 'window_group', 'INTEGER', 0, None, 0)] {'frame': dtype('int64'), 'window_group': dtype('int64')}
+
+codex
+**Findings**
+
+1. **Medium: exact legacy equivalence depends on canonical group IDs.**  
+   [acquisition.py:252](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:252) now uses preserved reference `WindowGroup` IDs. Legacy generated `window_group = frame_position % precursor_every` at [acquisition.py:214](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:214). These agree only when cycle position 1 maps to group 1, position 2 to group 2, etc. Contiguous but permuted IDs also differ. For non-canonical references the new result is internally and reference-correct, while legacy was inconsistent with its copied window table, but this is still a backward-compatibility change.
+
+2. **Medium: window row ordering is not proven equivalent.**  
+   The scheme reconstructs rows grouped in acquisition-cycle order; legacy retained whatever order `reference.dia_ms_ms_windows` supplied. The test sorts every column at [test_acquisition_scheme_parity.py:25](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py:25), masking ordering changes. SQLite itself promises no order without `ORDER BY`, so consumers should not rely on it, but the requested byte-for-behavior parity is not established. `dia_ms_ms_info` should remain frame-ascending because `to_bruker_info()` emits frames sequentially.
+
+3. **Low: the parity test does not exercise the migrated builder.**  
+   It tests connector conversion directly, using the reference file’s existing frame count, not the builder’s recomputed synthetic frame count. It therefore misses:
+   - `_setup()` branch selection and persistence;
+   - CE rounding at [acquisition.py:272](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:272);
+   - column order and dtypes;
+   - generated frame count and partial final cycles;
+   - fallback behavior;
+   - non-`1..N` or permuted groups.
+
+   Moreover, the legacy-formula assertion at [test_acquisition_scheme_parity.py:57](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py:57) would reject a valid non-canonical reference even though the new implementation correctly preserves it.
+
+4. **Low: fallback can conceal deployment skew.**  
+   [acquisition.py:227](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:227) silently falls back when the module is unavailable, with notification only under `verbose=True`. That preserves legacy behavior, but an unexpectedly old/mispackaged connector can go unnoticed. A warning would be preferable. Other extraction/API failures correctly propagate rather than degrade silently.
+
+5. **Low: in-memory integer dtypes change, but persisted behavior is safe.**  
+   Scheme columns are `uint32`; legacy-generated columns are normally `int64`. Pandas SQLite serialization maps both `uint32` and `int64` to SQLite `INTEGER`, and `read_sql` returns `int64`. Rust consumers read by column name into `u32`, so persisted simulator behavior should not break. Explicit casts would still make the builder’s public in-memory tables stable. Dictionary insertion also currently produces the expected column order.
+
+The `num_frames` recompute at [acquisition.py:182](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:182) is correct and sufficient for generated state: `_setup()` creates both frame and scan tables afterward. Scan layout is independent of RT timing, and no other precomputed RT-dependent table is retained.
+tokens used
+44,854
+**Findings**
+
+1. **Medium: exact legacy equivalence depends on canonical group IDs.**  
+   [acquisition.py:252](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:252) now uses preserved reference `WindowGroup` IDs. Legacy generated `window_group = frame_position % precursor_every` at [acquisition.py:214](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:214). These agree only when cycle position 1 maps to group 1, position 2 to group 2, etc. Contiguous but permuted IDs also differ. For non-canonical references the new result is internally and reference-correct, while legacy was inconsistent with its copied window table, but this is still a backward-compatibility change.
+
+2. **Medium: window row ordering is not proven equivalent.**  
+   The scheme reconstructs rows grouped in acquisition-cycle order; legacy retained whatever order `reference.dia_ms_ms_windows` supplied. The test sorts every column at [test_acquisition_scheme_parity.py:25](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py:25), masking ordering changes. SQLite itself promises no order without `ORDER BY`, so consumers should not rely on it, but the requested byte-for-behavior parity is not established. `dia_ms_ms_info` should remain frame-ascending because `to_bruker_info()` emits frames sequentially.
+
+3. **Low: the parity test does not exercise the migrated builder.**  
+   It tests connector conversion directly, using the reference file’s existing frame count, not the builder’s recomputed synthetic frame count. It therefore misses:
+   - `_setup()` branch selection and persistence;
+   - CE rounding at [acquisition.py:272](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:272);
+   - column order and dtypes;
+   - generated frame count and partial final cycles;
+   - fallback behavior;
+   - non-`1..N` or permuted groups.
+
+   Moreover, the legacy-formula assertion at [test_acquisition_scheme_parity.py:57](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py:57) would reject a valid non-canonical reference even though the new implementation correctly preserves it.
+
+4. **Low: fallback can conceal deployment skew.**  
+   [acquisition.py:227](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:227) silently falls back when the module is unavailable, with notification only under `verbose=True`. That preserves legacy behavior, but an unexpectedly old/mispackaged connector can go unnoticed. A warning would be preferable. Other extraction/API failures correctly propagate rather than degrade silently.
+
+5. **Low: in-memory integer dtypes change, but persisted behavior is safe.**  
+   Scheme columns are `uint32`; legacy-generated columns are normally `int64`. Pandas SQLite serialization maps both `uint32` and `int64` to SQLite `INTEGER`, and `read_sql` returns `int64`. Rust consumers read by column name into `u32`, so persisted simulator behavior should not break. Explicit casts would still make the builder’s public in-memory tables stable. Dictionary insertion also currently produces the expected column order.
+
+The `num_frames` recompute at [acquisition.py:182](/scratch/timsim-demo/SUBMISSION/rustims/packages/imspy-simulation/src/imspy_simulation/acquisition.py:182) is correct and sufficient for generated state: `_setup()` creates both frame and scan tables afterward. Scan layout is independent of RT timing, and no other precomputed RT-dependent table is retained.

--- a/PYO3.codex-review.md
+++ b/PYO3.codex-review.md
@@ -1,0 +1,244 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019eab5a-5941-7341-b762-61b408639746
+--------
+user
+Review this PyO3 (pyo3 0.23) module that exposes a Rust DIA-acquisition-scheme type to Python in a mass-spec toolkit. It wraps rustdf::sim::scheme::AcquisitionScheme (already reviewed) and is the Python entry point for the simulator to build a DIA layout and render Bruker DiaFrameMsMsWindows/DiaFrameMsMsInfo tables.
+
+Trusted context: AcquisitionScheme::from_bruker_d/from_thermo_raw/from_sciex_wiff return io::Result; to_bruker_windows/to_bruker_info return Result<Vec<row>, String>; the connector forwards 'thermo'/'sciex' cargo features to rustdf. Verified from Python on a real .d: from_bruker_d -> to_bruker_windows/to_bruker_info reproduce the source SQLite tables exactly (36 / 16543 rows). The column-list return is consumed as pandas DataFrames.
+
+Focus, ranked: 1) PyO3 correctness/idiom for pyo3 0.23 — #[pyclass]/#[pymethods]/#[staticmethod]/#[getter], the cfg-gated methods INSIDE one #[pymethods] block (is that valid without the multiple-pymethods feature?), the #[pyo3(signature=...)] with Option args, returning large tuples of Vec<u32>/Vec<f64> (correctness + are they materialized as Python lists efficiently/should they be numpy?). 2) error mapping (io/String -> PyValueError) — any lossy or misleading cases; should some be different exception types. 3) GIL/perf: to_bruker_info can return millions of rows as 2 Python lists while holding the GIL — is that a problem, and is releasing the GIL or returning numpy advisable? 4) API ergonomics for the DataFrame consumer (parallel column lists vs a single structured return; risk of column/length desync). 5) the feature-gated constructors: if built without thermo/sciex, are they cleanly absent (no broken symbols) and is that the intended degradation? 6) anything unsound, panics, or memory blowups. Concrete, ~500 words.
+
+<stdin>
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rustdf::sim::scheme::AcquisitionScheme;
+
+/// Python wrapper over the vendor-neutral DIA acquisition scheme
+/// (`rustdf::sim::scheme::AcquisitionScheme`).
+///
+/// Exposes the vendor extractors and the Bruker backward-compat adapter, so the
+/// Python simulator can build its DIA layout from a real Bruker/Thermo/SCIEX run
+/// (or an injected window table) and render the Bruker `DiaFrameMsMsWindows` /
+/// `DiaFrameMsMsInfo` tables. The `from_thermo_raw`/`from_sciex_wiff` constructors
+/// require the connector to be built with the `thermo`/`sciex` feature.
+#[pyclass]
+pub struct PyAcquisitionScheme {
+    pub inner: AcquisitionScheme,
+}
+
+fn val_err<E: ToString>(e: E) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+#[pymethods]
+impl PyAcquisitionScheme {
+    /// Extract the scheme from a Bruker timsTOF DIA `.d` folder.
+    #[staticmethod]
+    pub fn from_bruker_d(path: &str) -> PyResult<Self> {
+        AcquisitionScheme::from_bruker_d(path)
+            .map(|inner| Self { inner })
+            .map_err(val_err)
+    }
+
+    /// Extract from a Thermo Orbitrap `.raw` (requires the `thermo` feature).
+    #[cfg(feature = "thermo")]
+    #[staticmethod]
+    pub fn from_thermo_raw(path: &str) -> PyResult<Self> {
+        AcquisitionScheme::from_thermo_raw(path)
+            .map(|inner| Self { inner })
+            .map_err(val_err)
+    }
+
+    /// Extract from a SCIEX `.wiff` SWATH method (requires the `sciex` feature).
+    /// SCIEX rolling CE isn't stored per-window, so it's left `Unknown` unless a
+    /// linear rolling-CE model is supplied via `(ce_intercept, ce_slope_per_mz)`.
+    #[cfg(feature = "sciex")]
+    #[staticmethod]
+    #[pyo3(signature = (path, cycle_time_s, gradient_length_s, ce_intercept=None, ce_slope_per_mz=None))]
+    pub fn from_sciex_wiff(
+        path: &str,
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+        ce_intercept: Option<f64>,
+        ce_slope_per_mz: Option<f64>,
+    ) -> PyResult<Self> {
+        use rustdf::sim::scheme::CollisionEnergyPolicy;
+        let ce = match (ce_intercept, ce_slope_per_mz) {
+            (Some(intercept), Some(slope_per_mz)) => CollisionEnergyPolicy::Linear {
+                intercept,
+                slope_per_mz,
+            },
+            _ => CollisionEnergyPolicy::Unknown,
+        };
+        AcquisitionScheme::from_sciex_wiff(path, cycle_time_s, gradient_length_s, ce)
+            .map(|inner| Self { inner })
+            .map_err(val_err)
+    }
+
+    #[getter]
+    pub fn instrument(&self) -> String {
+        format!("{:?}", self.inner.instrument)
+    }
+
+    #[getter]
+    pub fn mz_range(&self) -> (f64, f64) {
+        self.inner.mz_range
+    }
+
+    #[getter]
+    pub fn provenance(&self) -> String {
+        format!(
+            "{:?}: {}",
+            self.inner.provenance.source, self.inner.provenance.notes
+        )
+    }
+
+    pub fn ms1_count(&self) -> usize {
+        self.inner.ms1_count()
+    }
+
+    pub fn n_windows(&self) -> usize {
+        self.inner.windows().count()
+    }
+
+    pub fn num_cycles(&self) -> Option<u64> {
+        self.inner.num_cycles()
+    }
+
+    pub fn validate(&self) -> PyResult<()> {
+        self.inner.validate().map_err(val_err)
+    }
+
+    /// Bruker `DiaFrameMsMsWindows` as column lists, ready for a DataFrame:
+    /// `(window_group, scan_start, scan_end, isolation_mz, isolation_width, collision_energy)`.
+    pub fn to_bruker_windows(
+        &self,
+    ) -> PyResult<(Vec<u32>, Vec<u32>, Vec<u32>, Vec<f64>, Vec<f64>, Vec<f64>)> {
+        let rows = self.inner.to_bruker_windows().map_err(val_err)?;
+        let mut wg = Vec::with_capacity(rows.len());
+        let mut ss = Vec::with_capacity(rows.len());
+        let mut se = Vec::with_capacity(rows.len());
+        let mut mz = Vec::with_capacity(rows.len());
+        let mut wd = Vec::with_capacity(rows.len());
+        let mut ce = Vec::with_capacity(rows.len());
+        for r in &rows {
+            wg.push(r.window_group);
+            ss.push(r.scan_num_begin);
+            se.push(r.scan_num_end);
+            mz.push(r.isolation_mz);
+            wd.push(r.isolation_width);
+            ce.push(r.collision_energy);
+        }
+        Ok((wg, ss, se, mz, wd, ce))
+    }
+
+    /// Bruker `DiaFrameMsMsInfo` as column lists for a `num_frames`-frame run:
+    /// `(frame, window_group)`.
+    pub fn to_bruker_info(&self, num_frames: u32) -> PyResult<(Vec<u32>, Vec<u32>)> {
+        let rows = self.inner.to_bruker_info(num_frames).map_err(val_err)?;
+        let mut frame = Vec::with_capacity(rows.len());
+        let mut wg = Vec::with_capacity(rows.len());
+        for r in &rows {
+            frame.push(r.frame_id);
+            wg.push(r.window_group);
+        }
+        Ok((frame, wg))
+    }
+}
+
+#[pymodule]
+pub fn py_acquisition(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyAcquisitionScheme>()?;
+    Ok(())
+}
+</stdin>
+codex
+I’ll verify the PyO3 0.23 macro and conversion behavior against its official documentation/source, then give findings ordered by severity with concrete recommendations.
+web search: 
+web search: site:pyo3.rs/v0.23.0 pymethods cfg feature multiple-pymethods
+web search: 
+web search: site:pyo3.rs/v0.23.4 allow_threads pymethod GIL release
+web search: 
+web search: site:docs.rs/pyo3/0.23.5 "From<io::Error>" PyErr
+codex
+**Findings**
+
+1. **High: `to_bruker_info` has serious GIL and memory scaling risk.**  
+   `Vec<u32>` correctly becomes `list[int]` in PyO3 0.23, but conversion allocates millions of Python integer objects while holding the GIL. The Rust work also runs with the GIL held even though no `Python` argument appears. For large runs this can block all Python threads and use far more memory than the underlying 8 bytes per row.
+
+   Prefer returning NumPy `uint32` arrays using `numpy::PyArray1::from_vec`, which transfers the Rust allocation into NumPy. If NumPy cannot be mandatory, offer a separate array-oriented method. Adding `py: Python<'_>` and wrapping Rust-only generation in `py.allow_threads(...)` helps computation, but Python-list conversion still requires the GIL. Constructors performing vendor I/O are also candidates for `allow_threads`.
+
+2. **Medium: I/O errors should not become `ValueError`.**  
+   `from_bruker_d`, `from_thermo_raw`, and `from_sciex_wiff` return `io::Result`; mapping every failure through `to_string()` loses the error kind, errno, and Python’s useful `FileNotFoundError`, `PermissionError`, etc. PyO3 provides `From<std::io::Error> for PyErr`, mapping these to `OSError` or its subclasses:
+
+   ```rust
+   .map_err(PyErr::from)
+   ```
+
+   `ValueError` is reasonable for validation and rendering failures represented only as `String`, assuming those strings describe invalid/inconsistent schemes rather than I/O or internal failures.
+
+3. **Medium: partial SCIEX CE input is silently discarded.**  
+   Supplying only `ce_intercept` or only `ce_slope_per_mz` produces `Unknown`. That is surprising and can silently change simulation output. Return `ValueError` unless both are supplied or both omitted. Consider also rejecting non-finite values here if the underlying constructor does not.
+
+4. **Low: the PyO3 macro arrangement is valid.**  
+   `#[cfg]`-gated methods inside one `#[pymethods]` block are fine. The `multiple-pymethods` feature is required only for multiple separate `#[pymethods]` blocks on one class. Disabled Thermo/SCIEX constructors therefore disappear cleanly with no unresolved symbols. This is reasonable degradation, though exposing module-level capability flags would improve discoverability.
+
+5. **Low: signatures and getters are otherwise correct.**  
+   `#[staticmethod]`, `#[getter]`, and the explicit defaults for trailing `Option<f64>` arguments are idiomatic for 0.23. Consider making CE arguments keyword-only:
+
+   ```rust
+   signature = (path, cycle_time_s, gradient_length_s, *, ce_intercept=None, ce_slope_per_mz=None)
+   ```
+
+6. **Low: positional column tuples are fragile.**  
+   The implementation itself cannot desynchronize lengths because every column is pushed in the same loop. The Python caller can, however, mislabel or reorder tuple positions. A mapping such as `{column_name: numpy_array}` is directly accepted by pandas and self-describing. `instrument` and `provenance` also rely on Rust `Debug` formatting, which is not a stable Python API; expose canonical strings or structured properties instead.
+
+No direct unsoundness or explicit panic path is present. The main operational hazard is list materialization for multi-million-row info tables.
+
+Sources: [PyO3 signatures](https://pyo3.rs/v0.23.3/function/signature.html), [PyO3 classes](https://pyo3.rs/v0.23.1/class.html), [PyO3 vector conversion](https://pyo3.rs/main/doc/src/pyo3/conversions/std/vec.rs), [NumPy ownership transfer](https://docs.rs/numpy/latest/numpy/array/struct.PyArray.html).
+tokens used
+28,680
+**Findings**
+
+1. **High: `to_bruker_info` has serious GIL and memory scaling risk.**  
+   `Vec<u32>` correctly becomes `list[int]` in PyO3 0.23, but conversion allocates millions of Python integer objects while holding the GIL. The Rust work also runs with the GIL held even though no `Python` argument appears. For large runs this can block all Python threads and use far more memory than the underlying 8 bytes per row.
+
+   Prefer returning NumPy `uint32` arrays using `numpy::PyArray1::from_vec`, which transfers the Rust allocation into NumPy. If NumPy cannot be mandatory, offer a separate array-oriented method. Adding `py: Python<'_>` and wrapping Rust-only generation in `py.allow_threads(...)` helps computation, but Python-list conversion still requires the GIL. Constructors performing vendor I/O are also candidates for `allow_threads`.
+
+2. **Medium: I/O errors should not become `ValueError`.**  
+   `from_bruker_d`, `from_thermo_raw`, and `from_sciex_wiff` return `io::Result`; mapping every failure through `to_string()` loses the error kind, errno, and Python’s useful `FileNotFoundError`, `PermissionError`, etc. PyO3 provides `From<std::io::Error> for PyErr`, mapping these to `OSError` or its subclasses:
+
+   ```rust
+   .map_err(PyErr::from)
+   ```
+
+   `ValueError` is reasonable for validation and rendering failures represented only as `String`, assuming those strings describe invalid/inconsistent schemes rather than I/O or internal failures.
+
+3. **Medium: partial SCIEX CE input is silently discarded.**  
+   Supplying only `ce_intercept` or only `ce_slope_per_mz` produces `Unknown`. That is surprising and can silently change simulation output. Return `ValueError` unless both are supplied or both omitted. Consider also rejecting non-finite values here if the underlying constructor does not.
+
+4. **Low: the PyO3 macro arrangement is valid.**  
+   `#[cfg]`-gated methods inside one `#[pymethods]` block are fine. The `multiple-pymethods` feature is required only for multiple separate `#[pymethods]` blocks on one class. Disabled Thermo/SCIEX constructors therefore disappear cleanly with no unresolved symbols. This is reasonable degradation, though exposing module-level capability flags would improve discoverability.
+
+5. **Low: signatures and getters are otherwise correct.**  
+   `#[staticmethod]`, `#[getter]`, and the explicit defaults for trailing `Option<f64>` arguments are idiomatic for 0.23. Consider making CE arguments keyword-only:
+
+   ```rust
+   signature = (path, cycle_time_s, gradient_length_s, *, ce_intercept=None, ce_slope_per_mz=None)
+   ```
+
+6. **Low: positional column tuples are fragile.**  
+   The implementation itself cannot desynchronize lengths because every column is pushed in the same loop. The Python caller can, however, mislabel or reorder tuple positions. A mapping such as `{column_name: numpy_array}` is directly accepted by pandas and self-describing. `instrument` and `provenance` also rely on Rust `Debug` formatting, which is not a stable Python API; expose canonical strings or structured properties instead.
+
+No direct unsoundness or explicit panic path is present. The main operational hazard is list materialization for multi-million-row info tables.
+
+Sources: [PyO3 signatures](https://pyo3.rs/v0.23.3/function/signature.html), [PyO3 classes](https://pyo3.rs/v0.23.1/class.html), [PyO3 vector conversion](https://pyo3.rs/main/doc/src/pyo3/conversions/std/vec.rs), [NumPy ownership transfer](https://docs.rs/numpy/latest/numpy/array/struct.PyArray.html).

--- a/TO_BRUKER.codex-review.md
+++ b/TO_BRUKER.codex-review.md
@@ -1,3 +1,23 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019eab2a-3eaf-7ff3-b7c8-3b38424d0466
+--------
+user
+Review ONLY the newly added code in this Rust file (the rest was already reviewed): the method AcquisitionScheme::to_bruker_windows (a backward-compat adapter that renders a vendor-neutral DIA scheme back to Bruker DiaFrameMsMsWindows rows) and its gated unit test bruker_windows_round_trip. Skim the rest only for interaction.
+
+Trusted context: crate::data::meta::DiaMsMsWindow { window_group:u32, scan_num_begin:u32, scan_num_end:u32, isolation_mz:f64, isolation_width:f64, collision_energy:f64 } and read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow> read the Bruker SQLite DiaFrameMsMsWindows table (no ORDER BY). from_bruker_d builds the scheme by grouping those rows by window_group (BTreeMap ascending) into one DiaMs2Frame per group with TimsMobility geometry. The scheme model: cycle is an ordered Vec<AcquisitionEvent> = Ms1 | DiaMs2Frame(windows:Vec<DiaWindow{isolation:{center_mz,width_mz}, collision_energy:CollisionEnergyPolicy{Value|Linear|Unknown}, geometry:DiaGeometry{MzOnly|TimsMobility{scan_start,scan_end}}}>). to_bruker_windows numbers window groups 1..N in cycle (frame) order; the round-trip test normalizes window-group ids to canonical 1..N on both sides and compares sorted exact-bit field tuples.
+
+Focus: 1) is to_bruker_windows a FAITHFUL inverse of from_bruker_d for real DIA-PASEF data — specifically the window-group renumbering (1..N by frame order vs original ids): when does the normalized round-trip hide a real id mismatch that would break the actual .d the Python builder writes (which uses reference WindowGroup ids)? Is losing the original WindowGroup id in the scheme model a real data-loss bug for backward compat? 2) CE handling — Value passthrough, Linear resolved at center (is center the right point vs Bruker's stored per-window CE?), Unknown rejected; any lossy/incorrect cases. 3) within-frame and cross-frame window ORDER preservation (SQL has no ORDER BY; from_bruker_d preserves insertion order in the Vec; does to_bruker_windows + the test correctly handle when source rows are interleaved across groups vs grouped?). 4) the test's canonical() normalization — does it actually prove faithfulness, or could it pass while masking a real regression? 5) any correctness bug, panic, or float-equality fragility. Concrete, ranked by severity, ~600 words.
+
+<stdin>
 //! Vendor-neutral DIA acquisition **scheme** (input/design side).
 //!
 //! An [`AcquisitionScheme`] describes one DIA cycle as an *ordered sequence of
@@ -122,12 +142,6 @@ pub struct DiaMs2Frame {
     pub analyzer: Analyzer,
     pub data_mode: DataMode,
     pub duration_s: Option<f64>,
-    /// The vendor's native group id for this frame, preserved for round-trip
-    /// fidelity (Bruker `WindowGroup`). `None` for vendors without one. The cycle
-    /// order is authoritative for *simultaneity/ordering*; this is *identity* only
-    /// — needed so a Bruker adapter regenerates the original `WindowGroup` values
-    /// that companion tables (`DiaFrameMsMsInfo`) reference.
-    pub vendor_group_id: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -231,7 +245,6 @@ impl AcquisitionScheme {
                 analyzer: ms1.analyzer,
                 data_mode: DataMode::Centroid,
                 duration_s: None,
-                vendor_group_id: None,
             }));
         }
         AcquisitionScheme {
@@ -432,27 +445,21 @@ impl AcquisitionScheme {
     /// backward-compatibility adapter for the existing timsTOF write path.
     ///
     /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
-    /// geometry (the Bruker-grid scan ranges). The `WindowGroup` id is the frame's
-    /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
-    /// round-trip keeps the ids that `DiaFrameMsMsInfo` references), else a 1..N
-    /// fallback in cycle order. A `Linear` CE policy is resolved at the window
-    /// center (a lossy materialization, not an inverse); `Unknown` CE and
-    /// non-timsTOF schemes are rejected. The scheme is validated first.
-    ///
-    /// Row order is not meaningful (the SQLite table has none); the companion
-    /// frame→group table `DiaFrameMsMsInfo` needs the run frame schedule and is a
-    /// separate step.
+    /// geometry (the Bruker-grid scan ranges). Window groups are numbered 1..N in
+    /// cycle order (the DIA-PASEF convention); a `Linear` CE policy is resolved at
+    /// the window center, and `Unknown` CE is rejected. Errors if the scheme is
+    /// not a timsTOF layout. (The companion frame→group table,
+    /// `DiaFrameMsMsInfo`, depends on the full run's frame schedule and is a
+    /// separate step.)
     pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
-        self.validate()?;
         if self.instrument != InstrumentKind::TimsTofDia {
             return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
         }
         let mut rows = Vec::new();
-        let mut seq: u32 = 0;
+        let mut group: u32 = 0;
         for ev in &self.cycle {
             if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
-                seq += 1;
-                let group = frame.vendor_group_id.unwrap_or(seq);
+                group += 1;
                 for w in &frame.windows {
                     let (scan_num_begin, scan_num_end) = match w.geometry {
                         DiaGeometry::TimsMobility {
@@ -543,13 +550,12 @@ impl AcquisitionScheme {
             duration_s: None,
         })];
         let n_groups = by_group.len();
-        for (group, ws) in by_group {
+        for (_group, ws) in by_group {
             cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
                 windows: ws,
                 analyzer: Analyzer::Tof,
                 data_mode: DataMode::Centroid,
                 duration_s: None,
-                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
             }));
         }
 
@@ -660,7 +666,6 @@ impl AcquisitionScheme {
                 analyzer: Analyzer::Tof,
                 data_mode: DataMode::Centroid,
                 duration_s: None,
-                vendor_group_id: None,
             }));
         }
         let scheme = AcquisitionScheme {
@@ -773,7 +778,6 @@ impl AcquisitionScheme {
                     analyzer: analyzer_of(ev.analyzer),
                     data_mode: data_mode_of(scan),
                     duration_s: None,
-                    vendor_group_id: None,
                 }));
             }
         }
@@ -883,7 +887,6 @@ mod tests {
             analyzer: Analyzer::Tof,
             data_mode: DataMode::Centroid,
             duration_s: None,
-            vendor_group_id: None,
         };
         let s = AcquisitionScheme {
             version: SCHEME_VERSION,
@@ -938,7 +941,6 @@ mod tests {
                 analyzer: Analyzer::Astms,
                 data_mode: DataMode::Centroid,
                 duration_s: None,
-                vendor_group_id: None,
             })
         };
         let mk = |cycle: Vec<AcquisitionEvent>| AcquisitionScheme {
@@ -975,7 +977,6 @@ mod tests {
             analyzer: Analyzer::Astms,
             data_mode: DataMode::Centroid,
             duration_s: Some(-1.0),
-            vendor_group_id: None,
         });
         assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), bad_dur]).validate().is_err());
     }
@@ -1028,17 +1029,20 @@ mod tests {
         let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
         assert_eq!(regenerated.len(), original.len(), "row count differs");
 
-        // Compare as a sorted multiset of EXACT field tuples, including the
-        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
-        // real id mismatch would fail. Row order in the table is not guaranteed.
-        fn tuples(
+        // Normalize window-group ids to canonical 1..N (ascending) on both sides,
+        // then compare as a sorted multiset of exact-bit field tuples.
+        fn canonical(
             rows: &[crate::data::meta::DiaMsMsWindow],
         ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+            let mut groups: Vec<u32> = rows.iter().map(|r| r.window_group).collect();
+            groups.sort_unstable();
+            groups.dedup();
             let mut out: Vec<_> = rows
                 .iter()
                 .map(|r| {
+                    let g = groups.iter().position(|&x| x == r.window_group).unwrap() as u32 + 1;
                     (
-                        r.window_group,
+                        g,
                         r.scan_num_begin,
                         r.scan_num_end,
                         r.isolation_mz.to_bits(),
@@ -1051,9 +1055,9 @@ mod tests {
             out
         }
         assert_eq!(
-            tuples(&regenerated),
-            tuples(&original),
-            "round-trip windows differ from source (incl. WindowGroup id)"
+            canonical(&regenerated),
+            canonical(&original),
+            "round-trip windows differ from source"
         );
         eprintln!(
             "bruker_windows_round_trip OK: {} rows match across {} groups",
@@ -1135,3 +1139,59 @@ mod tests {
         );
     }
 }
+</stdin>
+codex
+**Findings**
+
+1. **High: WindowGroup identity is lost, which can make the generated `.d` internally inconsistent.**  
+`from_bruker_d` discards the original `WindowGroup` value when converting each `BTreeMap` entry into a `DiaMs2Frame`. `to_bruker_windows` then invents IDs `1..N`.
+
+That is only faithful when the source IDs are already contiguous `1..N`, ordered exactly like the scheme frames, or when every referencing table is regenerated using the same new IDs. If the Python builder retains `DiaFrameMsMsInfo.WindowGroup` values from the reference `.d`, source groups such as `{2, 4, 7}` become `{1, 2, 3}` in `DiaFrameMsMsWindows` while frame rows still reference `{2, 4, 7}`. Some references then select the wrong group and others select none.
+
+This is real backward-compatibility data loss, not merely cosmetic renumbering. The model or extraction provenance needs to preserve the original group ID, or the writer must return an explicit old-to-new mapping and rewrite every reference consistently.
+
+2. **High: The round-trip test explicitly masks that identity-loss bug.**  
+`canonical()` rank-normalizes every distinct source group to `1..N`. Consequently, an input with groups `{10, 20}` passes after regeneration as `{1, 2}`, despite not being usable with unchanged reference `DiaFrameMsMsInfo` rows.
+
+The test proves only that window payloads and ascending group partitions survive. It does not prove table-level fidelity or compatibility with the produced `.d`. At minimum, real backward-compatible extraction should compare original IDs exactly. If renumbering is intentional, a second integration assertion must verify that all frame-to-group references are rewritten using the same mapping.
+
+3. **Medium: Physical frame order is not established and the test cannot detect an ordering regression.**  
+SQL row order is unspecified. `from_bruker_d` orders frames by ascending group ID and preserves database-return order only within each group. `to_bruker_windows` emits rows grouped by frame, so an interleaved source sequence such as `G1-A, G2-A, G1-B` becomes `G1-A, G1-B, G2-A`.
+
+The sorted-multiset comparison hides both within-frame and cross-frame row ordering. Row order may be semantically irrelevant to SQLite consumers, but then it should not be described as preserved. More importantly, if actual acquisition order differs from ascending `WindowGroup`, only `DiaFrameMsMsInfo` can recover it; this test will still pass while the scheme cycle is wrong.
+
+4. **Medium: `to_bruker_windows` accepts structurally invalid schemes without validation.**  
+It does not call `validate()`. An empty cycle returns `Ok(vec![])`; an empty MS2 frame consumes a group number but emits no row; non-finite or negative `Value` CE is passed through; invalid isolation widths and scan ranges are also emitted. This can produce malformed tables or group numbering inconsistent with companion metadata. Either call `validate()` first or enforce all adapter-specific invariants locally.
+
+5. **Low: CE behavior is faithful only for extracted Bruker `Value` policies.**  
+`Value` is exact-bit passthrough and therefore a proper inverse. `Unknown` rejection is correct. Resolving `Linear` at `isolation.center_mz` is reasonable given this policy’s documented definition, but it is a lossy materialization, not an inverse: Bruker stores one scalar per row, and any vendor rounding or CE determined from another coordinate cannot be recovered. The test never exercises `Linear`, so it validates none of this behavior.
+
+Exact-bit float comparison is appropriate for the extracted `Value` path and avoids tolerance ambiguity. There is no meaningful panic risk in `canonical()`; its `unwrap()` searches a group collected from the same rows.
+tokens used
+13,740
+**Findings**
+
+1. **High: WindowGroup identity is lost, which can make the generated `.d` internally inconsistent.**  
+`from_bruker_d` discards the original `WindowGroup` value when converting each `BTreeMap` entry into a `DiaMs2Frame`. `to_bruker_windows` then invents IDs `1..N`.
+
+That is only faithful when the source IDs are already contiguous `1..N`, ordered exactly like the scheme frames, or when every referencing table is regenerated using the same new IDs. If the Python builder retains `DiaFrameMsMsInfo.WindowGroup` values from the reference `.d`, source groups such as `{2, 4, 7}` become `{1, 2, 3}` in `DiaFrameMsMsWindows` while frame rows still reference `{2, 4, 7}`. Some references then select the wrong group and others select none.
+
+This is real backward-compatibility data loss, not merely cosmetic renumbering. The model or extraction provenance needs to preserve the original group ID, or the writer must return an explicit old-to-new mapping and rewrite every reference consistently.
+
+2. **High: The round-trip test explicitly masks that identity-loss bug.**  
+`canonical()` rank-normalizes every distinct source group to `1..N`. Consequently, an input with groups `{10, 20}` passes after regeneration as `{1, 2}`, despite not being usable with unchanged reference `DiaFrameMsMsInfo` rows.
+
+The test proves only that window payloads and ascending group partitions survive. It does not prove table-level fidelity or compatibility with the produced `.d`. At minimum, real backward-compatible extraction should compare original IDs exactly. If renumbering is intentional, a second integration assertion must verify that all frame-to-group references are rewritten using the same mapping.
+
+3. **Medium: Physical frame order is not established and the test cannot detect an ordering regression.**  
+SQL row order is unspecified. `from_bruker_d` orders frames by ascending group ID and preserves database-return order only within each group. `to_bruker_windows` emits rows grouped by frame, so an interleaved source sequence such as `G1-A, G2-A, G1-B` becomes `G1-A, G1-B, G2-A`.
+
+The sorted-multiset comparison hides both within-frame and cross-frame row ordering. Row order may be semantically irrelevant to SQLite consumers, but then it should not be described as preserved. More importantly, if actual acquisition order differs from ascending `WindowGroup`, only `DiaFrameMsMsInfo` can recover it; this test will still pass while the scheme cycle is wrong.
+
+4. **Medium: `to_bruker_windows` accepts structurally invalid schemes without validation.**  
+It does not call `validate()`. An empty cycle returns `Ok(vec![])`; an empty MS2 frame consumes a group number but emits no row; non-finite or negative `Value` CE is passed through; invalid isolation widths and scan ranges are also emitted. This can produce malformed tables or group numbering inconsistent with companion metadata. Either call `validate()` first or enforce all adapter-specific invariants locally.
+
+5. **Low: CE behavior is faithful only for extracted Bruker `Value` policies.**  
+`Value` is exact-bit passthrough and therefore a proper inverse. `Unknown` rejection is correct. Resolving `Linear` at `isolation.center_mz` is reasonable given this policy’s documented definition, but it is a lossy materialization, not an inverse: Bruker stores one scalar per row, and any vendor rounding or CE determined from another coordinate cannot be recovered. The test never exercises `Linear`, so it validates none of this behavior.
+
+Exact-bit float comparison is appropriate for the extracted `Value` path and avoids tolerance ambiguity. There is no meaningful panic risk in `canonical()`; its `unwrap()` searches a group collected from the same rows.

--- a/TO_BRUKER_V2.codex-review.md
+++ b/TO_BRUKER_V2.codex-review.md
@@ -1,0 +1,2798 @@
+Reading additional input from stdin...
+OpenAI Codex v0.136.0
+--------
+workdir: /scratch/timsim-demo/SUBMISSION/rustims
+model: gpt-5.5
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR]
+reasoning effort: medium
+reasoning summaries: none
+session id: 019eab32-7179-79e3-af5d-b09afe89d1ca
+--------
+user
+This is a REVISION of code you reviewed last round. Your prior review of to_bruker_windows found (High) that renumbering window groups 1..N lost the source Bruker WindowGroup identity, breaking round-trip fidelity with DiaFrameMsMsInfo, and that the round-trip test masked it via canonical normalization. The fix just applied: DiaMs2Frame now has a vendor_group_id: Option<u32> field; from_bruker_d sets it to the source WindowGroup (BTreeMap key), all other constructors set None; to_bruker_windows uses frame.vendor_group_id.unwrap_or(sequential 1..N) and now calls validate() first; the round-trip golden test now compares EXACT WindowGroup ids (no normalization).
+
+Verify ONLY whether this revision is correct and complete; skim the rest. Focus: 1) does vendor_group_id genuinely fix the identity-loss bug end-to-end — is it set on EVERY from_bruker_d frame, threaded through all 7 DiaMs2Frame construction sites correctly (from_window_table, from_thermo_raw, from_sciex_wiff, from_bruker_d, and the 3 test sites), and used correctly in to_bruker_windows? 2) any NEW bug introduced by the field addition or the to_bruker_windows changes (e.g. validate() now called first - does that change error semantics or reject previously-accepted valid Bruker schemes? could a from_bruker_d scheme fail its own validate() due to within-frame overlap or mz_range containment on real PASEF window groups?). 3) is the unwrap_or fallback sound when SOME frames have vendor_group_id and others don't (mixed)? could that collide a preserved id with a sequential one? 4) does the exact-id round-trip test now actually prove fidelity? 5) the from_window_table builder doesn't expose vendor_group_id (always None) - is that a gap for injected timsTOF schemes that need specific group ids? Concrete, ranked by severity, ~500 words.
+
+<stdin>
+//! Vendor-neutral DIA acquisition **scheme** (input/design side).
+//!
+//! An [`AcquisitionScheme`] describes one DIA cycle as an *ordered sequence of
+//! physical events* ([`AcquisitionEvent`]) and how that cycle tiles the
+//! gradient ([`RepeatPolicy`]). It is the design counterpart to the
+//! [`crate::sim::acquisition::AcquisitionWriter`] (output side): the simulator
+//! generates scans for the scheme, and a writer materializes them.
+//!
+//! The key modelling choice (per review) is that a *physical acquisition unit*
+//! is explicit: [`AcquisitionEvent::DiaMs2Frame`] carries a `Vec<DiaWindow>`, so
+//! a timsTOF MS2 frame holding several mobility-partitioned windows and a linear
+//! Astral/SCIEX MS2 scan (one window) are both represented without overloading a
+//! `window_group` id to imply simultaneity.
+
+use std::io;
+
+/// Current scheme schema version.
+pub const SCHEME_VERSION: u16 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstrumentKind {
+    TimsTofDia,
+    OrbitrapAstral,
+    SciexZenoTof,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Analyzer {
+    Ftms,
+    Astms,
+    Tof,
+    Itms,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataMode {
+    Profile,
+    Centroid,
+}
+
+/// An m/z isolation window (no ion mobility — see [`DiaGeometry`]).
+#[derive(Clone, Copy, Debug)]
+pub struct IsolationWindow {
+    pub center_mz: f64,
+    pub width_mz: f64,
+}
+
+impl IsolationWindow {
+    pub fn lower(&self) -> f64 {
+        self.center_mz - self.width_mz / 2.0
+    }
+    pub fn upper(&self) -> f64 {
+        self.center_mz + self.width_mz / 2.0
+    }
+}
+
+/// How a window's collision energy is determined.
+///
+/// `Value` covers both a per-window CE and a scheme-wide fixed CE (every window
+/// carries the same value) — there is intentionally no separate `Fixed` variant
+/// (they were structurally identical). `Unknown` means extraction could not
+/// recover it (e.g. SCIEX rolling CE) and a model must be supplied downstream —
+/// it is never silently invented.
+#[derive(Clone, Copy, Debug)]
+pub enum CollisionEnergyPolicy {
+    Value(f64),
+    Linear { intercept: f64, slope_per_mz: f64 },
+    Unknown,
+}
+
+impl CollisionEnergyPolicy {
+    /// Resolve the CE for a window centered at `center_mz`, if determinable.
+    pub fn at(&self, center_mz: f64) -> Option<f64> {
+        match *self {
+            CollisionEnergyPolicy::Value(v) => Some(v),
+            CollisionEnergyPolicy::Linear {
+                intercept,
+                slope_per_mz,
+            } => Some(intercept + slope_per_mz * center_mz),
+            CollisionEnergyPolicy::Unknown => None,
+        }
+    }
+}
+
+/// Window geometry: m/z only, or (timsTOF) an additional ion-mobility partition.
+/// Mobility is kept off [`IsolationWindow`] so "mobility on a non-IMS instrument"
+/// is unrepresentable. Scan numbers are Bruker-grid coordinates (they require the
+/// reference dataset's calibration to map to physical mobility).
+#[derive(Clone, Copy, Debug)]
+pub enum DiaGeometry {
+    MzOnly,
+    TimsMobility { scan_start: u32, scan_end: u32 },
+}
+
+/// One DIA isolation window within a frame.
+#[derive(Clone, Copy, Debug)]
+pub struct DiaWindow {
+    pub isolation: IsolationWindow,
+    pub collision_energy: CollisionEnergyPolicy,
+    pub geometry: DiaGeometry,
+}
+
+/// An MS1 (precursor) acquisition.
+#[derive(Clone, Debug)]
+pub struct Ms1Event {
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    /// The MS1 acquisition m/z range, if known. `None` when not recoverable
+    /// (e.g. Thermo `scan_event` does not carry it — it must not be confused
+    /// with the DIA window coverage in [`AcquisitionScheme::mz_range`]).
+    pub mz_range: Option<(f64, f64)>,
+    pub duration_s: Option<f64>,
+}
+
+/// One physical MS2 acquisition unit. Holds one window for Astral/SCIEX; several
+/// mobility-partitioned windows (sharing the frame) for timsTOF.
+#[derive(Clone, Debug)]
+pub struct DiaMs2Frame {
+    pub windows: Vec<DiaWindow>,
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub duration_s: Option<f64>,
+    /// The vendor's native group id for this frame, preserved for round-trip
+    /// fidelity (Bruker `WindowGroup`). `None` for vendors without one. The cycle
+    /// order is authoritative for *simultaneity/ordering*; this is *identity* only
+    /// — needed so a Bruker adapter regenerates the original `WindowGroup` values
+    /// that companion tables (`DiaFrameMsMsInfo`) reference.
+    pub vendor_group_id: Option<u32>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AcquisitionEvent {
+    Ms1(Ms1Event),
+    DiaMs2Frame(DiaMs2Frame),
+}
+
+/// How the cycle repeats over the gradient.
+#[derive(Clone, Copy, Debug)]
+pub enum RepeatPolicy {
+    /// The cycle repeats every `cycle_time_s`, starting at `start_time_s`, until
+    /// `gradient_length_s`. Per-event `duration_s` (when present) takes
+    /// precedence for fine RT placement; otherwise events are spread across the
+    /// cycle uniformly.
+    FixedCycleTime {
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+        start_time_s: f64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SchemeSource {
+    ExtractedBruker,
+    ExtractedThermo,
+    ExtractedSciex,
+    UserTable,
+    Programmatic,
+}
+
+/// Where the scheme came from (scheme-level attribution; not per-field).
+#[derive(Clone, Debug)]
+pub struct Provenance {
+    pub source: SchemeSource,
+    pub notes: String,
+}
+
+/// A vendor-neutral DIA acquisition design.
+#[derive(Clone, Debug)]
+pub struct AcquisitionScheme {
+    pub version: u16,
+    pub instrument: InstrumentKind,
+    pub cycle: Vec<AcquisitionEvent>,
+    pub repeat: RepeatPolicy,
+    pub mz_range: (f64, f64),
+    pub provenance: Provenance,
+}
+
+impl AcquisitionScheme {
+    /// Iterate every DIA window across all MS2 frames in the cycle.
+    pub fn windows(&self) -> impl Iterator<Item = &DiaWindow> {
+        self.cycle
+            .iter()
+            .flat_map(|e| match e {
+                AcquisitionEvent::DiaMs2Frame(f) => f.windows.as_slice(),
+                AcquisitionEvent::Ms1(_) => &[][..],
+            }
+            .iter())
+    }
+
+    /// Number of MS1 events in one cycle.
+    pub fn ms1_count(&self) -> usize {
+        self.cycle
+            .iter()
+            .filter(|e| matches!(e, AcquisitionEvent::Ms1(_)))
+            .count()
+    }
+
+    /// Number of full cycles that fit the gradient (if derivable).
+    pub fn num_cycles(&self) -> Option<u64> {
+        match self.repeat {
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s,
+            } if cycle_time_s.is_finite()
+                && cycle_time_s > 0.0
+                && gradient_length_s.is_finite()
+                && start_time_s.is_finite() =>
+            {
+                Some(((gradient_length_s - start_time_s).max(0.0) / cycle_time_s) as u64)
+            }
+            _ => None,
+        }
+    }
+
+    /// Build a scheme from an explicit window list (injected / CSV). One MS1
+    /// followed by one single-window MS2 frame per window.
+    pub fn from_window_table(
+        instrument: InstrumentKind,
+        ms1: Ms1Event,
+        windows: Vec<DiaWindow>,
+        repeat: RepeatPolicy,
+        mz_range: (f64, f64),
+    ) -> Self {
+        let mut cycle = vec![AcquisitionEvent::Ms1(ms1.clone())];
+        for w in windows {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![w],
+                analyzer: ms1.analyzer,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: None,
+            }));
+        }
+        AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument,
+            cycle,
+            repeat,
+            mz_range,
+            provenance: Provenance {
+                source: SchemeSource::UserTable,
+                notes: "built from explicit window table".to_string(),
+            },
+        }
+    }
+
+    /// Validate internal consistency. Returns a human-readable error on the first
+    /// problem found.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.version != SCHEME_VERSION {
+            return Err(format!(
+                "unsupported scheme version {} (this build supports {})",
+                self.version, SCHEME_VERSION
+            ));
+        }
+        if self.cycle.is_empty() {
+            return Err("empty cycle".into());
+        }
+        let (lo, hi) = self.mz_range;
+        if !(lo.is_finite() && hi.is_finite()) || lo >= hi {
+            return Err(format!("invalid mz_range ({lo}, {hi})"));
+        }
+        // Structure: exactly one MS1, as the first event, then >= 1 MS2 frame.
+        if !matches!(self.cycle.first(), Some(AcquisitionEvent::Ms1(_))) {
+            return Err("cycle must begin with an MS1 event".into());
+        }
+        if self.ms1_count() != 1 {
+            return Err(format!(
+                "cycle must contain exactly one MS1 event (has {})",
+                self.ms1_count()
+            ));
+        }
+        if !self
+            .cycle
+            .iter()
+            .any(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+        {
+            return Err("cycle has no MS2 frames".into());
+        }
+
+        let check_dur = |d: Option<f64>, what: &str| -> Result<(), String> {
+            match d {
+                Some(v) if !(v.is_finite() && v > 0.0) => {
+                    Err(format!("{what} duration must be finite and > 0"))
+                }
+                _ => Ok(()),
+            }
+        };
+
+        for ev in &self.cycle {
+            match ev {
+                AcquisitionEvent::Ms1(m) => {
+                    check_dur(m.duration_s, "MS1")?;
+                    if let Some((a, b)) = m.mz_range {
+                        if !(a.is_finite() && b.is_finite()) || a >= b {
+                            return Err(format!("invalid MS1 mz_range ({a}, {b})"));
+                        }
+                    }
+                }
+                AcquisitionEvent::DiaMs2Frame(frame) => {
+                    check_dur(frame.duration_s, "MS2 frame")?;
+                    if frame.windows.is_empty() {
+                        return Err("MS2 frame has no windows".into());
+                    }
+                    let multi = frame.windows.len() > 1;
+                    if multi && self.instrument != InstrumentKind::TimsTofDia {
+                        return Err(
+                            "multi-window MS2 frame is only valid for timsTOF (mobility-partitioned)"
+                                .into(),
+                        );
+                    }
+                    for (i, w) in frame.windows.iter().enumerate() {
+                        if !(w.isolation.width_mz.is_finite() && w.isolation.width_mz > 0.0) {
+                            return Err("window width must be finite and > 0".into());
+                        }
+                        if !w.isolation.center_mz.is_finite()
+                            || !w.isolation.lower().is_finite()
+                            || !w.isolation.upper().is_finite()
+                        {
+                            return Err("window m/z is not finite".into());
+                        }
+                        if w.isolation.lower() < lo - 1e-6 || w.isolation.upper() > hi + 1e-6 {
+                            return Err(format!(
+                                "window [{:.4}, {:.4}] outside mz_range [{lo:.4}, {hi:.4}]",
+                                w.isolation.lower(),
+                                w.isolation.upper()
+                            ));
+                        }
+                        match w.collision_energy {
+                            CollisionEnergyPolicy::Value(v) => {
+                                if !v.is_finite() || v < 0.0 {
+                                    return Err("collision energy must be finite and >= 0".into());
+                                }
+                            }
+                            CollisionEnergyPolicy::Linear {
+                                intercept,
+                                slope_per_mz,
+                            } => {
+                                if !intercept.is_finite() || !slope_per_mz.is_finite() {
+                                    return Err("non-finite linear CE coefficients".into());
+                                }
+                                match w.collision_energy.at(w.isolation.center_mz) {
+                                    Some(ce) if ce.is_finite() && ce >= 0.0 => {}
+                                    _ => {
+                                        return Err(
+                                            "linear CE resolves to non-finite or negative".into()
+                                        )
+                                    }
+                                }
+                            }
+                            CollisionEnergyPolicy::Unknown => {}
+                        }
+                        match w.geometry {
+                            DiaGeometry::TimsMobility {
+                                scan_start,
+                                scan_end,
+                            } => {
+                                if self.instrument != InstrumentKind::TimsTofDia {
+                                    return Err("mobility geometry is only valid for timsTOF".into());
+                                }
+                                if scan_start > scan_end {
+                                    return Err("mobility scan_start > scan_end".into());
+                                }
+                            }
+                            DiaGeometry::MzOnly => {
+                                if multi {
+                                    return Err(
+                                        "multi-window timsTOF frame requires mobility geometry on every window"
+                                            .into(),
+                                    );
+                                }
+                            }
+                        }
+                        // Within one frame, windows must not overlap in BOTH m/z
+                        // and mobility (overlap across sequential frames is fine).
+                        for w2 in &frame.windows[..i] {
+                            let mz_overlap = w.isolation.lower() < w2.isolation.upper()
+                                && w2.isolation.lower() < w.isolation.upper();
+                            let im_overlap = match (w.geometry, w2.geometry) {
+                                (
+                                    DiaGeometry::TimsMobility {
+                                        scan_start: a0,
+                                        scan_end: a1,
+                                    },
+                                    DiaGeometry::TimsMobility {
+                                        scan_start: b0,
+                                        scan_end: b1,
+                                    },
+                                ) => a0 <= b1 && b0 <= a1,
+                                _ => true, // m/z-only windows share all mobility
+                            };
+                            if mz_overlap && im_overlap {
+                                return Err(
+                                    "windows within one frame overlap in both m/z and mobility"
+                                        .into(),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        match self.repeat {
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s,
+            } => {
+                if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+                    return Err("cycle_time_s must be finite and > 0".into());
+                }
+                if !(gradient_length_s.is_finite() && gradient_length_s > 0.0) {
+                    return Err("gradient_length_s must be finite and > 0".into());
+                }
+                if !start_time_s.is_finite() || start_time_s < 0.0 {
+                    return Err("start_time_s must be finite and >= 0".into());
+                }
+                if start_time_s > gradient_length_s {
+                    return Err("start_time_s must be <= gradient_length_s".into());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl AcquisitionScheme {
+    /// Render the scheme's MS2 windows as Bruker `DiaFrameMsMsWindows` rows — the
+    /// backward-compatibility adapter for the existing timsTOF write path.
+    ///
+    /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
+    /// geometry (the Bruker-grid scan ranges). The `WindowGroup` id is the frame's
+    /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
+    /// round-trip keeps the ids that `DiaFrameMsMsInfo` references), else a 1..N
+    /// fallback in cycle order. A `Linear` CE policy is resolved at the window
+    /// center (a lossy materialization, not an inverse); `Unknown` CE and
+    /// non-timsTOF schemes are rejected. The scheme is validated first.
+    ///
+    /// Row order is not meaningful (the SQLite table has none); the companion
+    /// frame→group table `DiaFrameMsMsInfo` needs the run frame schedule and is a
+    /// separate step.
+    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+        self.validate()?;
+        if self.instrument != InstrumentKind::TimsTofDia {
+            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+        }
+        let mut rows = Vec::new();
+        let mut seq: u32 = 0;
+        for ev in &self.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+                seq += 1;
+                let group = frame.vendor_group_id.unwrap_or(seq);
+                for w in &frame.windows {
+                    let (scan_num_begin, scan_num_end) = match w.geometry {
+                        DiaGeometry::TimsMobility {
+                            scan_start,
+                            scan_end,
+                        } => (scan_start, scan_end),
+                        DiaGeometry::MzOnly => {
+                            return Err("timsTOF window lacks mobility geometry".into())
+                        }
+                    };
+                    let collision_energy = match w.collision_energy {
+                        CollisionEnergyPolicy::Value(v) => v,
+                        CollisionEnergyPolicy::Linear { .. } => w
+                            .collision_energy
+                            .at(w.isolation.center_mz)
+                            .ok_or("could not resolve linear CE")?,
+                        CollisionEnergyPolicy::Unknown => {
+                            return Err("window has unknown collision energy".into())
+                        }
+                    };
+                    rows.push(crate::data::meta::DiaMsMsWindow {
+                        window_group: group,
+                        scan_num_begin,
+                        scan_num_end,
+                        isolation_mz: w.isolation.center_mz,
+                        isolation_width: w.isolation.width_mz,
+                        collision_energy,
+                    });
+                }
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Extract the acquisition scheme from a real Bruker timsTOF DIA `.d`.
+    ///
+    /// Reads `DiaFrameMsMsWindows` and the frame table. Each **window group**
+    /// becomes one [`DiaMs2Frame`] holding its mobility-partitioned windows
+    /// (`TimsMobility` geometry — the scan ranges are Bruker-grid coordinates),
+    /// preceded by a single MS1 event. Cycle timing comes from the spacing of
+    /// the precursor (MS1) frames. The returned scheme is validated.
+    ///
+    /// Note: window groups are ordered by ascending `WindowGroup` id, which is
+    /// the DIA-PASEF acquisition order in practice; a file that reuses or
+    /// permutes group numbering would need ordering by first MS2-frame
+    /// occurrence (via `DiaFrameMsMsInfo`) instead.
+    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+        use std::collections::BTreeMap;
+
+        let folder = path.as_ref().to_string_lossy().into_owned();
+        let to_io =
+            |e: Box<dyn std::error::Error>| io::Error::new(io::ErrorKind::InvalidData, e.to_string());
+        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+        let frames = read_meta_data_sql(&folder).map_err(to_io)?;
+        if windows.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no DiaFrameMsMsWindows rows (not a DIA .d?)",
+            ));
+        }
+
+        // Group windows by window group (ascending); each group is a frame.
+        let mut by_group: BTreeMap<u32, Vec<DiaWindow>> = BTreeMap::new();
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        for w in &windows {
+            let dw = DiaWindow {
+                isolation: IsolationWindow {
+                    center_mz: w.isolation_mz,
+                    width_mz: w.isolation_width,
+                },
+                collision_energy: CollisionEnergyPolicy::Value(w.collision_energy),
+                geometry: DiaGeometry::TimsMobility {
+                    scan_start: w.scan_num_begin,
+                    scan_end: w.scan_num_end,
+                },
+            };
+            lo = lo.min(dw.isolation.lower());
+            hi = hi.max(dw.isolation.upper());
+            by_group.entry(w.window_group).or_default().push(dw);
+        }
+
+        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        })];
+        let n_groups = by_group.len();
+        for (group, ws) in by_group {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: ws,
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
+            }));
+        }
+
+        // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+        // Use the MEDIAN of the positive gaps between distinct, finite precursor
+        // times, so one anomalous interval doesn't set the whole cycle.
+        let mut prec_times: Vec<f64> = frames
+            .iter()
+            .filter(|f| f.ms_ms_type == 0 && f.time.is_finite())
+            .map(|f| f.time)
+            .collect();
+        prec_times.sort_by(f64::total_cmp);
+        prec_times.dedup();
+        let mut gaps: Vec<f64> = prec_times
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .filter(|g| *g > 0.0)
+            .collect();
+        if gaps.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "could not determine cycle time (need >= 2 distinct precursor frames)",
+            ));
+        }
+        gaps.sort_by(f64::total_cmp);
+        let cycle_time_s = gaps[gaps.len() / 2];
+
+        let times: Vec<f64> = frames.iter().map(|f| f.time).filter(|t| t.is_finite()).collect();
+        let start_time_s = times.iter().copied().fold(f64::INFINITY, f64::min);
+        let gradient_length_s = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+
+        let scheme = AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::TimsTofDia,
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: if start_time_s.is_finite() {
+                    start_time_s
+                } else {
+                    0.0
+                },
+            },
+            mz_range: (lo, hi),
+            provenance: Provenance {
+                source: SchemeSource::ExtractedBruker,
+                notes: format!("extracted from Bruker .d ({n_groups} window groups)"),
+            },
+        };
+        scheme
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(scheme)
+    }
+}
+
+#[cfg(feature = "sciex")]
+impl AcquisitionScheme {
+    /// Extract the SWATH scheme from a real SCIEX ZenoTOF `.wiff` method.
+    ///
+    /// Each SWATH window becomes a single-window [`DiaMs2Frame`] (no ion
+    /// mobility) preceded by an MS1.
+    ///
+    /// **Collision energy** is caller-supplied (`collision_energy`), because
+    /// SCIEX SWATH uses *rolling* CE computed by the instrument from an m/z
+    /// formula at acquisition time — it is **not** stored per-window in the
+    /// `.wiff` method (verified: the per-window MS2 parameter streams are
+    /// byte-identical across windows). Pass [`CollisionEnergyPolicy::Unknown`]
+    /// to leave it unset, or a [`CollisionEnergyPolicy::Linear`] rolling model.
+    /// The `.wiff` method also lacks run timing, so `cycle_time_s` /
+    /// `gradient_length_s` are caller-supplied. The returned scheme is validated.
+    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+        path: P,
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+        collision_energy: CollisionEnergyPolicy,
+    ) -> io::Result<Self> {
+        let method = sciexwiff::read_method(path)?;
+        if method.swath_windows.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no SWATH windows in the .wiff method",
+            ));
+        }
+        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        })];
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        let n = method.swath_windows.len();
+        for w in &method.swath_windows {
+            let iso = IsolationWindow {
+                center_mz: w.center_mz(),
+                width_mz: w.width_mz(),
+            };
+            lo = lo.min(iso.lower());
+            hi = hi.max(iso.upper());
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![DiaWindow {
+                    isolation: iso,
+                    collision_energy,
+                    geometry: DiaGeometry::MzOnly,
+                }],
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: None,
+            }));
+        }
+        let scheme = AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::SciexZenoTof,
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: 0.0,
+            },
+            mz_range: (lo, hi),
+            provenance: Provenance {
+                source: SchemeSource::ExtractedSciex,
+                notes: format!(
+                    "extracted from SCIEX .wiff method ({n} SWATH windows; CE caller-supplied, timing caller-supplied)"
+                ),
+            },
+        };
+        scheme
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(scheme)
+    }
+}
+
+#[cfg(feature = "thermo")]
+impl AcquisitionScheme {
+    /// Extract the acquisition scheme from a real Thermo `.raw` by walking the
+    /// first complete cycle (first MS1 up to the next MS1). Each MS2 scan becomes
+    /// a single-window [`DiaMs2Frame`] (Thermo has no mobility), with the
+    /// observed isolation center/width and CE.
+    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        use thermorawfile::RawFile;
+        let raw = RawFile::open(path)?;
+
+        let analyzer_of = |a: u8| match a {
+            4 => Analyzer::Ftms,
+            7 => Analyzer::Astms,
+            0 => Analyzer::Itms,
+            _ => Analyzer::Unknown,
+        };
+        let data_mode_of = |scan: u32| -> DataMode {
+            let i = (scan - raw.first_scan) as usize;
+            let pkt = (raw.data_addr + raw.index[i].offset) as usize;
+            if pkt + 8 <= raw.bytes.len() {
+                let ps = u32::from_le_bytes(raw.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+                if ps > 0 {
+                    DataMode::Profile
+                } else {
+                    DataMode::Centroid
+                }
+            } else {
+                DataMode::Centroid
+            }
+        };
+        let rt_of = |scan: u32| raw.index[(scan - raw.first_scan) as usize].time;
+
+        let mut cycle: Vec<AcquisitionEvent> = Vec::new();
+        let mut seen_ms1 = false;
+        let mut closed = false;
+        let mut start_rt = 0.0f64;
+        let mut cycle_time_s = 0.0f64;
+        let mut win_lo = f64::INFINITY;
+        let mut win_hi = f64::NEG_INFINITY;
+
+        for scan in raw.first_scan..=raw.last_scan {
+            let ev = match raw.scan_event(scan) {
+                Some(e) => e,
+                None => {
+                    // A missing event *inside* the selected cycle would silently
+                    // drop a window — reject it. Before the first MS1 it's ignorable.
+                    if seen_ms1 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("missing scan event for scan {scan} inside the first cycle"),
+                        ));
+                    }
+                    continue;
+                }
+            };
+            if ev.ms_order <= 1 {
+                if seen_ms1 {
+                    // start of the next cycle -> close this one
+                    cycle_time_s = (rt_of(scan) - start_rt).max(0.0);
+                    closed = true;
+                    break;
+                }
+                seen_ms1 = true;
+                start_rt = rt_of(scan);
+                cycle.push(AcquisitionEvent::Ms1(Ms1Event {
+                    analyzer: analyzer_of(ev.analyzer),
+                    data_mode: data_mode_of(scan),
+                    mz_range: None, // scan_event does not carry the MS1 range
+                    duration_s: None,
+                }));
+            } else if seen_ms1 {
+                let iso = IsolationWindow {
+                    center_mz: ev.isolation_center,
+                    width_mz: ev.isolation_width,
+                };
+                win_lo = win_lo.min(iso.lower());
+                win_hi = win_hi.max(iso.upper());
+                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                    windows: vec![DiaWindow {
+                        isolation: iso,
+                        collision_energy: CollisionEnergyPolicy::Value(ev.collision_energy),
+                        geometry: DiaGeometry::MzOnly,
+                    }],
+                    analyzer: analyzer_of(ev.analyzer),
+                    data_mode: data_mode_of(scan),
+                    duration_s: None,
+                    vendor_group_id: None,
+                }));
+            }
+        }
+
+        if !seen_ms1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "template has no MS1 scan",
+            ));
+        }
+        if !closed {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "template has only one cycle (no second MS1 to bound it); cannot determine cycle time",
+            ));
+        }
+        let mz_range = if win_lo.is_finite() && win_hi > win_lo {
+            (win_lo, win_hi)
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "first cycle has no usable MS2 isolation windows",
+            ));
+        };
+        let gradient_length_s = raw.index.last().map(|e| e.time).unwrap_or(0.0);
+        let n_ms2 = cycle
+            .iter()
+            .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+            .count();
+        // Instrument from the analyzers of events actually in the cycle (an ASTMS
+        // MS2 frame ⇒ Orbitrap Astral), not from incidental scans elsewhere.
+        let any_astms = cycle.iter().any(|e| {
+            matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.analyzer == Analyzer::Astms)
+        });
+
+        let scheme = AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: if any_astms {
+                InstrumentKind::OrbitrapAstral
+            } else {
+                InstrumentKind::Other
+            },
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: start_rt,
+            },
+            mz_range,
+            provenance: Provenance {
+                source: SchemeSource::ExtractedThermo,
+                notes: format!("extracted from Thermo .raw (first cycle: 1 MS1 + {n_ms2} MS2)"),
+            },
+        };
+        scheme
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(scheme)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linear_windows(n: usize) -> Vec<DiaWindow> {
+        (0..n)
+            .map(|i| DiaWindow {
+                isolation: IsolationWindow {
+                    center_mz: 400.0 + i as f64 * 10.0,
+                    width_mz: 10.0,
+                },
+                collision_energy: CollisionEnergyPolicy::Value(25.0),
+                geometry: DiaGeometry::MzOnly,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn from_window_table_validates() {
+        let s = AcquisitionScheme::from_window_table(
+            InstrumentKind::OrbitrapAstral,
+            Ms1Event {
+                analyzer: Analyzer::Ftms,
+                data_mode: DataMode::Profile,
+                mz_range: Some((390.0, 900.0)),
+                duration_s: None,
+            },
+            linear_windows(5),
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s: 1.0,
+                gradient_length_s: 600.0,
+                start_time_s: 0.0,
+            },
+            (390.0, 900.0),
+        );
+        s.validate().unwrap();
+        assert_eq!(s.windows().count(), 5);
+        assert_eq!(s.ms1_count(), 1);
+        assert_eq!(s.num_cycles(), Some(600));
+    }
+
+    #[test]
+    fn multi_window_frame_only_tims() {
+        let frame = DiaMs2Frame {
+            windows: linear_windows(3),
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            duration_s: None,
+            vendor_group_id: None,
+        };
+        let s = AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::OrbitrapAstral, // wrong: multi-window on non-tims
+            cycle: vec![
+                AcquisitionEvent::Ms1(Ms1Event {
+                    analyzer: Analyzer::Ftms,
+                    data_mode: DataMode::Profile,
+                    mz_range: Some((390.0, 900.0)),
+                    duration_s: None,
+                }),
+                AcquisitionEvent::DiaMs2Frame(frame),
+            ],
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s: 1.0,
+                gradient_length_s: 600.0,
+                start_time_s: 0.0,
+            },
+            mz_range: (390.0, 900.0),
+            provenance: Provenance {
+                source: SchemeSource::Programmatic,
+                notes: String::new(),
+            },
+        };
+        assert!(s.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_bad_schemes() {
+        let repeat = RepeatPolicy::FixedCycleTime {
+            cycle_time_s: 1.0,
+            gradient_length_s: 600.0,
+            start_time_s: 0.0,
+        };
+        let ms1 = || Ms1Event {
+            analyzer: Analyzer::Ftms,
+            data_mode: DataMode::Profile,
+            mz_range: Some((390.0, 900.0)),
+            duration_s: None,
+        };
+        let win = || DiaWindow {
+            isolation: IsolationWindow {
+                center_mz: 500.0,
+                width_mz: 10.0,
+            },
+            collision_energy: CollisionEnergyPolicy::Value(25.0),
+            geometry: DiaGeometry::MzOnly,
+        };
+        let frame = |w: DiaWindow| {
+            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![w],
+                analyzer: Analyzer::Astms,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: None,
+            })
+        };
+        let mk = |cycle: Vec<AcquisitionEvent>| AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::OrbitrapAstral,
+            cycle,
+            repeat,
+            mz_range: (390.0, 900.0),
+            provenance: Provenance {
+                source: SchemeSource::Programmatic,
+                notes: String::new(),
+            },
+        };
+
+        // valid baseline
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_ok());
+        // MS2 first (no leading MS1)
+        assert!(mk(vec![frame(win()), AcquisitionEvent::Ms1(ms1())]).validate().is_err());
+        // two MS1 in a cycle
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_err());
+        // MS1 with no MS2 frame
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1())]).validate().is_err());
+        // window outside mz_range
+        let mut oob = win();
+        oob.isolation.center_mz = 2000.0;
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(oob)]).validate().is_err());
+        // negative collision energy
+        let mut neg = win();
+        neg.collision_energy = CollisionEnergyPolicy::Value(-5.0);
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(neg)]).validate().is_err());
+        // bad event duration
+        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+            windows: vec![win()],
+            analyzer: Analyzer::Astms,
+            data_mode: DataMode::Centroid,
+            duration_s: Some(-1.0),
+            vendor_group_id: None,
+        });
+        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), bad_dur]).validate().is_err());
+    }
+
+    // Gated: set TIMSIM_BRUKER_DIA_D to a real Bruker DIA-PASEF .d folder.
+    #[test]
+    fn from_bruker_d_extracts_cycle() {
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_bruker_d_extracts_cycle: set TIMSIM_BRUKER_DIA_D=<dia .d>");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::TimsTofDia);
+        assert_eq!(s.ms1_count(), 1);
+        let n_win = s.windows().count();
+        assert!(n_win > 1, "expected several windows, got {n_win}");
+        // timsTOF windows carry mobility geometry with a known CE.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::TimsMobility { .. }));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_some());
+        }
+        // At least one frame should be mobility-partitioned (>1 window).
+        let multi = s.cycle.iter().any(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.windows.len() > 1));
+        let n_frames = s.cycle.iter().filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_))).count();
+        eprintln!(
+            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+            n_frames, n_win, if multi { "mobility-partitioned" } else { "single-window" },
+            s.mz_range.0, s.mz_range.1
+        );
+    }
+
+    // Gated: set TIMSIM_SCIEX_WIFF to a real ZenoTOF .wiff (OLE2 method).
+    // Gated: round-trip a real Bruker DIA .d through the scheme and back to the
+    // DiaFrameMsMsWindows rows; the regenerated table must match the source.
+    #[test]
+    fn bruker_windows_round_trip() {
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP bruker_windows_round_trip: set TIMSIM_BRUKER_DIA_D");
+                return;
+            }
+        };
+        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+        assert_eq!(regenerated.len(), original.len(), "row count differs");
+
+        // Compare as a sorted multiset of EXACT field tuples, including the
+        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
+        // real id mismatch would fail. Row order in the table is not guaranteed.
+        fn tuples(
+            rows: &[crate::data::meta::DiaMsMsWindow],
+        ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+            let mut out: Vec<_> = rows
+                .iter()
+                .map(|r| {
+                    (
+                        r.window_group,
+                        r.scan_num_begin,
+                        r.scan_num_end,
+                        r.isolation_mz.to_bits(),
+                        r.isolation_width.to_bits(),
+                        r.collision_energy.to_bits(),
+                    )
+                })
+                .collect();
+            out.sort_unstable();
+            out
+        }
+        assert_eq!(
+            tuples(&regenerated),
+            tuples(&original),
+            "round-trip windows differ from source (incl. WindowGroup id)"
+        );
+        eprintln!(
+            "bruker_windows_round_trip OK: {} rows match across {} groups",
+            original.len(),
+            scheme
+                .cycle
+                .iter()
+                .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+                .count()
+        );
+    }
+
+    #[cfg(feature = "sciex")]
+    #[test]
+    fn from_sciex_wiff_extracts_windows() {
+        let wiff = match std::env::var("TIMSIM_SCIEX_WIFF") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+                return;
+            }
+        };
+        // Default: CE unknown (rolling CE isn't in the .wiff method).
+        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, CollisionEnergyPolicy::Unknown)
+            .expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::SciexZenoTof);
+        assert_eq!(s.ms1_count(), 1);
+        let n = s.windows().count();
+        assert!(n > 10, "expected many SWATH windows, got {n}");
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::MzOnly));
+            assert!(matches!(w.collision_energy, CollisionEnergyPolicy::Unknown));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_none());
+        }
+        // Supplying a rolling-CE Linear model gives a resolvable, finite CE.
+        let rolling = CollisionEnergyPolicy::Linear { intercept: 5.0, slope_per_mz: 0.045 };
+        let s2 = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, rolling).expect("extract");
+        s2.validate().expect("valid with rolling CE");
+        for w in s2.windows() {
+            let ce = w.collision_energy.at(w.isolation.center_mz).expect("resolvable CE");
+            assert!(ce.is_finite() && ce > 0.0);
+        }
+        eprintln!(
+            "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",
+            n, s.mz_range.0, s.mz_range.1
+        );
+    }
+
+    #[cfg(feature = "thermo")]
+    #[test]
+    fn from_thermo_raw_extracts_cycle() {
+        let template = match std::env::var("TIMSIM_ASTRAL_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::OrbitrapAstral);
+        assert_eq!(s.ms1_count(), 1, "one MS1 per cycle");
+        let n_win = s.windows().count();
+        assert!(n_win > 1, "expected several MS2 windows, got {n_win}");
+        // Thermo: every window is m/z-only with a known CE.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::MzOnly));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_some());
+            assert!(w.isolation.width_mz > 0.0);
+        }
+        // centers should be (weakly) increasing across the first cycle is not
+        // guaranteed by Astral, but coverage must be a sane m/z span.
+        assert!(s.mz_range.0 > 100.0 && s.mz_range.1 < 3000.0 && s.mz_range.0 < s.mz_range.1);
+        eprintln!(
+            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+            s.instrument, n_win, s.mz_range.0, s.mz_range.1,
+            match s.repeat { RepeatPolicy::FixedCycleTime { cycle_time_s, .. } => cycle_time_s }
+        );
+    }
+}
+</stdin>
+codex
+I’ll verify the actual repository diff and all `DiaMs2Frame` construction/use sites, then run the focused tests or compile checks available.
+exec
+/bin/bash -lc "rg -n \"DiaMs2Frame\\s*\\{|vendor_group_id|to_bruker_windows|from_bruker_d|from_window_table|from_thermo_raw|from_sciex_wiff\" ." in /scratch/timsim-demo/SUBMISSION/rustims
+exec
+/bin/bash -lc 'git diff -- . && git status --short' in /scratch/timsim-demo/SUBMISSION/rustims
+exec
+/bin/bash -lc 'rg -n "struct DiaMsMsWindow|read_dia_ms_ms_windows|DiaFrameMsMsInfo|WindowGroup|window_group" src tests crates 2>/dev/null' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 198ms:
+./TO_BRUKER.codex-review.md:14:Review ONLY the newly added code in this Rust file (the rest was already reviewed): the method AcquisitionScheme::to_bruker_windows (a backward-compat adapter that renders a vendor-neutral DIA scheme back to Bruker DiaFrameMsMsWindows rows) and its gated unit test bruker_windows_round_trip. Skim the rest only for interaction.
+./TO_BRUKER.codex-review.md:16:Trusted context: crate::data::meta::DiaMsMsWindow { window_group:u32, scan_num_begin:u32, scan_num_end:u32, isolation_mz:f64, isolation_width:f64, collision_energy:f64 } and read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow> read the Bruker SQLite DiaFrameMsMsWindows table (no ORDER BY). from_bruker_d builds the scheme by grouping those rows by window_group (BTreeMap ascending) into one DiaMs2Frame per group with TimsMobility geometry. The scheme model: cycle is an ordered Vec<AcquisitionEvent> = Ms1 | DiaMs2Frame(windows:Vec<DiaWindow{isolation:{center_mz,width_mz}, collision_energy:CollisionEnergyPolicy{Value|Linear|Unknown}, geometry:DiaGeometry{MzOnly|TimsMobility{scan_start,scan_end}}}>). to_bruker_windows numbers window groups 1..N in cycle (frame) order; the round-trip test normalizes window-group ids to canonical 1..N on both sides and compares sorted exact-bit field tuples.
+./TO_BRUKER.codex-review.md:18:Focus: 1) is to_bruker_windows a FAITHFUL inverse of from_bruker_d for real DIA-PASEF data — specifically the window-group renumbering (1..N by frame order vs original ids): when does the normalized round-trip hide a real id mismatch that would break the actual .d the Python builder writes (which uses reference WindowGroup ids)? Is losing the original WindowGroup id in the scheme model a real data-loss bug for backward compat? 2) CE handling — Value passthrough, Linear resolved at center (is center the right point vs Bruker's stored per-window CE?), Unknown rejected; any lossy/incorrect cases. 3) within-frame and cross-frame window ORDER preservation (SQL has no ORDER BY; from_bruker_d preserves insertion order in the Vec; does to_bruker_windows + the test correctly handle when source rows are interleaved across groups vs grouped?). 4) the test's canonical() normalization — does it actually prove faithfulness, or could it pass while masking a real regression? 5) any correctness bug, panic, or float-equality fragility. Concrete, ranked by severity, ~600 words.
+./TO_BRUKER.codex-review.md:140:pub struct DiaMs2Frame {
+./TO_BRUKER.codex-review.md:234:    pub fn from_window_table(
+./TO_BRUKER.codex-review.md:243:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER.codex-review.md:454:    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+./TO_BRUKER.codex-review.md:456:            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+./TO_BRUKER.codex-review.md:509:    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./TO_BRUKER.codex-review.md:554:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER.codex-review.md:631:    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+./TO_BRUKER.codex-review.md:660:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER.codex-review.md:701:    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./TO_BRUKER.codex-review.md:772:                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER.codex-review.md:860:    fn from_window_table_validates() {
+./TO_BRUKER.codex-review.md:861:        let s = AcquisitionScheme::from_window_table(
+./TO_BRUKER.codex-review.md:885:        let frame = DiaMs2Frame {
+./TO_BRUKER.codex-review.md:939:            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER.codex-review.md:975:        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER.codex-review.md:986:    fn from_bruker_d_extracts_cycle() {
+./TO_BRUKER.codex-review.md:990:                eprintln!("SKIP from_bruker_d_extracts_cycle: set TIMSIM_BRUKER_DIA_D=<dia .d>");
+./TO_BRUKER.codex-review.md:994:        let s = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+./TO_BRUKER.codex-review.md:1009:            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+./TO_BRUKER.codex-review.md:1027:        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+./TO_BRUKER.codex-review.md:1028:        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+./TO_BRUKER.codex-review.md:1075:    fn from_sciex_wiff_extracts_windows() {
+./TO_BRUKER.codex-review.md:1079:                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+./TO_BRUKER.codex-review.md:1084:        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, CollisionEnergyPolicy::Unknown)
+./TO_BRUKER.codex-review.md:1098:        let s2 = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, rolling).expect("extract");
+./TO_BRUKER.codex-review.md:1105:            "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",
+./TO_BRUKER.codex-review.md:1112:    fn from_thermo_raw_extracts_cycle() {
+./TO_BRUKER.codex-review.md:1116:                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+./TO_BRUKER.codex-review.md:1120:        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+./TO_BRUKER.codex-review.md:1136:            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+./TO_BRUKER.codex-review.md:1147:`from_bruker_d` discards the original `WindowGroup` value when converting each `BTreeMap` entry into a `DiaMs2Frame`. `to_bruker_windows` then invents IDs `1..N`.
+./TO_BRUKER.codex-review.md:1159:SQL row order is unspecified. `from_bruker_d` orders frames by ascending group ID and preserves database-return order only within each group. `to_bruker_windows` emits rows grouped by frame, so an interleaved source sequence such as `G1-A, G2-A, G1-B` becomes `G1-A, G1-B, G2-A`.
+./TO_BRUKER.codex-review.md:1163:4. **Medium: `to_bruker_windows` accepts structurally invalid schemes without validation.**  
+./TO_BRUKER.codex-review.md:1175:`from_bruker_d` discards the original `WindowGroup` value when converting each `BTreeMap` entry into a `DiaMs2Frame`. `to_bruker_windows` then invents IDs `1..N`.
+./TO_BRUKER.codex-review.md:1187:SQL row order is unspecified. `from_bruker_d` orders frames by ascending group ID and preserves database-return order only within each group. `to_bruker_windows` emits rows grouped by frame, so an interleaved source sequence such as `G1-A, G2-A, G1-B` becomes `G1-A, G1-B, G2-A`.
+./TO_BRUKER.codex-review.md:1191:4. **Medium: `to_bruker_windows` accepts structurally invalid schemes without validation.**  
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:14:This is v2 of a vendor-neutral AcquisitionScheme design for a DIA mass-spec simulator (TimSim: Bruker timsTOF today, extending to Thermo Orbitrap Astral + SCIEX ZenoTOF). You reviewed v1; v2 applied your feedback: ordered cycle of events (Ms1Event/DiaMs2Event) instead of flat windows; DiaGeometry splits mobility out of the m/z IsolationWindow; CollisionEnergyPolicy enum (incl. Unknown) instead of scalar CE; MS1 promoted to a first-class event; scheme version + Provenance; an explicit to_bruker_tables() adapter + golden tests; and two usage modes (reference-derived layout+noise, and injected/user schemes). Context to trust: the Thermo/SCIEX Rust readers exist and are oracle-verified; thermorawfile::scan_event works per-scan on Astral (uniform 280-byte stride) so from_thermo_raw is NOT blocked; the ThermoRawWriter now authors MS2 isolation/CE via set_isolation (review item #6, fixed).
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:159:    pub fn from_bruker_d(path: &str) -> io::Result<Self>;      // DiaFrameMsMsWindows (+TimsMobility geometry)
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:161:    pub fn from_thermo_raw(path: &str) -> io::Result<Self>;    // walk one MS2 cycle via scan_event()
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:163:    pub fn from_sciex_wiff(path: &str) -> io::Result<Self>;    // SWATHMethod; CE => Unknown (rolling)
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:164:    pub fn from_window_table(rows, instrument) -> Self;        // injected / CSV
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:168:Each sets `provenance.source` accordingly. `from_thermo_raw` reads the first
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:175:  reference round trip: `from_thermo_raw(template)` → generate → `ThermoRawWriter`
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:215:  location works (uniform stride) so `from_thermo_raw` is unblocked.
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:230:- `from_thermo_raw(astral_template)`: N MS2 windows, monotonic centers, CE policy
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:232:- `from_sciex_wiff(zenotof)`: ~60 windows covering 399.5–899.9, CE `Unknown`.
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:233:- `from_bruker_d(ref)` → `to_bruker_tables()` golden-equal to today's Python path.
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:234:- End-to-end: `from_thermo_raw(template)` → generate 1×MS1 + N×MS2 → `ThermoRawWriter`
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:248:AcquisitionEvent::DiaMs2Frame {
+./ACQUISITION_SCHEME_PLAN.codex-review-v2.md:319:AcquisitionEvent::DiaMs2Frame {
+./EXTRACTORS.codex-review.md:14:Review the NEW code added to these two Rust files for a mass-spec simulator (TimSim): in scheme.rs, the extractors AcquisitionScheme::from_bruker_d and AcquisitionScheme::from_sciex_wiff (the data model, validate(), num_cycles, windows(), from_window_table, and from_thermo_raw were ALREADY reviewed — only skim them for interaction bugs). The second file is sciexwiff's new library API (read_method).
+./EXTRACTORS.codex-review.md:16:Trusted context: rustdf reads Bruker TDF natively — read_dia_ms_ms_windows(folder)->Vec<DiaMsMsWindow{window_group,scan_num_begin,scan_num_end,isolation_mz,isolation_width,collision_energy}> and read_meta_data_sql(folder)->Vec<FrameMeta{id,time:f64,ms_ms_type:i64,...}> (MsMsType==0 = MS1/precursor frame). from_bruker_d groups windows by window_group into DiaMs2Frame{TimsMobility windows} and derives cycle time from precursor-frame spacing; verified to extract 15 frames/36 windows from a real DIA-PASEF .d. from_sciex_wiff maps SWATH windows to single MzOnly frames with CE Unknown (SCIEX rolling CE not in the method) and caller-supplied timing; verified 60 windows on a real ZenoTOF .wiff. validate() (already reviewed) requires exactly one MS1 first then >=1 MS2 frame, finite/positive widths, window edges within mz_range, CE finite>=0 for Value/resolved-Linear, multi-window frames need TimsMobility on every window and no within-frame m/z+mobility overlap, start<=gradient. sciexwiff::read_method opens a .wiff OLE2 (cfb crate) and parses SWATHMethod (20B records from off 40) + TOFCalibrationData.
+./EXTRACTORS.codex-review.md:18:Focus: 1) from_bruker_d correctness — window-group grouping, cycle-time from precursor spacing (sorted; what if precursor times equal/unsorted/duplicated, or DIA uses a different MsMsType for MS1?), start/gradient via fold over f64 (NaN handling), whether the produced scheme always passes validate() (e.g. within-frame overlap on real PASEF groups; windows-within-mz_range by construction), empty/edge frames. 2) from_sciex_wiff — caller-supplied timing validation, window mapping, the Unknown-CE contract, mz_range. 3) sciexwiff read_method — bounds/stride safety on untrusted .wiff bytes, partial/short streams, the SWATHMethod record count derivation, calibration optionality. 4) any panic on malformed vendor files, and any case where an extractor returns a scheme that then fails validate() (surprising for a caller). Concrete, ranked by severity, cap ~700 words.
+./EXTRACTORS.codex-review.md:141:pub struct DiaMs2Frame {
+./EXTRACTORS.codex-review.md:235:    pub fn from_window_table(
+./EXTRACTORS.codex-review.md:244:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:452:    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./EXTRACTORS.codex-review.md:497:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:564:    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+./EXTRACTORS.codex-review.md:592:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:629:    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./EXTRACTORS.codex-review.md:700:                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:784:    fn from_window_table_validates() {
+./EXTRACTORS.codex-review.md:785:        let s = AcquisitionScheme::from_window_table(
+./EXTRACTORS.codex-review.md:809:        let frame = DiaMs2Frame {
+./EXTRACTORS.codex-review.md:863:            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:899:        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:910:    fn from_bruker_d_extracts_cycle() {
+./EXTRACTORS.codex-review.md:914:                eprintln!("SKIP from_bruker_d_extracts_cycle: set TIMSIM_BRUKER_DIA_D=<dia .d>");
+./EXTRACTORS.codex-review.md:918:        let s = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+./EXTRACTORS.codex-review.md:933:            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+./EXTRACTORS.codex-review.md:942:    fn from_sciex_wiff_extracts_windows() {
+./EXTRACTORS.codex-review.md:946:                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+./EXTRACTORS.codex-review.md:950:        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0).expect("extract");
+./EXTRACTORS.codex-review.md:963:            "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",
+./EXTRACTORS.codex-review.md:970:    fn from_thermo_raw_extracts_cycle() {
+./EXTRACTORS.codex-review.md:974:                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+./EXTRACTORS.codex-review.md:978:        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+./EXTRACTORS.codex-review.md:994:            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+./EXTRACTORS.codex-review.md:1252:   431	    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./EXTRACTORS.codex-review.md:1297:   476	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:1364:   543	    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+./EXTRACTORS.codex-review.md:1456:   543	    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+./EXTRACTORS.codex-review.md:1484:   571	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./EXTRACTORS.codex-review.md:1521:   608	    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./TO_BRUKER_V2.codex-review.md:14:This is a REVISION of code you reviewed last round. Your prior review of to_bruker_windows found (High) that renumbering window groups 1..N lost the source Bruker WindowGroup identity, breaking round-trip fidelity with DiaFrameMsMsInfo, and that the round-trip test masked it via canonical normalization. The fix just applied: DiaMs2Frame now has a vendor_group_id: Option<u32> field; from_bruker_d sets it to the source WindowGroup (BTreeMap key), all other constructors set None; to_bruker_windows uses frame.vendor_group_id.unwrap_or(sequential 1..N) and now calls validate() first; the round-trip golden test now compares EXACT WindowGroup ids (no normalization).
+./TO_BRUKER_V2.codex-review.md:16:Verify ONLY whether this revision is correct and complete; skim the rest. Focus: 1) does vendor_group_id genuinely fix the identity-loss bug end-to-end — is it set on EVERY from_bruker_d frame, threaded through all 7 DiaMs2Frame construction sites correctly (from_window_table, from_thermo_raw, from_sciex_wiff, from_bruker_d, and the 3 test sites), and used correctly in to_bruker_windows? 2) any NEW bug introduced by the field addition or the to_bruker_windows changes (e.g. validate() now called first - does that change error semantics or reject previously-accepted valid Bruker schemes? could a from_bruker_d scheme fail its own validate() due to within-frame overlap or mz_range containment on real PASEF window groups?). 3) is the unwrap_or fallback sound when SOME frames have vendor_group_id and others don't (mixed)? could that collide a preserved id with a sequential one? 4) does the exact-id round-trip test now actually prove fidelity? 5) the from_window_table builder doesn't expose vendor_group_id (always None) - is that a gap for injected timsTOF schemes that need specific group ids? Concrete, ranked by severity, ~500 words.
+./TO_BRUKER_V2.codex-review.md:138:pub struct DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:148:    pub vendor_group_id: Option<u32>,
+./TO_BRUKER_V2.codex-review.md:238:    pub fn from_window_table(
+./TO_BRUKER_V2.codex-review.md:247:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:252:                vendor_group_id: None,
+./TO_BRUKER_V2.codex-review.md:454:    /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
+./TO_BRUKER_V2.codex-review.md:463:    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+./TO_BRUKER_V2.codex-review.md:466:            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+./TO_BRUKER_V2.codex-review.md:473:                let group = frame.vendor_group_id.unwrap_or(seq);
+./TO_BRUKER_V2.codex-review.md:520:    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./TO_BRUKER_V2.codex-review.md:565:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:570:                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
+./TO_BRUKER_V2.codex-review.md:643:    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+./TO_BRUKER_V2.codex-review.md:672:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:681:                vendor_group_id: None,
+./TO_BRUKER_V2.codex-review.md:714:    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./TO_BRUKER_V2.codex-review.md:785:                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:794:                    vendor_group_id: None,
+./TO_BRUKER_V2.codex-review.md:874:    fn from_window_table_validates() {
+./TO_BRUKER_V2.codex-review.md:875:        let s = AcquisitionScheme::from_window_table(
+./TO_BRUKER_V2.codex-review.md:899:        let frame = DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:904:            vendor_group_id: None,
+./TO_BRUKER_V2.codex-review.md:954:            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:959:                vendor_group_id: None,
+./TO_BRUKER_V2.codex-review.md:991:        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./TO_BRUKER_V2.codex-review.md:996:            vendor_group_id: None,
+./TO_BRUKER_V2.codex-review.md:1003:    fn from_bruker_d_extracts_cycle() {
+./TO_BRUKER_V2.codex-review.md:1007:                eprintln!("SKIP from_bruker_d_extracts_cycle: set TIMSIM_BRUKER_DIA_D=<dia .d>");
+./TO_BRUKER_V2.codex-review.md:1011:        let s = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+./TO_BRUKER_V2.codex-review.md:1026:            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+./TO_BRUKER_V2.codex-review.md:1044:        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+./TO_BRUKER_V2.codex-review.md:1045:        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+./TO_BRUKER_V2.codex-review.md:1050:        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
+./TO_BRUKER_V2.codex-review.md:1089:    fn from_sciex_wiff_extracts_windows() {
+./TO_BRUKER_V2.codex-review.md:1093:                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+./TO_BRUKER_V2.codex-review.md:1098:        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, CollisionEnergyPolicy::Unknown)
+./TO_BRUKER_V2.codex-review.md:1112:        let s2 = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, rolling).expect("extract");
+./TO_BRUKER_V2.codex-review.md:1119:            "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",
+./TO_BRUKER_V2.codex-review.md:1126:    fn from_thermo_raw_extracts_cycle() {
+./TO_BRUKER_V2.codex-review.md:1130:                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+./TO_BRUKER_V2.codex-review.md:1134:        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+./TO_BRUKER_V2.codex-review.md:1150:            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+./TO_BRUKER_V2.codex-review.md:1160:/bin/bash -lc "rg -n \"DiaMs2Frame\\s*\\{|vendor_group_id|to_bruker_windows|from_bruker_d|from_window_table|from_thermo_raw|from_sciex_wiff\" ." in /scratch/timsim-demo/SUBMISSION/rustims
+./ACQUISITION_SCHEME_PLAN.codex-review.md:113:    pub fn from_bruker_d(path: &str) -> io::Result<Self>;       // DiaFrameMsMsWindows
+./ACQUISITION_SCHEME_PLAN.codex-review.md:115:    pub fn from_thermo_raw(path: &str) -> io::Result<Self>;     // walk MS2 scan_event()
+./ACQUISITION_SCHEME_PLAN.codex-review.md:117:    pub fn from_sciex_wiff(path: &str) -> io::Result<Self>;     // SWATHMethod
+./ACQUISITION_SCHEME_PLAN.codex-review.md:118:    pub fn from_window_table(...) -> Self;                       // hand-authored / CSV
+./ACQUISITION_SCHEME_PLAN.codex-review.md:122:- `from_thermo_raw`: iterate the template's first full cycle of MS2 scans, read
+./ACQUISITION_SCHEME_PLAN.codex-review.md:126:- `from_sciex_wiff`: `SWATHMethod` windows → `DiaWindow` (center = (lo+hi)/2,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:139:  `from_bruker_d(reference)` → identical behavior (the `mobility_scan_range`
+./ACQUISITION_SCHEME_PLAN.codex-review.md:143:  two halves. A round trip is: `from_thermo_raw(template)` → generate → author
+./ACQUISITION_SCHEME_PLAN.codex-review.md:168:6. **scan_event location for arbitrary scans** — `from_thermo_raw` needs to read
+./ACQUISITION_SCHEME_PLAN.codex-review.md:171:   (MS1 events are longer). Does `from_thermo_raw` need the variable-stride walk
+./ACQUISITION_SCHEME_PLAN.codex-review.md:176:- `from_thermo_raw(astral_template)` → assert N windows, monotonic centers,
+./ACQUISITION_SCHEME_PLAN.codex-review.md:178:- `from_sciex_wiff(zenotof_wiff)` → assert ~60 windows covering 399.5–899.9.
+./ACQUISITION_SCHEME_PLAN.codex-review.md:179:- `from_bruker_d(ref)` round-trips the existing `dia_ms_ms_windows` columns
+./ACQUISITION_SCHEME_PLAN.codex-review.md:181:- End-to-end: `from_thermo_raw(template)` → generate a 1-MS1 + N-MS2 cycle →
+./ACQUISITION_SCHEME_IMPL.codex-review.md:16:Context to trust: thermorawfile::scan_event(scan) returns {ms_order(1=MS1,2=MS2), analyzer(4=FTMS,7=ASTMS,0=ITMS), isolation_center, isolation_width, collision_energy} and works per-scan (uniform stride); RawFile exposes pub first_scan/last_scan/data_addr/bytes/index, and ScanIndexEntry has pub time/offset; packet profile_size is u32 at packet+4. from_thermo_raw is verified to extract 1 MS1 + 15 MS2 windows from a real Astral file.
+./ACQUISITION_SCHEME_IMPL.codex-review.md:18:Focus: 1) from_thermo_raw correctness — the first-cycle boundary detection (first MS1 .. next MS1), RT/cycle_time computation, mz_range derivation from window edges, analyzer/data_mode mapping, and edge cases (no MS2 before first MS1, only one cycle in the file so cycle_time stays 0, MS2 before any MS1, scan_event returning None mid-cycle, instrument detection via any_astms). 2) validate() completeness and correctness vs the model's invariants — anything it should reject but doesn't (e.g. overlapping/duplicate windows, MS1-only cycle, non-finite mz centers vs range membership, Linear CE finiteness, num_cycles with start>gradient). 3) the windows() iterator and num_cycles() arithmetic (truncation, negatives). 4) API/model soundness for the two consumers (extraction vs injection) and for the deferred Bruker/SCIEX extractors. 5) any correctness/robustness bug. Concrete, ranked by severity, cap ~750 words.
+./ACQUISITION_SCHEME_IMPL.codex-review.md:137:pub struct DiaMs2Frame {
+./ACQUISITION_SCHEME_IMPL.codex-review.md:227:    pub fn from_window_table(
+./ACQUISITION_SCHEME_IMPL.codex-review.md:236:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./ACQUISITION_SCHEME_IMPL.codex-review.md:344:    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./ACQUISITION_SCHEME_IMPL.codex-review.md:407:                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./ACQUISITION_SCHEME_IMPL.codex-review.md:482:    fn from_window_table_validates() {
+./ACQUISITION_SCHEME_IMPL.codex-review.md:483:        let s = AcquisitionScheme::from_window_table(
+./ACQUISITION_SCHEME_IMPL.codex-review.md:507:        let frame = DiaMs2Frame {
+./ACQUISITION_SCHEME_IMPL.codex-review.md:541:    fn from_thermo_raw_extracts_cycle() {
+./ACQUISITION_SCHEME_IMPL.codex-review.md:545:                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+./ACQUISITION_SCHEME_IMPL.codex-review.md:549:        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+./ACQUISITION_SCHEME_IMPL.codex-review.md:565:            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+./ACQUISITION_SCHEME_IMPL.codex-review.md:576:   `from_thermo_raw()` returns `cycle_time_s = 0.0` when no second MS1 exists, while `validate()` rejects it. Extraction should return `InvalidData`, or derive cycle time using a documented method. Returning an object guaranteed to fail validation is misleading.
+./ACQUISITION_SCHEME_IMPL.codex-review.md:622:   `from_thermo_raw()` returns `cycle_time_s = 0.0` when no second MS1 exists, while `validate()` rejects it. Extraction should return `InvalidData`, or derive cycle time using a documented method. Returning an object guaranteed to fail validation is misleading.
+./ACQUISITION_SCHEME_PLAN.md:141:    pub fn from_bruker_d(path: &str) -> io::Result<Self>;      // DiaFrameMsMsWindows (+TimsMobility geometry)
+./ACQUISITION_SCHEME_PLAN.md:143:    pub fn from_thermo_raw(path: &str) -> io::Result<Self>;    // walk one MS2 cycle via scan_event()
+./ACQUISITION_SCHEME_PLAN.md:145:    pub fn from_sciex_wiff(path: &str) -> io::Result<Self>;    // SWATHMethod; CE => Unknown (rolling)
+./ACQUISITION_SCHEME_PLAN.md:146:    pub fn from_window_table(rows, instrument) -> Self;        // injected / CSV
+./ACQUISITION_SCHEME_PLAN.md:150:Each sets `provenance.source` accordingly. `from_thermo_raw` reads the first
+./ACQUISITION_SCHEME_PLAN.md:157:  reference round trip: `from_thermo_raw(template)` → generate → `ThermoRawWriter`
+./ACQUISITION_SCHEME_PLAN.md:197:  location works (uniform stride) so `from_thermo_raw` is unblocked.
+./ACQUISITION_SCHEME_PLAN.md:212:- `from_thermo_raw(astral_template)`: N MS2 windows, monotonic centers, CE policy
+./ACQUISITION_SCHEME_PLAN.md:214:- `from_sciex_wiff(zenotof)`: ~60 windows covering 399.5–899.9, CE `Unknown`.
+./ACQUISITION_SCHEME_PLAN.md:215:- `from_bruker_d(ref)` → `to_bruker_tables()` golden-equal to today's Python path.
+./ACQUISITION_SCHEME_PLAN.md:216:- End-to-end: `from_thermo_raw(template)` → generate 1×MS1 + N×MS2 → `ThermoRawWriter`
+./rustdf/src/sim/scheme.rs:120:pub struct DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:130:    pub vendor_group_id: Option<u32>,
+./rustdf/src/sim/scheme.rs:220:    pub fn from_window_table(
+./rustdf/src/sim/scheme.rs:229:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:234:                vendor_group_id: None,
+./rustdf/src/sim/scheme.rs:436:    /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
+./rustdf/src/sim/scheme.rs:445:    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+./rustdf/src/sim/scheme.rs:448:            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+./rustdf/src/sim/scheme.rs:455:                let group = frame.vendor_group_id.unwrap_or(seq);
+./rustdf/src/sim/scheme.rs:502:    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./rustdf/src/sim/scheme.rs:547:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:552:                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
+./rustdf/src/sim/scheme.rs:625:    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+./rustdf/src/sim/scheme.rs:654:            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:663:                vendor_group_id: None,
+./rustdf/src/sim/scheme.rs:696:    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+./rustdf/src/sim/scheme.rs:767:                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:776:                    vendor_group_id: None,
+./rustdf/src/sim/scheme.rs:856:    fn from_window_table_validates() {
+./rustdf/src/sim/scheme.rs:857:        let s = AcquisitionScheme::from_window_table(
+./rustdf/src/sim/scheme.rs:881:        let frame = DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:886:            vendor_group_id: None,
+./rustdf/src/sim/scheme.rs:936:            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:941:                vendor_group_id: None,
+./rustdf/src/sim/scheme.rs:973:        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+./rustdf/src/sim/scheme.rs:978:            vendor_group_id: None,
+./rustdf/src/sim/scheme.rs:985:    fn from_bruker_d_extracts_cycle() {
+./rustdf/src/sim/scheme.rs:989:                eprintln!("SKIP from_bruker_d_extracts_cycle: set TIMSIM_BRUKER_DIA_D=<dia .d>");
+./rustdf/src/sim/scheme.rs:993:        let s = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+./rustdf/src/sim/scheme.rs:1008:            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+./rustdf/src/sim/scheme.rs:1026:        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+./rustdf/src/sim/scheme.rs:1027:        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+./rustdf/src/sim/scheme.rs:1032:        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
+./rustdf/src/sim/scheme.rs:1071:    fn from_sciex_wiff_extracts_windows() {
+./rustdf/src/sim/scheme.rs:1075:                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+./rustdf/src/sim/scheme.rs:1080:        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, CollisionEnergyPolicy::Unknown)
+./rustdf/src/sim/scheme.rs:1094:        let s2 = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, rolling).expect("extract");
+./rustdf/src/sim/scheme.rs:1101:            "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",
+./rustdf/src/sim/scheme.rs:1108:    fn from_thermo_raw_extracts_cycle() {
+./rustdf/src/sim/scheme.rs:1112:                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+./rustdf/src/sim/scheme.rs:1116:        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+./rustdf/src/sim/scheme.rs:1132:            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+
+ succeeded in 215ms:
+?? TO_BRUKER_V2.codex-review.md
+?? packages/imspy-predictors/scripts/compare_libraries.py
+?? packages/imspy-predictors/scripts/generate_calibrated_library.py
+?? primitives/
+?? rustdf/examples/build_bruker_pseudo_ms2.rs
+?? rustdf/examples/build_bruker_pseudo_ms2_v3.rs
+?? rustdf/examples/dump_bruker_ms1_centroids.rs
+?? scripts/compare_diann_to_truth.py
+?? scripts/reread_rustw_smoke.py
+
+ exited 2 in 238ms:
+codex
+The field is present at all seven live construction sites. The main remaining concern is mixed preserved/unassigned frames: the fallback is based on frame position, not on the set of reserved IDs, so collisions are possible and currently unvalidated. I’m checking commit history and test coverage to rank that accurately.
+exec
+/bin/bash -lc "sed -n '110,145p;210,245p;425,570p;1015,1065p' rustdf/src/sim/scheme.rs" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+    /// The MS1 acquisition m/z range, if known. `None` when not recoverable
+    /// (e.g. Thermo `scan_event` does not carry it — it must not be confused
+    /// with the DIA window coverage in [`AcquisitionScheme::mz_range`]).
+    pub mz_range: Option<(f64, f64)>,
+    pub duration_s: Option<f64>,
+}
+
+/// One physical MS2 acquisition unit. Holds one window for Astral/SCIEX; several
+/// mobility-partitioned windows (sharing the frame) for timsTOF.
+#[derive(Clone, Debug)]
+pub struct DiaMs2Frame {
+    pub windows: Vec<DiaWindow>,
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub duration_s: Option<f64>,
+    /// The vendor's native group id for this frame, preserved for round-trip
+    /// fidelity (Bruker `WindowGroup`). `None` for vendors without one. The cycle
+    /// order is authoritative for *simultaneity/ordering*; this is *identity* only
+    /// — needed so a Bruker adapter regenerates the original `WindowGroup` values
+    /// that companion tables (`DiaFrameMsMsInfo`) reference.
+    pub vendor_group_id: Option<u32>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AcquisitionEvent {
+    Ms1(Ms1Event),
+    DiaMs2Frame(DiaMs2Frame),
+}
+
+/// How the cycle repeats over the gradient.
+#[derive(Clone, Copy, Debug)]
+pub enum RepeatPolicy {
+    /// The cycle repeats every `cycle_time_s`, starting at `start_time_s`, until
+    /// `gradient_length_s`. Per-event `duration_s` (when present) takes
+    /// precedence for fine RT placement; otherwise events are spread across the
+    /// cycle uniformly.
+                && start_time_s.is_finite() =>
+            {
+                Some(((gradient_length_s - start_time_s).max(0.0) / cycle_time_s) as u64)
+            }
+            _ => None,
+        }
+    }
+
+    /// Build a scheme from an explicit window list (injected / CSV). One MS1
+    /// followed by one single-window MS2 frame per window.
+    pub fn from_window_table(
+        instrument: InstrumentKind,
+        ms1: Ms1Event,
+        windows: Vec<DiaWindow>,
+        repeat: RepeatPolicy,
+        mz_range: (f64, f64),
+    ) -> Self {
+        let mut cycle = vec![AcquisitionEvent::Ms1(ms1.clone())];
+        for w in windows {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![w],
+                analyzer: ms1.analyzer,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: None,
+            }));
+        }
+        AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument,
+            cycle,
+            repeat,
+            mz_range,
+            provenance: Provenance {
+                source: SchemeSource::UserTable,
+                notes: "built from explicit window table".to_string(),
+        }
+        Ok(())
+    }
+}
+
+impl AcquisitionScheme {
+    /// Render the scheme's MS2 windows as Bruker `DiaFrameMsMsWindows` rows — the
+    /// backward-compatibility adapter for the existing timsTOF write path.
+    ///
+    /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
+    /// geometry (the Bruker-grid scan ranges). The `WindowGroup` id is the frame's
+    /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
+    /// round-trip keeps the ids that `DiaFrameMsMsInfo` references), else a 1..N
+    /// fallback in cycle order. A `Linear` CE policy is resolved at the window
+    /// center (a lossy materialization, not an inverse); `Unknown` CE and
+    /// non-timsTOF schemes are rejected. The scheme is validated first.
+    ///
+    /// Row order is not meaningful (the SQLite table has none); the companion
+    /// frame→group table `DiaFrameMsMsInfo` needs the run frame schedule and is a
+    /// separate step.
+    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+        self.validate()?;
+        if self.instrument != InstrumentKind::TimsTofDia {
+            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+        }
+        let mut rows = Vec::new();
+        let mut seq: u32 = 0;
+        for ev in &self.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+                seq += 1;
+                let group = frame.vendor_group_id.unwrap_or(seq);
+                for w in &frame.windows {
+                    let (scan_num_begin, scan_num_end) = match w.geometry {
+                        DiaGeometry::TimsMobility {
+                            scan_start,
+                            scan_end,
+                        } => (scan_start, scan_end),
+                        DiaGeometry::MzOnly => {
+                            return Err("timsTOF window lacks mobility geometry".into())
+                        }
+                    };
+                    let collision_energy = match w.collision_energy {
+                        CollisionEnergyPolicy::Value(v) => v,
+                        CollisionEnergyPolicy::Linear { .. } => w
+                            .collision_energy
+                            .at(w.isolation.center_mz)
+                            .ok_or("could not resolve linear CE")?,
+                        CollisionEnergyPolicy::Unknown => {
+                            return Err("window has unknown collision energy".into())
+                        }
+                    };
+                    rows.push(crate::data::meta::DiaMsMsWindow {
+                        window_group: group,
+                        scan_num_begin,
+                        scan_num_end,
+                        isolation_mz: w.isolation.center_mz,
+                        isolation_width: w.isolation.width_mz,
+                        collision_energy,
+                    });
+                }
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Extract the acquisition scheme from a real Bruker timsTOF DIA `.d`.
+    ///
+    /// Reads `DiaFrameMsMsWindows` and the frame table. Each **window group**
+    /// becomes one [`DiaMs2Frame`] holding its mobility-partitioned windows
+    /// (`TimsMobility` geometry — the scan ranges are Bruker-grid coordinates),
+    /// preceded by a single MS1 event. Cycle timing comes from the spacing of
+    /// the precursor (MS1) frames. The returned scheme is validated.
+    ///
+    /// Note: window groups are ordered by ascending `WindowGroup` id, which is
+    /// the DIA-PASEF acquisition order in practice; a file that reuses or
+    /// permutes group numbering would need ordering by first MS2-frame
+    /// occurrence (via `DiaFrameMsMsInfo`) instead.
+    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+        use std::collections::BTreeMap;
+
+        let folder = path.as_ref().to_string_lossy().into_owned();
+        let to_io =
+            |e: Box<dyn std::error::Error>| io::Error::new(io::ErrorKind::InvalidData, e.to_string());
+        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+        let frames = read_meta_data_sql(&folder).map_err(to_io)?;
+        if windows.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no DiaFrameMsMsWindows rows (not a DIA .d?)",
+            ));
+        }
+
+        // Group windows by window group (ascending); each group is a frame.
+        let mut by_group: BTreeMap<u32, Vec<DiaWindow>> = BTreeMap::new();
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        for w in &windows {
+            let dw = DiaWindow {
+                isolation: IsolationWindow {
+                    center_mz: w.isolation_mz,
+                    width_mz: w.isolation_width,
+                },
+                collision_energy: CollisionEnergyPolicy::Value(w.collision_energy),
+                geometry: DiaGeometry::TimsMobility {
+                    scan_start: w.scan_num_begin,
+                    scan_end: w.scan_num_end,
+                },
+            };
+            lo = lo.min(dw.isolation.lower());
+            hi = hi.max(dw.isolation.upper());
+            by_group.entry(w.window_group).or_default().push(dw);
+        }
+
+        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        })];
+        let n_groups = by_group.len();
+        for (group, ws) in by_group {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: ws,
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
+            }));
+        }
+
+        // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+        // Use the MEDIAN of the positive gaps between distinct, finite precursor
+        // times, so one anomalous interval doesn't set the whole cycle.
+        let mut prec_times: Vec<f64> = frames
+            .iter()
+            .filter(|f| f.ms_ms_type == 0 && f.time.is_finite())
+            .map(|f| f.time)
+            .collect();
+        prec_times.sort_by(f64::total_cmp);
+        prec_times.dedup();
+        let mut gaps: Vec<f64> = prec_times
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .filter(|g| *g > 0.0)
+            .collect();
+    // Gated: round-trip a real Bruker DIA .d through the scheme and back to the
+    // DiaFrameMsMsWindows rows; the regenerated table must match the source.
+    #[test]
+    fn bruker_windows_round_trip() {
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP bruker_windows_round_trip: set TIMSIM_BRUKER_DIA_D");
+                return;
+            }
+        };
+        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+        assert_eq!(regenerated.len(), original.len(), "row count differs");
+
+        // Compare as a sorted multiset of EXACT field tuples, including the
+        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
+        // real id mismatch would fail. Row order in the table is not guaranteed.
+        fn tuples(
+            rows: &[crate::data::meta::DiaMsMsWindow],
+        ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+            let mut out: Vec<_> = rows
+                .iter()
+                .map(|r| {
+                    (
+                        r.window_group,
+                        r.scan_num_begin,
+                        r.scan_num_end,
+                        r.isolation_mz.to_bits(),
+                        r.isolation_width.to_bits(),
+                        r.collision_energy.to_bits(),
+                    )
+                })
+                .collect();
+            out.sort_unstable();
+            out
+        }
+        assert_eq!(
+            tuples(&regenerated),
+            tuples(&original),
+            "round-trip windows differ from source (incl. WindowGroup id)"
+        );
+        eprintln!(
+            "bruker_windows_round_trip OK: {} rows match across {} groups",
+            original.len(),
+            scheme
+                .cycle
+                .iter()
+                .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+                .count()
+
+exec
+/bin/bash -lc 'git log -5 --oneline -- rustdf/src/sim/scheme.rs && git blame -L 430,475 rustdf/src/sim/scheme.rs' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+d3429367 harden: codex review of to_bruker_windows — preserve WindowGroup identity
+4d7fdb8e feat(rustdf): AcquisitionScheme::to_bruker_windows (Bruker adapter) + round-trip golden test
+5fde3d5f harden: codex review of extractors + caller-supplied SCIEX CE
+75a851ca feat(rustdf): AcquisitionScheme::from_sciex_wiff extractor (+ sciex feature)
+20503b56 feat(rustdf): AcquisitionScheme::from_bruker_d extractor
+20503b562 (theGreatHerrLebert 2026-06-09 07:35:10 +0200 430) impl AcquisitionScheme {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 431)     /// Render the scheme's MS2 windows as Bruker `DiaFrameMsMsWindows` rows — the
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 432)     /// backward-compatibility adapter for the existing timsTOF write path.
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 433)     ///
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 434)     /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 435)     /// geometry (the Bruker-grid scan ranges). The `WindowGroup` id is the frame's
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 436)     /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 437)     /// round-trip keeps the ids that `DiaFrameMsMsInfo` references), else a 1..N
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 438)     /// fallback in cycle order. A `Linear` CE policy is resolved at the window
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 439)     /// center (a lossy materialization, not an inverse); `Unknown` CE and
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 440)     /// non-timsTOF schemes are rejected. The scheme is validated first.
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 441)     ///
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 442)     /// Row order is not meaningful (the SQLite table has none); the companion
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 443)     /// frame→group table `DiaFrameMsMsInfo` needs the run frame schedule and is a
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 444)     /// separate step.
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 445)     pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 446)         self.validate()?;
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 447)         if self.instrument != InstrumentKind::TimsTofDia {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 448)             return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 449)         }
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 450)         let mut rows = Vec::new();
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 451)         let mut seq: u32 = 0;
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 452)         for ev in &self.cycle {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 453)             if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 454)                 seq += 1;
+d34293676 (theGreatHerrLebert 2026-06-09 09:01:50 +0200 455)                 let group = frame.vendor_group_id.unwrap_or(seq);
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 456)                 for w in &frame.windows {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 457)                     let (scan_num_begin, scan_num_end) = match w.geometry {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 458)                         DiaGeometry::TimsMobility {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 459)                             scan_start,
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 460)                             scan_end,
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 461)                         } => (scan_start, scan_end),
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 462)                         DiaGeometry::MzOnly => {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 463)                             return Err("timsTOF window lacks mobility geometry".into())
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 464)                         }
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 465)                     };
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 466)                     let collision_energy = match w.collision_energy {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 467)                         CollisionEnergyPolicy::Value(v) => v,
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 468)                         CollisionEnergyPolicy::Linear { .. } => w
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 469)                             .collision_energy
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 470)                             .at(w.isolation.center_mz)
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 471)                             .ok_or("could not resolve linear CE")?,
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 472)                         CollisionEnergyPolicy::Unknown => {
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 473)                             return Err("window has unknown collision energy".into())
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 474)                         }
+4d7fdb8eb (theGreatHerrLebert 2026-06-09 08:53:39 +0200 475)                     };
+
+exec
+/bin/bash -lc "ls rustdf && sed -n '1,180p' rustdf/Cargo.toml && rg -n \"scheme|sim\" rustdf/src/lib.rs rustdf/src/sim/mod.rs Cargo.toml" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+Cargo.toml
+README.md
+examples
+src
+[package]
+name = "rustdf"
+version = "0.4.1"
+edition = "2021"
+authors = ["David Teschner <davidteschner@googlemail.com>"] # Add your name and email
+description = "A Rust library for interacting with Bruker TDF formatted Raw Data."
+license = "MIT" 
+repository = "https://github.com/theGreatHerrLebert/rustims" 
+documentation = "https://docs.rs/rustdf" 
+readme = "README.md" 
+keywords = ["dataframe", "sql", "compression", "parallel"]
+categories = ["data-structures", "science"]
+rust-version = "1.84"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Command-line argument parsing
+clap = { version = "4.5.32", features = ["derive"] }
+# Dynamic library loading
+libloading = "0.8.6"
+# SQLite with bundled binaries
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+# Compression libraries
+lzf = "1.0.0"
+zstd = "0.13.3"
+# Byte order utilities
+byteorder = "1.5.0"
+# Core library for computational proteomics
+mscore = { path = "../mscore", version = "0.4.1" }
+# Parallelism
+rayon = "1.10.0"
+# Serialization
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+# Random number generation
+rand = "0.8.5"
+rustc-hash = "2.1.0"
+bincode = "1.3.3"
+polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
+# Thermo .raw writer (private repo; only built with the `thermo` feature)
+thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "9f4c0affe60a639759883fb569d3c9f5f7601856", optional = true }
+# SCIEX .wiff method reader (private repo; only built with the `sciex` feature)
+sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "ef7c0cd7e59d3b51160e446cbe3af240d230668d", optional = true }
+
+[features]
+# Off by default: enable the Thermo .raw / SCIEX .wiff extractors + writers.
+# Each requires build-time access to its private repo.
+thermo = ["dep:thermorawfile"]
+sciex = ["dep:sciexwiff"]
+
+[package.metadata.docs.rs]
+features = ["all"]
+rustdf/src/sim/mod.rs:8:pub mod scheme;
+rustdf/src/lib.rs:2:pub mod sim;
+
+exec
+/bin/bash -lc 'git show HEAD''^:rustdf/src/sim/scheme.rs | sed -n '"'110,140p;425,470p;530,560p;1000,1055p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+    /// The MS1 acquisition m/z range, if known. `None` when not recoverable
+    /// (e.g. Thermo `scan_event` does not carry it — it must not be confused
+    /// with the DIA window coverage in [`AcquisitionScheme::mz_range`]).
+    pub mz_range: Option<(f64, f64)>,
+    pub duration_s: Option<f64>,
+}
+
+/// One physical MS2 acquisition unit. Holds one window for Astral/SCIEX; several
+/// mobility-partitioned windows (sharing the frame) for timsTOF.
+#[derive(Clone, Debug)]
+pub struct DiaMs2Frame {
+    pub windows: Vec<DiaWindow>,
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub duration_s: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AcquisitionEvent {
+    Ms1(Ms1Event),
+    DiaMs2Frame(DiaMs2Frame),
+}
+
+/// How the cycle repeats over the gradient.
+#[derive(Clone, Copy, Debug)]
+pub enum RepeatPolicy {
+    /// The cycle repeats every `cycle_time_s`, starting at `start_time_s`, until
+    /// `gradient_length_s`. Per-event `duration_s` (when present) takes
+    /// precedence for fine RT placement; otherwise events are spread across the
+    /// cycle uniformly.
+    FixedCycleTime {
+    /// backward-compatibility adapter for the existing timsTOF write path.
+    ///
+    /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
+    /// geometry (the Bruker-grid scan ranges). Window groups are numbered 1..N in
+    /// cycle order (the DIA-PASEF convention); a `Linear` CE policy is resolved at
+    /// the window center, and `Unknown` CE is rejected. Errors if the scheme is
+    /// not a timsTOF layout. (The companion frame→group table,
+    /// `DiaFrameMsMsInfo`, depends on the full run's frame schedule and is a
+    /// separate step.)
+    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+        if self.instrument != InstrumentKind::TimsTofDia {
+            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+        }
+        let mut rows = Vec::new();
+        let mut group: u32 = 0;
+        for ev in &self.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+                group += 1;
+                for w in &frame.windows {
+                    let (scan_num_begin, scan_num_end) = match w.geometry {
+                        DiaGeometry::TimsMobility {
+                            scan_start,
+                            scan_end,
+                        } => (scan_start, scan_end),
+                        DiaGeometry::MzOnly => {
+                            return Err("timsTOF window lacks mobility geometry".into())
+                        }
+                    };
+                    let collision_energy = match w.collision_energy {
+                        CollisionEnergyPolicy::Value(v) => v,
+                        CollisionEnergyPolicy::Linear { .. } => w
+                            .collision_energy
+                            .at(w.isolation.center_mz)
+                            .ok_or("could not resolve linear CE")?,
+                        CollisionEnergyPolicy::Unknown => {
+                            return Err("window has unknown collision energy".into())
+                        }
+                    };
+                    rows.push(crate::data::meta::DiaMsMsWindow {
+                        window_group: group,
+                        scan_num_begin,
+                        scan_num_end,
+                        isolation_mz: w.isolation.center_mz,
+                        isolation_width: w.isolation.width_mz,
+                        collision_energy,
+                    });
+            duration_s: None,
+        })];
+        let n_groups = by_group.len();
+        for (_group, ws) in by_group {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: ws,
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            }));
+        }
+
+        // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+        // Use the MEDIAN of the positive gaps between distinct, finite precursor
+        // times, so one anomalous interval doesn't set the whole cycle.
+        let mut prec_times: Vec<f64> = frames
+            .iter()
+            .filter(|f| f.ms_ms_type == 0 && f.time.is_finite())
+            .map(|f| f.time)
+            .collect();
+        prec_times.sort_by(f64::total_cmp);
+        prec_times.dedup();
+        let mut gaps: Vec<f64> = prec_times
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .filter(|g| *g > 0.0)
+            .collect();
+        if gaps.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "could not determine cycle time (need >= 2 distinct precursor frames)",
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP bruker_windows_round_trip: set TIMSIM_BRUKER_DIA_D");
+                return;
+            }
+        };
+        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+        assert_eq!(regenerated.len(), original.len(), "row count differs");
+
+        // Normalize window-group ids to canonical 1..N (ascending) on both sides,
+        // then compare as a sorted multiset of exact-bit field tuples.
+        fn canonical(
+            rows: &[crate::data::meta::DiaMsMsWindow],
+        ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+            let mut groups: Vec<u32> = rows.iter().map(|r| r.window_group).collect();
+            groups.sort_unstable();
+            groups.dedup();
+            let mut out: Vec<_> = rows
+                .iter()
+                .map(|r| {
+                    let g = groups.iter().position(|&x| x == r.window_group).unwrap() as u32 + 1;
+                    (
+                        g,
+                        r.scan_num_begin,
+                        r.scan_num_end,
+                        r.isolation_mz.to_bits(),
+                        r.isolation_width.to_bits(),
+                        r.collision_energy.to_bits(),
+                    )
+                })
+                .collect();
+            out.sort_unstable();
+            out
+        }
+        assert_eq!(
+            canonical(&regenerated),
+            canonical(&original),
+            "round-trip windows differ from source"
+        );
+        eprintln!(
+            "bruker_windows_round_trip OK: {} rows match across {} groups",
+            original.len(),
+            scheme
+                .cycle
+                .iter()
+                .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+                .count()
+        );
+    }
+
+    #[cfg(feature = "sciex")]
+    #[test]
+    fn from_sciex_wiff_extracts_windows() {
+
+exec
+/bin/bash -lc 'git show --stat --oneline d3429367 && git show --format=fuller --find-renames d3429367 -- rustdf/src/sim/scheme.rs' in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+d3429367 harden: codex review of to_bruker_windows — preserve WindowGroup identity
+ TO_BRUKER.codex-review.md | 1197 +++++++++++++++++++++++++++++++++++++++++++++
+ rustdf/src/sim/scheme.rs  |   56 ++-
+ 2 files changed, 1233 insertions(+), 20 deletions(-)
+commit d342936765b23a278165b82efdac39b30f61540e
+Author:     theGreatHerrLebert <davidteschner@googlemail.com>
+AuthorDate: Tue Jun 9 09:01:50 2026 +0200
+Commit:     theGreatHerrLebert <davidteschner@googlemail.com>
+CommitDate: Tue Jun 9 09:01:50 2026 +0200
+
+    harden: codex review of to_bruker_windows — preserve WindowGroup identity
+    
+    Codex #1/#2: renumbering window groups 1..N lost the source WindowGroup ids, so a
+    Bruker round-trip could desync from DiaFrameMsMsInfo (which references the original
+    ids) — and the round-trip test masked it via canonical normalization.
+    
+    - DiaMs2Frame gains vendor_group_id: Option<u32> (identity only; cycle order still
+      governs ordering/simultaneity). from_bruker_d sets it to the source WindowGroup;
+      other vendors None.
+    - to_bruker_windows uses vendor_group_id when present (else 1..N fallback) and now
+      calls validate() first (#4).
+    - round-trip golden test compares EXACT WindowGroup ids (no normalization).
+    
+    Verified on the real DIA-PASEF .d: 36 rows / 15 groups round-trip bit-exact
+    including WindowGroup id. Includes the codex review.
+
+diff --git a/rustdf/src/sim/scheme.rs b/rustdf/src/sim/scheme.rs
+index 65337c24..a5a0c106 100644
+--- a/rustdf/src/sim/scheme.rs
++++ b/rustdf/src/sim/scheme.rs
+@@ -122,6 +122,12 @@ pub struct DiaMs2Frame {
+     pub analyzer: Analyzer,
+     pub data_mode: DataMode,
+     pub duration_s: Option<f64>,
++    /// The vendor's native group id for this frame, preserved for round-trip
++    /// fidelity (Bruker `WindowGroup`). `None` for vendors without one. The cycle
++    /// order is authoritative for *simultaneity/ordering*; this is *identity* only
++    /// — needed so a Bruker adapter regenerates the original `WindowGroup` values
++    /// that companion tables (`DiaFrameMsMsInfo`) reference.
++    pub vendor_group_id: Option<u32>,
+ }
+ 
+ #[derive(Clone, Debug)]
+@@ -225,6 +231,7 @@ impl AcquisitionScheme {
+                 analyzer: ms1.analyzer,
+                 data_mode: DataMode::Centroid,
+                 duration_s: None,
++                vendor_group_id: None,
+             }));
+         }
+         AcquisitionScheme {
+@@ -425,21 +432,27 @@ impl AcquisitionScheme {
+     /// backward-compatibility adapter for the existing timsTOF write path.
+     ///
+     /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
+-    /// geometry (the Bruker-grid scan ranges). Window groups are numbered 1..N in
+-    /// cycle order (the DIA-PASEF convention); a `Linear` CE policy is resolved at
+-    /// the window center, and `Unknown` CE is rejected. Errors if the scheme is
+-    /// not a timsTOF layout. (The companion frame→group table,
+-    /// `DiaFrameMsMsInfo`, depends on the full run's frame schedule and is a
+-    /// separate step.)
++    /// geometry (the Bruker-grid scan ranges). The `WindowGroup` id is the frame's
++    /// preserved [`DiaMs2Frame::vendor_group_id`] when present (so a Bruker
++    /// round-trip keeps the ids that `DiaFrameMsMsInfo` references), else a 1..N
++    /// fallback in cycle order. A `Linear` CE policy is resolved at the window
++    /// center (a lossy materialization, not an inverse); `Unknown` CE and
++    /// non-timsTOF schemes are rejected. The scheme is validated first.
++    ///
++    /// Row order is not meaningful (the SQLite table has none); the companion
++    /// frame→group table `DiaFrameMsMsInfo` needs the run frame schedule and is a
++    /// separate step.
+     pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
++        self.validate()?;
+         if self.instrument != InstrumentKind::TimsTofDia {
+             return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+         }
+         let mut rows = Vec::new();
+-        let mut group: u32 = 0;
++        let mut seq: u32 = 0;
+         for ev in &self.cycle {
+             if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+-                group += 1;
++                seq += 1;
++                let group = frame.vendor_group_id.unwrap_or(seq);
+                 for w in &frame.windows {
+                     let (scan_num_begin, scan_num_end) = match w.geometry {
+                         DiaGeometry::TimsMobility {
+@@ -530,12 +543,13 @@ impl AcquisitionScheme {
+             duration_s: None,
+         })];
+         let n_groups = by_group.len();
+-        for (_group, ws) in by_group {
++        for (group, ws) in by_group {
+             cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                 windows: ws,
+                 analyzer: Analyzer::Tof,
+                 data_mode: DataMode::Centroid,
+                 duration_s: None,
++                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
+             }));
+         }
+ 
+@@ -646,6 +660,7 @@ impl AcquisitionScheme {
+                 analyzer: Analyzer::Tof,
+                 data_mode: DataMode::Centroid,
+                 duration_s: None,
++                vendor_group_id: None,
+             }));
+         }
+         let scheme = AcquisitionScheme {
+@@ -758,6 +773,7 @@ impl AcquisitionScheme {
+                     analyzer: analyzer_of(ev.analyzer),
+                     data_mode: data_mode_of(scan),
+                     duration_s: None,
++                    vendor_group_id: None,
+                 }));
+             }
+         }
+@@ -867,6 +883,7 @@ mod tests {
+             analyzer: Analyzer::Tof,
+             data_mode: DataMode::Centroid,
+             duration_s: None,
++            vendor_group_id: None,
+         };
+         let s = AcquisitionScheme {
+             version: SCHEME_VERSION,
+@@ -921,6 +938,7 @@ mod tests {
+                 analyzer: Analyzer::Astms,
+                 data_mode: DataMode::Centroid,
+                 duration_s: None,
++                vendor_group_id: None,
+             })
+         };
+         let mk = |cycle: Vec<AcquisitionEvent>| AcquisitionScheme {
+@@ -957,6 +975,7 @@ mod tests {
+             analyzer: Analyzer::Astms,
+             data_mode: DataMode::Centroid,
+             duration_s: Some(-1.0),
++            vendor_group_id: None,
+         });
+         assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), bad_dur]).validate().is_err());
+     }
+@@ -1009,20 +1028,17 @@ mod tests {
+         let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+         assert_eq!(regenerated.len(), original.len(), "row count differs");
+ 
+-        // Normalize window-group ids to canonical 1..N (ascending) on both sides,
+-        // then compare as a sorted multiset of exact-bit field tuples.
+-        fn canonical(
++        // Compare as a sorted multiset of EXACT field tuples, including the
++        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
++        // real id mismatch would fail. Row order in the table is not guaranteed.
++        fn tuples(
+             rows: &[crate::data::meta::DiaMsMsWindow],
+         ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+-            let mut groups: Vec<u32> = rows.iter().map(|r| r.window_group).collect();
+-            groups.sort_unstable();
+-            groups.dedup();
+             let mut out: Vec<_> = rows
+                 .iter()
+                 .map(|r| {
+-                    let g = groups.iter().position(|&x| x == r.window_group).unwrap() as u32 + 1;
+                     (
+-                        g,
++                        r.window_group,
+                         r.scan_num_begin,
+                         r.scan_num_end,
+                         r.isolation_mz.to_bits(),
+@@ -1035,9 +1051,9 @@ mod tests {
+             out
+         }
+         assert_eq!(
+-            canonical(&regenerated),
+-            canonical(&original),
+-            "round-trip windows differ from source"
++            tuples(&regenerated),
++            tuples(&original),
++            "round-trip windows differ from source (incl. WindowGroup id)"
+         );
+         eprintln!(
+             "bruker_windows_round_trip OK: {} rows match across {} groups",
+
+exec
+/bin/bash -lc 'cargo test -p rustdf sim::scheme::tests --lib' in /scratch/timsim-demo/SUBMISSION/rustims
+exec
+/bin/bash -lc "nl -ba rustdf/src/sim/scheme.rs | sed -n '118,134p;220,238p;300,430p;445,462p;540,556p;648,667p;760,780p;875,982p;1020,1062p'" in /scratch/timsim-demo/SUBMISSION/rustims
+ succeeded in 0ms:
+   118	/// mobility-partitioned windows (sharing the frame) for timsTOF.
+   119	#[derive(Clone, Debug)]
+   120	pub struct DiaMs2Frame {
+   121	    pub windows: Vec<DiaWindow>,
+   122	    pub analyzer: Analyzer,
+   123	    pub data_mode: DataMode,
+   124	    pub duration_s: Option<f64>,
+   125	    /// The vendor's native group id for this frame, preserved for round-trip
+   126	    /// fidelity (Bruker `WindowGroup`). `None` for vendors without one. The cycle
+   127	    /// order is authoritative for *simultaneity/ordering*; this is *identity* only
+   128	    /// — needed so a Bruker adapter regenerates the original `WindowGroup` values
+   129	    /// that companion tables (`DiaFrameMsMsInfo`) reference.
+   130	    pub vendor_group_id: Option<u32>,
+   131	}
+   132	
+   133	#[derive(Clone, Debug)]
+   134	pub enum AcquisitionEvent {
+   220	    pub fn from_window_table(
+   221	        instrument: InstrumentKind,
+   222	        ms1: Ms1Event,
+   223	        windows: Vec<DiaWindow>,
+   224	        repeat: RepeatPolicy,
+   225	        mz_range: (f64, f64),
+   226	    ) -> Self {
+   227	        let mut cycle = vec![AcquisitionEvent::Ms1(ms1.clone())];
+   228	        for w in windows {
+   229	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   230	                windows: vec![w],
+   231	                analyzer: ms1.analyzer,
+   232	                data_mode: DataMode::Centroid,
+   233	                duration_s: None,
+   234	                vendor_group_id: None,
+   235	            }));
+   236	        }
+   237	        AcquisitionScheme {
+   238	            version: SCHEME_VERSION,
+   300	                        }
+   301	                    }
+   302	                }
+   303	                AcquisitionEvent::DiaMs2Frame(frame) => {
+   304	                    check_dur(frame.duration_s, "MS2 frame")?;
+   305	                    if frame.windows.is_empty() {
+   306	                        return Err("MS2 frame has no windows".into());
+   307	                    }
+   308	                    let multi = frame.windows.len() > 1;
+   309	                    if multi && self.instrument != InstrumentKind::TimsTofDia {
+   310	                        return Err(
+   311	                            "multi-window MS2 frame is only valid for timsTOF (mobility-partitioned)"
+   312	                                .into(),
+   313	                        );
+   314	                    }
+   315	                    for (i, w) in frame.windows.iter().enumerate() {
+   316	                        if !(w.isolation.width_mz.is_finite() && w.isolation.width_mz > 0.0) {
+   317	                            return Err("window width must be finite and > 0".into());
+   318	                        }
+   319	                        if !w.isolation.center_mz.is_finite()
+   320	                            || !w.isolation.lower().is_finite()
+   321	                            || !w.isolation.upper().is_finite()
+   322	                        {
+   323	                            return Err("window m/z is not finite".into());
+   324	                        }
+   325	                        if w.isolation.lower() < lo - 1e-6 || w.isolation.upper() > hi + 1e-6 {
+   326	                            return Err(format!(
+   327	                                "window [{:.4}, {:.4}] outside mz_range [{lo:.4}, {hi:.4}]",
+   328	                                w.isolation.lower(),
+   329	                                w.isolation.upper()
+   330	                            ));
+   331	                        }
+   332	                        match w.collision_energy {
+   333	                            CollisionEnergyPolicy::Value(v) => {
+   334	                                if !v.is_finite() || v < 0.0 {
+   335	                                    return Err("collision energy must be finite and >= 0".into());
+   336	                                }
+   337	                            }
+   338	                            CollisionEnergyPolicy::Linear {
+   339	                                intercept,
+   340	                                slope_per_mz,
+   341	                            } => {
+   342	                                if !intercept.is_finite() || !slope_per_mz.is_finite() {
+   343	                                    return Err("non-finite linear CE coefficients".into());
+   344	                                }
+   345	                                match w.collision_energy.at(w.isolation.center_mz) {
+   346	                                    Some(ce) if ce.is_finite() && ce >= 0.0 => {}
+   347	                                    _ => {
+   348	                                        return Err(
+   349	                                            "linear CE resolves to non-finite or negative".into()
+   350	                                        )
+   351	                                    }
+   352	                                }
+   353	                            }
+   354	                            CollisionEnergyPolicy::Unknown => {}
+   355	                        }
+   356	                        match w.geometry {
+   357	                            DiaGeometry::TimsMobility {
+   358	                                scan_start,
+   359	                                scan_end,
+   360	                            } => {
+   361	                                if self.instrument != InstrumentKind::TimsTofDia {
+   362	                                    return Err("mobility geometry is only valid for timsTOF".into());
+   363	                                }
+   364	                                if scan_start > scan_end {
+   365	                                    return Err("mobility scan_start > scan_end".into());
+   366	                                }
+   367	                            }
+   368	                            DiaGeometry::MzOnly => {
+   369	                                if multi {
+   370	                                    return Err(
+   371	                                        "multi-window timsTOF frame requires mobility geometry on every window"
+   372	                                            .into(),
+   373	                                    );
+   374	                                }
+   375	                            }
+   376	                        }
+   377	                        // Within one frame, windows must not overlap in BOTH m/z
+   378	                        // and mobility (overlap across sequential frames is fine).
+   379	                        for w2 in &frame.windows[..i] {
+   380	                            let mz_overlap = w.isolation.lower() < w2.isolation.upper()
+   381	                                && w2.isolation.lower() < w.isolation.upper();
+   382	                            let im_overlap = match (w.geometry, w2.geometry) {
+   383	                                (
+   384	                                    DiaGeometry::TimsMobility {
+   385	                                        scan_start: a0,
+   386	                                        scan_end: a1,
+   387	                                    },
+   388	                                    DiaGeometry::TimsMobility {
+   389	                                        scan_start: b0,
+   390	                                        scan_end: b1,
+   391	                                    },
+   392	                                ) => a0 <= b1 && b0 <= a1,
+   393	                                _ => true, // m/z-only windows share all mobility
+   394	                            };
+   395	                            if mz_overlap && im_overlap {
+   396	                                return Err(
+   397	                                    "windows within one frame overlap in both m/z and mobility"
+   398	                                        .into(),
+   399	                                );
+   400	                            }
+   401	                        }
+   402	                    }
+   403	                }
+   404	            }
+   405	        }
+   406	        match self.repeat {
+   407	            RepeatPolicy::FixedCycleTime {
+   408	                cycle_time_s,
+   409	                gradient_length_s,
+   410	                start_time_s,
+   411	            } => {
+   412	                if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+   413	                    return Err("cycle_time_s must be finite and > 0".into());
+   414	                }
+   415	                if !(gradient_length_s.is_finite() && gradient_length_s > 0.0) {
+   416	                    return Err("gradient_length_s must be finite and > 0".into());
+   417	                }
+   418	                if !start_time_s.is_finite() || start_time_s < 0.0 {
+   419	                    return Err("start_time_s must be finite and >= 0".into());
+   420	                }
+   421	                if start_time_s > gradient_length_s {
+   422	                    return Err("start_time_s must be <= gradient_length_s".into());
+   423	                }
+   424	            }
+   425	        }
+   426	        Ok(())
+   427	    }
+   428	}
+   429	
+   430	impl AcquisitionScheme {
+   445	    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+   446	        self.validate()?;
+   447	        if self.instrument != InstrumentKind::TimsTofDia {
+   448	            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+   449	        }
+   450	        let mut rows = Vec::new();
+   451	        let mut seq: u32 = 0;
+   452	        for ev in &self.cycle {
+   453	            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+   454	                seq += 1;
+   455	                let group = frame.vendor_group_id.unwrap_or(seq);
+   456	                for w in &frame.windows {
+   457	                    let (scan_num_begin, scan_num_end) = match w.geometry {
+   458	                        DiaGeometry::TimsMobility {
+   459	                            scan_start,
+   460	                            scan_end,
+   461	                        } => (scan_start, scan_end),
+   462	                        DiaGeometry::MzOnly => {
+   540	            analyzer: Analyzer::Tof,
+   541	            data_mode: DataMode::Centroid,
+   542	            mz_range: None,
+   543	            duration_s: None,
+   544	        })];
+   545	        let n_groups = by_group.len();
+   546	        for (group, ws) in by_group {
+   547	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   548	                windows: ws,
+   549	                analyzer: Analyzer::Tof,
+   550	                data_mode: DataMode::Centroid,
+   551	                duration_s: None,
+   552	                vendor_group_id: Some(group), // preserve Bruker WindowGroup identity
+   553	            }));
+   554	        }
+   555	
+   556	        // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+   648	            let iso = IsolationWindow {
+   649	                center_mz: w.center_mz(),
+   650	                width_mz: w.width_mz(),
+   651	            };
+   652	            lo = lo.min(iso.lower());
+   653	            hi = hi.max(iso.upper());
+   654	            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   655	                windows: vec![DiaWindow {
+   656	                    isolation: iso,
+   657	                    collision_energy,
+   658	                    geometry: DiaGeometry::MzOnly,
+   659	                }],
+   660	                analyzer: Analyzer::Tof,
+   661	                data_mode: DataMode::Centroid,
+   662	                duration_s: None,
+   663	                vendor_group_id: None,
+   664	            }));
+   665	        }
+   666	        let scheme = AcquisitionScheme {
+   667	            version: SCHEME_VERSION,
+   760	            } else if seen_ms1 {
+   761	                let iso = IsolationWindow {
+   762	                    center_mz: ev.isolation_center,
+   763	                    width_mz: ev.isolation_width,
+   764	                };
+   765	                win_lo = win_lo.min(iso.lower());
+   766	                win_hi = win_hi.max(iso.upper());
+   767	                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   768	                    windows: vec![DiaWindow {
+   769	                        isolation: iso,
+   770	                        collision_energy: CollisionEnergyPolicy::Value(ev.collision_energy),
+   771	                        geometry: DiaGeometry::MzOnly,
+   772	                    }],
+   773	                    analyzer: analyzer_of(ev.analyzer),
+   774	                    data_mode: data_mode_of(scan),
+   775	                    duration_s: None,
+   776	                    vendor_group_id: None,
+   777	                }));
+   778	            }
+   779	        }
+   780	
+   875	        assert_eq!(s.ms1_count(), 1);
+   876	        assert_eq!(s.num_cycles(), Some(600));
+   877	    }
+   878	
+   879	    #[test]
+   880	    fn multi_window_frame_only_tims() {
+   881	        let frame = DiaMs2Frame {
+   882	            windows: linear_windows(3),
+   883	            analyzer: Analyzer::Tof,
+   884	            data_mode: DataMode::Centroid,
+   885	            duration_s: None,
+   886	            vendor_group_id: None,
+   887	        };
+   888	        let s = AcquisitionScheme {
+   889	            version: SCHEME_VERSION,
+   890	            instrument: InstrumentKind::OrbitrapAstral, // wrong: multi-window on non-tims
+   891	            cycle: vec![
+   892	                AcquisitionEvent::Ms1(Ms1Event {
+   893	                    analyzer: Analyzer::Ftms,
+   894	                    data_mode: DataMode::Profile,
+   895	                    mz_range: Some((390.0, 900.0)),
+   896	                    duration_s: None,
+   897	                }),
+   898	                AcquisitionEvent::DiaMs2Frame(frame),
+   899	            ],
+   900	            repeat: RepeatPolicy::FixedCycleTime {
+   901	                cycle_time_s: 1.0,
+   902	                gradient_length_s: 600.0,
+   903	                start_time_s: 0.0,
+   904	            },
+   905	            mz_range: (390.0, 900.0),
+   906	            provenance: Provenance {
+   907	                source: SchemeSource::Programmatic,
+   908	                notes: String::new(),
+   909	            },
+   910	        };
+   911	        assert!(s.validate().is_err());
+   912	    }
+   913	
+   914	    #[test]
+   915	    fn validate_rejects_bad_schemes() {
+   916	        let repeat = RepeatPolicy::FixedCycleTime {
+   917	            cycle_time_s: 1.0,
+   918	            gradient_length_s: 600.0,
+   919	            start_time_s: 0.0,
+   920	        };
+   921	        let ms1 = || Ms1Event {
+   922	            analyzer: Analyzer::Ftms,
+   923	            data_mode: DataMode::Profile,
+   924	            mz_range: Some((390.0, 900.0)),
+   925	            duration_s: None,
+   926	        };
+   927	        let win = || DiaWindow {
+   928	            isolation: IsolationWindow {
+   929	                center_mz: 500.0,
+   930	                width_mz: 10.0,
+   931	            },
+   932	            collision_energy: CollisionEnergyPolicy::Value(25.0),
+   933	            geometry: DiaGeometry::MzOnly,
+   934	        };
+   935	        let frame = |w: DiaWindow| {
+   936	            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   937	                windows: vec![w],
+   938	                analyzer: Analyzer::Astms,
+   939	                data_mode: DataMode::Centroid,
+   940	                duration_s: None,
+   941	                vendor_group_id: None,
+   942	            })
+   943	        };
+   944	        let mk = |cycle: Vec<AcquisitionEvent>| AcquisitionScheme {
+   945	            version: SCHEME_VERSION,
+   946	            instrument: InstrumentKind::OrbitrapAstral,
+   947	            cycle,
+   948	            repeat,
+   949	            mz_range: (390.0, 900.0),
+   950	            provenance: Provenance {
+   951	                source: SchemeSource::Programmatic,
+   952	                notes: String::new(),
+   953	            },
+   954	        };
+   955	
+   956	        // valid baseline
+   957	        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_ok());
+   958	        // MS2 first (no leading MS1)
+   959	        assert!(mk(vec![frame(win()), AcquisitionEvent::Ms1(ms1())]).validate().is_err());
+   960	        // two MS1 in a cycle
+   961	        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), AcquisitionEvent::Ms1(ms1()), frame(win())]).validate().is_err());
+   962	        // MS1 with no MS2 frame
+   963	        assert!(mk(vec![AcquisitionEvent::Ms1(ms1())]).validate().is_err());
+   964	        // window outside mz_range
+   965	        let mut oob = win();
+   966	        oob.isolation.center_mz = 2000.0;
+   967	        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(oob)]).validate().is_err());
+   968	        // negative collision energy
+   969	        let mut neg = win();
+   970	        neg.collision_energy = CollisionEnergyPolicy::Value(-5.0);
+   971	        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), frame(neg)]).validate().is_err());
+   972	        // bad event duration
+   973	        let bad_dur = AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+   974	            windows: vec![win()],
+   975	            analyzer: Analyzer::Astms,
+   976	            data_mode: DataMode::Centroid,
+   977	            duration_s: Some(-1.0),
+   978	            vendor_group_id: None,
+   979	        });
+   980	        assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), bad_dur]).validate().is_err());
+   981	    }
+   982	
+  1020	            Ok(p) => p,
+  1021	            Err(_) => {
+  1022	                eprintln!("SKIP bruker_windows_round_trip: set TIMSIM_BRUKER_DIA_D");
+  1023	                return;
+  1024	            }
+  1025	        };
+  1026	        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+  1027	        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+  1028	        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+  1029	        assert_eq!(regenerated.len(), original.len(), "row count differs");
+  1030	
+  1031	        // Compare as a sorted multiset of EXACT field tuples, including the
+  1032	        // WindowGroup id (preserved via vendor_group_id) — no normalization, so a
+  1033	        // real id mismatch would fail. Row order in the table is not guaranteed.
+  1034	        fn tuples(
+  1035	            rows: &[crate::data::meta::DiaMsMsWindow],
+  1036	        ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+  1037	            let mut out: Vec<_> = rows
+  1038	                .iter()
+  1039	                .map(|r| {
+  1040	                    (
+  1041	                        r.window_group,
+  1042	                        r.scan_num_begin,
+  1043	                        r.scan_num_end,
+  1044	                        r.isolation_mz.to_bits(),
+  1045	                        r.isolation_width.to_bits(),
+  1046	                        r.collision_energy.to_bits(),
+  1047	                    )
+  1048	                })
+  1049	                .collect();
+  1050	            out.sort_unstable();
+  1051	            out
+  1052	        }
+  1053	        assert_eq!(
+  1054	            tuples(&regenerated),
+  1055	            tuples(&original),
+  1056	            "round-trip windows differ from source (incl. WindowGroup id)"
+  1057	        );
+  1058	        eprintln!(
+  1059	            "bruker_windows_round_trip OK: {} rows match across {} groups",
+  1060	            original.len(),
+  1061	            scheme
+  1062	                .cycle
+
+codex
+The exact-ID golden comparison is now meaningful: it sorts only row tuples and retains raw `WindowGroup`, so renumbering can no longer hide. The `validate()` call does not add a new Bruker-extraction failure path because `from_bruker_d` already validates the same scheme before returning; it does change which error is reported first for arbitrary invalid/non-tims schemes.
+ succeeded in 40050ms:
+   Compiling libc v0.2.186
+   Compiling proc-macro2 v1.0.106
+   Compiling quote v1.0.45
+   Compiling unicode-ident v1.0.24
+   Compiling cfg-if v1.0.4
+   Compiling find-msvc-tools v0.1.9
+   Compiling shlex v2.0.1
+   Compiling autocfg v1.5.1
+   Compiling version_check v0.9.5
+   Compiling libm v0.2.16
+   Compiling serde_core v1.0.228
+   Compiling zerocopy v0.8.50
+   Compiling serde v1.0.228
+   Compiling crossbeam-utils v0.8.21
+   Compiling object v0.37.3
+   Compiling rayon-core v1.13.0
+   Compiling memchr v2.8.1
+   Compiling getrandom v0.3.4
+   Compiling either v1.16.0
+   Compiling bitflags v2.13.0
+   Compiling regex-syntax v0.8.10
+   Compiling rustversion v1.0.22
+   Compiling once_cell v1.21.4
+   Compiling allocator-api2 v0.2.21
+   Compiling ahash v0.8.12
+   Compiling array-init-cursor v0.2.1
+   Compiling num-traits v0.2.19
+   Compiling smallvec v1.15.1
+   Compiling parking_lot_core v0.9.12
+   Compiling thiserror v1.0.69
+   Compiling planus v0.3.1
+   Compiling scopeguard v1.2.0
+   Compiling aho-corasick v1.1.4
+   Compiling itoa v1.0.18
+   Compiling target-features v0.1.6
+   Compiling crossbeam-epoch v0.9.18
+   Compiling syn v1.0.109
+   Compiling pkg-config v0.3.33
+   Compiling crossbeam-deque v0.8.6
+   Compiling syn v2.0.117
+   Compiling lock_api v0.4.14
+   Compiling polars-utils v0.43.1
+   Compiling ryu v1.0.23
+   Compiling static_assertions v1.1.0
+   Compiling castaway v0.2.4
+   Compiling simdutf8 v0.1.5
+   Compiling equivalent v1.0.2
+   Compiling hashbrown v0.17.1
+   Compiling jobserver v0.1.34
+   Compiling memmap2 v0.7.1
+   Compiling cc v1.2.63
+   Compiling parking_lot v0.12.5
+   Compiling raw-cpuid v11.6.0
+   Compiling matrixmultiply v0.3.10
+   Compiling rayon v1.12.0
+   Compiling polars-schema v0.43.1
+   Compiling bytes v1.11.1
+   Compiling iana-time-zone v0.1.65
+   Compiling chrono v0.4.45
+   Compiling num-integer v0.1.46
+   Compiling num-complex v0.4.6
+   Compiling polars-arrow v0.43.1
+   Compiling rawpointer v0.2.1
+   Compiling regex-automata v0.4.14
+   Compiling atoi_simd v0.15.6
+   Compiling ethnum v1.5.3
+   Compiling dyn-clone v1.0.20
+   Compiling indexmap v2.14.0
+   Compiling rustix v1.1.4
+   Compiling strength_reduce v0.2.4
+   Compiling fast-float v0.2.0
+   Compiling streaming-iterator v0.1.9
+   Compiling polars-compute v0.43.1
+   Compiling litrs v1.0.0
+   Compiling stacker v0.1.24
+   Compiling zstd-sys v2.0.16+zstd.1.5.7
+   Compiling linux-raw-sys v0.12.1
+   Compiling getrandom v0.2.17
+   Compiling lz4-sys v1.11.1+lz4-1.10.0
+   Compiling polars-core v0.43.1
+   Compiling unicode-width v0.2.2
+   Compiling rand_core v0.6.4
+   Compiling crc32fast v1.5.0
+   Compiling document-features v0.2.12
+   Compiling paste v1.0.15
+   Compiling unicode-segmentation v1.13.3
+   Compiling alloc-no-stdlib v2.0.4
+   Compiling zstd-safe v7.2.4
+   Compiling ar_archive_writer v0.5.1
+   Compiling alloc-stdlib v0.2.2
+   Compiling ndarray v0.15.6
+   Compiling polars-ops v0.43.1
+   Compiling xxhash-rust v0.8.15
+   Compiling adler2 v2.0.1
+   Compiling simd-adler32 v0.3.9
+   Compiling snap v1.1.1
+   Compiling fallible-streaming-iterator v0.1.9
+   Compiling ppv-lite86 v0.2.21
+   Compiling miniz_oxide v0.8.9
+   Compiling brotli-decompressor v4.0.3
+   Compiling regex v1.12.3
+   Compiling approx v0.5.1
+   Compiling argminmax v0.6.3
+   Compiling crossterm v0.29.0
+   Compiling vcpkg v0.2.15
+   Compiling rand_chacha v0.3.1
+   Compiling utf8parse v0.2.2
+   Compiling flate2 v1.1.9
+   Compiling anstyle-parse v1.0.0
+   Compiling psm v0.1.31
+   Compiling rand v0.8.6
+   Compiling comfy-table v7.2.2
+   Compiling serde_derive v1.0.228
+   Compiling bytemuck_derive v1.10.2
+   Compiling thiserror-impl v1.0.69
+   Compiling nalgebra-macros v0.2.2
+   Compiling libsqlite3-sys v0.30.1
+   Compiling rand_distr v0.4.3
+   Compiling brotli v6.0.0
+   Compiling streaming-decompression v0.1.2
+   Compiling now v0.1.3
+   Compiling num-rational v0.4.2
+   Compiling atoi v2.0.0
+   Compiling anstyle-query v1.1.5
+   Compiling is_terminal_polyfill v1.70.2
+   Compiling parquet-format-safe v0.2.4
+   Compiling zmij v1.0.21
+   Compiling anstyle v1.0.14
+   Compiling virtue v0.0.18
+   Compiling base64 v0.22.1
+   Compiling colorchoice v1.0.5
+   Compiling typenum v1.20.1
+   Compiling anstream v1.0.0
+   Compiling bytemuck v1.25.0
+   Compiling polars v0.43.1
+   Compiling percent-encoding v2.3.2
+   Compiling clap_lex v1.1.0
+   Compiling multiversion-macros v0.7.4
+   Compiling safe_arch v0.7.4
+   Compiling bincode_derive v2.0.1
+   Compiling serde_json v1.0.150
+   Compiling home v0.5.12
+   Compiling strsim v0.11.1
+   Compiling heck v0.5.0
+   Compiling glob v0.3.3
+   Compiling unty v0.0.4
+   Compiling clap_builder v4.6.0
+   Compiling clap_derive v4.6.1
+   Compiling wide v0.7.33
+   Compiling ordered-float v4.6.0
+   Compiling itertools v0.14.0
+   Compiling fallible-iterator v0.3.0
+   Compiling bincode v2.0.1
+   Compiling libloading v0.8.9
+   Compiling rustc-hash v2.1.2
+   Compiling lzf v1.0.0
+   Compiling byteorder v1.5.0
+   Compiling multiversion v0.7.4
+   Compiling simba v0.9.1
+   Compiling hashbrown v0.14.5
+   Compiling polars-arrow-format v0.1.0
+   Compiling compact_str v0.8.2
+   Compiling bincode v1.3.3
+   Compiling clap v4.6.1
+   Compiling hashlink v0.9.1
+   Compiling polars-error v0.43.1
+   Compiling zstd v0.13.3
+   Compiling nalgebra v0.33.3
+   Compiling rusqlite v0.32.1
+   Compiling lz4 v1.28.1
+   Compiling polars-row v0.43.1
+   Compiling statrs v0.18.0
+   Compiling mscore v0.4.1 (/scratch/timsim-demo/SUBMISSION/rustims/mscore)
+   Compiling polars-parquet v0.43.1
+   Compiling polars-time v0.43.1
+   Compiling polars-io v0.43.1
+   Compiling rustdf v0.4.1 (/scratch/timsim-demo/SUBMISSION/rustims/rustdf)
+warning: unused import: `rand::prelude::IteratorRandom`
+  --> rustdf/src/data/dia.rs:12:5
+   |
+12 | use rand::prelude::IteratorRandom;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: creating a mutable reference to mutable static
+   --> rustdf/src/data/raw.rs:269:46
+    |
+269 |         if let Some((mz, intens)) = unsafe { EXTRACT_BUF_DATA.take() } {
+    |                                              ^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
+    |
+    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
+    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
+    = note: `#[warn(static_mut_refs)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
+
+warning: creating a mutable reference to mutable static
+   --> rustdf/src/data/raw.rs:304:28
+    |
+304 |         let out = unsafe { PASEF_BUF_DATA.take() }.unwrap_or_default();
+    |                            ^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
+    |
+    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
+    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html>
+
+warning: `rustdf` (lib test) generated 3 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 39.96s
+     Running unittests src/lib.rs (target/debug/deps/rustdf-308eae90b4e80287)
+
+running 5 tests
+test sim::scheme::tests::from_bruker_d_extracts_cycle ... ok
+test sim::scheme::tests::bruker_windows_round_trip ... ok
+test sim::scheme::tests::from_window_table_validates ... ok
+test sim::scheme::tests::multi_window_frame_only_tims ... ok
+test sim::scheme::tests::validate_rejects_bad_schemes ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
+
+
+codex
+**Findings**
+
+1. **Medium: mixed or duplicate group IDs can silently collide.**  
+   [scheme.rs:451](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:451) assigns `None` frames their positional ID without reserving IDs used by `Some`. For example, `[Some(2), None]` emits both frames as group `2`; two `Some(7)` frames also merge into one group. `validate()` does not detect either case. The adapter should either reject mixed/duplicate assignments or allocate fallback IDs from the unused ID set.
+
+2. **Medium: the golden test may still not prove the regression is fixed.**  
+   [scheme.rs:1031](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:1031) now correctly compares exact IDs, but if the gated dataset uses canonical IDs `1..N`, the old renumbering implementation would also pass. The test is also skipped when `TIMSIM_BRUKER_DIA_D` is unset. Add an unconditional unit test with noncanonical IDs such as `7` and `42`, asserting exact output IDs. Include a mixed-ID collision case once its semantics are defined.
+
+3. **Low: `from_window_table` cannot preserve caller-specified Bruker IDs.**  
+   [scheme.rs:220](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:220) always assigns `None`. This is fine for fresh injected schemes using generated IDs, and callers can construct `DiaMs2Frame` directly. It is a functional gap if CSV/window-table injection must match an existing `DiaFrameMsMsInfo` table with specific IDs.
+
+The core extraction round trip is otherwise fixed correctly. Every `from_bruker_d` frame receives its exact `BTreeMap` key at [scheme.rs:546](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:546), while all six other construction sites explicitly use `None`. `to_bruker_windows` uses the preserved value correctly.
+
+Calling `validate()` first changes error precedence for invalid/non-tims schemes, but does not newly reject schemes returned by `from_bruker_d`, because that extractor already performs the same validation. The overlap and m/z-containment risks therefore predate this revision; `mz_range` is derived from the exact extracted window edges.
+
+Focused tests compile and pass: 5 passed. The environment-gated Bruker tests reported success but may have taken their skip path.
+tokens used
+86,136
+**Findings**
+
+1. **Medium: mixed or duplicate group IDs can silently collide.**  
+   [scheme.rs:451](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:451) assigns `None` frames their positional ID without reserving IDs used by `Some`. For example, `[Some(2), None]` emits both frames as group `2`; two `Some(7)` frames also merge into one group. `validate()` does not detect either case. The adapter should either reject mixed/duplicate assignments or allocate fallback IDs from the unused ID set.
+
+2. **Medium: the golden test may still not prove the regression is fixed.**  
+   [scheme.rs:1031](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:1031) now correctly compares exact IDs, but if the gated dataset uses canonical IDs `1..N`, the old renumbering implementation would also pass. The test is also skipped when `TIMSIM_BRUKER_DIA_D` is unset. Add an unconditional unit test with noncanonical IDs such as `7` and `42`, asserting exact output IDs. Include a mixed-ID collision case once its semantics are defined.
+
+3. **Low: `from_window_table` cannot preserve caller-specified Bruker IDs.**  
+   [scheme.rs:220](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:220) always assigns `None`. This is fine for fresh injected schemes using generated IDs, and callers can construct `DiaMs2Frame` directly. It is a functional gap if CSV/window-table injection must match an existing `DiaFrameMsMsInfo` table with specific IDs.
+
+The core extraction round trip is otherwise fixed correctly. Every `from_bruker_d` frame receives its exact `BTreeMap` key at [scheme.rs:546](/scratch/timsim-demo/SUBMISSION/rustims/rustdf/src/sim/scheme.rs:546), while all six other construction sites explicitly use `None`. `to_bruker_windows` uses the preserved value correctly.
+
+Calling `validate()` first changes error precedence for invalid/non-tims schemes, but does not newly reject schemes returned by `from_bruker_d`, because that extractor already performs the same validation. The overlap and m/z-containment risks therefore predate this revision; `mz_range` is derived from the exact extracted window edges.
+
+Focused tests compile and pass: 5 passed. The environment-gated Bruker tests reported success but may have taken their skip path.

--- a/imspy_connector/Cargo.toml
+++ b/imspy_connector/Cargo.toml
@@ -17,3 +17,9 @@ serde_json = "1.0.140"
 rayon = "1.10.0"
 regex = "1.11.1"
 rustc-hash = "2.1.0"
+
+[features]
+# Forward the vendor extractors to rustdf (each needs its private repo at build
+# time). Off by default: the core connector + Bruker scheme path stay unaffected.
+thermo = ["rustdf/thermo"]
+sciex = ["rustdf/sciex"]

--- a/imspy_connector/src/lib.rs
+++ b/imspy_connector/src/lib.rs
@@ -22,6 +22,7 @@ pub mod py_sumformula;
 pub mod py_ml_utility;
 pub mod py_feature;
 pub mod py_pseudo;
+pub mod py_acquisition;
 
 #[pymodule]
 fn imspy_connector(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -46,5 +47,6 @@ fn imspy_connector(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pymodule!(py_ml_utility::py_ml_utility))?;
     m.add_wrapped(wrap_pymodule!(py_feature::py_feature))?;
     m.add_wrapped(wrap_pymodule!(py_pseudo::py_pseudo))?;
+    m.add_wrapped(wrap_pymodule!(py_acquisition::py_acquisition))?;
     Ok(())
 }

--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -1,5 +1,7 @@
+use numpy::IntoPyArray;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use rustdf::sim::scheme::AcquisitionScheme;
 
 /// Python wrapper over the vendor-neutral DIA acquisition scheme
@@ -9,12 +11,14 @@ use rustdf::sim::scheme::AcquisitionScheme;
 /// Python simulator can build its DIA layout from a real Bruker/Thermo/SCIEX run
 /// (or an injected window table) and render the Bruker `DiaFrameMsMsWindows` /
 /// `DiaFrameMsMsInfo` tables. The `from_thermo_raw`/`from_sciex_wiff` constructors
-/// require the connector to be built with the `thermo`/`sciex` feature.
+/// require the connector to be built with the `thermo`/`sciex` feature
+/// (see [`has_thermo`]/[`has_sciex`]).
 #[pyclass]
 pub struct PyAcquisitionScheme {
     pub inner: AcquisitionScheme,
 }
 
+/// Validation/rendering failures (a `String`) -> `ValueError`.
 fn val_err<E: ToString>(e: E) -> PyErr {
     PyValueError::new_err(e.to_string())
 }
@@ -23,28 +27,34 @@ fn val_err<E: ToString>(e: E) -> PyErr {
 impl PyAcquisitionScheme {
     /// Extract the scheme from a Bruker timsTOF DIA `.d` folder.
     #[staticmethod]
-    pub fn from_bruker_d(path: &str) -> PyResult<Self> {
-        AcquisitionScheme::from_bruker_d(path)
-            .map(|inner| Self { inner })
-            .map_err(val_err)
+    pub fn from_bruker_d(py: Python<'_>, path: &str) -> PyResult<Self> {
+        // I/O errors map to OSError/FileNotFoundError via PyErr::from; release the
+        // GIL while reading the .d's SQLite metadata.
+        let inner = py
+            .allow_threads(|| AcquisitionScheme::from_bruker_d(path))
+            .map_err(PyErr::from)?;
+        Ok(Self { inner })
     }
 
     /// Extract from a Thermo Orbitrap `.raw` (requires the `thermo` feature).
     #[cfg(feature = "thermo")]
     #[staticmethod]
-    pub fn from_thermo_raw(path: &str) -> PyResult<Self> {
-        AcquisitionScheme::from_thermo_raw(path)
-            .map(|inner| Self { inner })
-            .map_err(val_err)
+    pub fn from_thermo_raw(py: Python<'_>, path: &str) -> PyResult<Self> {
+        let inner = py
+            .allow_threads(|| AcquisitionScheme::from_thermo_raw(path))
+            .map_err(PyErr::from)?;
+        Ok(Self { inner })
     }
 
     /// Extract from a SCIEX `.wiff` SWATH method (requires the `sciex` feature).
     /// SCIEX rolling CE isn't stored per-window, so it's left `Unknown` unless a
-    /// linear rolling-CE model is supplied via `(ce_intercept, ce_slope_per_mz)`.
+    /// linear rolling-CE model is supplied; supplying only one of the two CE
+    /// coefficients is an error (never silently dropped).
     #[cfg(feature = "sciex")]
     #[staticmethod]
-    #[pyo3(signature = (path, cycle_time_s, gradient_length_s, ce_intercept=None, ce_slope_per_mz=None))]
+    #[pyo3(signature = (path, cycle_time_s, gradient_length_s, *, ce_intercept=None, ce_slope_per_mz=None))]
     pub fn from_sciex_wiff(
+        py: Python<'_>,
         path: &str,
         cycle_time_s: f64,
         gradient_length_s: f64,
@@ -53,17 +63,25 @@ impl PyAcquisitionScheme {
     ) -> PyResult<Self> {
         use rustdf::sim::scheme::CollisionEnergyPolicy;
         let ce = match (ce_intercept, ce_slope_per_mz) {
-            (Some(intercept), Some(slope_per_mz)) => CollisionEnergyPolicy::Linear {
-                intercept,
-                slope_per_mz,
-            },
-            _ => CollisionEnergyPolicy::Unknown,
+            (Some(intercept), Some(slope_per_mz)) => {
+                CollisionEnergyPolicy::Linear { intercept, slope_per_mz }
+            }
+            (None, None) => CollisionEnergyPolicy::Unknown,
+            _ => {
+                return Err(PyValueError::new_err(
+                    "supply both ce_intercept and ce_slope_per_mz, or neither",
+                ))
+            }
         };
-        AcquisitionScheme::from_sciex_wiff(path, cycle_time_s, gradient_length_s, ce)
-            .map(|inner| Self { inner })
-            .map_err(val_err)
+        let inner = py
+            .allow_threads(|| {
+                AcquisitionScheme::from_sciex_wiff(path, cycle_time_s, gradient_length_s, ce)
+            })
+            .map_err(PyErr::from)?;
+        Ok(Self { inner })
     }
 
+    /// Instrument kind (canonical enum variant name, e.g. `"TimsTofDia"`).
     #[getter]
     pub fn instrument(&self) -> String {
         format!("{:?}", self.inner.instrument)
@@ -98,18 +116,14 @@ impl PyAcquisitionScheme {
         self.inner.validate().map_err(val_err)
     }
 
-    /// Bruker `DiaFrameMsMsWindows` as column lists, ready for a DataFrame:
-    /// `(window_group, scan_start, scan_end, isolation_mz, isolation_width, collision_energy)`.
-    pub fn to_bruker_windows(
-        &self,
-    ) -> PyResult<(Vec<u32>, Vec<u32>, Vec<u32>, Vec<f64>, Vec<f64>, Vec<f64>)> {
+    /// Bruker `DiaFrameMsMsWindows` as a column dict of NumPy arrays, ready for
+    /// `pandas.DataFrame(...)`: keys `window_group, scan_start, scan_end,
+    /// isolation_mz, isolation_width, collision_energy`.
+    pub fn to_bruker_windows<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let rows = self.inner.to_bruker_windows().map_err(val_err)?;
-        let mut wg = Vec::with_capacity(rows.len());
-        let mut ss = Vec::with_capacity(rows.len());
-        let mut se = Vec::with_capacity(rows.len());
-        let mut mz = Vec::with_capacity(rows.len());
-        let mut wd = Vec::with_capacity(rows.len());
-        let mut ce = Vec::with_capacity(rows.len());
+        let n = rows.len();
+        let (mut wg, mut ss, mut se) = (Vec::with_capacity(n), Vec::with_capacity(n), Vec::with_capacity(n));
+        let (mut mz, mut wd, mut ce) = (Vec::with_capacity(n), Vec::with_capacity(n), Vec::with_capacity(n));
         for r in &rows {
             wg.push(r.window_group);
             ss.push(r.scan_num_begin);
@@ -118,12 +132,23 @@ impl PyAcquisitionScheme {
             wd.push(r.isolation_width);
             ce.push(r.collision_energy);
         }
-        Ok((wg, ss, se, mz, wd, ce))
+        let d = PyDict::new(py);
+        d.set_item("window_group", wg.into_pyarray(py))?;
+        d.set_item("scan_start", ss.into_pyarray(py))?;
+        d.set_item("scan_end", se.into_pyarray(py))?;
+        d.set_item("isolation_mz", mz.into_pyarray(py))?;
+        d.set_item("isolation_width", wd.into_pyarray(py))?;
+        d.set_item("collision_energy", ce.into_pyarray(py))?;
+        Ok(d)
     }
 
-    /// Bruker `DiaFrameMsMsInfo` as column lists for a `num_frames`-frame run:
-    /// `(frame, window_group)`.
-    pub fn to_bruker_info(&self, num_frames: u32) -> PyResult<(Vec<u32>, Vec<u32>)> {
+    /// Bruker `DiaFrameMsMsInfo` as a column dict of NumPy arrays for a
+    /// `num_frames`-frame run: keys `frame, window_group`.
+    pub fn to_bruker_info<'py>(
+        &self,
+        py: Python<'py>,
+        num_frames: u32,
+    ) -> PyResult<Bound<'py, PyDict>> {
         let rows = self.inner.to_bruker_info(num_frames).map_err(val_err)?;
         let mut frame = Vec::with_capacity(rows.len());
         let mut wg = Vec::with_capacity(rows.len());
@@ -131,12 +156,29 @@ impl PyAcquisitionScheme {
             frame.push(r.frame_id);
             wg.push(r.window_group);
         }
-        Ok((frame, wg))
+        let d = PyDict::new(py);
+        d.set_item("frame", frame.into_pyarray(py))?;
+        d.set_item("window_group", wg.into_pyarray(py))?;
+        Ok(d)
     }
+}
+
+/// Whether this build includes the Thermo `.raw` extractor.
+#[pyfunction]
+pub fn has_thermo() -> bool {
+    cfg!(feature = "thermo")
+}
+
+/// Whether this build includes the SCIEX `.wiff` extractor.
+#[pyfunction]
+pub fn has_sciex() -> bool {
+    cfg!(feature = "sciex")
 }
 
 #[pymodule]
 pub fn py_acquisition(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAcquisitionScheme>()?;
+    m.add_function(wrap_pyfunction!(has_thermo, m)?)?;
+    m.add_function(wrap_pyfunction!(has_sciex, m)?)?;
     Ok(())
 }

--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -1,5 +1,5 @@
 use numpy::IntoPyArray;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rustdf::sim::scheme::AcquisitionScheme;
@@ -184,14 +184,64 @@ impl PyAcquisitionScheme {
 #[pyclass]
 pub struct PyThermoRawWriter {
     inner: rustdf::sim::acquisition::ThermoRawWriter,
+    /// Set after a successful `finalize`. Guards against write-after-finalize
+    /// (which would leave the on-disk `.raw` stale) and double-finalize.
+    finalized: bool,
+}
+
+/// Caller-fault writer errors (`InvalidInput`/`InvalidData` — e.g. malformed
+/// peaks, exhausted template capacity) map to `ValueError`; genuine filesystem
+/// failures fall through to PyO3's default `io::Error` -> `OSError`.
+#[cfg(feature = "thermo")]
+fn writer_err(e: std::io::Error) -> PyErr {
+    use std::io::ErrorKind::{InvalidData, InvalidInput};
+    match e.kind() {
+        InvalidInput | InvalidData => PyValueError::new_err(e.to_string()),
+        _ => PyErr::from(e),
+    }
+}
+
+/// Validate and pack `(mz, intensity)` peak arrays into the writer's tuple form,
+/// rejecting the casts that would silently corrupt the output (NaN/inf m/z or
+/// intensity, non-positive m/z, negative intensity, overflow past `f32::MAX`).
+#[cfg(feature = "thermo")]
+fn pack_peaks(mz: &[f64], intensity: &[f64]) -> PyResult<Vec<(f64, f32)>> {
+    if mz.len() != intensity.len() {
+        return Err(PyValueError::new_err("mz and intensity must have equal length"));
+    }
+    if mz.is_empty() {
+        // A blank Replace scan silently erases the template slot — refuse it
+        // rather than make accidental data loss a one-liner.
+        return Err(PyValueError::new_err("peak arrays must be non-empty"));
+    }
+    let mut peaks = Vec::with_capacity(mz.len());
+    for (i, (&m, &inten)) in mz.iter().zip(intensity).enumerate() {
+        if !m.is_finite() || m <= 0.0 {
+            return Err(PyValueError::new_err(format!(
+                "mz[{i}] must be finite and > 0 (got {m})"
+            )));
+        }
+        if !inten.is_finite() || inten < 0.0 {
+            return Err(PyValueError::new_err(format!(
+                "intensity[{i}] must be finite and >= 0 (got {inten})"
+            )));
+        }
+        if inten > f32::MAX as f64 {
+            return Err(PyValueError::new_err(format!(
+                "intensity[{i}] overflows f32 (got {inten})"
+            )));
+        }
+        peaks.push((m, inten as f32));
+    }
+    Ok(peaks)
 }
 
 #[cfg(feature = "thermo")]
 #[pymethods]
 impl PyThermoRawWriter {
     /// Open `template` and prepare to author into `out`. Pass
-    /// `overlay_merge_tol_ppm` to overlay onto the real template signal instead
-    /// of replacing it.
+    /// `overlay_merge_tol_ppm` (finite, > 0) to overlay onto the real template
+    /// signal instead of replacing it.
     #[staticmethod]
     #[pyo3(signature = (template, out, overlay_merge_tol_ppm=None))]
     pub fn from_template(
@@ -201,13 +251,20 @@ impl PyThermoRawWriter {
         overlay_merge_tol_ppm: Option<f64>,
     ) -> PyResult<Self> {
         use rustdf::sim::acquisition::{ThermoRawWriter, WriteMode};
+        if let Some(tol) = overlay_merge_tol_ppm {
+            if !tol.is_finite() || tol <= 0.0 {
+                return Err(PyValueError::new_err(
+                    "overlay_merge_tol_ppm must be finite and > 0",
+                ));
+            }
+        }
         let mut w = py
             .allow_threads(|| ThermoRawWriter::from_template(template, out))
             .map_err(PyErr::from)?;
         if let Some(tol) = overlay_merge_tol_ppm {
             w = w.with_mode(WriteMode::Overlay { merge_tol_ppm: tol });
         }
-        Ok(Self { inner: w })
+        Ok(Self { inner: w, finalized: false })
     }
 
     /// Template (MS1, MS2) scan capacity, so a run can be checked to fit.
@@ -216,6 +273,10 @@ impl PyThermoRawWriter {
     }
 
     /// Author an MS1 scan from peak arrays (intensity cast to f32).
+    ///
+    /// `retention_time` is ordering/provenance metadata only — the template's
+    /// own scan retention times are preserved, so this value is not written to
+    /// the `.raw`. It is accepted to keep MS1/MS2 call sites symmetric.
     pub fn write_ms1(
         &mut self,
         retention_time: f64,
@@ -223,20 +284,22 @@ impl PyThermoRawWriter {
         intensity: Vec<f64>,
     ) -> PyResult<()> {
         use rustdf::sim::acquisition::{AcquisitionWriter, ScanDescriptor};
-        if mz.len() != intensity.len() {
-            return Err(PyValueError::new_err("mz and intensity must have equal length"));
-        }
-        let peaks = mz.iter().zip(&intensity).map(|(&m, &i)| (m, i as f32)).collect();
+        self.ensure_open()?;
+        let peaks = pack_peaks(&mz, &intensity)?;
         let d = ScanDescriptor {
             ms_level: 1,
             retention_time,
             isolation: None,
             peaks,
         };
-        self.inner.write_scan(&d).map_err(PyErr::from)
+        self.inner.write_scan(&d).map_err(writer_err)
     }
 
     /// Author an MS2 scan with its isolation window + collision energy.
+    ///
+    /// `retention_time` is ordering/provenance metadata only (see `write_ms1`).
+    /// In `Overlay` mode the isolation/CE are left as the template's; the
+    /// supplied values only take effect in `Replace` mode.
     pub fn write_ms2(
         &mut self,
         retention_time: f64,
@@ -247,10 +310,17 @@ impl PyThermoRawWriter {
         intensity: Vec<f64>,
     ) -> PyResult<()> {
         use rustdf::sim::acquisition::{AcquisitionWriter, IsolationWindow, ScanDescriptor};
-        if mz.len() != intensity.len() {
-            return Err(PyValueError::new_err("mz and intensity must have equal length"));
+        self.ensure_open()?;
+        if !isolation_center.is_finite() || isolation_center <= 0.0 {
+            return Err(PyValueError::new_err("isolation_center must be finite and > 0"));
         }
-        let peaks = mz.iter().zip(&intensity).map(|(&m, &i)| (m, i as f32)).collect();
+        if !isolation_width.is_finite() || isolation_width <= 0.0 {
+            return Err(PyValueError::new_err("isolation_width must be finite and > 0"));
+        }
+        if !collision_energy.is_finite() || collision_energy < 0.0 {
+            return Err(PyValueError::new_err("collision_energy must be finite and >= 0"));
+        }
+        let peaks = pack_peaks(&mz, &intensity)?;
         let d = ScanDescriptor {
             ms_level: 2,
             retention_time,
@@ -261,13 +331,34 @@ impl PyThermoRawWriter {
             }),
             peaks,
         };
-        self.inner.write_scan(&d).map_err(PyErr::from)
+        self.inner.write_scan(&d).map_err(writer_err)
     }
 
-    /// Recompute the checksum and write the `.raw` to disk.
+    /// Recompute the checksum and write the `.raw` to disk. May be called once;
+    /// subsequent writes or finalizes raise `RuntimeError`.
     pub fn finalize(&mut self, py: Python<'_>) -> PyResult<()> {
         use rustdf::sim::acquisition::AcquisitionWriter;
-        py.allow_threads(|| self.inner.finalize()).map_err(PyErr::from)
+        if self.finalized {
+            return Err(PyRuntimeError::new_err("writer already finalized"));
+        }
+        py.allow_threads(|| self.inner.finalize())
+            .map_err(writer_err)?;
+        self.finalized = true;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "thermo")]
+impl PyThermoRawWriter {
+    /// Reject writes after a successful `finalize` (the on-disk `.raw` would go
+    /// stale otherwise).
+    fn ensure_open(&self) -> PyResult<()> {
+        if self.finalized {
+            return Err(PyRuntimeError::new_err(
+                "writer already finalized; no further scans can be written",
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -112,6 +112,17 @@ impl PyAcquisitionScheme {
         self.inner.num_cycles()
     }
 
+    /// Number of events in one cycle (1 MS1 + N MS2 frames) — the Bruker
+    /// `precursor_every` (frames per cycle).
+    pub fn cycle_length(&self) -> usize {
+        self.inner.cycle.len()
+    }
+
+    /// Number of MS2 frames (window groups) per cycle.
+    pub fn n_ms2_frames(&self) -> usize {
+        self.inner.cycle.len() - self.inner.ms1_count()
+    }
+
     pub fn validate(&self) -> PyResult<()> {
         self.inner.validate().map_err(val_err)
     }
@@ -163,6 +174,103 @@ impl PyAcquisitionScheme {
     }
 }
 
+/// Thermo `.raw` writer (template-mutation), exposed to the Python simulator.
+///
+/// Open a real Astral/Orbitrap `.raw` template, push MS1/MS2 scans in acquisition
+/// order, and `finalize`. `Replace` rewrites template scans; `Overlay`
+/// (`overlay_merge_tol_ppm`) adds simulated peaks onto the real template signal
+/// (real⊕sim). Requires the `thermo` feature.
+#[cfg(feature = "thermo")]
+#[pyclass]
+pub struct PyThermoRawWriter {
+    inner: rustdf::sim::acquisition::ThermoRawWriter,
+}
+
+#[cfg(feature = "thermo")]
+#[pymethods]
+impl PyThermoRawWriter {
+    /// Open `template` and prepare to author into `out`. Pass
+    /// `overlay_merge_tol_ppm` to overlay onto the real template signal instead
+    /// of replacing it.
+    #[staticmethod]
+    #[pyo3(signature = (template, out, overlay_merge_tol_ppm=None))]
+    pub fn from_template(
+        py: Python<'_>,
+        template: &str,
+        out: &str,
+        overlay_merge_tol_ppm: Option<f64>,
+    ) -> PyResult<Self> {
+        use rustdf::sim::acquisition::{ThermoRawWriter, WriteMode};
+        let mut w = py
+            .allow_threads(|| ThermoRawWriter::from_template(template, out))
+            .map_err(PyErr::from)?;
+        if let Some(tol) = overlay_merge_tol_ppm {
+            w = w.with_mode(WriteMode::Overlay { merge_tol_ppm: tol });
+        }
+        Ok(Self { inner: w })
+    }
+
+    /// Template (MS1, MS2) scan capacity, so a run can be checked to fit.
+    pub fn capacity(&self) -> (usize, usize) {
+        self.inner.capacity()
+    }
+
+    /// Author an MS1 scan from peak arrays (intensity cast to f32).
+    pub fn write_ms1(
+        &mut self,
+        retention_time: f64,
+        mz: Vec<f64>,
+        intensity: Vec<f64>,
+    ) -> PyResult<()> {
+        use rustdf::sim::acquisition::{AcquisitionWriter, ScanDescriptor};
+        if mz.len() != intensity.len() {
+            return Err(PyValueError::new_err("mz and intensity must have equal length"));
+        }
+        let peaks = mz.iter().zip(&intensity).map(|(&m, &i)| (m, i as f32)).collect();
+        let d = ScanDescriptor {
+            ms_level: 1,
+            retention_time,
+            isolation: None,
+            peaks,
+        };
+        self.inner.write_scan(&d).map_err(PyErr::from)
+    }
+
+    /// Author an MS2 scan with its isolation window + collision energy.
+    pub fn write_ms2(
+        &mut self,
+        retention_time: f64,
+        isolation_center: f64,
+        isolation_width: f64,
+        collision_energy: f64,
+        mz: Vec<f64>,
+        intensity: Vec<f64>,
+    ) -> PyResult<()> {
+        use rustdf::sim::acquisition::{AcquisitionWriter, IsolationWindow, ScanDescriptor};
+        if mz.len() != intensity.len() {
+            return Err(PyValueError::new_err("mz and intensity must have equal length"));
+        }
+        let peaks = mz.iter().zip(&intensity).map(|(&m, &i)| (m, i as f32)).collect();
+        let d = ScanDescriptor {
+            ms_level: 2,
+            retention_time,
+            isolation: Some(IsolationWindow {
+                center_mz: isolation_center,
+                width_mz: isolation_width,
+                collision_energy,
+            }),
+            peaks,
+        };
+        self.inner.write_scan(&d).map_err(PyErr::from)
+    }
+
+    /// Recompute the checksum and write the `.raw` to disk.
+    pub fn finalize(&mut self, py: Python<'_>) -> PyResult<()> {
+        use rustdf::sim::acquisition::AcquisitionWriter;
+        py.allow_threads(|| self.inner.finalize()).map_err(PyErr::from)
+    }
+}
+
 /// Whether this build includes the Thermo `.raw` extractor.
 #[pyfunction]
 pub fn has_thermo() -> bool {
@@ -178,6 +286,8 @@ pub fn has_sciex() -> bool {
 #[pymodule]
 pub fn py_acquisition(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAcquisitionScheme>()?;
+    #[cfg(feature = "thermo")]
+    m.add_class::<PyThermoRawWriter>()?;
     m.add_function(wrap_pyfunction!(has_thermo, m)?)?;
     m.add_function(wrap_pyfunction!(has_sciex, m)?)?;
     Ok(())

--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -1,0 +1,142 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rustdf::sim::scheme::AcquisitionScheme;
+
+/// Python wrapper over the vendor-neutral DIA acquisition scheme
+/// (`rustdf::sim::scheme::AcquisitionScheme`).
+///
+/// Exposes the vendor extractors and the Bruker backward-compat adapter, so the
+/// Python simulator can build its DIA layout from a real Bruker/Thermo/SCIEX run
+/// (or an injected window table) and render the Bruker `DiaFrameMsMsWindows` /
+/// `DiaFrameMsMsInfo` tables. The `from_thermo_raw`/`from_sciex_wiff` constructors
+/// require the connector to be built with the `thermo`/`sciex` feature.
+#[pyclass]
+pub struct PyAcquisitionScheme {
+    pub inner: AcquisitionScheme,
+}
+
+fn val_err<E: ToString>(e: E) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
+#[pymethods]
+impl PyAcquisitionScheme {
+    /// Extract the scheme from a Bruker timsTOF DIA `.d` folder.
+    #[staticmethod]
+    pub fn from_bruker_d(path: &str) -> PyResult<Self> {
+        AcquisitionScheme::from_bruker_d(path)
+            .map(|inner| Self { inner })
+            .map_err(val_err)
+    }
+
+    /// Extract from a Thermo Orbitrap `.raw` (requires the `thermo` feature).
+    #[cfg(feature = "thermo")]
+    #[staticmethod]
+    pub fn from_thermo_raw(path: &str) -> PyResult<Self> {
+        AcquisitionScheme::from_thermo_raw(path)
+            .map(|inner| Self { inner })
+            .map_err(val_err)
+    }
+
+    /// Extract from a SCIEX `.wiff` SWATH method (requires the `sciex` feature).
+    /// SCIEX rolling CE isn't stored per-window, so it's left `Unknown` unless a
+    /// linear rolling-CE model is supplied via `(ce_intercept, ce_slope_per_mz)`.
+    #[cfg(feature = "sciex")]
+    #[staticmethod]
+    #[pyo3(signature = (path, cycle_time_s, gradient_length_s, ce_intercept=None, ce_slope_per_mz=None))]
+    pub fn from_sciex_wiff(
+        path: &str,
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+        ce_intercept: Option<f64>,
+        ce_slope_per_mz: Option<f64>,
+    ) -> PyResult<Self> {
+        use rustdf::sim::scheme::CollisionEnergyPolicy;
+        let ce = match (ce_intercept, ce_slope_per_mz) {
+            (Some(intercept), Some(slope_per_mz)) => CollisionEnergyPolicy::Linear {
+                intercept,
+                slope_per_mz,
+            },
+            _ => CollisionEnergyPolicy::Unknown,
+        };
+        AcquisitionScheme::from_sciex_wiff(path, cycle_time_s, gradient_length_s, ce)
+            .map(|inner| Self { inner })
+            .map_err(val_err)
+    }
+
+    #[getter]
+    pub fn instrument(&self) -> String {
+        format!("{:?}", self.inner.instrument)
+    }
+
+    #[getter]
+    pub fn mz_range(&self) -> (f64, f64) {
+        self.inner.mz_range
+    }
+
+    #[getter]
+    pub fn provenance(&self) -> String {
+        format!(
+            "{:?}: {}",
+            self.inner.provenance.source, self.inner.provenance.notes
+        )
+    }
+
+    pub fn ms1_count(&self) -> usize {
+        self.inner.ms1_count()
+    }
+
+    pub fn n_windows(&self) -> usize {
+        self.inner.windows().count()
+    }
+
+    pub fn num_cycles(&self) -> Option<u64> {
+        self.inner.num_cycles()
+    }
+
+    pub fn validate(&self) -> PyResult<()> {
+        self.inner.validate().map_err(val_err)
+    }
+
+    /// Bruker `DiaFrameMsMsWindows` as column lists, ready for a DataFrame:
+    /// `(window_group, scan_start, scan_end, isolation_mz, isolation_width, collision_energy)`.
+    pub fn to_bruker_windows(
+        &self,
+    ) -> PyResult<(Vec<u32>, Vec<u32>, Vec<u32>, Vec<f64>, Vec<f64>, Vec<f64>)> {
+        let rows = self.inner.to_bruker_windows().map_err(val_err)?;
+        let mut wg = Vec::with_capacity(rows.len());
+        let mut ss = Vec::with_capacity(rows.len());
+        let mut se = Vec::with_capacity(rows.len());
+        let mut mz = Vec::with_capacity(rows.len());
+        let mut wd = Vec::with_capacity(rows.len());
+        let mut ce = Vec::with_capacity(rows.len());
+        for r in &rows {
+            wg.push(r.window_group);
+            ss.push(r.scan_num_begin);
+            se.push(r.scan_num_end);
+            mz.push(r.isolation_mz);
+            wd.push(r.isolation_width);
+            ce.push(r.collision_energy);
+        }
+        Ok((wg, ss, se, mz, wd, ce))
+    }
+
+    /// Bruker `DiaFrameMsMsInfo` as column lists for a `num_frames`-frame run:
+    /// `(frame, window_group)`.
+    pub fn to_bruker_info(&self, num_frames: u32) -> PyResult<(Vec<u32>, Vec<u32>)> {
+        let rows = self.inner.to_bruker_info(num_frames).map_err(val_err)?;
+        let mut frame = Vec::with_capacity(rows.len());
+        let mut wg = Vec::with_capacity(rows.len());
+        for r in &rows {
+            frame.push(r.frame_id);
+            wg.push(r.window_group);
+        }
+        Ok((frame, wg))
+    }
+}
+
+#[pymodule]
+pub fn py_acquisition(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyAcquisitionScheme>()?;
+    Ok(())
+}

--- a/packages/imspy-simulation/src/imspy_simulation/acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/acquisition.py
@@ -177,6 +177,9 @@ class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
             if verbose:
                 print('Using reference dataset cycle length:', np.round(rt_cycle_length, 4))
             self.rt_cycle_length = rt_cycle_length
+            # Recompute the frame count: the base __init__ computed it from the
+            # passed rt_cycle_length before this reference-derived value replaced it.
+            self.num_frames = calculate_number_frames(self.gradient_length, rt_cycle_length)
 
         self.acquisition_name = acquisition_name
         self.scan_table = None
@@ -214,25 +217,57 @@ class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
 
         return pd.DataFrame(table_list)
 
+    def _layout_from_scheme(self, verbose: bool = True):
+        """Derive the DIA window + frame→group tables from the reference `.d` via
+        the vendor-neutral ``AcquisitionScheme`` (imspy_connector.py_acquisition).
+
+        Returns ``(dia_ms_ms_windows, frames_to_window_groups, precursor_every)``
+        or ``None`` if the connector lacks the scheme module (legacy fallback).
+        """
+        try:
+            import imspy_connector
+            acq = imspy_connector.py_acquisition
+        except (ImportError, AttributeError):
+            if verbose:
+                print('py_acquisition unavailable; using legacy reference layout')
+            return None
+
+        scheme = acq.PyAcquisitionScheme.from_bruker_d(self.reference.data_path)
+        precursor_every = scheme.cycle_length()
+        windows = pd.DataFrame(scheme.to_bruker_windows())
+        info = pd.DataFrame(scheme.to_bruker_info(int(self.num_frames)))
+        if verbose:
+            print(f'Using AcquisitionScheme layout: {len(windows)} windows, '
+                  f'{scheme.n_ms2_frames()} groups, precursor_every={precursor_every}')
+        return windows, info, precursor_every
+
     def _setup(self, verbose: bool = True):
         self.frame_table = self.generate_frame_table(verbose=verbose)
         self.scan_table = self.generate_scan_table(verbose=verbose)
 
-        if self.use_reference_ds_layout:
-            self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
-            self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
-                columns={
-                    'WindowGroup': 'window_group',
-                    'ScanNumBegin': 'scan_start',
-                    'ScanNumEnd': 'scan_end',
-                    'IsolationMz': 'isolation_mz',
-                    'IsolationWidth': 'isolation_width',
-                    'CollisionEnergy': 'collision_energy',
-                }
-            )
+        scheme_layout = self._layout_from_scheme(verbose=verbose) if self.use_reference_ds_layout else None
 
-        self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
-        self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
+        if scheme_layout is not None:
+            # Vendor-neutral path: windows + frame→group come from the scheme.
+            self.dia_ms_ms_windows, frames_to_window_groups, self.precursor_every = scheme_layout
+            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+            self.frames_to_window_groups = frames_to_window_groups
+        else:
+            # Legacy path: copy the reference .d's window table directly.
+            if self.use_reference_ds_layout:
+                self.precursor_every = int(np.diff(self.reference.precursor_frames)[0])
+                self.dia_ms_ms_windows = self.reference.dia_ms_ms_windows.rename(
+                    columns={
+                        'WindowGroup': 'window_group',
+                        'ScanNumBegin': 'scan_start',
+                        'ScanNumEnd': 'scan_end',
+                        'IsolationMz': 'isolation_mz',
+                        'IsolationWidth': 'isolation_width',
+                        'CollisionEnergy': 'collision_energy',
+                    }
+                )
+            self.frame_table['ms_type'] = self.calculate_frame_types(verbose=verbose)
+            self.frames_to_window_groups = self.generate_frame_to_window_group_table(verbose=verbose)
 
         if self.round_collision_energy:
             self.dia_ms_ms_windows['collision_energy'] = np.round(self.dia_ms_ms_windows['collision_energy'].values,

--- a/packages/imspy-simulation/src/imspy_simulation/acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/acquisition.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Dict
 
@@ -228,14 +229,31 @@ class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
             import imspy_connector
             acq = imspy_connector.py_acquisition
         except (ImportError, AttributeError):
-            if verbose:
-                print('py_acquisition unavailable; using legacy reference layout')
+            warnings.warn(
+                'imspy_connector.py_acquisition is unavailable; falling back to the '
+                'legacy reference-.d layout read. Update/rebuild the connector to use '
+                'the vendor-neutral AcquisitionScheme path.',
+                RuntimeWarning,
+                stacklevel=2,
+            )
             return None
 
         scheme = acq.PyAcquisitionScheme.from_bruker_d(self.reference.data_path)
         precursor_every = scheme.cycle_length()
         windows = pd.DataFrame(scheme.to_bruker_windows())
         info = pd.DataFrame(scheme.to_bruker_info(int(self.num_frames)))
+        # Scheme columns come back as numpy uint32; cast integer columns to int64
+        # so the in-memory tables match the legacy dtypes (SQLite stores INTEGER
+        # either way) and avoid uint32-wrap surprises for downstream consumers.
+        for col in ("window_group", "scan_start", "scan_end"):
+            windows[col] = windows[col].astype("int64")
+        for col in ("frame", "window_group"):
+            info[col] = info[col].astype("int64")
+        # Note: window-group ids are the reference's real WindowGroup values
+        # (preserved by the scheme), so this matches the reference .d exactly. For a
+        # non-canonical/permuted reference this differs from the legacy position
+        # formula (wg = index % precursor_every) — by being correct, since the
+        # legacy info was inconsistent with its own copied window table.
         if verbose:
             print(f'Using AcquisitionScheme layout: {len(windows)} windows, '
                   f'{scheme.n_ms2_frames()} groups, precursor_every={precursor_every}')

--- a/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py
+++ b/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py
@@ -1,0 +1,68 @@
+"""Golden parity: the vendor-neutral AcquisitionScheme (via imspy_connector)
+must reproduce the Bruker DIA layout the legacy `use_reference_ds_layout` path
+copies from the reference `.d` — both the `DiaFrameMsMsWindows` window table and
+the per-frame `DiaFrameMsMsInfo` (frame→group) table.
+
+Gated on TIMSIM_BRUKER_DIA_D pointing at a real DIA-PASEF `.d`.
+"""
+import os
+import sqlite3
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import imspy_connector
+
+acq = imspy_connector.py_acquisition
+DIA_D = os.environ.get("TIMSIM_BRUKER_DIA_D")
+pytestmark = pytest.mark.skipif(
+    not DIA_D, reason="set TIMSIM_BRUKER_DIA_D to a real DIA-PASEF .d folder"
+)
+
+
+def _norm(df, cols):
+    return df[cols].astype(float).round(6).sort_values(cols).reset_index(drop=True)
+
+
+def test_scheme_windows_match_reference():
+    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
+    windows = pd.DataFrame(scheme.to_bruker_windows())
+
+    con = sqlite3.connect(DIA_D + "/analysis.tdf")
+    ref = pd.read_sql(
+        "SELECT WindowGroup window_group, ScanNumBegin scan_start, ScanNumEnd scan_end, "
+        "IsolationMz isolation_mz, IsolationWidth isolation_width, "
+        "CollisionEnergy collision_energy FROM DiaFrameMsMsWindows",
+        con,
+    )
+    cols = list(ref.columns)
+    assert len(windows) == len(ref)
+    pd.testing.assert_frame_equal(_norm(windows, cols), _norm(ref, cols))
+
+
+def test_scheme_info_matches_reference_and_legacy_formula():
+    scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
+    con = sqlite3.connect(DIA_D + "/analysis.tdf")
+    num_frames = int(con.execute("SELECT MAX(Id) FROM Frames").fetchone()[0])
+
+    info = pd.DataFrame(scheme.to_bruker_info(num_frames))
+
+    # (a) matches the .d's own DiaFrameMsMsInfo exactly
+    ref = pd.read_sql("SELECT Frame frame, WindowGroup window_group FROM DiaFrameMsMsInfo", con)
+    pd.testing.assert_frame_equal(
+        _norm(info, ["frame", "window_group"]), _norm(ref, ["frame", "window_group"])
+    )
+
+    # (b) matches the legacy position formula (index % precursor_every, ms2 only)
+    pe = scheme.cycle_length()
+    legacy = pd.DataFrame(
+        [
+            {"frame": f, "window_group": (f - 1) % pe}
+            for f in range(1, num_frames + 1)
+            if (f - 1) % pe != 0
+        ]
+    )
+    pd.testing.assert_frame_equal(
+        _norm(info, ["frame", "window_group"]), _norm(legacy, ["frame", "window_group"])
+    )

--- a/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py
+++ b/packages/imspy-simulation/tests/test_acquisition_scheme_parity.py
@@ -41,28 +41,21 @@ def test_scheme_windows_match_reference():
     pd.testing.assert_frame_equal(_norm(windows, cols), _norm(ref, cols))
 
 
-def test_scheme_info_matches_reference_and_legacy_formula():
+def test_scheme_info_matches_reference():
+    # The true contract: the scheme's DiaFrameMsMsInfo must reproduce the
+    # reference .d's table exactly. (We intentionally do NOT assert equality with
+    # the legacy `window_group = index % precursor_every` position formula: that
+    # only holds for canonical 1..N references, and where it differs the scheme is
+    # the correct one — it preserves the real WindowGroup ids.)
     scheme = acq.PyAcquisitionScheme.from_bruker_d(DIA_D)
     con = sqlite3.connect(DIA_D + "/analysis.tdf")
     num_frames = int(con.execute("SELECT MAX(Id) FROM Frames").fetchone()[0])
 
     info = pd.DataFrame(scheme.to_bruker_info(num_frames))
-
-    # (a) matches the .d's own DiaFrameMsMsInfo exactly
     ref = pd.read_sql("SELECT Frame frame, WindowGroup window_group FROM DiaFrameMsMsInfo", con)
+    assert len(info) == len(ref)
     pd.testing.assert_frame_equal(
         _norm(info, ["frame", "window_group"]), _norm(ref, ["frame", "window_group"])
     )
-
-    # (b) matches the legacy position formula (index % precursor_every, ms2 only)
-    pe = scheme.cycle_length()
-    legacy = pd.DataFrame(
-        [
-            {"frame": f, "window_group": (f - 1) % pe}
-            for f in range(1, num_frames + 1)
-            if (f - 1) % pe != 0
-        ]
-    )
-    pd.testing.assert_frame_equal(
-        _norm(info, ["frame", "window_group"]), _norm(legacy, ["frame", "window_group"])
-    )
+    # info is emitted frame-ascending.
+    assert info["frame"].is_monotonic_increasing

--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -40,7 +40,7 @@ rustc-hash = "2.1.0"
 bincode = "1.3.3"
 polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
 # Thermo .raw writer (private repo; only built with the `thermo` feature)
-thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "c245dc662813809378bfd58de34fc52aa9a41485", optional = true }
+thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "9f4c0affe60a639759883fb569d3c9f5f7601856", optional = true }
 
 [features]
 # Off by default: enables the Thermo .raw AcquisitionWriter. Requires build-time

--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -42,7 +42,7 @@ polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
 # Thermo .raw writer (private repo; only built with the `thermo` feature)
 thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "9f4c0affe60a639759883fb569d3c9f5f7601856", optional = true }
 # SCIEX .wiff method reader (private repo; only built with the `sciex` feature)
-sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "4e8ff07842bb52a0bd9fe601cc61fd95a68b9080", optional = true }
+sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "ef7c0cd7e59d3b51160e446cbe3af240d230668d", optional = true }
 
 [features]
 # Off by default: enable the Thermo .raw / SCIEX .wiff extractors + writers.

--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -40,7 +40,7 @@ rustc-hash = "2.1.0"
 bincode = "1.3.3"
 polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
 # Thermo .raw writer (private repo; only built with the `thermo` feature)
-thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "64fec1a2eec4800d82451c0a60398ef327e05ac2", optional = true }
+thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "c245dc662813809378bfd58de34fc52aa9a41485", optional = true }
 
 [features]
 # Off by default: enables the Thermo .raw AcquisitionWriter. Requires build-time

--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -39,6 +39,13 @@ rand = "0.8.5"
 rustc-hash = "2.1.0"
 bincode = "1.3.3"
 polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
+# Thermo .raw writer (private repo; only built with the `thermo` feature)
+thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "64fec1a2eec4800d82451c0a60398ef327e05ac2", optional = true }
+
+[features]
+# Off by default: enables the Thermo .raw AcquisitionWriter. Requires build-time
+# access to the private thermorawfile repo.
+thermo = ["dep:thermorawfile"]
 
 [package.metadata.docs.rs]
-features = ["all"] 
+features = ["all"]

--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -41,11 +41,14 @@ bincode = "1.3.3"
 polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
 # Thermo .raw writer (private repo; only built with the `thermo` feature)
 thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "9f4c0affe60a639759883fb569d3c9f5f7601856", optional = true }
+# SCIEX .wiff method reader (private repo; only built with the `sciex` feature)
+sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "4e8ff07842bb52a0bd9fe601cc61fd95a68b9080", optional = true }
 
 [features]
-# Off by default: enables the Thermo .raw AcquisitionWriter. Requires build-time
-# access to the private thermorawfile repo.
+# Off by default: enable the Thermo .raw / SCIEX .wiff extractors + writers.
+# Each requires build-time access to its private repo.
 thermo = ["dep:thermorawfile"]
+sciex = ["dep:sciexwiff"]
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/rustdf/src/sim/acquisition.rs
+++ b/rustdf/src/sim/acquisition.rs
@@ -55,7 +55,14 @@ mod thermo {
     /// The template supplies the frequency grid + calibration; synthetic peaks
     /// are placed at their exact m/z within each packet's byte budget. The
     /// calibration is read once from the first scan (it is ≈constant across a
-    /// run); each scan's own frequency grid is taken from its profile.
+    /// run); each scan's own frequency grid is taken from its profile. For MS2,
+    /// a descriptor's [`IsolationWindow`] (center/width/CE) is authored into the
+    /// scan event via `set_isolation`, so the output's MS2 metadata reflects the
+    /// intended scheme rather than only the template's.
+    ///
+    /// Current limitation: this *replaces* the template scan's signal. A future
+    /// **overlay** mode (keep the real template signal and add simulated peaks)
+    /// would support the "reference run = layout + real noise" real⊕sim workflow.
     pub struct ThermoRawWriter {
         raw: RawFile,
         out_path: PathBuf,
@@ -135,7 +142,15 @@ mod thermo {
                     )
                 })?;
                 self.cent_cur += 1;
-                self.raw.author_centroids(t, &scan.peaks)
+                self.raw.author_centroids(t, &scan.peaks)?;
+                // Author the descriptor's isolation window + CE into the scan
+                // event so the output's MS2 metadata reflects the intended
+                // scheme, not just the template's.
+                if let Some(iso) = scan.isolation {
+                    self.raw
+                        .set_isolation(t, iso.center_mz, iso.width_mz, iso.collision_energy)?;
+                }
+                Ok(())
             }
         }
 
@@ -222,6 +237,15 @@ mod tests {
         assert!((cents[0].mz - 150.1).abs() < 0.01);
         assert!((cents[2].mz - 610.3).abs() < 0.01);
 
-        eprintln!("thermo_roundtrip OK: MS1 {:?}, MS2 {} peaks", ms1_mz, cents.len());
+        // The authored isolation window + CE must be reflected in the scan event.
+        let ev = rf.scan_event(cent_scan.unwrap()).expect("ms2 scan event");
+        assert!((ev.isolation_center - 500.0).abs() < 0.01, "authored isolation center");
+        assert!((ev.isolation_width - 2.0).abs() < 0.01, "authored isolation width");
+        assert!((ev.collision_energy - 25.0).abs() < 0.1, "authored CE");
+
+        eprintln!(
+            "thermo_roundtrip OK: MS1 {:?}, MS2 {} peaks, MS2 iso {:.2}±{:.2} CE {:.1}",
+            ms1_mz, cents.len(), ev.isolation_center, ev.isolation_width, ev.collision_energy
+        );
     }
 }

--- a/rustdf/src/sim/acquisition.rs
+++ b/rustdf/src/sim/acquisition.rs
@@ -39,13 +39,23 @@ pub trait AcquisitionWriter {
 }
 
 #[cfg(feature = "thermo")]
-pub use thermo::ThermoRawWriter;
+pub use thermo::{ThermoRawWriter, WriteMode};
 
 #[cfg(feature = "thermo")]
 mod thermo {
     use super::*;
     use std::path::{Path, PathBuf};
     use thermorawfile::{Calibration, RawFile};
+
+    /// How `ThermoRawWriter` combines simulated peaks with the template scan.
+    #[derive(Clone, Copy, Debug)]
+    pub enum WriteMode {
+        /// Replace the template scan's signal with the simulated peaks.
+        Replace,
+        /// Add simulated peaks onto the template's real signal (real⊕sim);
+        /// `merge_tol_ppm` merges near-coincident centroids on MS2.
+        Overlay { merge_tol_ppm: f64 },
+    }
 
     /// Authors scans into a Thermo `.raw` by **template-mutation**: open a real
     /// `.raw`, overwrite template scans of matching type in acquisition order
@@ -73,6 +83,7 @@ mod thermo {
         centroid_scans: Vec<u32>,
         prof_cur: usize,
         cent_cur: usize,
+        mode: WriteMode,
     }
 
     impl ThermoRawWriter {
@@ -114,7 +125,16 @@ mod thermo {
                 centroid_scans,
                 prof_cur: 0,
                 cent_cur: 0,
+                mode: WriteMode::Replace,
             })
+        }
+
+        /// Set the write mode (default [`WriteMode::Replace`]). Use
+        /// [`WriteMode::Overlay`] for the reference-run = layout + real-noise
+        /// (real⊕sim) workflow.
+        pub fn with_mode(mut self, mode: WriteMode) -> Self {
+            self.mode = mode;
+            self
         }
 
         /// Template MS1/MS2 capacity, so callers can check a run fits.
@@ -133,7 +153,12 @@ mod thermo {
                     )
                 })?;
                 self.prof_cur += 1;
-                self.raw.author_profile(t, &scan.peaks, &self.calib)
+                match self.mode {
+                    WriteMode::Replace => self.raw.author_profile(t, &scan.peaks, &self.calib),
+                    WriteMode::Overlay { .. } => {
+                        self.raw.overlay_profile(t, &scan.peaks, &self.calib)
+                    }
+                }
             } else {
                 let t = *self.centroid_scans.get(self.cent_cur).ok_or_else(|| {
                     io::Error::new(
@@ -142,15 +167,29 @@ mod thermo {
                     )
                 })?;
                 self.cent_cur += 1;
-                self.raw.author_centroids(t, &scan.peaks)?;
-                // Author the descriptor's isolation window + CE into the scan
-                // event so the output's MS2 metadata reflects the intended
-                // scheme, not just the template's.
-                if let Some(iso) = scan.isolation {
-                    self.raw
-                        .set_isolation(t, iso.center_mz, iso.width_mz, iso.collision_energy)?;
+                match self.mode {
+                    WriteMode::Replace => {
+                        self.raw.author_centroids(t, &scan.peaks)?;
+                        // Author the descriptor's isolation window + CE into the
+                        // scan event so the output's MS2 metadata reflects the
+                        // intended scheme, not just the template's.
+                        if let Some(iso) = scan.isolation {
+                            self.raw.set_isolation(
+                                t,
+                                iso.center_mz,
+                                iso.width_mz,
+                                iso.collision_energy,
+                            )?;
+                        }
+                        Ok(())
+                    }
+                    // Overlay keeps the template's real signal + acquisition
+                    // metadata (the scheme is derived from this template), so the
+                    // isolation/CE are left as the template's.
+                    WriteMode::Overlay { merge_tol_ppm } => {
+                        self.raw.overlay_centroids(t, &scan.peaks, merge_tol_ppm)
+                    }
                 }
-                Ok(())
             }
         }
 
@@ -247,5 +286,59 @@ mod tests {
             "thermo_roundtrip OK: MS1 {:?}, MS2 {} peaks, MS2 iso {:.2}±{:.2} CE {:.1}",
             ms1_mz, cents.len(), ev.isolation_center, ev.isolation_width, ev.collision_energy
         );
+    }
+
+    // Gated: overlay (real⊕sim) — sim peaks added onto the template's real signal.
+    #[test]
+    fn thermo_overlay() {
+        let template = match std::env::var("TIMSIM_ASTRAL_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP thermo_overlay: set TIMSIM_ASTRAL_TEMPLATE=<astral .raw>");
+                return;
+            }
+        };
+        let out = std::env::temp_dir().join("rustdf_thermo_overlay.raw");
+
+        // Baseline counts from the untouched template.
+        let base = thermorawfile::RawFile::open(&template).unwrap();
+        let (mut prof_scan, mut cent_scan) = (None, None);
+        for i in 0..base.index.len() {
+            let scan = base.first_scan + i as u32;
+            let pkt = (base.data_addr + base.index[i].offset) as usize;
+            let psize = u32::from_le_bytes(base.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+            if psize > 0 && prof_scan.is_none() { prof_scan = Some(scan); }
+            if psize == 0 && cent_scan.is_none() { cent_scan = Some(scan); }
+        }
+        let base_pts = base.profile(prof_scan.unwrap()).unwrap().point_count();
+        let base_cents = base.centroid_peaks(cent_scan.unwrap()).len();
+
+        let mut w = ThermoRawWriter::from_template(&template, &out)
+            .expect("open")
+            .with_mode(WriteMode::Overlay { merge_tol_ppm: 10.0 });
+        w.write_scan(&ScanDescriptor {
+            ms_level: 1, retention_time: 0.0, isolation: None,
+            peaks: vec![(555.5, 9.9e5), (744.4, 7.7e5)],
+        }).unwrap();
+        w.write_scan(&ScanDescriptor {
+            ms_level: 2, retention_time: 0.01,
+            isolation: Some(IsolationWindow { center_mz: 490.0, width_mz: 2.0, collision_energy: 25.0 }),
+            peaks: vec![(333.33, 5.0e5), (888.88, 4.0e5)],
+        }).unwrap();
+        w.finalize().unwrap();
+
+        let rf = thermorawfile::RawFile::open(&out).unwrap();
+        assert!(rf.checksum_valid());
+        let cal = rf.calibration_at_event(rf.scantrailer_addr as usize + 4).unwrap();
+        let prof = rf.profile(prof_scan.unwrap()).unwrap();
+        // Real signal retained (point count grew, not replaced) + sim m/z present.
+        assert!(prof.point_count() >= base_pts, "real profile points dropped");
+        let has = |mz: f64| prof.chunks.iter().any(|c|
+            (0..c.signal.len()).any(|j| (prof.mz_of_bin(c.first_bin + j as u32, &cal) - mz).abs() < 0.02));
+        assert!(has(555.5) && has(744.4), "sim MS1 peaks missing");
+        let cents = rf.centroid_peaks(cent_scan.unwrap());
+        assert!(cents.len() >= base_cents + 1, "MS2 real centroids not retained / sim not added");
+        eprintln!("thermo_overlay OK: MS1 {}->{} pts (+sim), MS2 {}->{} centroids",
+            base_pts, prof.point_count(), base_cents, cents.len());
     }
 }

--- a/rustdf/src/sim/acquisition.rs
+++ b/rustdf/src/sim/acquisition.rs
@@ -152,13 +152,16 @@ mod thermo {
                         "template exhausted of MS1 (profile) scans",
                     )
                 })?;
-                self.prof_cur += 1;
+                // Only advance the cursor once authoring fully succeeds, so a
+                // failed write doesn't permanently consume the template slot.
                 match self.mode {
                     WriteMode::Replace => self.raw.author_profile(t, &scan.peaks, &self.calib),
                     WriteMode::Overlay { .. } => {
                         self.raw.overlay_profile(t, &scan.peaks, &self.calib)
                     }
-                }
+                }?;
+                self.prof_cur += 1;
+                Ok(())
             } else {
                 let t = *self.centroid_scans.get(self.cent_cur).ok_or_else(|| {
                     io::Error::new(
@@ -166,7 +169,6 @@ mod thermo {
                         "template exhausted of MS2 (centroid) scans",
                     )
                 })?;
-                self.cent_cur += 1;
                 match self.mode {
                     WriteMode::Replace => {
                         self.raw.author_centroids(t, &scan.peaks)?;
@@ -181,15 +183,17 @@ mod thermo {
                                 iso.collision_energy,
                             )?;
                         }
-                        Ok(())
                     }
                     // Overlay keeps the template's real signal + acquisition
                     // metadata (the scheme is derived from this template), so the
                     // isolation/CE are left as the template's.
                     WriteMode::Overlay { merge_tol_ppm } => {
-                        self.raw.overlay_centroids(t, &scan.peaks, merge_tol_ppm)
+                        self.raw.overlay_centroids(t, &scan.peaks, merge_tol_ppm)?
                     }
                 }
+                // Slot consumed only after the centroid+isolation write succeeded.
+                self.cent_cur += 1;
+                Ok(())
             }
         }
 

--- a/rustdf/src/sim/acquisition.rs
+++ b/rustdf/src/sim/acquisition.rs
@@ -1,0 +1,227 @@
+//! Vendor-neutral acquisition-writer abstraction.
+//!
+//! [`AcquisitionWriter`] turns vendor-neutral [`ScanDescriptor`]s into a vendor
+//! raw file. The first implementation is [`ThermoRawWriter`] (Thermo `.raw`, via
+//! the `thermo` feature + the `thermorawfile` crate); a Bruker `.d` adapter over
+//! the existing write path is a planned follow-up.
+
+use std::io;
+
+/// MS2 quadrupole isolation window.
+#[derive(Clone, Copy, Debug)]
+pub struct IsolationWindow {
+    pub center_mz: f64,
+    pub width_mz: f64,
+    pub collision_energy: f64,
+}
+
+/// One vendor-neutral scan: a peak list plus acquisition metadata.
+///
+/// Intentionally has **no ion-mobility dimension** — it is the
+/// Bruker∩Thermo∩SCIEX common denominator. IMS-bearing Bruker frames are handled
+/// by the Bruker writer, which can flatten or carry mobility separately.
+#[derive(Clone, Debug)]
+pub struct ScanDescriptor {
+    pub ms_level: u8,
+    pub retention_time: f64,
+    /// Present for MS2 (the precursor isolation window).
+    pub isolation: Option<IsolationWindow>,
+    /// `(m/z, intensity)` pairs; need not be sorted (writers sort).
+    pub peaks: Vec<(f64, f32)>,
+}
+
+/// A sink that writes vendor-neutral scans into a vendor raw file. Scans are
+/// written in acquisition order; `finalize` flushes the file (and fixes any
+/// integrity checksum).
+pub trait AcquisitionWriter {
+    fn write_scan(&mut self, scan: &ScanDescriptor) -> io::Result<()>;
+    fn finalize(&mut self) -> io::Result<()>;
+}
+
+#[cfg(feature = "thermo")]
+pub use thermo::ThermoRawWriter;
+
+#[cfg(feature = "thermo")]
+mod thermo {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use thermorawfile::{Calibration, RawFile};
+
+    /// Authors scans into a Thermo `.raw` by **template-mutation**: open a real
+    /// `.raw`, overwrite template scans of matching type in acquisition order
+    /// (MS1 → profile via `author_profile`, MS2 → centroids via
+    /// `author_centroids`), and save on [`AcquisitionWriter::finalize`].
+    ///
+    /// The template supplies the frequency grid + calibration; synthetic peaks
+    /// are placed at their exact m/z within each packet's byte budget. The
+    /// calibration is read once from the first scan (it is ≈constant across a
+    /// run); each scan's own frequency grid is taken from its profile.
+    pub struct ThermoRawWriter {
+        raw: RawFile,
+        out_path: PathBuf,
+        calib: Calibration,
+        /// Template scans that carry a profile (treated as MS1 targets).
+        profile_scans: Vec<u32>,
+        /// Centroid-only template scans (treated as MS2 targets).
+        centroid_scans: Vec<u32>,
+        prof_cur: usize,
+        cent_cur: usize,
+    }
+
+    impl ThermoRawWriter {
+        /// Open `template` and prepare to author into `out`.
+        pub fn from_template<P: AsRef<Path>, Q: AsRef<Path>>(
+            template: P,
+            out: Q,
+        ) -> io::Result<Self> {
+            let raw = RawFile::open(template)?;
+            let calib = raw
+                .calibration_at_event(raw.scantrailer_addr as usize + 4)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "no MS1 calibration in template")
+                })?;
+
+            // Classify template scans by packet type: a non-zero profile section
+            // marks an MS1-style (FTMS profile) scan; centroid-only is MS2 (ASTMS).
+            let mut profile_scans = Vec::new();
+            let mut centroid_scans = Vec::new();
+            for (i, e) in raw.index.iter().enumerate() {
+                let pkt = (raw.data_addr + e.offset) as usize;
+                if pkt + 8 > raw.bytes.len() {
+                    continue;
+                }
+                let profile_size =
+                    u32::from_le_bytes(raw.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+                let scan = raw.first_scan + i as u32;
+                if profile_size > 0 {
+                    profile_scans.push(scan);
+                } else {
+                    centroid_scans.push(scan);
+                }
+            }
+            Ok(Self {
+                raw,
+                out_path: out.as_ref().to_path_buf(),
+                calib,
+                profile_scans,
+                centroid_scans,
+                prof_cur: 0,
+                cent_cur: 0,
+            })
+        }
+
+        /// Template MS1/MS2 capacity, so callers can check a run fits.
+        pub fn capacity(&self) -> (usize, usize) {
+            (self.profile_scans.len(), self.centroid_scans.len())
+        }
+    }
+
+    impl AcquisitionWriter for ThermoRawWriter {
+        fn write_scan(&mut self, scan: &ScanDescriptor) -> io::Result<()> {
+            if scan.ms_level <= 1 {
+                let t = *self.profile_scans.get(self.prof_cur).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "template exhausted of MS1 (profile) scans",
+                    )
+                })?;
+                self.prof_cur += 1;
+                self.raw.author_profile(t, &scan.peaks, &self.calib)
+            } else {
+                let t = *self.centroid_scans.get(self.cent_cur).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "template exhausted of MS2 (centroid) scans",
+                    )
+                })?;
+                self.cent_cur += 1;
+                self.raw.author_centroids(t, &scan.peaks)
+            }
+        }
+
+        fn finalize(&mut self) -> io::Result<()> {
+            let path = self.out_path.clone();
+            self.raw.save(path)
+        }
+    }
+}
+
+#[cfg(all(test, feature = "thermo"))]
+mod tests {
+    use super::*;
+
+    // Gated: set TIMSIM_ASTRAL_TEMPLATE to a real Orbitrap Astral .raw to run.
+    // `cargo test --features thermo -- --nocapture thermo_roundtrip`
+    #[test]
+    fn thermo_roundtrip() {
+        let template = match std::env::var("TIMSIM_ASTRAL_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP thermo_roundtrip: set TIMSIM_ASTRAL_TEMPLATE=<astral .raw>");
+                return;
+            }
+        };
+        let out = std::env::temp_dir().join("rustdf_thermo_roundtrip.raw");
+
+        let mut w = ThermoRawWriter::from_template(&template, &out).expect("open template");
+        let (n_ms1, n_ms2) = w.capacity();
+        assert!(n_ms1 > 0 && n_ms2 > 0, "template has no MS1/MS2 scans");
+
+        let ms1 = ScanDescriptor {
+            ms_level: 1,
+            retention_time: 0.0,
+            isolation: None,
+            peaks: vec![(500.0, 1.0e6), (700.0, 5.0e5)],
+        };
+        let ms2 = ScanDescriptor {
+            ms_level: 2,
+            retention_time: 0.01,
+            isolation: Some(IsolationWindow {
+                center_mz: 500.0,
+                width_mz: 2.0,
+                collision_energy: 25.0,
+            }),
+            peaks: vec![(150.1, 3.0e4), (420.2, 8.0e4), (610.3, 5.0e4)],
+        };
+        w.write_scan(&ms1).expect("write MS1");
+        w.write_scan(&ms2).expect("write MS2");
+        w.finalize().expect("finalize");
+
+        // Read back through thermorawfile and confirm the authored peaks.
+        let rf = thermorawfile::RawFile::open(&out).expect("reopen");
+        assert!(rf.checksum_valid(), "checksum invalid");
+
+        // The writer used the first profile scan for MS1 and first centroid scan for MS2.
+        let cal = rf
+            .calibration_at_event(rf.scantrailer_addr as usize + 4)
+            .unwrap();
+        let mut prof_scan = None;
+        let mut cent_scan = None;
+        for i in 0..rf.index.len() {
+            let scan = rf.first_scan + i as u32;
+            let pkt = (rf.data_addr + rf.index[i].offset) as usize;
+            let psize = u32::from_le_bytes(rf.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+            if psize > 0 && prof_scan.is_none() {
+                prof_scan = Some(scan);
+            }
+            if psize == 0 && cent_scan.is_none() {
+                cent_scan = Some(scan);
+            }
+        }
+        let prof = rf.profile(prof_scan.unwrap()).expect("ms1 profile");
+        assert_eq!(prof.chunks.len(), 2, "MS1 peak count");
+        let ms1_mz: Vec<f64> = prof
+            .chunks
+            .iter()
+            .map(|c| prof.mz_of_bin(c.first_bin, &cal))
+            .collect();
+        assert!((ms1_mz[0] - 500.0).abs() < 0.01 && (ms1_mz[1] - 700.0).abs() < 0.01);
+
+        let cents = rf.centroid_peaks(cent_scan.unwrap());
+        assert_eq!(cents.len(), 3, "MS2 peak count");
+        assert!((cents[0].mz - 150.1).abs() < 0.01);
+        assert!((cents[2].mz - 610.3).abs() < 0.01);
+
+        eprintln!("thermo_roundtrip OK: MS1 {:?}, MS2 {} peaks", ms1_mz, cents.len());
+    }
+}

--- a/rustdf/src/sim/mod.rs
+++ b/rustdf/src/sim/mod.rs
@@ -5,4 +5,5 @@ pub mod dia;
 pub mod handle;
 pub mod lazy_builder;
 pub mod precursor;
+pub mod scheme;
 pub mod utility;

--- a/rustdf/src/sim/mod.rs
+++ b/rustdf/src/sim/mod.rs
@@ -1,3 +1,4 @@
+pub mod acquisition;
 pub mod containers;
 pub mod dda;
 pub mod dia;

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -427,7 +427,12 @@ impl AcquisitionScheme {
     /// becomes one [`DiaMs2Frame`] holding its mobility-partitioned windows
     /// (`TimsMobility` geometry — the scan ranges are Bruker-grid coordinates),
     /// preceded by a single MS1 event. Cycle timing comes from the spacing of
-    /// the precursor (MS1) frames.
+    /// the precursor (MS1) frames. The returned scheme is validated.
+    ///
+    /// Note: window groups are ordered by ascending `WindowGroup` id, which is
+    /// the DIA-PASEF acquisition order in practice; a file that reuses or
+    /// permutes group numbering would need ordering by first MS2-frame
+    /// occurrence (via `DiaFrameMsMsInfo`) instead.
     pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
         use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
         use std::collections::BTreeMap;
@@ -482,33 +487,34 @@ impl AcquisitionScheme {
         }
 
         // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+        // Use the MEDIAN of the positive gaps between distinct, finite precursor
+        // times, so one anomalous interval doesn't set the whole cycle.
         let mut prec_times: Vec<f64> = frames
             .iter()
-            .filter(|f| f.ms_ms_type == 0)
+            .filter(|f| f.ms_ms_type == 0 && f.time.is_finite())
             .map(|f| f.time)
             .collect();
-        prec_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let cycle_time_s = if prec_times.len() >= 2 {
-            (prec_times[1] - prec_times[0]).max(0.0)
-        } else {
-            0.0
-        };
-        if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+        prec_times.sort_by(f64::total_cmp);
+        prec_times.dedup();
+        let mut gaps: Vec<f64> = prec_times
+            .windows(2)
+            .map(|w| w[1] - w[0])
+            .filter(|g| *g > 0.0)
+            .collect();
+        if gaps.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "could not determine cycle time (need >= 2 precursor frames)",
+                "could not determine cycle time (need >= 2 distinct precursor frames)",
             ));
         }
-        let start_time_s = frames
-            .iter()
-            .map(|f| f.time)
-            .fold(f64::INFINITY, f64::min);
-        let gradient_length_s = frames
-            .iter()
-            .map(|f| f.time)
-            .fold(f64::NEG_INFINITY, f64::max);
+        gaps.sort_by(f64::total_cmp);
+        let cycle_time_s = gaps[gaps.len() / 2];
 
-        Ok(AcquisitionScheme {
+        let times: Vec<f64> = frames.iter().map(|f| f.time).filter(|t| t.is_finite()).collect();
+        let start_time_s = times.iter().copied().fold(f64::INFINITY, f64::min);
+        let gradient_length_s = times.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+
+        let scheme = AcquisitionScheme {
             version: SCHEME_VERSION,
             instrument: InstrumentKind::TimsTofDia,
             cycle,
@@ -526,7 +532,11 @@ impl AcquisitionScheme {
                 source: SchemeSource::ExtractedBruker,
                 notes: format!("extracted from Bruker .d ({n_groups} window groups)"),
             },
-        })
+        };
+        scheme
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(scheme)
     }
 }
 
@@ -535,15 +545,21 @@ impl AcquisitionScheme {
     /// Extract the SWATH scheme from a real SCIEX ZenoTOF `.wiff` method.
     ///
     /// Each SWATH window becomes a single-window [`DiaMs2Frame`] (no ion
-    /// mobility) preceded by an MS1. SCIEX uses **rolling collision energy**,
-    /// which is not stored in the `.wiff` SWATH method, so CE is
-    /// [`CollisionEnergyPolicy::Unknown`] (a model must be supplied downstream;
-    /// it is never invented). The `.wiff` method also does not carry run timing,
-    /// so `cycle_time_s` and `gradient_length_s` are caller-supplied.
+    /// mobility) preceded by an MS1.
+    ///
+    /// **Collision energy** is caller-supplied (`collision_energy`), because
+    /// SCIEX SWATH uses *rolling* CE computed by the instrument from an m/z
+    /// formula at acquisition time — it is **not** stored per-window in the
+    /// `.wiff` method (verified: the per-window MS2 parameter streams are
+    /// byte-identical across windows). Pass [`CollisionEnergyPolicy::Unknown`]
+    /// to leave it unset, or a [`CollisionEnergyPolicy::Linear`] rolling model.
+    /// The `.wiff` method also lacks run timing, so `cycle_time_s` /
+    /// `gradient_length_s` are caller-supplied. The returned scheme is validated.
     pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
         path: P,
         cycle_time_s: f64,
         gradient_length_s: f64,
+        collision_energy: CollisionEnergyPolicy,
     ) -> io::Result<Self> {
         let method = sciexwiff::read_method(path)?;
         if method.swath_windows.is_empty() {
@@ -571,7 +587,7 @@ impl AcquisitionScheme {
             cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
                 windows: vec![DiaWindow {
                     isolation: iso,
-                    collision_energy: CollisionEnergyPolicy::Unknown,
+                    collision_energy,
                     geometry: DiaGeometry::MzOnly,
                 }],
                 analyzer: Analyzer::Tof,
@@ -579,7 +595,7 @@ impl AcquisitionScheme {
                 duration_s: None,
             }));
         }
-        Ok(AcquisitionScheme {
+        let scheme = AcquisitionScheme {
             version: SCHEME_VERSION,
             instrument: InstrumentKind::SciexZenoTof,
             cycle,
@@ -592,10 +608,14 @@ impl AcquisitionScheme {
             provenance: Provenance {
                 source: SchemeSource::ExtractedSciex,
                 notes: format!(
-                    "extracted from SCIEX .wiff method ({n} SWATH windows; rolling CE unknown, timing caller-supplied)"
+                    "extracted from SCIEX .wiff method ({n} SWATH windows; CE caller-supplied, timing caller-supplied)"
                 ),
             },
-        })
+        };
+        scheme
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(scheme)
     }
 }
 
@@ -720,7 +740,7 @@ impl AcquisitionScheme {
             matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.analyzer == Analyzer::Astms)
         });
 
-        Ok(AcquisitionScheme {
+        let scheme = AcquisitionScheme {
             version: SCHEME_VERSION,
             instrument: if any_astms {
                 InstrumentKind::OrbitrapAstral
@@ -738,7 +758,11 @@ impl AcquisitionScheme {
                 source: SchemeSource::ExtractedThermo,
                 notes: format!("extracted from Thermo .raw (first cycle: 1 MS1 + {n_ms2} MS2)"),
             },
-        })
+        };
+        scheme
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(scheme)
     }
 }
 
@@ -926,17 +950,26 @@ mod tests {
                 return;
             }
         };
-        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0).expect("extract");
+        // Default: CE unknown (rolling CE isn't in the .wiff method).
+        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, CollisionEnergyPolicy::Unknown)
+            .expect("extract");
         s.validate().expect("valid scheme");
         assert_eq!(s.instrument, InstrumentKind::SciexZenoTof);
         assert_eq!(s.ms1_count(), 1);
         let n = s.windows().count();
         assert!(n > 10, "expected many SWATH windows, got {n}");
-        // SCIEX: m/z-only windows, rolling CE not recoverable -> Unknown.
         for w in s.windows() {
             assert!(matches!(w.geometry, DiaGeometry::MzOnly));
             assert!(matches!(w.collision_energy, CollisionEnergyPolicy::Unknown));
             assert!(w.collision_energy.at(w.isolation.center_mz).is_none());
+        }
+        // Supplying a rolling-CE Linear model gives a resolvable, finite CE.
+        let rolling = CollisionEnergyPolicy::Linear { intercept: 5.0, slope_per_mz: 0.045 };
+        let s2 = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0, rolling).expect("extract");
+        s2.validate().expect("valid with rolling CE");
+        for w in s2.windows() {
+            let ce = w.collision_energy.at(w.isolation.center_mz).expect("resolvable CE");
+            assert!(ce.is_finite() && ce > 0.0);
         }
         eprintln!(
             "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -530,6 +530,75 @@ impl AcquisitionScheme {
     }
 }
 
+#[cfg(feature = "sciex")]
+impl AcquisitionScheme {
+    /// Extract the SWATH scheme from a real SCIEX ZenoTOF `.wiff` method.
+    ///
+    /// Each SWATH window becomes a single-window [`DiaMs2Frame`] (no ion
+    /// mobility) preceded by an MS1. SCIEX uses **rolling collision energy**,
+    /// which is not stored in the `.wiff` SWATH method, so CE is
+    /// [`CollisionEnergyPolicy::Unknown`] (a model must be supplied downstream;
+    /// it is never invented). The `.wiff` method also does not carry run timing,
+    /// so `cycle_time_s` and `gradient_length_s` are caller-supplied.
+    pub fn from_sciex_wiff<P: AsRef<std::path::Path>>(
+        path: P,
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+    ) -> io::Result<Self> {
+        let method = sciexwiff::read_method(path)?;
+        if method.swath_windows.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no SWATH windows in the .wiff method",
+            ));
+        }
+        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        })];
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        let n = method.swath_windows.len();
+        for w in &method.swath_windows {
+            let iso = IsolationWindow {
+                center_mz: w.center_mz(),
+                width_mz: w.width_mz(),
+            };
+            lo = lo.min(iso.lower());
+            hi = hi.max(iso.upper());
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![DiaWindow {
+                    isolation: iso,
+                    collision_energy: CollisionEnergyPolicy::Unknown,
+                    geometry: DiaGeometry::MzOnly,
+                }],
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            }));
+        }
+        Ok(AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::SciexZenoTof,
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: 0.0,
+            },
+            mz_range: (lo, hi),
+            provenance: Provenance {
+                source: SchemeSource::ExtractedSciex,
+                notes: format!(
+                    "extracted from SCIEX .wiff method ({n} SWATH windows; rolling CE unknown, timing caller-supplied)"
+                ),
+            },
+        })
+    }
+}
+
 #[cfg(feature = "thermo")]
 impl AcquisitionScheme {
     /// Extract the acquisition scheme from a real Thermo `.raw` by walking the
@@ -843,6 +912,35 @@ mod tests {
             "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
             n_frames, n_win, if multi { "mobility-partitioned" } else { "single-window" },
             s.mz_range.0, s.mz_range.1
+        );
+    }
+
+    // Gated: set TIMSIM_SCIEX_WIFF to a real ZenoTOF .wiff (OLE2 method).
+    #[cfg(feature = "sciex")]
+    #[test]
+    fn from_sciex_wiff_extracts_windows() {
+        let wiff = match std::env::var("TIMSIM_SCIEX_WIFF") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_sciex_wiff_extracts_windows: set TIMSIM_SCIEX_WIFF=<.wiff>");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_sciex_wiff(&wiff, 3.5, 1800.0).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::SciexZenoTof);
+        assert_eq!(s.ms1_count(), 1);
+        let n = s.windows().count();
+        assert!(n > 10, "expected many SWATH windows, got {n}");
+        // SCIEX: m/z-only windows, rolling CE not recoverable -> Unknown.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::MzOnly));
+            assert!(matches!(w.collision_energy, CollisionEnergyPolicy::Unknown));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_none());
+        }
+        eprintln!(
+            "from_sciex_wiff OK: SciexZenoTof, {} SWATH windows, mz {:.1}..{:.1}",
+            n, s.mz_range.0, s.mz_range.1
         );
     }
 

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -443,41 +443,10 @@ impl AcquisitionScheme {
     /// frame→group table `DiaFrameMsMsInfo` needs the run frame schedule and is a
     /// separate step.
     pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
-        self.validate()?;
-        if self.instrument != InstrumentKind::TimsTofDia {
-            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
-        }
-        use std::collections::HashSet;
-        // Reserve explicit (vendor_group_id) ids first, rejecting duplicates among
-        // them; fallback ids for `None` frames are then drawn from the unused set,
-        // so a preserved id and a positional fallback can never collide.
-        let mut reserved: HashSet<u32> = HashSet::new();
-        for ev in &self.cycle {
-            if let AcquisitionEvent::DiaMs2Frame(f) = ev {
-                if let Some(g) = f.vendor_group_id {
-                    if !reserved.insert(g) {
-                        return Err(format!("duplicate vendor window-group id {g}"));
-                    }
-                }
-            }
-        }
+        let layout = self.bruker_group_layout()?;
         let mut rows = Vec::new();
-        let mut assigned: HashSet<u32> = HashSet::new();
-        let mut next_seq: u32 = 1;
-        for ev in &self.cycle {
-            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
-                let group = match frame.vendor_group_id {
-                    Some(g) => g,
-                    None => {
-                        while reserved.contains(&next_seq) || assigned.contains(&next_seq) {
-                            next_seq += 1;
-                        }
-                        next_seq
-                    }
-                };
-                if !assigned.insert(group) {
-                    return Err(format!("window-group id {group} collides"));
-                }
+        for (ev, slot) in self.cycle.iter().zip(&layout) {
+            if let (AcquisitionEvent::DiaMs2Frame(frame), Some(group)) = (ev, slot) {
                 for w in &frame.windows {
                     let (scan_num_begin, scan_num_end) = match w.geometry {
                         DiaGeometry::TimsMobility {
@@ -499,7 +468,7 @@ impl AcquisitionScheme {
                         }
                     };
                     rows.push(crate::data::meta::DiaMsMsWindow {
-                        window_group: group,
+                        window_group: *group,
                         scan_num_begin,
                         scan_num_end,
                         isolation_mz: w.isolation.center_mz,
@@ -510,6 +479,99 @@ impl AcquisitionScheme {
             }
         }
         Ok(rows)
+    }
+
+    /// Per-cycle-position window-group id: `None` for an MS1 event, `Some(group)`
+    /// for an MS2 frame. The group id is the frame's preserved `vendor_group_id`
+    /// (Bruker `WindowGroup`) when set, else a collision-safe positional id drawn
+    /// from the unused set (so preserved and fallback ids never collide).
+    /// Duplicate explicit ids are rejected. Validates first; requires a timsTOF
+    /// scheme. This is the single source of truth shared by `to_bruker_windows`
+    /// and `to_bruker_info`, so the two tables always agree.
+    fn bruker_group_layout(&self) -> Result<Vec<Option<u32>>, String> {
+        self.validate()?;
+        if self.instrument != InstrumentKind::TimsTofDia {
+            return Err("Bruker tables require a timsTOF (TimsTofDia) scheme".into());
+        }
+        use std::collections::HashSet;
+        let mut reserved: HashSet<u32> = HashSet::new();
+        for ev in &self.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(f) = ev {
+                if let Some(g) = f.vendor_group_id {
+                    if !reserved.insert(g) {
+                        return Err(format!("duplicate vendor window-group id {g}"));
+                    }
+                }
+            }
+        }
+        let mut layout = Vec::with_capacity(self.cycle.len());
+        let mut assigned: HashSet<u32> = HashSet::new();
+        let mut next_seq: u32 = 1;
+        for ev in &self.cycle {
+            match ev {
+                AcquisitionEvent::Ms1(_) => layout.push(None),
+                AcquisitionEvent::DiaMs2Frame(frame) => {
+                    let group = match frame.vendor_group_id {
+                        Some(g) => g,
+                        None => {
+                            while reserved.contains(&next_seq) || assigned.contains(&next_seq) {
+                                next_seq += 1;
+                            }
+                            next_seq
+                        }
+                    };
+                    if !assigned.insert(group) {
+                        return Err(format!("window-group id {group} collides"));
+                    }
+                    layout.push(Some(group));
+                }
+            }
+        }
+        Ok(layout)
+    }
+
+    /// Generate the Bruker `DiaFrameMsMsInfo` (frame → window group) rows for a run
+    /// of `num_frames` total frames, tiling the scheme's cycle. Frame ids are
+    /// 1-based; cycle position `(frame_id - 1) % cycle_len` selects the event, MS1
+    /// frames produce no row, and each MS2 frame maps to its window-group id (the
+    /// same ids `to_bruker_windows` emits, so the two tables are consistent). The
+    /// final cycle may be partial.
+    pub fn to_bruker_info(
+        &self,
+        num_frames: u32,
+    ) -> Result<Vec<crate::data::meta::DiaMsMisInfo>, String> {
+        let layout = self.bruker_group_layout()?;
+        let fpc = layout.len() as u32;
+        if fpc == 0 {
+            return Err("empty cycle".into());
+        }
+        let mut rows = Vec::new();
+        for frame_id in 1..=num_frames {
+            let pos = ((frame_id - 1) % fpc) as usize;
+            if let Some(group) = layout[pos] {
+                rows.push(crate::data::meta::DiaMsMisInfo {
+                    frame_id,
+                    window_group: group,
+                });
+            }
+        }
+        Ok(rows)
+    }
+
+    /// Both Bruker DIA tables for a `num_frames`-frame run: the
+    /// `DiaFrameMsMsWindows` rows and the `DiaFrameMsMsInfo` (frame→group) rows,
+    /// with consistent window-group ids.
+    pub fn to_bruker_tables(
+        &self,
+        num_frames: u32,
+    ) -> Result<
+        (
+            Vec<crate::data::meta::DiaMsMsWindow>,
+            Vec<crate::data::meta::DiaMsMisInfo>,
+        ),
+        String,
+    > {
+        Ok((self.to_bruker_windows()?, self.to_bruker_info(num_frames)?))
     }
 
     /// Extract the acquisition scheme from a real Bruker timsTOF DIA `.d`.
@@ -1143,6 +1205,82 @@ mod tests {
                 .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
                 .count()
         );
+    }
+
+    // Unconditional: DiaFrameMsMsInfo tiling + windows/info group-id consistency.
+    #[test]
+    fn to_bruker_info_tiling() {
+        let frame = |c: f64| {
+            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![DiaWindow {
+                    isolation: IsolationWindow { center_mz: c, width_mz: 10.0 },
+                    collision_energy: CollisionEnergyPolicy::Value(25.0),
+                    geometry: DiaGeometry::TimsMobility { scan_start: 0, scan_end: 100 },
+                }],
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: None,
+            })
+        };
+        let s = AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::TimsTofDia,
+            cycle: vec![
+                AcquisitionEvent::Ms1(Ms1Event {
+                    analyzer: Analyzer::Tof,
+                    data_mode: DataMode::Centroid,
+                    mz_range: None,
+                    duration_s: None,
+                }),
+                frame(500.0),
+                frame(600.0),
+            ],
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s: 1.0,
+                gradient_length_s: 600.0,
+                start_time_s: 0.0,
+            },
+            mz_range: (300.0, 900.0),
+            provenance: Provenance { source: SchemeSource::Programmatic, notes: String::new() },
+        };
+        // cycle = [MS1, g1, g2]; num_frames=6: 1->skip, 2->g1, 3->g2, 4->skip, 5->g1, 6->g2
+        let info: Vec<(u32, u32)> = s
+            .to_bruker_info(6)
+            .unwrap()
+            .iter()
+            .map(|r| (r.frame_id, r.window_group))
+            .collect();
+        assert_eq!(info, vec![(2, 1), (3, 2), (5, 1), (6, 2)]);
+        // The two tables must reference the same set of window-group ids.
+        let (windows, info2) = s.to_bruker_tables(6).unwrap();
+        let wg: std::collections::BTreeSet<u32> = windows.iter().map(|w| w.window_group).collect();
+        let ig: std::collections::BTreeSet<u32> = info2.iter().map(|r| r.window_group).collect();
+        assert_eq!(wg, ig, "windows/info group ids disagree");
+    }
+
+    // Gated: regenerate DiaFrameMsMsInfo for the .d's full frame count and match.
+    #[test]
+    fn bruker_info_round_trip() {
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP bruker_info_round_trip: set TIMSIM_BRUKER_DIA_D");
+                return;
+            }
+        };
+        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        let frames = crate::data::meta::read_meta_data_sql(&d).expect("frames");
+        let num_frames = frames.iter().map(|f| f.id).max().unwrap_or(0) as u32;
+        let regenerated = scheme.to_bruker_info(num_frames).expect("to_bruker_info");
+        let original = crate::data::meta::read_dia_ms_ms_info(&d).expect("read source");
+        let key = |r: &crate::data::meta::DiaMsMisInfo| (r.frame_id, r.window_group);
+        let mut a: Vec<_> = regenerated.iter().map(key).collect();
+        let mut b: Vec<_> = original.iter().map(key).collect();
+        a.sort_unstable();
+        b.sort_unstable();
+        assert_eq!(a, b, "DiaFrameMsMsInfo round-trip differs from source");
+        eprintln!("bruker_info_round_trip OK: {} (frame, group) rows over {num_frames} frames", a.len());
     }
 
     #[cfg(feature = "sciex")]

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -421,6 +421,59 @@ impl AcquisitionScheme {
 }
 
 impl AcquisitionScheme {
+    /// Render the scheme's MS2 windows as Bruker `DiaFrameMsMsWindows` rows — the
+    /// backward-compatibility adapter for the existing timsTOF write path.
+    ///
+    /// Each MS2 frame is one window group; its windows must carry `TimsMobility`
+    /// geometry (the Bruker-grid scan ranges). Window groups are numbered 1..N in
+    /// cycle order (the DIA-PASEF convention); a `Linear` CE policy is resolved at
+    /// the window center, and `Unknown` CE is rejected. Errors if the scheme is
+    /// not a timsTOF layout. (The companion frame→group table,
+    /// `DiaFrameMsMsInfo`, depends on the full run's frame schedule and is a
+    /// separate step.)
+    pub fn to_bruker_windows(&self) -> Result<Vec<crate::data::meta::DiaMsMsWindow>, String> {
+        if self.instrument != InstrumentKind::TimsTofDia {
+            return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
+        }
+        let mut rows = Vec::new();
+        let mut group: u32 = 0;
+        for ev in &self.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+                group += 1;
+                for w in &frame.windows {
+                    let (scan_num_begin, scan_num_end) = match w.geometry {
+                        DiaGeometry::TimsMobility {
+                            scan_start,
+                            scan_end,
+                        } => (scan_start, scan_end),
+                        DiaGeometry::MzOnly => {
+                            return Err("timsTOF window lacks mobility geometry".into())
+                        }
+                    };
+                    let collision_energy = match w.collision_energy {
+                        CollisionEnergyPolicy::Value(v) => v,
+                        CollisionEnergyPolicy::Linear { .. } => w
+                            .collision_energy
+                            .at(w.isolation.center_mz)
+                            .ok_or("could not resolve linear CE")?,
+                        CollisionEnergyPolicy::Unknown => {
+                            return Err("window has unknown collision energy".into())
+                        }
+                    };
+                    rows.push(crate::data::meta::DiaMsMsWindow {
+                        window_group: group,
+                        scan_num_begin,
+                        scan_num_end,
+                        isolation_mz: w.isolation.center_mz,
+                        isolation_width: w.isolation.width_mz,
+                        collision_energy,
+                    });
+                }
+            }
+        }
+        Ok(rows)
+    }
+
     /// Extract the acquisition scheme from a real Bruker timsTOF DIA `.d`.
     ///
     /// Reads `DiaFrameMsMsWindows` and the frame table. Each **window group**
@@ -940,6 +993,63 @@ mod tests {
     }
 
     // Gated: set TIMSIM_SCIEX_WIFF to a real ZenoTOF .wiff (OLE2 method).
+    // Gated: round-trip a real Bruker DIA .d through the scheme and back to the
+    // DiaFrameMsMsWindows rows; the regenerated table must match the source.
+    #[test]
+    fn bruker_windows_round_trip() {
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP bruker_windows_round_trip: set TIMSIM_BRUKER_DIA_D");
+                return;
+            }
+        };
+        let scheme = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        let regenerated = scheme.to_bruker_windows().expect("to_bruker_windows");
+        let original = crate::data::meta::read_dia_ms_ms_windows(&d).expect("read source");
+        assert_eq!(regenerated.len(), original.len(), "row count differs");
+
+        // Normalize window-group ids to canonical 1..N (ascending) on both sides,
+        // then compare as a sorted multiset of exact-bit field tuples.
+        fn canonical(
+            rows: &[crate::data::meta::DiaMsMsWindow],
+        ) -> Vec<(u32, u32, u32, u64, u64, u64)> {
+            let mut groups: Vec<u32> = rows.iter().map(|r| r.window_group).collect();
+            groups.sort_unstable();
+            groups.dedup();
+            let mut out: Vec<_> = rows
+                .iter()
+                .map(|r| {
+                    let g = groups.iter().position(|&x| x == r.window_group).unwrap() as u32 + 1;
+                    (
+                        g,
+                        r.scan_num_begin,
+                        r.scan_num_end,
+                        r.isolation_mz.to_bits(),
+                        r.isolation_width.to_bits(),
+                        r.collision_energy.to_bits(),
+                    )
+                })
+                .collect();
+            out.sort_unstable();
+            out
+        }
+        assert_eq!(
+            canonical(&regenerated),
+            canonical(&original),
+            "round-trip windows differ from source"
+        );
+        eprintln!(
+            "bruker_windows_round_trip OK: {} rows match across {} groups",
+            original.len(),
+            scheme
+                .cycle
+                .iter()
+                .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+                .count()
+        );
+    }
+
     #[cfg(feature = "sciex")]
     #[test]
     fn from_sciex_wiff_extracts_windows() {

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -12,7 +12,6 @@
 //! Astral/SCIEX MS2 scan (one window) are both represented without overloading a
 //! `window_group` id to imply simultaneity.
 
-#[cfg(feature = "thermo")]
 use std::io;
 
 /// Current scheme schema version.
@@ -421,6 +420,116 @@ impl AcquisitionScheme {
     }
 }
 
+impl AcquisitionScheme {
+    /// Extract the acquisition scheme from a real Bruker timsTOF DIA `.d`.
+    ///
+    /// Reads `DiaFrameMsMsWindows` and the frame table. Each **window group**
+    /// becomes one [`DiaMs2Frame`] holding its mobility-partitioned windows
+    /// (`TimsMobility` geometry — the scan ranges are Bruker-grid coordinates),
+    /// preceded by a single MS1 event. Cycle timing comes from the spacing of
+    /// the precursor (MS1) frames.
+    pub fn from_bruker_d<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        use crate::data::meta::{read_dia_ms_ms_windows, read_meta_data_sql};
+        use std::collections::BTreeMap;
+
+        let folder = path.as_ref().to_string_lossy().into_owned();
+        let to_io =
+            |e: Box<dyn std::error::Error>| io::Error::new(io::ErrorKind::InvalidData, e.to_string());
+        let windows = read_dia_ms_ms_windows(&folder).map_err(to_io)?;
+        let frames = read_meta_data_sql(&folder).map_err(to_io)?;
+        if windows.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no DiaFrameMsMsWindows rows (not a DIA .d?)",
+            ));
+        }
+
+        // Group windows by window group (ascending); each group is a frame.
+        let mut by_group: BTreeMap<u32, Vec<DiaWindow>> = BTreeMap::new();
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        for w in &windows {
+            let dw = DiaWindow {
+                isolation: IsolationWindow {
+                    center_mz: w.isolation_mz,
+                    width_mz: w.isolation_width,
+                },
+                collision_energy: CollisionEnergyPolicy::Value(w.collision_energy),
+                geometry: DiaGeometry::TimsMobility {
+                    scan_start: w.scan_num_begin,
+                    scan_end: w.scan_num_end,
+                },
+            };
+            lo = lo.min(dw.isolation.lower());
+            hi = hi.max(dw.isolation.upper());
+            by_group.entry(w.window_group).or_default().push(dw);
+        }
+
+        let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        })];
+        let n_groups = by_group.len();
+        for (_group, ws) in by_group {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: ws,
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            }));
+        }
+
+        // Cycle timing from the precursor (MS1, MsMsType == 0) frame spacing.
+        let mut prec_times: Vec<f64> = frames
+            .iter()
+            .filter(|f| f.ms_ms_type == 0)
+            .map(|f| f.time)
+            .collect();
+        prec_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let cycle_time_s = if prec_times.len() >= 2 {
+            (prec_times[1] - prec_times[0]).max(0.0)
+        } else {
+            0.0
+        };
+        if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "could not determine cycle time (need >= 2 precursor frames)",
+            ));
+        }
+        let start_time_s = frames
+            .iter()
+            .map(|f| f.time)
+            .fold(f64::INFINITY, f64::min);
+        let gradient_length_s = frames
+            .iter()
+            .map(|f| f.time)
+            .fold(f64::NEG_INFINITY, f64::max);
+
+        Ok(AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::TimsTofDia,
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: if start_time_s.is_finite() {
+                    start_time_s
+                } else {
+                    0.0
+                },
+            },
+            mz_range: (lo, hi),
+            provenance: Provenance {
+                source: SchemeSource::ExtractedBruker,
+                notes: format!("extracted from Bruker .d ({n_groups} window groups)"),
+            },
+        })
+    }
+}
+
 #[cfg(feature = "thermo")]
 impl AcquisitionScheme {
     /// Extract the acquisition scheme from a real Thermo `.raw` by walking the
@@ -704,6 +813,37 @@ mod tests {
             duration_s: Some(-1.0),
         });
         assert!(mk(vec![AcquisitionEvent::Ms1(ms1()), bad_dur]).validate().is_err());
+    }
+
+    // Gated: set TIMSIM_BRUKER_DIA_D to a real Bruker DIA-PASEF .d folder.
+    #[test]
+    fn from_bruker_d_extracts_cycle() {
+        let d = match std::env::var("TIMSIM_BRUKER_DIA_D") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_bruker_d_extracts_cycle: set TIMSIM_BRUKER_DIA_D=<dia .d>");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_bruker_d(&d).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::TimsTofDia);
+        assert_eq!(s.ms1_count(), 1);
+        let n_win = s.windows().count();
+        assert!(n_win > 1, "expected several windows, got {n_win}");
+        // timsTOF windows carry mobility geometry with a known CE.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::TimsMobility { .. }));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_some());
+        }
+        // At least one frame should be mobility-partitioned (>1 window).
+        let multi = s.cycle.iter().any(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(f) if f.windows.len() > 1));
+        let n_frames = s.cycle.iter().filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_))).count();
+        eprintln!(
+            "from_bruker_d OK: TimsTofDia, {} frames, {} windows ({}), mz {:.1}..{:.1}",
+            n_frames, n_win, if multi { "mobility-partitioned" } else { "single-window" },
+            s.mz_range.0, s.mz_range.1
+        );
     }
 
     #[cfg(feature = "thermo")]

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -447,12 +447,37 @@ impl AcquisitionScheme {
         if self.instrument != InstrumentKind::TimsTofDia {
             return Err("to_bruker_windows requires a timsTOF (TimsTofDia) scheme".into());
         }
+        use std::collections::HashSet;
+        // Reserve explicit (vendor_group_id) ids first, rejecting duplicates among
+        // them; fallback ids for `None` frames are then drawn from the unused set,
+        // so a preserved id and a positional fallback can never collide.
+        let mut reserved: HashSet<u32> = HashSet::new();
+        for ev in &self.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(f) = ev {
+                if let Some(g) = f.vendor_group_id {
+                    if !reserved.insert(g) {
+                        return Err(format!("duplicate vendor window-group id {g}"));
+                    }
+                }
+            }
+        }
         let mut rows = Vec::new();
-        let mut seq: u32 = 0;
+        let mut assigned: HashSet<u32> = HashSet::new();
+        let mut next_seq: u32 = 1;
         for ev in &self.cycle {
             if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
-                seq += 1;
-                let group = frame.vendor_group_id.unwrap_or(seq);
+                let group = match frame.vendor_group_id {
+                    Some(g) => g,
+                    None => {
+                        while reserved.contains(&next_seq) || assigned.contains(&next_seq) {
+                            next_seq += 1;
+                        }
+                        next_seq
+                    }
+                };
+                if !assigned.insert(group) {
+                    return Err(format!("window-group id {group} collides"));
+                }
                 for w in &frame.windows {
                     let (scan_num_begin, scan_num_end) = match w.geometry {
                         DiaGeometry::TimsMobility {
@@ -1012,6 +1037,60 @@ mod tests {
     }
 
     // Gated: set TIMSIM_SCIEX_WIFF to a real ZenoTOF .wiff (OLE2 method).
+    // Unconditional: to_bruker_windows must preserve explicit vendor_group_ids
+    // (incl. non-canonical), allocate non-colliding ids for None frames, and
+    // reject duplicate explicit ids. (The gated round-trip uses a real .d whose
+    // ids are already 1..N, so it can't prove non-canonical preservation alone.)
+    #[test]
+    fn to_bruker_windows_group_ids() {
+        let frame = |gid: Option<u32>, center: f64| {
+            AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![DiaWindow {
+                    isolation: IsolationWindow { center_mz: center, width_mz: 10.0 },
+                    collision_energy: CollisionEnergyPolicy::Value(25.0),
+                    geometry: DiaGeometry::TimsMobility { scan_start: 0, scan_end: 100 },
+                }],
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+                vendor_group_id: gid,
+            })
+        };
+        let mk = |frames: Vec<AcquisitionEvent>| {
+            let mut cycle = vec![AcquisitionEvent::Ms1(Ms1Event {
+                analyzer: Analyzer::Tof,
+                data_mode: DataMode::Centroid,
+                mz_range: None,
+                duration_s: None,
+            })];
+            cycle.extend(frames);
+            AcquisitionScheme {
+                version: SCHEME_VERSION,
+                instrument: InstrumentKind::TimsTofDia,
+                cycle,
+                repeat: RepeatPolicy::FixedCycleTime {
+                    cycle_time_s: 1.0,
+                    gradient_length_s: 600.0,
+                    start_time_s: 0.0,
+                },
+                mz_range: (300.0, 900.0),
+                provenance: Provenance { source: SchemeSource::Programmatic, notes: String::new() },
+            }
+        };
+        let ids = |s: &AcquisitionScheme| {
+            s.to_bruker_windows().map(|r| r.iter().map(|w| w.window_group).collect::<Vec<_>>())
+        };
+
+        // preserved non-canonical ids
+        assert_eq!(ids(&mk(vec![frame(Some(7), 500.0), frame(Some(42), 600.0)])).unwrap(), vec![7, 42]);
+        // all-None -> sequential 1..N
+        assert_eq!(ids(&mk(vec![frame(None, 500.0), frame(None, 600.0)])).unwrap(), vec![1, 2]);
+        // mixed: None allocates a free id (1), avoiding the reserved 7
+        assert_eq!(ids(&mk(vec![frame(Some(7), 500.0), frame(None, 600.0)])).unwrap(), vec![7, 1]);
+        // duplicate explicit ids rejected
+        assert!(ids(&mk(vec![frame(Some(5), 500.0), frame(Some(5), 600.0)])).is_err());
+    }
+
     // Gated: round-trip a real Bruker DIA .d through the scheme and back to the
     // DiaFrameMsMsWindows rows; the regenerated table must match the source.
     #[test]

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -1,0 +1,550 @@
+//! Vendor-neutral DIA acquisition **scheme** (input/design side).
+//!
+//! An [`AcquisitionScheme`] describes one DIA cycle as an *ordered sequence of
+//! physical events* ([`AcquisitionEvent`]) and how that cycle tiles the
+//! gradient ([`RepeatPolicy`]). It is the design counterpart to the
+//! [`crate::sim::acquisition::AcquisitionWriter`] (output side): the simulator
+//! generates scans for the scheme, and a writer materializes them.
+//!
+//! The key modelling choice (per review) is that a *physical acquisition unit*
+//! is explicit: [`AcquisitionEvent::DiaMs2Frame`] carries a `Vec<DiaWindow>`, so
+//! a timsTOF MS2 frame holding several mobility-partitioned windows and a linear
+//! Astral/SCIEX MS2 scan (one window) are both represented without overloading a
+//! `window_group` id to imply simultaneity.
+
+use std::io;
+
+/// Current scheme schema version.
+pub const SCHEME_VERSION: u16 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstrumentKind {
+    TimsTofDia,
+    OrbitrapAstral,
+    SciexZenoTof,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Analyzer {
+    Ftms,
+    Astms,
+    Tof,
+    Itms,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DataMode {
+    Profile,
+    Centroid,
+}
+
+/// An m/z isolation window (no ion mobility — see [`DiaGeometry`]).
+#[derive(Clone, Copy, Debug)]
+pub struct IsolationWindow {
+    pub center_mz: f64,
+    pub width_mz: f64,
+}
+
+impl IsolationWindow {
+    pub fn lower(&self) -> f64 {
+        self.center_mz - self.width_mz / 2.0
+    }
+    pub fn upper(&self) -> f64 {
+        self.center_mz + self.width_mz / 2.0
+    }
+}
+
+/// How a window's collision energy is determined.
+///
+/// `Value` covers both a per-window CE and a scheme-wide fixed CE (every window
+/// carries the same value) — there is intentionally no separate `Fixed` variant
+/// (they were structurally identical). `Unknown` means extraction could not
+/// recover it (e.g. SCIEX rolling CE) and a model must be supplied downstream —
+/// it is never silently invented.
+#[derive(Clone, Copy, Debug)]
+pub enum CollisionEnergyPolicy {
+    Value(f64),
+    Linear { intercept: f64, slope_per_mz: f64 },
+    Unknown,
+}
+
+impl CollisionEnergyPolicy {
+    /// Resolve the CE for a window centered at `center_mz`, if determinable.
+    pub fn at(&self, center_mz: f64) -> Option<f64> {
+        match *self {
+            CollisionEnergyPolicy::Value(v) => Some(v),
+            CollisionEnergyPolicy::Linear {
+                intercept,
+                slope_per_mz,
+            } => Some(intercept + slope_per_mz * center_mz),
+            CollisionEnergyPolicy::Unknown => None,
+        }
+    }
+}
+
+/// Window geometry: m/z only, or (timsTOF) an additional ion-mobility partition.
+/// Mobility is kept off [`IsolationWindow`] so "mobility on a non-IMS instrument"
+/// is unrepresentable. Scan numbers are Bruker-grid coordinates (they require the
+/// reference dataset's calibration to map to physical mobility).
+#[derive(Clone, Copy, Debug)]
+pub enum DiaGeometry {
+    MzOnly,
+    TimsMobility { scan_start: u32, scan_end: u32 },
+}
+
+/// One DIA isolation window within a frame.
+#[derive(Clone, Copy, Debug)]
+pub struct DiaWindow {
+    pub isolation: IsolationWindow,
+    pub collision_energy: CollisionEnergyPolicy,
+    pub geometry: DiaGeometry,
+}
+
+/// An MS1 (precursor) acquisition.
+#[derive(Clone, Debug)]
+pub struct Ms1Event {
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub mz_range: (f64, f64),
+    pub duration_s: Option<f64>,
+}
+
+/// One physical MS2 acquisition unit. Holds one window for Astral/SCIEX; several
+/// mobility-partitioned windows (sharing the frame) for timsTOF.
+#[derive(Clone, Debug)]
+pub struct DiaMs2Frame {
+    pub windows: Vec<DiaWindow>,
+    pub analyzer: Analyzer,
+    pub data_mode: DataMode,
+    pub duration_s: Option<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub enum AcquisitionEvent {
+    Ms1(Ms1Event),
+    DiaMs2Frame(DiaMs2Frame),
+}
+
+/// How the cycle repeats over the gradient.
+#[derive(Clone, Copy, Debug)]
+pub enum RepeatPolicy {
+    /// The cycle repeats every `cycle_time_s`, starting at `start_time_s`, until
+    /// `gradient_length_s`. Per-event `duration_s` (when present) takes
+    /// precedence for fine RT placement; otherwise events are spread across the
+    /// cycle uniformly.
+    FixedCycleTime {
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+        start_time_s: f64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SchemeSource {
+    ExtractedBruker,
+    ExtractedThermo,
+    ExtractedSciex,
+    UserTable,
+    Programmatic,
+}
+
+/// Where the scheme came from (scheme-level attribution; not per-field).
+#[derive(Clone, Debug)]
+pub struct Provenance {
+    pub source: SchemeSource,
+    pub notes: String,
+}
+
+/// A vendor-neutral DIA acquisition design.
+#[derive(Clone, Debug)]
+pub struct AcquisitionScheme {
+    pub version: u16,
+    pub instrument: InstrumentKind,
+    pub cycle: Vec<AcquisitionEvent>,
+    pub repeat: RepeatPolicy,
+    pub mz_range: (f64, f64),
+    pub provenance: Provenance,
+}
+
+impl AcquisitionScheme {
+    /// Iterate every DIA window across all MS2 frames in the cycle.
+    pub fn windows(&self) -> impl Iterator<Item = &DiaWindow> {
+        self.cycle
+            .iter()
+            .flat_map(|e| match e {
+                AcquisitionEvent::DiaMs2Frame(f) => f.windows.as_slice(),
+                AcquisitionEvent::Ms1(_) => &[][..],
+            }
+            .iter())
+    }
+
+    /// Number of MS1 events in one cycle.
+    pub fn ms1_count(&self) -> usize {
+        self.cycle
+            .iter()
+            .filter(|e| matches!(e, AcquisitionEvent::Ms1(_)))
+            .count()
+    }
+
+    /// Number of full cycles that fit the gradient (if derivable).
+    pub fn num_cycles(&self) -> Option<u64> {
+        match self.repeat {
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s,
+            } if cycle_time_s > 0.0 => {
+                Some(((gradient_length_s - start_time_s).max(0.0) / cycle_time_s) as u64)
+            }
+            _ => None,
+        }
+    }
+
+    /// Build a scheme from an explicit window list (injected / CSV). One MS1
+    /// followed by one single-window MS2 frame per window.
+    pub fn from_window_table(
+        instrument: InstrumentKind,
+        ms1: Ms1Event,
+        windows: Vec<DiaWindow>,
+        repeat: RepeatPolicy,
+        mz_range: (f64, f64),
+    ) -> Self {
+        let mut cycle = vec![AcquisitionEvent::Ms1(ms1.clone())];
+        for w in windows {
+            cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                windows: vec![w],
+                analyzer: ms1.analyzer,
+                data_mode: DataMode::Centroid,
+                duration_s: None,
+            }));
+        }
+        AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument,
+            cycle,
+            repeat,
+            mz_range,
+            provenance: Provenance {
+                source: SchemeSource::UserTable,
+                notes: "built from explicit window table".to_string(),
+            },
+        }
+    }
+
+    /// Validate internal consistency. Returns a human-readable error on the first
+    /// problem found.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.version != SCHEME_VERSION {
+            return Err(format!(
+                "unsupported scheme version {} (this build supports {})",
+                self.version, SCHEME_VERSION
+            ));
+        }
+        if self.cycle.is_empty() {
+            return Err("empty cycle".into());
+        }
+        if self.ms1_count() == 0 {
+            return Err("cycle has no MS1 event".into());
+        }
+        let (lo, hi) = self.mz_range;
+        if !(lo.is_finite() && hi.is_finite()) || lo >= hi {
+            return Err(format!("invalid mz_range ({lo}, {hi})"));
+        }
+        for ev in &self.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(frame) = ev {
+                if frame.windows.is_empty() {
+                    return Err("MS2 frame has no windows".into());
+                }
+                if frame.windows.len() > 1 && self.instrument != InstrumentKind::TimsTofDia {
+                    return Err(
+                        "multi-window MS2 frame is only valid for timsTOF (mobility-partitioned)"
+                            .into(),
+                    );
+                }
+                for w in &frame.windows {
+                    if !(w.isolation.width_mz.is_finite() && w.isolation.width_mz > 0.0) {
+                        return Err("window width must be finite and > 0".into());
+                    }
+                    if !w.isolation.center_mz.is_finite() {
+                        return Err("window center m/z is not finite".into());
+                    }
+                    if let CollisionEnergyPolicy::Value(v) = w.collision_energy {
+                        if !v.is_finite() {
+                            return Err("non-finite collision energy".into());
+                        }
+                    }
+                    match w.geometry {
+                        DiaGeometry::TimsMobility {
+                            scan_start,
+                            scan_end,
+                        } => {
+                            if self.instrument != InstrumentKind::TimsTofDia {
+                                return Err(
+                                    "mobility geometry is only valid for timsTOF".into()
+                                );
+                            }
+                            if scan_start > scan_end {
+                                return Err("mobility scan_start > scan_end".into());
+                            }
+                        }
+                        DiaGeometry::MzOnly => {}
+                    }
+                }
+            }
+        }
+        match self.repeat {
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s,
+            } => {
+                if !(cycle_time_s.is_finite() && cycle_time_s > 0.0) {
+                    return Err("cycle_time_s must be finite and > 0".into());
+                }
+                if !(gradient_length_s.is_finite() && gradient_length_s > 0.0) {
+                    return Err("gradient_length_s must be finite and > 0".into());
+                }
+                if !start_time_s.is_finite() || start_time_s < 0.0 {
+                    return Err("start_time_s must be finite and >= 0".into());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "thermo")]
+impl AcquisitionScheme {
+    /// Extract the acquisition scheme from a real Thermo `.raw` by walking the
+    /// first complete cycle (first MS1 up to the next MS1). Each MS2 scan becomes
+    /// a single-window [`DiaMs2Frame`] (Thermo has no mobility), with the
+    /// observed isolation center/width and CE.
+    pub fn from_thermo_raw<P: AsRef<std::path::Path>>(path: P) -> io::Result<Self> {
+        use thermorawfile::RawFile;
+        let raw = RawFile::open(path)?;
+
+        let analyzer_of = |a: u8| match a {
+            4 => Analyzer::Ftms,
+            7 => Analyzer::Astms,
+            0 => Analyzer::Itms,
+            _ => Analyzer::Unknown,
+        };
+        let data_mode_of = |scan: u32| -> DataMode {
+            let i = (scan - raw.first_scan) as usize;
+            let pkt = (raw.data_addr + raw.index[i].offset) as usize;
+            if pkt + 8 <= raw.bytes.len() {
+                let ps = u32::from_le_bytes(raw.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+                if ps > 0 {
+                    DataMode::Profile
+                } else {
+                    DataMode::Centroid
+                }
+            } else {
+                DataMode::Centroid
+            }
+        };
+        let rt_of = |scan: u32| raw.index[(scan - raw.first_scan) as usize].time;
+
+        let mut cycle: Vec<AcquisitionEvent> = Vec::new();
+        let mut seen_ms1 = false;
+        let mut start_rt = 0.0f64;
+        let mut cycle_time_s = 0.0f64;
+        let mut win_lo = f64::INFINITY;
+        let mut win_hi = f64::NEG_INFINITY;
+        let mut any_astms = false;
+
+        for scan in raw.first_scan..=raw.last_scan {
+            let ev = match raw.scan_event(scan) {
+                Some(e) => e,
+                None => continue,
+            };
+            if ev.analyzer == 7 {
+                any_astms = true;
+            }
+            if ev.ms_order <= 1 {
+                if seen_ms1 {
+                    // start of the next cycle -> close this one
+                    cycle_time_s = (rt_of(scan) - start_rt).max(0.0);
+                    break;
+                }
+                seen_ms1 = true;
+                start_rt = rt_of(scan);
+                cycle.push(AcquisitionEvent::Ms1(Ms1Event {
+                    analyzer: analyzer_of(ev.analyzer),
+                    data_mode: data_mode_of(scan),
+                    mz_range: (0.0, 0.0), // filled below
+                    duration_s: None,
+                }));
+            } else if seen_ms1 {
+                let iso = IsolationWindow {
+                    center_mz: ev.isolation_center,
+                    width_mz: ev.isolation_width,
+                };
+                win_lo = win_lo.min(iso.lower());
+                win_hi = win_hi.max(iso.upper());
+                cycle.push(AcquisitionEvent::DiaMs2Frame(DiaMs2Frame {
+                    windows: vec![DiaWindow {
+                        isolation: iso,
+                        collision_energy: CollisionEnergyPolicy::Value(ev.collision_energy),
+                        geometry: DiaGeometry::MzOnly,
+                    }],
+                    analyzer: analyzer_of(ev.analyzer),
+                    data_mode: data_mode_of(scan),
+                    duration_s: None,
+                }));
+            }
+        }
+
+        if cycle.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "no scan events found in template",
+            ));
+        }
+        let mz_range = if win_lo.is_finite() && win_hi > win_lo {
+            (win_lo, win_hi)
+        } else {
+            (0.0, 0.0)
+        };
+        for ev in &mut cycle {
+            if let AcquisitionEvent::Ms1(m) = ev {
+                m.mz_range = mz_range;
+            }
+        }
+        let gradient_length_s = raw.index.last().map(|e| e.time).unwrap_or(0.0);
+        let n_ms2 = cycle
+            .iter()
+            .filter(|e| matches!(e, AcquisitionEvent::DiaMs2Frame(_)))
+            .count();
+
+        Ok(AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: if any_astms {
+                InstrumentKind::OrbitrapAstral
+            } else {
+                InstrumentKind::Other
+            },
+            cycle,
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s,
+                gradient_length_s,
+                start_time_s: start_rt,
+            },
+            mz_range,
+            provenance: Provenance {
+                source: SchemeSource::ExtractedThermo,
+                notes: format!("extracted from Thermo .raw (first cycle: 1 MS1 + {n_ms2} MS2)"),
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linear_windows(n: usize) -> Vec<DiaWindow> {
+        (0..n)
+            .map(|i| DiaWindow {
+                isolation: IsolationWindow {
+                    center_mz: 400.0 + i as f64 * 10.0,
+                    width_mz: 10.0,
+                },
+                collision_energy: CollisionEnergyPolicy::Value(25.0),
+                geometry: DiaGeometry::MzOnly,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn from_window_table_validates() {
+        let s = AcquisitionScheme::from_window_table(
+            InstrumentKind::OrbitrapAstral,
+            Ms1Event {
+                analyzer: Analyzer::Ftms,
+                data_mode: DataMode::Profile,
+                mz_range: (390.0, 900.0),
+                duration_s: None,
+            },
+            linear_windows(5),
+            RepeatPolicy::FixedCycleTime {
+                cycle_time_s: 1.0,
+                gradient_length_s: 600.0,
+                start_time_s: 0.0,
+            },
+            (390.0, 900.0),
+        );
+        s.validate().unwrap();
+        assert_eq!(s.windows().count(), 5);
+        assert_eq!(s.ms1_count(), 1);
+        assert_eq!(s.num_cycles(), Some(600));
+    }
+
+    #[test]
+    fn multi_window_frame_only_tims() {
+        let frame = DiaMs2Frame {
+            windows: linear_windows(3),
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            duration_s: None,
+        };
+        let s = AcquisitionScheme {
+            version: SCHEME_VERSION,
+            instrument: InstrumentKind::OrbitrapAstral, // wrong: multi-window on non-tims
+            cycle: vec![
+                AcquisitionEvent::Ms1(Ms1Event {
+                    analyzer: Analyzer::Ftms,
+                    data_mode: DataMode::Profile,
+                    mz_range: (390.0, 900.0),
+                    duration_s: None,
+                }),
+                AcquisitionEvent::DiaMs2Frame(frame),
+            ],
+            repeat: RepeatPolicy::FixedCycleTime {
+                cycle_time_s: 1.0,
+                gradient_length_s: 600.0,
+                start_time_s: 0.0,
+            },
+            mz_range: (390.0, 900.0),
+            provenance: Provenance {
+                source: SchemeSource::Programmatic,
+                notes: String::new(),
+            },
+        };
+        assert!(s.validate().is_err());
+    }
+
+    #[cfg(feature = "thermo")]
+    #[test]
+    fn from_thermo_raw_extracts_cycle() {
+        let template = match std::env::var("TIMSIM_ASTRAL_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP from_thermo_raw_extracts_cycle: set TIMSIM_ASTRAL_TEMPLATE");
+                return;
+            }
+        };
+        let s = AcquisitionScheme::from_thermo_raw(&template).expect("extract");
+        s.validate().expect("valid scheme");
+        assert_eq!(s.instrument, InstrumentKind::OrbitrapAstral);
+        assert_eq!(s.ms1_count(), 1, "one MS1 per cycle");
+        let n_win = s.windows().count();
+        assert!(n_win > 1, "expected several MS2 windows, got {n_win}");
+        // Thermo: every window is m/z-only with a known CE.
+        for w in s.windows() {
+            assert!(matches!(w.geometry, DiaGeometry::MzOnly));
+            assert!(w.collision_energy.at(w.isolation.center_mz).is_some());
+            assert!(w.isolation.width_mz > 0.0);
+        }
+        // centers should be (weakly) increasing across the first cycle is not
+        // guaranteed by Astral, but coverage must be a sane m/z span.
+        assert!(s.mz_range.0 > 100.0 && s.mz_range.1 < 3000.0 && s.mz_range.0 < s.mz_range.1);
+        eprintln!(
+            "from_thermo_raw OK: instrument={:?}, {} MS2 windows, mz {:.1}..{:.1}, cycle {:.4}s",
+            s.instrument, n_win, s.mz_range.0, s.mz_range.1,
+            match s.repeat { RepeatPolicy::FixedCycleTime { cycle_time_s, .. } => cycle_time_s }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Wires the `thermorawfile` crate into `rustdf` behind a **vendor-neutral acquisition-writer abstraction**, so TimSim can emit Thermo `.raw` the same way it emits Bruker `.d`. This is the *output* side of multi-instrument support; the *input* side (`AcquisitionScheme`) is designed in `ACQUISITION_SCHEME_PLAN.md` (not yet implemented).

## Changes

- **`rustdf/src/sim/acquisition.rs`** (new):
  - `ScanDescriptor` — vendor-neutral scan: `ms_level`, RT, optional MS2 `IsolationWindow`, `(m/z, intensity)` peaks. No ion-mobility dimension (the Bruker∩Thermo∩SCIEX common denominator).
  - `trait AcquisitionWriter { write_scan; finalize }`.
  - `ThermoRawWriter` (feature `thermo`): template-mutation writer over `thermorawfile`. Opens a real Astral/Orbitrap `.raw`, classifies template scans by packet type (profile ⇒ MS1 via `author_profile`, centroid-only ⇒ MS2 via `author_centroids`), authors peaks into the next matching template scan, and — for MS2 — authors the descriptor's isolation center/width/CE into the scan event via `set_isolation`. Saves on `finalize`.
- **`rustdf/Cargo.toml`**: `thermorawfile` as an **optional git dependency** (private repo, pinned by rev) behind the **off-by-default `thermo` feature**, so the core build/CI is unaffected.
- **`ACQUISITION_SCHEME_PLAN.md`** (+ two Codex review rounds): design for the vendor-neutral `AcquisitionScheme` (input side) — ordered cycle of events, `DiaGeometry`/`CollisionEnergyPolicy`, MS1 as a first-class event, Bruker `to_bruker_tables()` adapter, two usage modes (reference-derived layout+noise, injected). Converged but not yet implemented.

## Testing

- Default build (`thermo` off): unaffected.
- `--features thermo`: fetches + compiles the private dep cleanly.
- Gated round-trip test (`TIMSIM_ASTRAL_TEMPLATE=<astral .raw>`): authors an MS1 (profile) + MS2 (centroid) via the trait, reads back through `thermorawfile`, and is **cross-verified by Thermo's own RawFileReader** — the rustdf-authored `.raw` reports the authored MS1 (TIC 1.5e6), MS2 peaks (TIC 1.6e5), and MS2 isolation (500±2) + CE (25) correctly.

## Scope / follow-ups (not in this PR)

- Bruker `.d` adapter behind the same trait.
- `AcquisitionScheme` implementation (incl. explicit `DiaMs2Frame` grouping per the v2 review).
- **Overlay writer mode** (merge simulated peaks onto real template signal) for the reference-run = layout + real-noise (real⊕sim) workflow.

The `thermorawfile` crate (Thermo `.raw` reader/writer: ASTMS centroids, FTMS profile, freq↔m/z calibration, variable-count authoring) lives in its own private repo and was independently oracle-verified.