### PR TITLE
feat(tims-viewer): native wgpu GPU viewer for timsTOF raw data (Phase 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,10 @@
 members = [
     "mscore",
     "rustdf",
-    "rustms", 
+    "rustms",
     "imspy_connector",
-    "imsjl_connector"
+    "imsjl_connector",
+    "tims-viewer"
 ]
 
 resolver = "2"

--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -42,6 +42,8 @@ rayon = "1.10"
 crossbeam-channel = "0.5"
 # f32 -> f16 conversion for the R16Float volume texture
 half = { version = "2", features = ["bytemuck"] }
+# PNG screenshot export
+png = "0.17"
 
 [features]
 default = []

--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -40,6 +40,8 @@ env_logger = "0.11"
 clap = { version = "4.5", features = ["derive"] }
 rayon = "1.10"
 crossbeam-channel = "0.5"
+# f32 -> f16 conversion for the R16Float volume texture
+half = { version = "2", features = ["bytemuck"] }
 
 [features]
 default = []

--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "tims-viewer"
+version = "0.1.0"
+edition = "2021"
+authors = ["David Teschner <davidteschner@googlemail.com>"]
+description = "Native GPU viewer for Bruker timsTOF raw data (point cloud + volume rendering)."
+license = "MIT"
+repository = "https://github.com/theGreatHerrLebert/rustims"
+rust-version = "1.84"
+
+[[bin]]
+name = "tims-viewer"
+path = "src/main.rs"
+
+[dependencies]
+# Local data layer (zero-copy access to raw timsTOF frames)
+rustdf = { path = "../rustdf", version = "0.4.1" }
+mscore = { path = "../mscore", version = "0.4.1" }
+
+# GPU + windowing + UI. Pin the triple exactly: this is a known-compatible set
+# (egui-wgpu 0.29 -> wgpu 22, egui-winit 0.29 -> winit 0.30). Broad ranges risk a
+# resolution that mixes incompatible majors.
+wgpu = "=22.1.0"
+winit = "=0.30.5"
+egui = "=0.29.1"
+egui-wgpu = "=0.29.1"
+egui-winit = { version = "=0.29.1", default-features = false, features = ["links", "wayland", "x11"] }
+
+# Math / GPU data
+bytemuck = { version = "1.21", features = ["derive"] }
+glam = { version = "0.29", features = ["bytemuck"] }
+
+# Async bridge for wgpu adapter/device requests
+pollster = "0.3"
+
+# Misc
+anyhow = "1"
+log = "0.4"
+env_logger = "0.11"
+clap = { version = "4.5", features = ["derive"] }
+rayon = "1.10"
+crossbeam-channel = "0.5"
+
+[features]
+default = []
+# Pack positions/intensity as f16 to roughly double on-GPU point capacity.
+compact = []
+
+# This crate is a leaf binary; keep its own release profile knobs consistent with the
+# workspace (panic=abort etc. are inherited from the workspace [profile.release]).

--- a/tims-viewer/NEXT_VIEWER_STEPS.md
+++ b/tims-viewer/NEXT_VIEWER_STEPS.md
@@ -1,0 +1,60 @@
+# tims-viewer — next steps
+
+Future ideas for the native GPU timsTOF RAW viewer, captured at the end of the
+initial build (Phases 1–3 complete on branch `feat/tims-viewer`, PR #406).
+
+## Where it stands today
+
+- **Point cloud**: streaming load, device-budget downsampling with stratified
+  peak-preservation, GPU compaction + `draw_indirect` visible-set reduction,
+  additive-density and structural-opaque modes.
+- **Volume**: trilinear cloud-in-cell density voxelization → R16F 3D texture,
+  fullscreen raycaster (composite + MIP), density-domain auto transfer range.
+- **Shared**: live RT / m-z / 1-K0 window filtering, MS1/MS2 toggle, transfer
+  function (lin/sqrt/log) + colormaps, orbit camera.
+- **Annotations**: DDA precursor crosses / DIA isolation-window boxes, clipped
+  to the active window.
+- **Export**: headless `--render-png` (volume/points, `--ms`, `--annotations`,
+  transfer overrides) — works over SSH with no display.
+- Verified on a real 1.9 GB HeLa DDA run; 12 tests incl. offscreen-GPU renders;
+  6 codex review rounds.
+
+## Candidate next steps
+
+Roughly ordered by value-to-effort.
+
+1. **Live region refinement (region LOD).** When the user narrows the window,
+   reload just the in-window frames at higher density (the `RefineRegion`
+   command + generation plumbing is already shaped for this in the loader). Turns
+   "coarse globally" into "crisp where you're looking."
+2. **In-app screenshot button.** The headless `offscreen` path already does the
+   render-to-PNG; wire a UI button / `S` key that renders the live view offscreen
+   and saves a PNG (and optionally save/restore camera pose).
+3. **Axis gizmo + tick labels + colorbar.** Right now it's a bare cube; drawing
+   the m/z / 1-K0 / RT axes with real-unit ticks (we keep the `AxisTransform`s)
+   and an intensity colorbar would make renders self-explanatory.
+4. **Point picking / hover readout.** Click or hover to report the real
+   (m/z, 1/K0, RT, intensity) under the cursor — needs a pick pass or CPU
+   nearest-search against a spatial index.
+5. **DIA showcase.** Render a DIA-PASEF run to exercise the isolation-window box
+   overlay end-to-end on real data (only DDA was validated during the build).
+6. **GPU compute voxelization + empty-space skipping.** Move trilinear deposition
+   to a compute scatter (atomics on a u32 grid) so the volume revoxelizes live as
+   filters change, and add an occupancy mip to skip empty bricks in the raycast.
+7. **Multi-run overlay / comparison.** Load two runs (e.g. condition A vs B) and
+   render them in distinct colormaps in the same cube.
+8. **Quality / polish.** Weighted-blended OIT for translucent structural points;
+   `compact` f16 point format to double on-GPU capacity; perceptual exposure auto
+   from a histogram; configurable volume resolution; save/load view presets.
+
+## Notes / gotchas for whoever picks this up
+
+- Frame ids must be contiguous `1..=N` (rustdf indexes frames by vector
+  position; the loader validates this at load).
+- timsTOF intensities span ~6 orders of magnitude with a low noise floor — raise
+  `i_min` (transfer) to threshold noise out, or renders look like static.
+- The dev box is headless; verify with `cargo test -p tims-viewer` (includes real
+  offscreen-GPU smokes) and `--render-png ... DEMO` / a `.d` path. Inspect PNGs
+  directly. The windowed app needs a display, run it on a workstation.
+- Pinned dependency triple: wgpu `=22.1` / winit `=0.30.5` / egui `=0.29.1`
+  (+ egui-wgpu/egui-winit). Keep them locked together when bumping.

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -286,21 +286,39 @@ impl Gfx {
         for _ in 0..MAX_CHUNKS_PER_FRAME {
             match self.loader.rx.try_recv() {
                 Ok(LoadMsg::Chunk { points, .. }) => {
-                    // Voxelize into the CPU max-grid (for volume mode) and upload to GPU.
+                    // Volume density: deposit intensity*weight so the density is
+                    // independent of the downsample ratio (weight = 1/p = stride).
                     for p in &points {
-                        self.grid.deposit(p.pos, p.intensity);
+                        self.grid.deposit(p.pos, p.intensity * p.weight);
                     }
+                    self.points.append(&self.queue, &points);
+                }
+                Ok(LoadMsg::PeakChunk { points }) => {
+                    // Peaks are display-only enrichment; append to the cloud but do NOT
+                    // add to the volume density (would double-count dense cells).
                     self.points.append(&self.queue, &points);
                 }
                 Ok(LoadMsg::Progress(p)) => self.state.load_progress = p,
                 Ok(LoadMsg::Stats { i_min, i_max }) => {
-                    self.state.i_min = i_min;
-                    self.state.i_max = i_max;
+                    // Point-intensity range; only relevant to point mode (volume uses a
+                    // density range derived from the grid).
+                    if self.state.view_mode == ViewMode::Points {
+                        self.state.i_min = i_min;
+                        self.state.i_max = i_max;
+                    }
                 }
                 Ok(LoadMsg::Annotations { lines }) => {
                     self.annotations.upload(&self.device, &lines);
                 }
-                Ok(LoadMsg::Done { .. }) => self.state.load_progress = 1.0,
+                Ok(LoadMsg::Done { .. }) => {
+                    self.state.load_progress = 1.0;
+                    // Recompute the volume range against the now-complete grid.
+                    if self.state.view_mode == ViewMode::Volume {
+                        let (lo, hi) = self.grid.density_percentiles();
+                        self.state.i_min = lo;
+                        self.state.i_max = hi;
+                    }
+                }
                 Ok(LoadMsg::Error(e)) => {
                     log::error!("loader error: {e}");
                     self.state.load_failed = true;

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -131,6 +131,11 @@ impl App {
 
         log::info!("adapter: {:?}", adapter.get_info());
         let limits = adapter.limits();
+        // GPU compaction needs compute + indirect execution; fall back to draw-all
+        // (vertex-shader culling) on backends that lack them (e.g. some GL drivers).
+        let dl_flags = adapter.get_downlevel_capabilities().flags;
+        let supports_compaction = dl_flags.contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
+            && dl_flags.contains(wgpu::DownlevelFlags::INDIRECT_EXECUTION);
         let (device, queue) = pollster::block_on(adapter.request_device(
             &wgpu::DeviceDescriptor {
                 label: Some("tims-viewer-device"),
@@ -172,13 +177,21 @@ impl App {
             .min((total as usize).max(1))
             .max(1) as u32;
         log::info!(
-            "point budget={} capacity={} (device max_buffer_size={} MiB)",
+            "point budget={} capacity={} compaction={} (device max_buffer_size={} MiB)",
             plan.budget,
             capacity,
+            supports_compaction,
             limits.max_buffer_size / (1024 * 1024)
         );
 
-        let points = PointCloudRenderer::new(&device, &queue, format, DEPTH_FORMAT, capacity);
+        let points = PointCloudRenderer::new(
+            &device,
+            &queue,
+            format,
+            DEPTH_FORMAT,
+            capacity,
+            supports_compaction,
+        );
 
         let n_colormaps = COLORMAP_NAMES.len() as u32;
         let mut state = AppState::new(plan.meta.bounds, total, n_colormaps);
@@ -355,6 +368,9 @@ impl Gfx {
         let user_bufs =
             self.egui_renderer
                 .update_buffers(&self.device, &self.queue, &mut encoder, &tris, &screen_desc);
+
+        // Cull + compact visible points (compute) before the scene pass.
+        self.points.prepare(&self.queue, &mut encoder);
 
         // 3D pass.
         {

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -18,7 +18,8 @@ use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
 use crate::data::meta::MetaIndex;
 use crate::render::colormap::COLORMAP_NAMES;
 use crate::render::point_cloud::PointCloudRenderer;
-use crate::state::AppState;
+use crate::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
+use crate::state::{AppState, ViewMode};
 use crate::ui;
 
 const DEFAULT_BUDGET: usize = 12_000_000;
@@ -54,6 +55,8 @@ struct Gfx {
     egui_renderer: egui_wgpu::Renderer,
 
     points: PointCloudRenderer,
+    volume: VolumeRenderer,
+    grid: VolumeGrid,
     camera: OrbitCamera,
     state: AppState,
     loader: LoaderHandle,
@@ -192,6 +195,8 @@ impl App {
             capacity,
             supports_compaction,
         );
+        let volume = VolumeRenderer::new(&device, &queue, format, DEPTH_FORMAT, VOLUME_DIMS);
+        let grid = VolumeGrid::new(VOLUME_DIMS);
 
         let n_colormaps = COLORMAP_NAMES.len() as u32;
         let mut state = AppState::new(plan.meta.bounds, total, n_colormaps);
@@ -234,6 +239,8 @@ impl App {
             egui_state,
             egui_renderer,
             points,
+            volume,
+            grid,
             camera: OrbitCamera::default(),
             state,
             loader,
@@ -267,6 +274,10 @@ impl Gfx {
         for _ in 0..MAX_CHUNKS_PER_FRAME {
             match self.loader.rx.try_recv() {
                 Ok(LoadMsg::Chunk { points, .. }) => {
+                    // Voxelize into the CPU max-grid (for volume mode) and upload to GPU.
+                    for p in &points {
+                        self.grid.deposit(p.pos, p.intensity);
+                    }
                     self.points.append(&self.queue, &points);
                 }
                 Ok(LoadMsg::Progress(p)) => self.state.load_progress = p,
@@ -320,6 +331,17 @@ impl Gfx {
         self.points.update_camera(&self.queue, &cam);
         self.points.update_params(&self.queue, &self.state.params());
 
+        // Volume mode: update the raycaster uniform and (re)upload the grid if it grew.
+        if self.state.view_mode == ViewMode::Volume {
+            let inv_vp = self.camera.inv_view_proj(aspect);
+            self.volume
+                .update_uniform(&self.queue, &self.state.volume_uniform(inv_vp));
+            if self.grid.dirty() {
+                self.volume.upload(&self.queue, &self.grid.to_f16());
+                self.grid.clear_dirty();
+            }
+        }
+
         // Acquire the surface BEFORE any egui texture upload, so a surface error
         // returns without leaking uploaded-but-never-freed egui textures (texture
         // `set` and `free` are then always paired within one successful frame).
@@ -369,8 +391,10 @@ impl Gfx {
             self.egui_renderer
                 .update_buffers(&self.device, &self.queue, &mut encoder, &tris, &screen_desc);
 
-        // Cull + compact visible points (compute) before the scene pass.
-        self.points.prepare(&self.queue, &mut encoder);
+        // Cull + compact visible points (compute) before the scene pass (points mode only).
+        if self.state.view_mode == ViewMode::Points {
+            self.points.prepare(&self.queue, &mut encoder);
+        }
 
         // 3D pass.
         {
@@ -400,7 +424,10 @@ impl Gfx {
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });
-            self.points.render(&mut rpass, self.state.render_mode);
+            match self.state.view_mode {
+                ViewMode::Points => self.points.render(&mut rpass, self.state.point_mode),
+                ViewMode::Volume => self.volume.render(&mut rpass),
+            }
         }
 
         // egui pass (load existing color, no depth).

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -17,6 +17,7 @@ use crate::data::demo::DemoSource;
 use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
 use crate::data::meta::MetaIndex;
 use crate::render::colormap::COLORMAP_NAMES;
+use crate::render::annotation::AnnotationRenderer;
 use crate::render::point_cloud::PointCloudRenderer;
 use crate::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
 use crate::state::{AppState, ViewMode};
@@ -57,6 +58,7 @@ struct Gfx {
     points: PointCloudRenderer,
     volume: VolumeRenderer,
     grid: VolumeGrid,
+    annotations: AnnotationRenderer,
     camera: OrbitCamera,
     state: AppState,
     loader: LoaderHandle,
@@ -204,6 +206,7 @@ impl App {
         );
         let volume = VolumeRenderer::new(&device, &queue, format, DEPTH_FORMAT, VOLUME_DIMS);
         let grid = VolumeGrid::new(VOLUME_DIMS);
+        let annotations = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
 
         let n_colormaps = COLORMAP_NAMES.len() as u32;
         let mut state = AppState::new(plan.meta.bounds, total, n_colormaps);
@@ -248,6 +251,7 @@ impl App {
             points,
             volume,
             grid,
+            annotations,
             camera: OrbitCamera::default(),
             state,
             loader,
@@ -292,6 +296,9 @@ impl Gfx {
                 Ok(LoadMsg::Stats { i_min, i_max }) => {
                     self.state.i_min = i_min;
                     self.state.i_max = i_max;
+                }
+                Ok(LoadMsg::Annotations { lines }) => {
+                    self.annotations.upload(&self.device, &lines);
                 }
                 Ok(LoadMsg::Done { .. }) => self.state.load_progress = 1.0,
                 Ok(LoadMsg::Error(e)) => {
@@ -375,6 +382,7 @@ impl Gfx {
         );
         self.points.update_camera(&self.queue, &cam);
         self.points.update_params(&self.queue, &self.state.params());
+        self.annotations.update_camera(&self.queue, &cam);
 
         // Volume mode: update the raycaster uniform (incl. the density scale) and
         // (re)upload the grid if it grew.
@@ -447,6 +455,9 @@ impl Gfx {
             match self.state.view_mode {
                 ViewMode::Points => self.points.render(&mut rpass, self.state.point_mode),
                 ViewMode::Volume => self.volume.render(&mut rpass),
+            }
+            if self.state.show_annotations {
+                self.annotations.render(&mut rpass);
             }
         }
 

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -1,0 +1,515 @@
+//! Application orchestrator: window, wgpu, egui, camera, and the render loop that
+//! drains the streaming loader.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::Result;
+use winit::application::ApplicationHandler;
+use winit::dpi::PhysicalPosition;
+use winit::event::{ElementState, MouseButton, MouseScrollDelta, WindowEvent};
+use winit::event_loop::ActiveEventLoop;
+use winit::keyboard::ModifiersState;
+use winit::window::{Window, WindowId};
+
+use crate::camera::OrbitCamera;
+use crate::data::demo::DemoSource;
+use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
+use crate::data::meta::MetaIndex;
+use crate::render::colormap::COLORMAP_NAMES;
+use crate::render::point_cloud::PointCloudRenderer;
+use crate::state::AppState;
+use crate::ui;
+
+const DEFAULT_BUDGET: usize = 12_000_000;
+
+/// How the run will be loaded once the window is up.
+pub struct Plan {
+    pub meta: MetaIndex,
+    pub is_demo: bool,
+    pub budget: usize,
+}
+
+impl Plan {
+    pub fn new(meta: MetaIndex, is_demo: bool, budget: Option<usize>) -> Self {
+        Plan {
+            meta,
+            is_demo,
+            budget: budget.unwrap_or(DEFAULT_BUDGET),
+        }
+    }
+}
+
+/// Everything that exists only once the window/GPU are live.
+struct Gfx {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    depth_view: wgpu::TextureView,
+
+    egui_ctx: egui::Context,
+    egui_state: egui_winit::State,
+    egui_renderer: egui_wgpu::Renderer,
+
+    points: PointCloudRenderer,
+    camera: OrbitCamera,
+    state: AppState,
+    loader: LoaderHandle,
+
+    // interaction
+    modifiers: ModifiersState,
+    left_down: bool,
+    right_down: bool,
+    middle_down: bool,
+    last_cursor: Option<PhysicalPosition<f64>>,
+
+    last_frame: Instant,
+    fps_smooth: f32,
+    /// Set when a fatal GPU error (e.g. surface OOM) should end the event loop.
+    pending_exit: bool,
+}
+
+pub struct App {
+    plan: Option<Plan>,
+    gfx: Option<Gfx>,
+}
+
+impl App {
+    pub fn new(plan: Plan) -> Self {
+        App {
+            plan: Some(plan),
+            gfx: None,
+        }
+    }
+}
+
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+
+fn create_depth(device: &wgpu::Device, config: &wgpu::SurfaceConfiguration) -> wgpu::TextureView {
+    let tex = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("depth"),
+        size: wgpu::Extent3d {
+            width: config.width.max(1),
+            height: config.height.max(1),
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: DEPTH_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    tex.create_view(&wgpu::TextureViewDescriptor::default())
+}
+
+impl App {
+    fn init_gfx(&mut self, event_loop: &ActiveEventLoop) -> Result<Gfx> {
+        let plan = self.plan.take().expect("plan already consumed");
+
+        let attrs = Window::default_attributes()
+            .with_title("tims-viewer")
+            .with_inner_size(winit::dpi::LogicalSize::new(1280.0, 800.0));
+        let window = Arc::new(event_loop.create_window(attrs)?);
+
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY | wgpu::Backends::GL,
+            ..Default::default()
+        });
+        let surface = instance.create_surface(window.clone())?;
+
+        let adapter = pollster::block_on(instance.request_adapter(
+            &wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                force_fallback_adapter: false,
+                compatible_surface: Some(&surface),
+            },
+        ))
+        .ok_or_else(|| anyhow::anyhow!("no suitable GPU adapter found"))?;
+
+        log::info!("adapter: {:?}", adapter.get_info());
+        let limits = adapter.limits();
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("tims-viewer-device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: limits.clone(),
+                memory_hints: wgpu::MemoryHints::Performance,
+            },
+            None,
+        ))?;
+
+        let size = window.inner_size();
+        let caps = surface.get_capabilities(&adapter);
+        let format = caps
+            .formats
+            .iter()
+            .copied()
+            .find(|f| f.is_srgb())
+            .unwrap_or(caps.formats[0]);
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width: size.width.max(1),
+            height: size.height.max(1),
+            present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
+            alpha_mode: caps.alpha_modes[0],
+            view_formats: vec![],
+        };
+        surface.configure(&device, &config);
+        let depth_view = create_depth(&device, &config);
+
+        // Derive a safe capacity from device limits and the requested budget.
+        let bytes_per_point = std::mem::size_of::<crate::data::point::GpuPoint>() as u64;
+        let max_by_buffer = (limits.max_buffer_size / bytes_per_point) as usize;
+        let total = plan.meta.total_points_estimate;
+        let capacity = plan
+            .budget
+            .min(max_by_buffer)
+            .min((total as usize).max(1))
+            .max(1) as u32;
+        log::info!(
+            "point budget={} capacity={} (device max_buffer_size={} MiB)",
+            plan.budget,
+            capacity,
+            limits.max_buffer_size / (1024 * 1024)
+        );
+
+        let points = PointCloudRenderer::new(&device, &queue, format, DEPTH_FORMAT, capacity);
+
+        let n_colormaps = COLORMAP_NAMES.len() as u32;
+        let mut state = AppState::new(plan.meta.bounds, total, n_colormaps);
+        state.capacity = capacity;
+        state.downsample_stride =
+            crate::data::loader::stride_for(total, capacity as usize) as u32;
+
+        // egui plumbing.
+        let egui_ctx = egui::Context::default();
+        let egui_state = egui_winit::State::new(
+            egui_ctx.clone(),
+            egui::ViewportId::ROOT,
+            window.as_ref(),
+            Some(window.scale_factor() as f32),
+            None,
+            None,
+        );
+        let egui_renderer = egui_wgpu::Renderer::new(&device, format, None, 1, true);
+
+        // Spawn the loader.
+        let mode = if plan.is_demo {
+            LoaderMode::Demo(DemoSource::new(plan.meta.frames.len(), total))
+        } else {
+            let frame_ids = plan.meta.frames.iter().map(|f| f.id).collect();
+            LoaderMode::Real {
+                path: plan.meta.data_path.clone(),
+                frame_ids,
+            }
+        };
+        let loader = LoaderHandle::spawn(mode, plan.meta.bounds, total, capacity as usize);
+
+        Ok(Gfx {
+            window,
+            surface,
+            device,
+            queue,
+            config,
+            depth_view,
+            egui_ctx,
+            egui_state,
+            egui_renderer,
+            points,
+            camera: OrbitCamera::default(),
+            state,
+            loader,
+            modifiers: ModifiersState::empty(),
+            left_down: false,
+            right_down: false,
+            middle_down: false,
+            last_cursor: None,
+            last_frame: Instant::now(),
+            fps_smooth: 0.0,
+            pending_exit: false,
+        })
+    }
+}
+
+impl Gfx {
+    fn resize(&mut self, width: u32, height: u32) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        self.config.width = width;
+        self.config.height = height;
+        self.surface.configure(&self.device, &self.config);
+        self.depth_view = create_depth(&self.device, &self.config);
+    }
+
+    /// Drain the loader channel, bounding work per frame.
+    fn pump_loader(&mut self) {
+        // Cap chunks per frame so a fast loader can't stall the UI with uploads.
+        const MAX_CHUNKS_PER_FRAME: usize = 16;
+        for _ in 0..MAX_CHUNKS_PER_FRAME {
+            match self.loader.rx.try_recv() {
+                Ok(LoadMsg::Chunk { points, .. }) => {
+                    self.points.append(&self.queue, &points);
+                }
+                Ok(LoadMsg::Progress(p)) => self.state.load_progress = p,
+                Ok(LoadMsg::Stats { i_min, i_max }) => {
+                    self.state.i_min = i_min;
+                    self.state.i_max = i_max;
+                }
+                Ok(LoadMsg::Done { .. }) => self.state.load_progress = 1.0,
+                Ok(LoadMsg::Error(e)) => {
+                    log::error!("loader error: {e}");
+                    self.state.load_failed = true;
+                    self.state.load_progress = 1.0;
+                }
+                Err(crossbeam_channel::TryRecvError::Empty) => break,
+                Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                    // Normal completion drops the sender after Done (progress==1.0).
+                    // A disconnect before that means the loader thread died (panic).
+                    if self.state.load_progress < 1.0 {
+                        log::error!("loader thread ended before completing the load");
+                        self.state.load_failed = true;
+                        self.state.load_progress = 1.0;
+                    }
+                    break;
+                }
+            }
+        }
+        self.state.resident_points = self.points.resident();
+    }
+
+    fn render(&mut self) {
+        self.pump_loader();
+
+        // FPS (exponential smoothing).
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_frame).as_secs_f32().max(1e-4);
+        self.last_frame = now;
+        let inst = 1.0 / dt;
+        self.fps_smooth = if self.fps_smooth == 0.0 {
+            inst
+        } else {
+            self.fps_smooth * 0.9 + inst * 0.1
+        };
+        self.state.fps = self.fps_smooth;
+
+        // Uniforms.
+        let aspect = self.config.width as f32 / self.config.height.max(1) as f32;
+        let cam = self.camera.to_uniform(
+            aspect,
+            [self.config.width as f32, self.config.height as f32],
+        );
+        self.points.update_camera(&self.queue, &cam);
+        self.points.update_params(&self.queue, &self.state.params());
+
+        // Acquire the surface BEFORE any egui texture upload, so a surface error
+        // returns without leaking uploaded-but-never-freed egui textures (texture
+        // `set` and `free` are then always paired within one successful frame).
+        let frame = match self.surface.get_current_texture() {
+            Ok(f) => f,
+            Err(wgpu::SurfaceError::Lost) | Err(wgpu::SurfaceError::Outdated) => {
+                self.surface.configure(&self.device, &self.config);
+                return;
+            }
+            Err(wgpu::SurfaceError::Timeout) => return,
+            Err(wgpu::SurfaceError::OutOfMemory) => {
+                log::error!("surface out of memory; exiting");
+                self.pending_exit = true;
+                return;
+            }
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        // egui frame.
+        let raw_input = self.egui_state.take_egui_input(self.window.as_ref());
+        let full_output = self.egui_ctx.run(raw_input, |ctx| {
+            ui::build(ctx, &mut self.state, &mut self.camera);
+        });
+        self.egui_state
+            .handle_platform_output(self.window.as_ref(), full_output.platform_output);
+        let tris = self
+            .egui_ctx
+            .tessellate(full_output.shapes, full_output.pixels_per_point);
+        for (id, delta) in &full_output.textures_delta.set {
+            self.egui_renderer
+                .update_texture(&self.device, &self.queue, *id, delta);
+        }
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("frame-encoder"),
+            });
+
+        let screen_desc = egui_wgpu::ScreenDescriptor {
+            size_in_pixels: [self.config.width, self.config.height],
+            pixels_per_point: full_output.pixels_per_point,
+        };
+        let user_bufs =
+            self.egui_renderer
+                .update_buffers(&self.device, &self.queue, &mut encoder, &tris, &screen_desc);
+
+        // 3D pass.
+        {
+            let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("scene-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.02,
+                            g: 0.02,
+                            b: 0.035,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &self.depth_view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            self.points.render(&mut rpass, self.state.render_mode);
+        }
+
+        // egui pass (load existing color, no depth).
+        {
+            let mut rpass = encoder
+                .begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("egui-pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                })
+                .forget_lifetime();
+            self.egui_renderer.render(&mut rpass, &tris, &screen_desc);
+        }
+
+        self.queue
+            .submit(user_bufs.into_iter().chain(std::iter::once(encoder.finish())));
+        frame.present();
+
+        for id in &full_output.textures_delta.free {
+            self.egui_renderer.free_texture(id);
+        }
+    }
+
+    fn handle_cursor(&mut self, pos: PhysicalPosition<f64>) {
+        if let Some(last) = self.last_cursor {
+            let dx = (pos.x - last.x) as f32;
+            let dy = (pos.y - last.y) as f32;
+            let shift = self.modifiers.shift_key();
+            if self.middle_down || self.right_down || (self.left_down && shift) {
+                self.camera.pan(dx, dy);
+            } else if self.left_down {
+                self.camera.orbit(dx, dy);
+            }
+        }
+        self.last_cursor = Some(pos);
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.gfx.is_some() {
+            return;
+        }
+        match self.init_gfx(event_loop) {
+            Ok(gfx) => self.gfx = Some(gfx),
+            Err(e) => {
+                log::error!("failed to initialize graphics: {e:#}");
+                event_loop.exit();
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _id: WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(gfx) = self.gfx.as_mut() else {
+            return;
+        };
+
+        // egui gets first dibs.
+        let resp = gfx.egui_state.on_window_event(gfx.window.as_ref(), &event);
+        if resp.repaint {
+            gfx.window.request_redraw();
+        }
+        let consumed = resp.consumed;
+
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(size) => gfx.resize(size.width, size.height),
+            WindowEvent::ModifiersChanged(m) => gfx.modifiers = m.state(),
+            WindowEvent::RedrawRequested => gfx.render(),
+            // Handle button state BEFORE the consumed-guard: a release that egui
+            // consumes (drag ended over a panel) must still clear the button, or the
+            // camera keeps orbiting on the next move. Presses only start a drag when
+            // egui did not consume them (so dragging a slider doesn't orbit).
+            WindowEvent::MouseInput { state, button, .. } => {
+                let down = state == ElementState::Pressed;
+                let set = if down { !consumed } else { false };
+                match button {
+                    MouseButton::Left => gfx.left_down = set,
+                    MouseButton::Right => gfx.right_down = set,
+                    MouseButton::Middle => gfx.middle_down = set,
+                    _ => {}
+                }
+                if !down {
+                    gfx.last_cursor = None;
+                }
+            }
+            _ if consumed => {
+                // egui handled it; don't drive the camera.
+                gfx.last_cursor = None;
+            }
+            WindowEvent::CursorMoved { position, .. } => gfx.handle_cursor(position),
+            WindowEvent::CursorLeft { .. } => gfx.last_cursor = None,
+            WindowEvent::MouseWheel { delta, .. } => {
+                let s = match delta {
+                    MouseScrollDelta::LineDelta(_, y) => y,
+                    MouseScrollDelta::PixelDelta(p) => (p.y as f32) / 50.0,
+                };
+                gfx.camera.zoom(s);
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if let Some(gfx) = self.gfx.as_ref() {
+            if gfx.pending_exit {
+                event_loop.exit();
+                return;
+            }
+            // Drive continuous redraws so streaming data animates in.
+            gfx.window.request_redraw();
+        }
+    }
+}

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -174,11 +174,16 @@ impl App {
         let bytes_per_point = std::mem::size_of::<crate::data::point::GpuPoint>() as u64;
         let max_by_buffer = (limits.max_buffer_size / bytes_per_point) as usize;
         let total = plan.meta.total_points_estimate;
-        let capacity = plan
-            .budget
-            .min(max_by_buffer)
-            .min((total as usize).max(1))
-            .max(1) as u32;
+        let mut cap = plan.budget.min(max_by_buffer).min((total as usize).max(1));
+        // When compaction is on, the master + compacted buffers are bound as storage,
+        // which is capped by max_storage_buffer_binding_size (often much smaller than
+        // max_buffer_size, e.g. 128 MiB) — exceeding it fails bind-group validation.
+        if supports_compaction {
+            let max_by_storage =
+                (limits.max_storage_buffer_binding_size as u64 / bytes_per_point) as usize;
+            cap = cap.min(max_by_storage);
+        }
+        let capacity = cap.max(1) as u32;
         log::info!(
             "point budget={} capacity={} compaction={} (device max_buffer_size={} MiB)",
             plan.budget,
@@ -322,26 +327,6 @@ impl Gfx {
         };
         self.state.fps = self.fps_smooth;
 
-        // Uniforms.
-        let aspect = self.config.width as f32 / self.config.height.max(1) as f32;
-        let cam = self.camera.to_uniform(
-            aspect,
-            [self.config.width as f32, self.config.height as f32],
-        );
-        self.points.update_camera(&self.queue, &cam);
-        self.points.update_params(&self.queue, &self.state.params());
-
-        // Volume mode: update the raycaster uniform and (re)upload the grid if it grew.
-        if self.state.view_mode == ViewMode::Volume {
-            let inv_vp = self.camera.inv_view_proj(aspect);
-            self.volume
-                .update_uniform(&self.queue, &self.state.volume_uniform(inv_vp));
-            if self.grid.dirty() {
-                self.volume.upload(&self.queue, &self.grid.to_f16());
-                self.grid.clear_dirty();
-            }
-        }
-
         // Acquire the surface BEFORE any egui texture upload, so a surface error
         // returns without leaking uploaded-but-never-freed egui textures (texture
         // `set` and `free` are then always paired within one successful frame).
@@ -375,6 +360,30 @@ impl Gfx {
         for (id, delta) in &full_output.textures_delta.set {
             self.egui_renderer
                 .update_texture(&self.device, &self.queue, *id, delta);
+        }
+
+        // Uniforms — computed AFTER egui so they reflect this frame's UI/camera changes
+        // (otherwise a Points->Volume switch renders one frame with a stale matrix and
+        // an un-uploaded texture).
+        let aspect = self.config.width as f32 / self.config.height.max(1) as f32;
+        let cam = self.camera.to_uniform(
+            aspect,
+            [self.config.width as f32, self.config.height as f32],
+        );
+        self.points.update_camera(&self.queue, &cam);
+        self.points.update_params(&self.queue, &self.state.params());
+
+        // Volume mode: update the raycaster uniform (incl. the density scale) and
+        // (re)upload the grid if it grew.
+        if self.state.view_mode == ViewMode::Volume {
+            let inv_vp = self.camera.inv_view_proj(aspect);
+            let mut vu = self.state.volume_uniform(inv_vp);
+            vu.density_scale = self.grid.density_scale();
+            self.volume.update_uniform(&self.queue, &vu);
+            if self.grid.dirty() {
+                self.volume.upload(&self.queue, &self.grid.to_f16_scaled());
+                self.grid.clear_dirty();
+            }
         }
 
         let mut encoder = self

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -72,6 +72,8 @@ struct Gfx {
     fps_smooth: f32,
     /// Set when a fatal GPU error (e.g. surface OOM) should end the event loop.
     pending_exit: bool,
+    /// Previous frame's view mode, to auto-range the transfer fn on Points->Volume.
+    last_view_mode: ViewMode,
 }
 
 pub struct App {
@@ -257,6 +259,7 @@ impl App {
             last_frame: Instant::now(),
             fps_smooth: 0.0,
             pending_exit: false,
+            last_view_mode: ViewMode::Points,
         })
     }
 }
@@ -376,6 +379,13 @@ impl Gfx {
         // Volume mode: update the raycaster uniform (incl. the density scale) and
         // (re)upload the grid if it grew.
         if self.state.view_mode == ViewMode::Volume {
+            // On entering volume mode, auto-range the transfer fn to the density
+            // distribution (density sums differ in range from per-point intensity).
+            if self.last_view_mode != ViewMode::Volume {
+                let (lo, hi) = self.grid.density_percentiles();
+                self.state.i_min = lo;
+                self.state.i_max = hi;
+            }
             let inv_vp = self.camera.inv_view_proj(aspect);
             let mut vu = self.state.volume_uniform(inv_vp);
             vu.density_scale = self.grid.density_scale();
@@ -385,6 +395,7 @@ impl Gfx {
                 self.grid.clear_dirty();
             }
         }
+        self.last_view_mode = self.state.view_mode;
 
         let mut encoder = self
             .device

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -398,9 +398,12 @@ impl Gfx {
             aspect,
             [self.config.width as f32, self.config.height as f32],
         );
+        let params = self.state.params();
         self.points.update_camera(&self.queue, &cam);
-        self.points.update_params(&self.queue, &self.state.params());
+        self.points.update_params(&self.queue, &params);
         self.annotations.update_camera(&self.queue, &cam);
+        self.annotations
+            .update_filter(&self.queue, params.filter_min, params.filter_max);
 
         // Volume mode: update the raycaster uniform (incl. the density scale) and
         // (re)upload the grid if it grew.

--- a/tims-viewer/src/camera.rs
+++ b/tims-viewer/src/camera.rs
@@ -1,0 +1,135 @@
+//! Orbit camera around the normalized data cube.
+
+use glam::{Mat4, Vec3};
+
+use crate::render::uniforms::CameraUniform;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Projection {
+    Perspective,
+    Orthographic,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum AxisView {
+    /// Look down the m/z axis.
+    Mz,
+    /// Look down the mobility axis.
+    Mobility,
+    /// Look down the retention-time axis.
+    Rt,
+}
+
+pub struct OrbitCamera {
+    pub target: Vec3,
+    pub distance: f32,
+    /// Azimuth around world Y, radians.
+    pub yaw: f32,
+    /// Elevation, radians, clamped away from the poles.
+    pub pitch: f32,
+    pub fovy: f32,
+    pub znear: f32,
+    pub zfar: f32,
+    pub projection: Projection,
+}
+
+impl Default for OrbitCamera {
+    fn default() -> Self {
+        OrbitCamera {
+            target: Vec3::ZERO,
+            distance: 4.0,
+            yaw: 0.7,
+            pitch: 0.5,
+            fovy: 45f32.to_radians(),
+            znear: 0.05,
+            zfar: 100.0,
+            projection: Projection::Perspective,
+        }
+    }
+}
+
+const PITCH_LIMIT: f32 = 1.5533; // ~89 degrees
+
+impl OrbitCamera {
+    pub fn reset(&mut self) {
+        let proj = self.projection;
+        *self = OrbitCamera::default();
+        self.projection = proj;
+    }
+
+    pub fn set_axis_view(&mut self, axis: AxisView) {
+        self.target = Vec3::ZERO;
+        self.distance = 4.0;
+        match axis {
+            AxisView::Mz => {
+                self.yaw = std::f32::consts::FRAC_PI_2;
+                self.pitch = 0.0;
+            }
+            AxisView::Mobility => {
+                self.yaw = 0.0;
+                self.pitch = PITCH_LIMIT;
+            }
+            AxisView::Rt => {
+                self.yaw = 0.0;
+                self.pitch = 0.0;
+            }
+        }
+    }
+
+    fn eye(&self) -> Vec3 {
+        let (sp, cp) = self.pitch.sin_cos();
+        let (sy, cy) = self.yaw.sin_cos();
+        let dir = Vec3::new(cp * sy, sp, cp * cy);
+        self.target + dir * self.distance
+    }
+
+    /// World-space right and up vectors of the camera (for billboarding).
+    fn basis(&self) -> (Vec3, Vec3, Vec3) {
+        let eye = self.eye();
+        let forward = (self.target - eye).normalize_or_zero();
+        let right = forward.cross(Vec3::Y).normalize_or_zero();
+        let up = right.cross(forward).normalize_or_zero();
+        (right, up, forward)
+    }
+
+    pub fn orbit(&mut self, dx: f32, dy: f32) {
+        self.yaw -= dx * 0.005;
+        self.pitch = (self.pitch + dy * 0.005).clamp(-PITCH_LIMIT, PITCH_LIMIT);
+    }
+
+    pub fn pan(&mut self, dx: f32, dy: f32) {
+        let (right, up, _) = self.basis();
+        let scale = self.distance * 0.0015;
+        self.target += (-right * dx + up * dy) * scale;
+    }
+
+    pub fn zoom(&mut self, scroll: f32) {
+        self.distance = (self.distance * (-scroll * 0.1).exp()).clamp(0.2, 50.0);
+    }
+
+    pub fn view_proj(&self, aspect: f32) -> Mat4 {
+        let eye = self.eye();
+        let view = Mat4::look_at_rh(eye, self.target, Vec3::Y);
+        let proj = match self.projection {
+            Projection::Perspective => {
+                Mat4::perspective_rh(self.fovy, aspect.max(1e-3), self.znear, self.zfar)
+            }
+            Projection::Orthographic => {
+                let half_h = self.distance * (self.fovy * 0.5).tan();
+                let half_w = half_h * aspect.max(1e-3);
+                Mat4::orthographic_rh(-half_w, half_w, -half_h, half_h, self.znear, self.zfar)
+            }
+        };
+        proj * view
+    }
+
+    pub fn to_uniform(&self, aspect: f32, viewport: [f32; 2]) -> CameraUniform {
+        let (right, up, _) = self.basis();
+        CameraUniform {
+            view_proj: self.view_proj(aspect).to_cols_array_2d(),
+            right: [right.x, right.y, right.z, 0.0],
+            up: [up.x, up.y, up.z, 0.0],
+            viewport: [viewport[0], viewport[1], 0.0, 0.0],
+        }
+    }
+}

--- a/tims-viewer/src/camera.rs
+++ b/tims-viewer/src/camera.rs
@@ -123,6 +123,12 @@ impl OrbitCamera {
         proj * view
     }
 
+    /// Inverse view-projection (column-major arrays), for reconstructing world-space
+    /// rays in the volume raycaster.
+    pub fn inv_view_proj(&self, aspect: f32) -> [[f32; 4]; 4] {
+        self.view_proj(aspect).inverse().to_cols_array_2d()
+    }
+
     pub fn to_uniform(&self, aspect: f32, viewport: [f32; 2]) -> CameraUniform {
         let (right, up, _) = self.basis();
         CameraUniform {

--- a/tims-viewer/src/data/demo.rs
+++ b/tims-viewer/src/data/demo.rs
@@ -1,0 +1,188 @@
+//! Synthetic timsTOF-shaped point cloud for the `DEMO` path (no Bruker data needed).
+//!
+//! Produces a handful of chromatographic "blobs" — gaussian clusters in (m/z, 1/K0)
+//! that elute across retention time — plus a sparse noise floor, with log-normal
+//! intensities. This exercises the whole pipeline (sampling, both render modes, UI,
+//! camera) deterministically.
+
+/// Tiny deterministic PRNG (xorshift64*) — avoids pulling in an RNG dependency and
+/// keeps the demo reproducible across runs.
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng(seed | 1)
+    }
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    /// Uniform in [0, 1).
+    #[inline]
+    pub fn unif(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+    /// Standard normal via Box–Muller.
+    #[inline]
+    pub fn normal(&mut self) -> f64 {
+        let u1 = self.unif().max(1e-12);
+        let u2 = self.unif();
+        (-2.0 * u1.ln()).sqrt() * (std::f64::consts::TAU * u2).cos()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Blob {
+    mz: f64,
+    im: f64,
+    rt: f64,
+    rt_sigma: f64,
+    mz_sigma: f64,
+    im_sigma: f64,
+    log_amp: f64,
+    is_ms2: bool,
+}
+
+/// A raw demo point in real units (pre-normalization).
+#[derive(Clone, Copy)]
+pub struct RawDemoPoint {
+    pub mz: f64,
+    pub im: f64,
+    pub rt: f64,
+    pub intensity: f64,
+    pub is_ms2: bool,
+}
+
+/// Generator of synthetic frames. Each call to [`Self::frame`] returns the points for
+/// one retention-time frame, so the loader can stream them like real frames.
+pub struct DemoSource {
+    blobs: Vec<Blob>,
+    rt_min: f64,
+    rt_max: f64,
+    mz_min: f64,
+    mz_max: f64,
+    im_min: f64,
+    im_max: f64,
+    total_points: u64,
+    num_frames: usize,
+}
+
+impl DemoSource {
+    pub fn new(num_frames: usize, total_points: u64) -> Self {
+        let (mz_min, mz_max) = (100.0, 1700.0);
+        let (im_min, im_max) = (0.6, 1.6);
+        let rt_max = (num_frames.max(1) - 1) as f64 * 0.5;
+        let mut rng = Rng::new(0xC0FFEE);
+        let n_blobs = 60;
+        let mut blobs = Vec::with_capacity(n_blobs);
+        for _ in 0..n_blobs {
+            blobs.push(Blob {
+                mz: mz_min + rng.unif() * (mz_max - mz_min),
+                im: im_min + rng.unif() * (im_max - im_min),
+                rt: rng.unif() * rt_max,
+                rt_sigma: rt_max * (0.01 + 0.04 * rng.unif()),
+                mz_sigma: 0.3 + 2.0 * rng.unif(),
+                im_sigma: 0.005 + 0.02 * rng.unif(),
+                log_amp: 8.0 + 5.0 * rng.unif(), // ~e^8..e^13 dynamic range
+                is_ms2: rng.unif() < 0.1,
+            });
+        }
+        DemoSource {
+            blobs,
+            rt_min: 0.0,
+            rt_max,
+            mz_min,
+            mz_max,
+            im_min,
+            im_max,
+            total_points,
+            num_frames,
+        }
+    }
+
+    pub fn num_frames(&self) -> usize {
+        self.num_frames
+    }
+
+    /// Exact point count for frame `idx`: `total_points` split across frames by
+    /// quotient + remainder, so the per-frame counts sum to exactly `total_points`
+    /// (some frames may legitimately get zero). This keeps the generated total in sync
+    /// with the metadata estimate and GPU capacity even for tiny configs.
+    fn frame_count(&self, idx: usize) -> usize {
+        let nf = self.num_frames.max(1) as u64;
+        let base = self.total_points / nf;
+        let rem = self.total_points % nf;
+        (base + if (idx as u64) < rem { 1 } else { 0 }) as usize
+    }
+
+    /// Generate the points for frame `idx` (0-based).
+    pub fn frame(&self, idx: usize) -> Vec<RawDemoPoint> {
+        let rt = idx as f64 * 0.5;
+        // Per-frame RNG seed keeps generation deterministic and frame-independent.
+        let mut rng = Rng::new(0x5EED_0000 ^ (idx as u64).wrapping_mul(0x9E37_79B9));
+        let points_per_frame = self.frame_count(idx);
+        if points_per_frame == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(points_per_frame);
+
+        // Weight each blob by its gaussian elution profile at this RT.
+        let weights: Vec<f64> = self
+            .blobs
+            .iter()
+            .map(|b| {
+                let d = (rt - b.rt) / b.rt_sigma;
+                (-0.5 * d * d).exp()
+            })
+            .collect();
+        let wsum: f64 = weights.iter().sum::<f64>() + 1e-9;
+
+        // ~85% of points belong to blobs, ~15% are background noise.
+        let n_signal = (points_per_frame as f64 * 0.85) as usize;
+        let n_noise = points_per_frame - n_signal;
+
+        for _ in 0..n_signal {
+            // Pick a blob proportional to its current elution weight.
+            let mut pick = rng.unif() * wsum;
+            let mut bi = 0usize;
+            for (i, w) in weights.iter().enumerate() {
+                pick -= *w;
+                if pick <= 0.0 {
+                    bi = i;
+                    break;
+                }
+            }
+            let b = self.blobs[bi];
+            let mz = (b.mz + rng.normal() * b.mz_sigma).clamp(self.mz_min, self.mz_max);
+            let im = (b.im + rng.normal() * b.im_sigma).clamp(self.im_min, self.im_max);
+            // Log-normal intensity scaled by elution profile.
+            let prof = weights[bi].max(1e-3);
+            let intensity = (b.log_amp + 0.4 * rng.normal()).exp() * prof;
+            out.push(RawDemoPoint {
+                mz,
+                im,
+                rt,
+                intensity: intensity.max(1.0),
+                is_ms2: b.is_ms2,
+            });
+        }
+
+        for _ in 0..n_noise {
+            out.push(RawDemoPoint {
+                mz: self.mz_min + rng.unif() * (self.mz_max - self.mz_min),
+                im: self.im_min + rng.unif() * (self.im_max - self.im_min),
+                rt,
+                intensity: (3.0 + 1.5 * rng.normal()).exp().max(1.0),
+                is_ms2: false,
+            });
+        }
+        let _ = self.rt_min;
+        let _ = self.rt_max;
+        out
+    }
+}

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -31,8 +31,12 @@ use super::point::{AxisBounds, GpuPoint};
 /// (Phase 1.5); the single Phase-1 load uses generation 0.
 #[allow(dead_code)]
 pub enum LoadMsg {
-    /// A batch of packed points belonging to `generation`.
+    /// A batch of systematic (density-base) points belonging to `generation`.
     Chunk { generation: u64, points: Vec<GpuPoint> },
+    /// A batch of peak points (per-cell brightest) — display-only enrichment for the
+    /// point cloud; consumers must NOT add these to the volume density (they would
+    /// double-count) and they are not part of the systematic density base.
+    PeakChunk { points: Vec<GpuPoint> },
     /// Fractional load progress in `[0, 1]`.
     Progress(f32),
     /// Robust intensity range (p1/p99) for transfer-function defaults.
@@ -158,11 +162,12 @@ fn run_loader(
     let stride = stride_for(total_estimate, systematic_budget);
     let weight = stride as f32;
     let mut systematic_count: u64 = 0;
-    // Flat peak grid indexed by cell: (best intensity, best point) over ALL points.
-    // A direct-indexed Vec (no hashing) is far faster than a HashMap across the
-    // hundreds of millions of per-point updates. Sentinel intensity -1 = unoccupied.
+    // Flat peak grid indexed by cell: (best intensity, source index, best point) over
+    // ALL points. A direct-indexed Vec (no hashing) is far faster than a HashMap across
+    // the hundreds of millions of per-point updates. Sentinel intensity -1 = unoccupied;
+    // the source index lets us drop peaks the systematic sampler already emitted.
     let n_cells = (PEAK_DIMS[0] * PEAK_DIMS[1] * PEAK_DIMS[2]) as usize;
-    let mut peaks: Vec<(f32, GpuPoint)> = vec![(-1.0, ZERO_POINT); n_cells];
+    let mut peaks: Vec<(f32, u64, GpuPoint)> = vec![(-1.0, 0, ZERO_POINT); n_cells];
 
     // Subsample intensities into a reservoir for percentile defaults.
     let mut reservoir: Vec<f32> = Vec::with_capacity(RESERVOIR_CAP);
@@ -257,7 +262,8 @@ fn run_loader(
             let slot = &mut peaks[peak_cell(pos) as usize];
             if intensity > slot.0 {
                 slot.0 = intensity;
-                slot.1 = GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [0, 0] };
+                slot.1 = global_i;
+                slot.2 = GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [0, 0] };
             }
             // Systematic density base.
             if global_i % stride_u64 == 0 {
@@ -307,20 +313,29 @@ fn run_loader(
 
     flush!();
 
-    // Emit the brightest peaks to fill the reserved budget headroom. Sort by intensity
-    // so the strongest survive if there are more occupied cells than headroom.
+    // Emit the brightest peaks to fill the reserved budget headroom, but only peaks the
+    // systematic sampler did NOT already emit (source index not a multiple of stride) so
+    // they add genuinely-new sparse points rather than duplicates. Sort by intensity so
+    // the strongest survive if occupied cells exceed the headroom.
     let peak_room = budget.saturating_sub(systematic_count as usize);
-    if peak_room > 0 {
-        let mut peak_pts: Vec<(f32, GpuPoint)> =
-            peaks.into_iter().filter(|(i, _)| *i >= 0.0).collect();
-        peak_pts.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-        for (_, gp) in peak_pts.into_iter().take(peak_room) {
-            chunk.push(gp);
-            if chunk.len() >= CHUNK_POINTS {
-                flush!();
-            }
+    if peak_room > 0 && stride_u64 > 1 {
+        let mut peak_pts: Vec<GpuPoint> = peaks
+            .into_iter()
+            .filter(|(i, gi, _)| *i >= 0.0 && gi % stride_u64 != 0)
+            .map(|(_, _, gp)| gp)
+            .collect();
+        // Strongest first.
+        peak_pts.sort_by(|a, b| {
+            b.intensity
+                .partial_cmp(&a.intensity)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        peak_pts.truncate(peak_room);
+        for batch in peak_pts.chunks(CHUNK_POINTS) {
+            send_cancellable!(LoadMsg::PeakChunk {
+                points: batch.to_vec(),
+            });
         }
-        flush!();
     }
 
     // Annotation overlay (real data only — needs the dataset's scan->mobility converter
@@ -560,6 +575,9 @@ mod tests {
                 Ok(LoadMsg::Done { .. }) => {
                     saw_done = true;
                     break;
+                }
+                Ok(LoadMsg::PeakChunk { points: p }) => {
+                    points += p.len();
                 }
                 Ok(LoadMsg::Error(e)) => panic!("loader error: {e}"),
                 Ok(LoadMsg::Progress(_)) | Ok(LoadMsg::Annotations { .. }) => {}

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -4,11 +4,10 @@
 //! point budget, packs `GpuPoint`s, and sends them to the render thread over a bounded
 //! channel so the event loop never blocks on I/O and the cloud builds progressively.
 //!
-//! Phase 1 uses **per-frame stride sampling** with an exact per-frame quota (so the
-//! total can never exceed the budget) and stores each kept point's weight `1/p` for
-//! brightness-invariant additive rendering. Stratified, peak-preserving sampling is the
-//! Phase 1.5 / Phase 3 upgrade (see the plan); the message/generation plumbing here is
-//! already shaped for it.
+//! Sampling is **stratified**: a global systematic stride provides a count-bounded,
+//! RT-unbiased density base (each kept point weighted `1/p` for brightness-invariant
+//! additive rendering), and a coarse spatial grid additionally keeps the brightest
+//! point in every occupied cell so sparse high-intensity features always survive.
 
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -113,14 +112,27 @@ pub fn stride_for(total_estimate: u64, budget: usize) -> usize {
     }
 }
 
-/// Offset of the first kept index in a frame, given how many source points were already
-/// seen (`phase = points_seen % stride`). Keeping `offset, offset+stride, ...` in every
-/// frame is exactly global systematic sampling over the concatenated point stream, so
-/// the total kept is `ceil(total/stride) <= budget` and each kept point truly stands in
-/// for `stride` source points (weight `1/p`).
+/// Coarse spatial grid for peak preservation (m/z, 1/K0, RT cells).
+const PEAK_DIMS: [u32; 3] = [128, 64, 128];
+/// Placeholder point for the peak-grid HashMap entry API.
+const ZERO_POINT: GpuPoint = GpuPoint {
+    pos: [0.0; 3],
+    intensity: 0.0,
+    weight: 1.0,
+    flags: 0,
+    _pad: [0, 0],
+};
+
+/// Map a normalized-cube position to a coarse peak-grid cell index.
 #[inline]
-fn systematic_offset(phase: usize, stride: usize) -> usize {
-    (stride - phase % stride) % stride
+fn peak_cell(pos: [f32; 3]) -> u32 {
+    let axis = |n: f32, dim: u32| -> u32 {
+        (((n * 0.5 + 0.5).clamp(0.0, 1.0) * dim as f32) as u32).min(dim - 1)
+    };
+    let x = axis(pos[0], PEAK_DIMS[0]);
+    let y = axis(pos[1], PEAK_DIMS[1]);
+    let z = axis(pos[2], PEAK_DIMS[2]);
+    x + PEAK_DIMS[0] * (y + PEAK_DIMS[1] * z)
 }
 
 #[allow(unused_assignments)] // final flush! reassigns `chunk` which is then dropped
@@ -132,8 +144,19 @@ fn run_loader(
     tx: &Sender<LoadMsg>,
     cmd_rx: &Receiver<LoadCmd>,
 ) {
-    let stride = stride_for(total_estimate, budget);
+    // Stratified sampling: spend ~85% of the budget on a systematic density base, and
+    // reserve the rest for per-cell intensity PEAKS so sparse high-intensity features
+    // always survive (pure systematic sampling can statistically miss them).
+    let systematic_budget = ((budget * 85) / 100).max(1);
+    let stride = stride_for(total_estimate, systematic_budget);
     let weight = stride as f32;
+    let mut systematic_count: u64 = 0;
+    // Flat peak grid indexed by cell: (best intensity, best point) over ALL points.
+    // A direct-indexed Vec (no hashing) is far faster than a HashMap across the
+    // hundreds of millions of per-point updates. Sentinel intensity -1 = unoccupied.
+    let n_cells = (PEAK_DIMS[0] * PEAK_DIMS[1] * PEAK_DIMS[2]) as usize;
+    let mut peaks: Vec<(f32, GpuPoint)> = vec![(-1.0, ZERO_POINT); n_cells];
+
     // Subsample intensities into a reservoir for percentile defaults.
     let mut reservoir: Vec<f32> = Vec::with_capacity(RESERVOIR_CAP);
     let mut kept_counter: u64 = 0;
@@ -211,16 +234,41 @@ fn run_loader(
     };
 
     let mut last_progress = -1.0f32;
-    // Phase carried ACROSS frames so sampling is global systematic, not per-frame
-    // (per-frame resets overshoot the budget on short frames and bias the kept tail).
-    let mut phase = 0usize;
+    // Cumulative point index across the whole run; keeping every `stride`-th is global
+    // systematic sampling (count-bounded, RT-unbiased).
+    let mut global_i: u64 = 0;
+    let stride_u64 = stride as u64;
+
+    // Per-point handler shared by both sources: update the peak grid for EVERY point,
+    // and emit every stride-th into the systematic density base.
+    macro_rules! handle_point {
+        ($mz:expr, $im:expr, $rt:expr, $it:expr, $ms2:expr) => {{
+            let intensity = $it;
+            let pos = bounds.normalize($mz, $im, $rt);
+            let flags = if $ms2 { GpuPoint::MS2_FLAG } else { 0 };
+            // Peak: keep the highest-intensity point per coarse cell.
+            let slot = &mut peaks[peak_cell(pos) as usize];
+            if intensity > slot.0 {
+                slot.0 = intensity;
+                slot.1 = GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [0, 0] };
+            }
+            // Systematic density base.
+            if global_i % stride_u64 == 0 {
+                chunk.push(GpuPoint { pos, intensity, weight, flags, _pad: [0, 0] });
+                systematic_count += 1;
+                reservoir_push(&mut reservoir, &mut kept_counter, sample_every, intensity);
+                if chunk.len() >= CHUNK_POINTS {
+                    flush!();
+                }
+            }
+            global_i += 1;
+        }};
+    }
 
     for idx in 0..n_frames {
         if cancelled!() {
             return;
         }
-
-        // Gather this frame's points as (pos_norm, intensity, is_ms2).
         match &mode {
             LoaderMode::Real { frame_ids, .. } => {
                 let ds = dataset.as_ref().unwrap();
@@ -232,55 +280,13 @@ fn run_loader(
                 let it = frame.ims_frame.intensity.as_slice();
                 // Validate parallel arrays — never zip past the shortest.
                 let n = mz.len().min(im.len()).min(it.len());
-                let offset = systematic_offset(phase, stride);
-                phase = (phase + n) % stride;
-                let mut j = offset;
-                while j < n {
-                    push_point(
-                        &mut chunk,
-                        &bounds,
-                        mz[j],
-                        im[j],
-                        rt,
-                        it[j] as f32,
-                        weight,
-                        is_ms2,
-                    );
-                    reservoir_push(&mut reservoir, &mut kept_counter, sample_every, it[j] as f32);
-                    if chunk.len() >= CHUNK_POINTS {
-                        flush!();
-                    }
-                    j += stride;
+                for j in 0..n {
+                    handle_point!(mz[j], im[j], rt, it[j] as f32, is_ms2);
                 }
             }
             LoaderMode::Demo(d) => {
-                let pts = d.frame(idx);
-                let n = pts.len();
-                let offset = systematic_offset(phase, stride);
-                phase = (phase + n) % stride;
-                let mut j = offset;
-                while j < n {
-                    let p = pts[j];
-                    push_point(
-                        &mut chunk,
-                        &bounds,
-                        p.mz,
-                        p.im,
-                        p.rt,
-                        p.intensity as f32,
-                        weight,
-                        p.is_ms2,
-                    );
-                    reservoir_push(
-                        &mut reservoir,
-                        &mut kept_counter,
-                        sample_every,
-                        p.intensity as f32,
-                    );
-                    if chunk.len() >= CHUNK_POINTS {
-                        flush!();
-                    }
-                    j += stride;
+                for p in d.frame(idx) {
+                    handle_point!(p.mz, p.im, p.rt, p.intensity as f32, p.is_ms2);
                 }
             }
         }
@@ -293,6 +299,22 @@ fn run_loader(
     }
 
     flush!();
+
+    // Emit the brightest peaks to fill the reserved budget headroom. Sort by intensity
+    // so the strongest survive if there are more occupied cells than headroom.
+    let peak_room = budget.saturating_sub(systematic_count as usize);
+    if peak_room > 0 {
+        let mut peak_pts: Vec<(f32, GpuPoint)> =
+            peaks.into_iter().filter(|(i, _)| *i >= 0.0).collect();
+        peak_pts.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+        for (_, gp) in peak_pts.into_iter().take(peak_room) {
+            chunk.push(gp);
+            if chunk.len() >= CHUNK_POINTS {
+                flush!();
+            }
+        }
+        flush!();
+    }
 
     // Robust intensity range from the reservoir.
     if !reservoir.is_empty() {
@@ -308,27 +330,6 @@ fn run_loader(
 
     send_cancellable!(LoadMsg::Done {
         generation: GENERATION,
-    });
-}
-
-#[inline]
-fn push_point(
-    chunk: &mut Vec<GpuPoint>,
-    bounds: &AxisBounds,
-    mz: f64,
-    im: f64,
-    rt: f64,
-    intensity: f32,
-    weight: f32,
-    is_ms2: bool,
-) {
-    let pos = bounds.normalize(mz, im, rt);
-    chunk.push(GpuPoint {
-        pos,
-        intensity,
-        weight,
-        flags: if is_ms2 { GpuPoint::MS2_FLAG } else { 0 },
-        _pad: [0, 0],
     });
 }
 
@@ -371,26 +372,38 @@ mod tests {
     }
 
     #[test]
-    fn systematic_sampling_bounded_over_uneven_frames() {
-        // Carrying phase across frames keeps exactly ceil(total/stride) points, even
-        // with short/empty frames — per-frame offset resets would overshoot this.
-        for stride in [2usize, 3, 5, 7] {
-            let frame_lens = [1usize, 2, 1, 0, 9, 4, 3, 1, 1, 1];
-            let total: usize = frame_lens.iter().sum();
-            let mut phase = 0usize;
-            let mut kept = 0usize;
+    fn cumulative_systematic_sampling_is_bounded() {
+        // The loader keeps every stride-th point by a cumulative global index, which is
+        // global systematic sampling: kept == ceil(total/stride), independent of how the
+        // points are split into frames.
+        for stride in [2u64, 3, 5, 7] {
+            let frame_lens = [1u64, 2, 1, 0, 9, 4, 3, 1, 1, 1];
+            let total: u64 = frame_lens.iter().sum();
+            let mut global_i = 0u64;
+            let mut kept = 0u64;
             for &n in &frame_lens {
-                let offset = systematic_offset(phase, stride);
-                phase = (phase + n) % stride;
-                let mut j = offset;
-                while j < n {
-                    kept += 1;
-                    j += stride;
+                for _ in 0..n {
+                    if global_i % stride == 0 {
+                        kept += 1;
+                    }
+                    global_i += 1;
                 }
             }
             let bound = total.div_ceil(stride);
             assert_eq!(kept, bound, "stride={stride}: kept {kept} != ceil bound {bound}");
         }
+    }
+
+    #[test]
+    fn peak_cell_in_range_and_distinct() {
+        // Corners map inside the grid; opposite corners differ.
+        let lo = peak_cell([-1.0, -1.0, -1.0]);
+        let hi = peak_cell([1.0, 1.0, 1.0]);
+        let max = PEAK_DIMS[0] * PEAK_DIMS[1] * PEAK_DIMS[2];
+        assert_eq!(lo, 0);
+        assert!(hi < max && hi != lo);
+        // Out-of-range clamps rather than overflowing.
+        assert!(peak_cell([5.0, -5.0, 2.0]) < max);
     }
 
     #[test]

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -1,0 +1,436 @@
+//! Background streaming loader.
+//!
+//! Runs on its own thread, streams frames (real or synthetic), downsamples to the
+//! point budget, packs `GpuPoint`s, and sends them to the render thread over a bounded
+//! channel so the event loop never blocks on I/O and the cloud builds progressively.
+//!
+//! Phase 1 uses **per-frame stride sampling** with an exact per-frame quota (so the
+//! total can never exceed the budget) and stores each kept point's weight `1/p` for
+//! brightness-invariant additive rendering. Stratified, peak-preserving sampling is the
+//! Phase 1.5 / Phase 3 upgrade (see the plan); the message/generation plumbing here is
+//! already shaped for it.
+
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
+
+use mscore::data::spectrum::MsType;
+use rustdf::data::dataset::TimsDataset;
+use rustdf::data::handle::TimsData;
+
+use super::demo::DemoSource;
+use super::point::{AxisBounds, GpuPoint};
+
+/// Messages from the loader thread to the render thread.
+///
+/// `generation` is carried now but only consumed once region-refinement lands
+/// (Phase 1.5); the single Phase-1 load uses generation 0.
+#[allow(dead_code)]
+pub enum LoadMsg {
+    /// A batch of packed points belonging to `generation`.
+    Chunk { generation: u64, points: Vec<GpuPoint> },
+    /// Fractional load progress in `[0, 1]`.
+    Progress(f32),
+    /// Robust intensity range (p1/p99) for transfer-function defaults.
+    Stats { i_min: f32, i_max: f32 },
+    /// All frames for `generation` have been streamed.
+    Done { generation: u64 },
+    /// Fatal error; loading stopped.
+    Error(String),
+}
+
+/// Commands from the render thread to the loader thread.
+pub enum LoadCmd {
+    /// Abandon the current load and exit.
+    Cancel,
+}
+
+/// What to stream.
+pub enum LoaderMode {
+    Real { path: String, frame_ids: Vec<u32> },
+    Demo(DemoSource),
+}
+
+/// Owns the loader thread and the channels to talk to it.
+pub struct LoaderHandle {
+    pub rx: Receiver<LoadMsg>,
+    cmd_tx: Sender<LoadCmd>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl LoaderHandle {
+    pub fn spawn(
+        mode: LoaderMode,
+        bounds: AxisBounds,
+        total_estimate: u64,
+        budget: usize,
+    ) -> Self {
+        let (msg_tx, msg_rx) = bounded::<LoadMsg>(8);
+        let (cmd_tx, cmd_rx) = bounded::<LoadCmd>(4);
+        let handle = std::thread::Builder::new()
+            .name("tims-loader".into())
+            .spawn(move || {
+                run_loader(mode, bounds, total_estimate, budget, &msg_tx, &cmd_rx);
+            })
+            .expect("failed to spawn loader thread");
+        LoaderHandle {
+            rx: msg_rx,
+            cmd_tx,
+            handle: Some(handle),
+        }
+    }
+}
+
+impl Drop for LoaderHandle {
+    fn drop(&mut self) {
+        let _ = self.cmd_tx.send(LoadCmd::Cancel);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+const GENERATION: u64 = 0; // single generation in Phase 1
+const CHUNK_POINTS: usize = 300_000;
+const RESERVOIR_CAP: usize = 200_000;
+
+/// Sampling stride derived from the budget.
+///
+/// Uses **ceiling** division so the kept count never exceeds the budget: keeping every
+/// `stride`-th point yields `~total/stride <= budget` points. (Rounding instead would
+/// let e.g. total=149, budget=100 round to stride 1 and emit all 149, biasing the view
+/// toward early frames once the GPU buffer truncates the tail.)
+pub fn stride_for(total_estimate: u64, budget: usize) -> usize {
+    if total_estimate == 0 || budget == 0 {
+        return 1;
+    }
+    let budget = budget as u64;
+    if budget >= total_estimate {
+        1
+    } else {
+        total_estimate.div_ceil(budget).max(1) as usize
+    }
+}
+
+/// Offset of the first kept index in a frame, given how many source points were already
+/// seen (`phase = points_seen % stride`). Keeping `offset, offset+stride, ...` in every
+/// frame is exactly global systematic sampling over the concatenated point stream, so
+/// the total kept is `ceil(total/stride) <= budget` and each kept point truly stands in
+/// for `stride` source points (weight `1/p`).
+#[inline]
+fn systematic_offset(phase: usize, stride: usize) -> usize {
+    (stride - phase % stride) % stride
+}
+
+#[allow(unused_assignments)] // final flush! reassigns `chunk` which is then dropped
+fn run_loader(
+    mode: LoaderMode,
+    bounds: AxisBounds,
+    total_estimate: u64,
+    budget: usize,
+    tx: &Sender<LoadMsg>,
+    cmd_rx: &Receiver<LoadCmd>,
+) {
+    let stride = stride_for(total_estimate, budget);
+    let weight = stride as f32;
+    // Subsample intensities into a reservoir for percentile defaults.
+    let mut reservoir: Vec<f32> = Vec::with_capacity(RESERVOIR_CAP);
+    let mut kept_counter: u64 = 0;
+    let sample_every = (budget / RESERVOIR_CAP).max(1) as u64;
+
+    let mut chunk: Vec<GpuPoint> = Vec::with_capacity(CHUNK_POINTS);
+
+    macro_rules! cancelled {
+        () => {
+            matches!(cmd_rx.try_recv(), Ok(LoadCmd::Cancel))
+        };
+    }
+
+    // Send a message, blocking politely if the channel is full but still watching for
+    // cancellation so the loader can never wedge on a full channel during shutdown.
+    macro_rules! send_cancellable {
+        ($msg:expr) => {{
+            let mut m = $msg;
+            loop {
+                match tx.try_send(m) {
+                    Ok(()) => break,
+                    Err(TrySendError::Full(back)) => {
+                        if cancelled!() {
+                            return;
+                        }
+                        m = back;
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(_) => return, // receiver gone
+                }
+            }
+        }};
+    }
+
+    // Flush a chunk, blocking politely if the channel is full but still watching for
+    // cancellation so the loader can never wedge.
+    macro_rules! flush {
+        () => {{
+            if !chunk.is_empty() {
+                let mut payload = std::mem::take(&mut chunk);
+                loop {
+                    match tx.try_send(LoadMsg::Chunk {
+                        generation: GENERATION,
+                        points: payload,
+                    }) {
+                        Ok(()) => break,
+                        Err(TrySendError::Full(LoadMsg::Chunk { points, .. })) => {
+                            if cancelled!() {
+                                return;
+                            }
+                            payload = points;
+                            std::thread::sleep(Duration::from_millis(1));
+                        }
+                        Err(_) => return, // receiver gone
+                    }
+                }
+                chunk = Vec::with_capacity(CHUNK_POINTS);
+            }
+        }};
+    }
+
+    let n_frames = match &mode {
+        LoaderMode::Real { frame_ids, .. } => frame_ids.len(),
+        LoaderMode::Demo(d) => d.num_frames(),
+    };
+    if n_frames == 0 {
+        let _ = tx.send(LoadMsg::Error("run has no frames".into()));
+        return;
+    }
+
+    // Open the real dataset once (SDK-free, thread-safe converter).
+    let dataset = match &mode {
+        LoaderMode::Real { path, .. } => Some(TimsDataset::new("NO_SDK", path, false, false)),
+        LoaderMode::Demo(_) => None,
+    };
+
+    let mut last_progress = -1.0f32;
+    // Phase carried ACROSS frames so sampling is global systematic, not per-frame
+    // (per-frame resets overshoot the budget on short frames and bias the kept tail).
+    let mut phase = 0usize;
+
+    for idx in 0..n_frames {
+        if cancelled!() {
+            return;
+        }
+
+        // Gather this frame's points as (pos_norm, intensity, is_ms2).
+        match &mode {
+            LoaderMode::Real { frame_ids, .. } => {
+                let ds = dataset.as_ref().unwrap();
+                let frame = ds.get_frame(frame_ids[idx]);
+                let rt = frame.ims_frame.retention_time;
+                let is_ms2 = !matches!(frame.ms_type, MsType::Precursor);
+                let mz = frame.ims_frame.mz.as_slice();
+                let im = frame.ims_frame.mobility.as_slice();
+                let it = frame.ims_frame.intensity.as_slice();
+                // Validate parallel arrays — never zip past the shortest.
+                let n = mz.len().min(im.len()).min(it.len());
+                let offset = systematic_offset(phase, stride);
+                phase = (phase + n) % stride;
+                let mut j = offset;
+                while j < n {
+                    push_point(
+                        &mut chunk,
+                        &bounds,
+                        mz[j],
+                        im[j],
+                        rt,
+                        it[j] as f32,
+                        weight,
+                        is_ms2,
+                    );
+                    reservoir_push(&mut reservoir, &mut kept_counter, sample_every, it[j] as f32);
+                    if chunk.len() >= CHUNK_POINTS {
+                        flush!();
+                    }
+                    j += stride;
+                }
+            }
+            LoaderMode::Demo(d) => {
+                let pts = d.frame(idx);
+                let n = pts.len();
+                let offset = systematic_offset(phase, stride);
+                phase = (phase + n) % stride;
+                let mut j = offset;
+                while j < n {
+                    let p = pts[j];
+                    push_point(
+                        &mut chunk,
+                        &bounds,
+                        p.mz,
+                        p.im,
+                        p.rt,
+                        p.intensity as f32,
+                        weight,
+                        p.is_ms2,
+                    );
+                    reservoir_push(
+                        &mut reservoir,
+                        &mut kept_counter,
+                        sample_every,
+                        p.intensity as f32,
+                    );
+                    if chunk.len() >= CHUNK_POINTS {
+                        flush!();
+                    }
+                    j += stride;
+                }
+            }
+        }
+
+        let progress = (idx + 1) as f32 / n_frames as f32;
+        if progress - last_progress >= 0.01 {
+            let _ = tx.try_send(LoadMsg::Progress(progress));
+            last_progress = progress;
+        }
+    }
+
+    flush!();
+
+    // Robust intensity range from the reservoir.
+    if !reservoir.is_empty() {
+        reservoir.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let p = |q: f32| {
+            let i = ((reservoir.len() as f32 - 1.0) * q).round() as usize;
+            reservoir[i.min(reservoir.len() - 1)]
+        };
+        let i_min = p(0.01).max(1.0);
+        let i_max = p(0.99).max(i_min * 1.0001);
+        send_cancellable!(LoadMsg::Stats { i_min, i_max });
+    }
+
+    send_cancellable!(LoadMsg::Done {
+        generation: GENERATION,
+    });
+}
+
+#[inline]
+fn push_point(
+    chunk: &mut Vec<GpuPoint>,
+    bounds: &AxisBounds,
+    mz: f64,
+    im: f64,
+    rt: f64,
+    intensity: f32,
+    weight: f32,
+    is_ms2: bool,
+) {
+    let pos = bounds.normalize(mz, im, rt);
+    chunk.push(GpuPoint {
+        pos,
+        intensity,
+        weight,
+        flags: if is_ms2 { GpuPoint::MS2_FLAG } else { 0 },
+        _pad: [0, 0],
+    });
+}
+
+#[inline]
+fn reservoir_push(reservoir: &mut Vec<f32>, counter: &mut u64, sample_every: u64, v: f32) {
+    if *counter % sample_every == 0 && reservoir.len() < RESERVOIR_CAP {
+        reservoir.push(v);
+    }
+    *counter = counter.wrapping_add(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::point::{AxisBounds, AxisTransform};
+    use std::time::Duration;
+
+    fn demo_bounds() -> AxisBounds {
+        AxisBounds {
+            mz: AxisTransform::new(100.0, 1700.0),
+            im: AxisTransform::new(0.6, 1.6),
+            rt: AxisTransform::new(0.0, 10.0),
+        }
+    }
+
+    #[test]
+    fn stride_matches_budget_ratio() {
+        assert_eq!(stride_for(100, 100), 1);
+        assert_eq!(stride_for(100, 1000), 1); // budget >= total -> keep all
+        assert_eq!(stride_for(1000, 100), 10);
+        assert_eq!(stride_for(0, 100), 1); // no divide-by-zero
+        // Ceiling, not rounding: 149/100 must give 2 (keeps ~75 <= budget), never 1
+        // (which would emit all 149 and truncate the tail at the GPU buffer).
+        assert_eq!(stride_for(149, 100), 2);
+        // Ceiling never lets total/stride exceed the budget.
+        for (total, budget) in [(149u64, 100usize), (1_000_000, 25_000), (7, 3)] {
+            let s = stride_for(total, budget) as u64;
+            assert!(total / s <= budget as u64, "total={total} budget={budget} s={s}");
+        }
+    }
+
+    #[test]
+    fn systematic_sampling_bounded_over_uneven_frames() {
+        // Carrying phase across frames keeps exactly ceil(total/stride) points, even
+        // with short/empty frames — per-frame offset resets would overshoot this.
+        for stride in [2usize, 3, 5, 7] {
+            let frame_lens = [1usize, 2, 1, 0, 9, 4, 3, 1, 1, 1];
+            let total: usize = frame_lens.iter().sum();
+            let mut phase = 0usize;
+            let mut kept = 0usize;
+            for &n in &frame_lens {
+                let offset = systematic_offset(phase, stride);
+                phase = (phase + n) % stride;
+                let mut j = offset;
+                while j < n {
+                    kept += 1;
+                    j += stride;
+                }
+            }
+            let bound = total.div_ceil(stride);
+            assert_eq!(kept, bound, "stride={stride}: kept {kept} != ceil bound {bound}");
+        }
+    }
+
+    #[test]
+    fn demo_loader_streams_and_respects_budget() {
+        let total = 100_000u64;
+        let budget = 50_000usize;
+        let demo = DemoSource::new(20, total);
+        let handle =
+            LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget);
+
+        let mut points = 0usize;
+        let mut saw_done = false;
+        let mut saw_stats = false;
+        loop {
+            match handle.rx.recv_timeout(Duration::from_secs(15)) {
+                Ok(LoadMsg::Chunk { points: p, .. }) => {
+                    // Every packed point must be finite and inside the cube.
+                    for gp in &p {
+                        assert!(gp.pos.iter().all(|c| c.is_finite()));
+                        assert!(gp.weight >= 1.0);
+                    }
+                    points += p.len();
+                }
+                Ok(LoadMsg::Stats { i_min, i_max }) => {
+                    assert!(i_min > 0.0 && i_max > i_min);
+                    saw_stats = true;
+                }
+                Ok(LoadMsg::Done { .. }) => {
+                    saw_done = true;
+                    break;
+                }
+                Ok(LoadMsg::Error(e)) => panic!("loader error: {e}"),
+                Ok(LoadMsg::Progress(_)) => {}
+                Err(e) => panic!("loader timed out / disconnected: {e}"),
+            }
+        }
+        assert!(saw_done, "loader never signaled Done");
+        assert!(saw_stats, "loader never sent intensity Stats");
+        assert!(points > 0, "loader produced no points");
+        // ~budget points (stride=2 over 100k); allow generous slack.
+        assert!(points <= 70_000, "downsample exceeded budget: {points}");
+    }
+}

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -15,8 +15,12 @@ use std::time::Duration;
 use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
 
 use mscore::data::spectrum::MsType;
+use rustdf::data::acquisition::AcquisitionMode;
 use rustdf::data::dataset::TimsDataset;
-use rustdf::data::handle::TimsData;
+use rustdf::data::handle::{IndexConverter, TimsData};
+use rustdf::data::meta::{
+    read_dda_precursor_meta, read_dia_ms_ms_info, read_dia_ms_ms_windows, read_meta_data_sql,
+};
 
 use super::demo::DemoSource;
 use super::point::{AxisBounds, GpuPoint};
@@ -33,6 +37,9 @@ pub enum LoadMsg {
     Progress(f32),
     /// Robust intensity range (p1/p99) for transfer-function defaults.
     Stats { i_min: f32, i_max: f32 },
+    /// Annotation overlay geometry: line-list vertices (pairs = segments) in the
+    /// normalized cube (DDA precursor crosses / DIA isolation-window boxes).
+    Annotations { lines: Vec<[f32; 3]> },
     /// All frames for `generation` have been streamed.
     Done { generation: u64 },
     /// Fatal error; loading stopped.
@@ -316,6 +323,15 @@ fn run_loader(
         flush!();
     }
 
+    // Annotation overlay (real data only — needs the dataset's scan->mobility converter
+    // and the DDA/DIA metadata tables).
+    if let (LoaderMode::Real { path, .. }, Some(ds)) = (&mode, &dataset) {
+        let lines = build_annotations(ds, path, &bounds);
+        if !lines.is_empty() {
+            send_cancellable!(LoadMsg::Annotations { lines });
+        }
+    }
+
     // Robust intensity range from the reservoir.
     if !reservoir.is_empty() {
         reservoir.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
@@ -331,6 +347,116 @@ fn run_loader(
     send_cancellable!(LoadMsg::Done {
         generation: GENERATION,
     });
+}
+
+/// Build annotation-overlay line geometry (normalized cube) from the run's DDA/DIA
+/// metadata. DDA precursors -> small 3D crosses; DIA isolation windows -> wireframe
+/// boxes. Returns line-list vertices (consecutive pairs are segments).
+fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<[f32; 3]> {
+    // frame_id -> retention time (ids are contiguous 1..=N, validated at load).
+    let meta = match read_meta_data_sql(path) {
+        Ok(m) => m,
+        Err(_) => return Vec::new(),
+    };
+    let max_id = meta.iter().map(|m| m.id).max().unwrap_or(0).max(0) as usize;
+    let mut rt_by = vec![0f64; max_id + 1];
+    for m in &meta {
+        if m.id >= 0 {
+            rt_by[m.id as usize] = m.time;
+        }
+    }
+    let rt_of = |fid: u32| rt_by.get(fid as usize).copied().unwrap_or(0.0);
+
+    let mut lines: Vec<[f32; 3]> = Vec::new();
+    match ds.get_acquisition_mode() {
+        AcquisitionMode::DDA | AcquisitionMode::PRECURSOR => {
+            if let Ok(precursors) = read_dda_precursor_meta(path) {
+                for p in precursors {
+                    let fid = p.precursor_frame_id.max(0) as u32;
+                    let scan = p.precursor_average_scan_number.round().max(0.0) as u32;
+                    let im = ds
+                        .scan_to_inverse_mobility(fid, &vec![scan])
+                        .first()
+                        .copied()
+                        .unwrap_or(0.0);
+                    let pos = bounds.normalize(p.precursor_mz_highest_intensity, im, rt_of(fid));
+                    push_cross(&mut lines, pos, 0.012);
+                }
+            }
+        }
+        AcquisitionMode::DIA => {
+            if let (Ok(windows), Ok(info)) =
+                (read_dia_ms_ms_windows(path), read_dia_ms_ms_info(path))
+            {
+                // Per window group: RT span and a representative frame for scan->mobility.
+                let mut grp_rt: std::collections::HashMap<u32, (f64, f64)> = Default::default();
+                let mut grp_frame: std::collections::HashMap<u32, u32> = Default::default();
+                for di in &info {
+                    let rt = rt_of(di.frame_id);
+                    let e = grp_rt
+                        .entry(di.window_group)
+                        .or_insert((f64::INFINITY, f64::NEG_INFINITY));
+                    e.0 = e.0.min(rt);
+                    e.1 = e.1.max(rt);
+                    grp_frame.entry(di.window_group).or_insert(di.frame_id);
+                }
+                for w in &windows {
+                    let fid = grp_frame.get(&w.window_group).copied().unwrap_or(1);
+                    let ims = ds.scan_to_inverse_mobility(fid, &vec![w.scan_num_begin, w.scan_num_end]);
+                    let im0 = ims.first().copied().unwrap_or(0.0);
+                    let im1 = ims.get(1).copied().unwrap_or(im0);
+                    let (rt0, rt1) = grp_rt.get(&w.window_group).copied().unwrap_or((0.0, 0.0));
+                    let mz0 = w.isolation_mz - w.isolation_width * 0.5;
+                    let mz1 = w.isolation_mz + w.isolation_width * 0.5;
+                    push_box(&mut lines, bounds, (mz0, mz1), (im0, im1), (rt0, rt1));
+                }
+            }
+        }
+        AcquisitionMode::Unknown => {}
+    }
+    lines
+}
+
+/// Append a 3-segment axis-aligned cross centered at `c` (half-length `h`).
+fn push_cross(lines: &mut Vec<[f32; 3]>, c: [f32; 3], h: f32) {
+    lines.push([c[0] - h, c[1], c[2]]);
+    lines.push([c[0] + h, c[1], c[2]]);
+    lines.push([c[0], c[1] - h, c[2]]);
+    lines.push([c[0], c[1] + h, c[2]]);
+    lines.push([c[0], c[1], c[2] - h]);
+    lines.push([c[0], c[1], c[2] + h]);
+}
+
+/// Append the 12 edges of an axis-aligned box spanning the given real-unit ranges.
+fn push_box(
+    lines: &mut Vec<[f32; 3]>,
+    bounds: &AxisBounds,
+    mz: (f64, f64),
+    im: (f64, f64),
+    rt: (f64, f64),
+) {
+    // 8 corners (normalized).
+    let corner = |a: f64, b: f64, c: f64| bounds.normalize(a, b, c);
+    let c = [
+        corner(mz.0, im.0, rt.0),
+        corner(mz.1, im.0, rt.0),
+        corner(mz.1, im.1, rt.0),
+        corner(mz.0, im.1, rt.0),
+        corner(mz.0, im.0, rt.1),
+        corner(mz.1, im.0, rt.1),
+        corner(mz.1, im.1, rt.1),
+        corner(mz.0, im.1, rt.1),
+    ];
+    // 12 edges as index pairs.
+    const EDGES: [(usize, usize); 12] = [
+        (0, 1), (1, 2), (2, 3), (3, 0), // bottom (rt0)
+        (4, 5), (5, 6), (6, 7), (7, 4), // top (rt1)
+        (0, 4), (1, 5), (2, 6), (3, 7), // verticals
+    ];
+    for (a, b) in EDGES {
+        lines.push(c[a]);
+        lines.push(c[b]);
+    }
 }
 
 #[inline]
@@ -436,7 +562,7 @@ mod tests {
                     break;
                 }
                 Ok(LoadMsg::Error(e)) => panic!("loader error: {e}"),
-                Ok(LoadMsg::Progress(_)) => {}
+                Ok(LoadMsg::Progress(_)) | Ok(LoadMsg::Annotations { .. }) => {}
                 Err(e) => panic!("loader timed out / disconnected: {e}"),
             }
         }

--- a/tims-viewer/src/data/meta.rs
+++ b/tims-viewer/src/data/meta.rs
@@ -1,0 +1,139 @@
+//! Run metadata read from the TDF SQLite tables — cheap, no binary frame decoding.
+//!
+//! This gives us the axis ranges, a frame-id → retention-time map, per-frame MS type,
+//! and a total-point estimate before touching `analysis.tdf_bin`, so the camera and
+//! axis cube can render instantly while points stream in.
+
+use anyhow::{Context, Result};
+
+use rustdf::data::meta::{read_global_meta_sql, read_meta_data_sql};
+
+use super::point::{AxisBounds, AxisTransform};
+
+/// Per-frame info we keep resident for the whole session.
+/// `is_ms2`/`num_peaks` back per-frame LOD and filtering planned for later phases.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub struct FrameInfo {
+    pub id: u32,
+    pub retention_time: f64,
+    /// True for MS2 / fragment frames (`ms_ms_type != 0`).
+    pub is_ms2: bool,
+    pub num_peaks: u64,
+}
+
+/// Lightweight index over a run's metadata.
+pub struct MetaIndex {
+    pub data_path: String,
+    pub frames: Vec<FrameInfo>,
+    pub bounds: AxisBounds,
+    pub total_points_estimate: u64,
+}
+
+impl MetaIndex {
+    /// Load metadata for a real `.d` folder.
+    pub fn load(data_path: &str) -> Result<Self> {
+        let global = read_global_meta_sql(data_path)
+            .map_err(|e| anyhow::anyhow!("read_global_meta_sql failed: {e:?}"))
+            .context("reading global TDF metadata")?;
+        let meta = read_meta_data_sql(data_path)
+            .map_err(|e| anyhow::anyhow!("read_meta_data_sql failed: {e:?}"))
+            .context("reading per-frame TDF metadata")?;
+
+        anyhow::ensure!(!meta.is_empty(), "TDF run contains no frames");
+
+        let mut frames = Vec::with_capacity(meta.len());
+        let mut rt_min = f64::INFINITY;
+        let mut rt_max = f64::NEG_INFINITY;
+        let mut total: u64 = 0;
+        for m in &meta {
+            // Keep FrameMeta.id as the frame id we pass to get_frame. rustdf's get_frame
+            // indexes its own frame_meta_data by position (id - 1) from the same
+            // unordered SQL query, so we require ids to appear in exact 1..=N positional
+            // order (validated below). Checked-convert to avoid an i64->u32 wrap.
+            let id = u32::try_from(m.id)
+                .map_err(|_| anyhow::anyhow!("frame id {} is out of u32 range", m.id))?;
+            let num_peaks = m.num_peaks.max(0) as u64;
+            if num_peaks > 0 {
+                rt_min = rt_min.min(m.time);
+                rt_max = rt_max.max(m.time);
+            }
+            total = total.saturating_add(num_peaks);
+            frames.push(FrameInfo {
+                id,
+                retention_time: m.time,
+                is_ms2: m.ms_ms_type != 0,
+                num_peaks,
+            });
+        }
+
+        // rustdf looks up frames by vector position (id - 1) from the same query, so the
+        // metadata must arrive in exact 1..=N order. Checking the id *set* isn't enough:
+        // an unordered result like [2,1,3] passes a set check but makes get_frame(2) read
+        // position 1 (id 1's data). Require positional order so this can't silently
+        // corrupt the view; timsTOF runs satisfy it.
+        let n = frames.len();
+        let ordered = frames
+            .iter()
+            .enumerate()
+            .all(|(i, f)| f.id == i as u32 + 1);
+        anyhow::ensure!(
+            ordered,
+            "frame metadata is not in contiguous 1..={n} positional order \
+             (first id {:?}, last id {:?}); the viewer relies on rustdf's position-based \
+             frame indexing",
+            frames.first().map(|f| f.id),
+            frames.last().map(|f| f.id),
+        );
+
+        if !rt_min.is_finite() || !rt_max.is_finite() {
+            // No non-empty frames carried RT; fall back to the full frame span.
+            rt_min = frames.first().map(|f| f.retention_time).unwrap_or(0.0);
+            rt_max = frames.last().map(|f| f.retention_time).unwrap_or(1.0);
+        }
+
+        let bounds = AxisBounds {
+            mz: AxisTransform::new(
+                global.mz_acquisition_range_lower,
+                global.mz_acquisition_range_upper,
+            ),
+            im: AxisTransform::new(
+                global.one_over_k0_range_lower,
+                global.one_over_k0_range_upper,
+            ),
+            rt: AxisTransform::new(rt_min, rt_max),
+        };
+
+        Ok(MetaIndex {
+            data_path: data_path.to_string(),
+            frames,
+            bounds,
+            total_points_estimate: total,
+        })
+    }
+
+    /// Synthetic metadata for the `DEMO` path (no Bruker data required).
+    pub fn demo(num_frames: usize, total_points: u64) -> Self {
+        let mut frames = Vec::with_capacity(num_frames);
+        for i in 0..num_frames {
+            let rt = i as f64 * 0.5; // 0.5 s spacing
+            frames.push(FrameInfo {
+                id: (i + 1) as u32,
+                retention_time: rt,
+                is_ms2: i % 10 == 9, // ~10% MS2
+                num_peaks: total_points / num_frames.max(1) as u64,
+            });
+        }
+        let bounds = AxisBounds {
+            mz: AxisTransform::new(100.0, 1700.0),
+            im: AxisTransform::new(0.6, 1.6),
+            rt: AxisTransform::new(0.0, (num_frames.max(1) - 1) as f64 * 0.5),
+        };
+        MetaIndex {
+            data_path: "DEMO".to_string(),
+            frames,
+            bounds,
+            total_points_estimate: total_points,
+        }
+    }
+}

--- a/tims-viewer/src/data/mod.rs
+++ b/tims-viewer/src/data/mod.rs
@@ -1,0 +1,6 @@
+//! Data layer: metadata, streaming loader, GPU point format, and the synthetic source.
+
+pub mod demo;
+pub mod loader;
+pub mod meta;
+pub mod point;

--- a/tims-viewer/src/data/point.rs
+++ b/tims-viewer/src/data/point.rs
@@ -1,0 +1,127 @@
+//! GPU point format, axis normalization, and the shared spatial bounds.
+
+use bytemuck::{Pod, Zeroable};
+
+/// One renderable data point, packed for the GPU as instance data.
+///
+/// Layout is 32 bytes, 16-byte aligned, so a `Vec<GpuPoint>` uploads directly as a
+/// vertex (instance-step) buffer via `bytemuck::cast_slice`.
+///
+/// `weight` is the number of original points this sample represents (`1/p` of the
+/// downsample). Carrying it lets additive-density rendering stay brightness-invariant
+/// regardless of the downsample ratio (see the shared density/exposure model).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct GpuPoint {
+    /// Position in the normalized cube `[-1, 1]^3` (x=m/z, y=1/K0, z=RT).
+    pub pos: [f32; 3],
+    /// Raw intensity (counts).
+    pub intensity: f32,
+    /// Sample weight = `1/p` (how many source points this one stands in for).
+    pub weight: f32,
+    /// Bit flags. bit0: 0 = MS1/precursor, 1 = MS2/fragment.
+    pub flags: u32,
+    pub _pad: [u32; 2],
+}
+
+impl GpuPoint {
+    pub const MS2_FLAG: u32 = 1;
+
+    /// `wgpu` vertex-buffer layout describing the instance step-mode attributes.
+    pub fn layout() -> wgpu::VertexBufferLayout<'static> {
+        const ATTRS: [wgpu::VertexAttribute; 4] = wgpu::vertex_attr_array![
+            0 => Float32x3, // pos
+            1 => Float32,   // intensity
+            2 => Float32,   // weight
+            3 => Uint32,    // flags
+        ];
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<GpuPoint>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &ATTRS,
+        }
+    }
+}
+
+/// Affine mapping between a real-unit axis range and the normalized cube `[-1, 1]`.
+#[derive(Clone, Copy, Debug)]
+pub struct AxisTransform {
+    pub min: f64,
+    pub max: f64,
+}
+
+impl AxisTransform {
+    pub fn new(min: f64, max: f64) -> Self {
+        // Guard against a degenerate (zero-width) range.
+        if (max - min).abs() < f64::EPSILON {
+            AxisTransform {
+                min,
+                max: min + 1.0,
+            }
+        } else {
+            AxisTransform { min, max }
+        }
+    }
+
+    /// Map a real value into `[-1, 1]`.
+    #[inline]
+    pub fn normalize(&self, v: f64) -> f32 {
+        (2.0 * (v - self.min) / (self.max - self.min) - 1.0) as f32
+    }
+
+    /// Map a normalized `[-1, 1]` value back to real units.
+    /// Used by axis-tick labeling (and tested); kept ahead of the gizmo work.
+    #[allow(dead_code)]
+    #[inline]
+    pub fn denormalize(&self, n: f32) -> f64 {
+        self.min + ((n as f64) + 1.0) * 0.5 * (self.max - self.min)
+    }
+}
+
+/// The three spatial axes of the run, in real units, plus their normalizers.
+#[derive(Clone, Copy, Debug)]
+pub struct AxisBounds {
+    /// x-axis: m/z (Th).
+    pub mz: AxisTransform,
+    /// y-axis: inverse ion mobility 1/K0.
+    pub im: AxisTransform,
+    /// z-axis: retention time (seconds).
+    pub rt: AxisTransform,
+}
+
+impl AxisBounds {
+    /// Normalize a `(mz, im, rt)` real-unit triple into cube coordinates.
+    #[inline]
+    pub fn normalize(&self, mz: f64, im: f64, rt: f64) -> [f32; 3] {
+        [self.mz.normalize(mz), self.im.normalize(im), self.rt.normalize(rt)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gpu_point_is_32_bytes() {
+        assert_eq!(std::mem::size_of::<GpuPoint>(), 32);
+    }
+
+    #[test]
+    fn axis_transform_round_trip() {
+        let t = AxisTransform::new(100.0, 1700.0);
+        for v in [100.0, 400.0, 900.5, 1700.0] {
+            let n = t.normalize(v);
+            let back = t.denormalize(n);
+            assert!((back - v).abs() < 1e-6, "round-trip failed for {v}: {back}");
+        }
+        assert!((t.normalize(100.0) + 1.0).abs() < 1e-6);
+        assert!((t.normalize(1700.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn axis_transform_handles_degenerate_range() {
+        let t = AxisTransform::new(5.0, 5.0);
+        // Must not divide by zero / produce NaN.
+        assert!(t.normalize(5.0).is_finite());
+    }
+}

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -47,6 +47,9 @@ struct Args {
     /// MS level to render: all | ms1 | ms2.
     #[arg(long, default_value = "all")]
     ms: String,
+    /// With --render-png: overlay DDA precursor / DIA isolation-window annotations.
+    #[arg(long)]
+    annotations: bool,
     /// Output image width / height for --render-png.
     #[arg(long, default_value_t = 1280)]
     width: u32,
@@ -105,6 +108,7 @@ fn main() -> Result<()> {
             volume: args.volume,
             mip: args.mip,
             ms,
+            annotations: args.annotations,
             i_min: args.i_min,
             i_max: args.i_max,
             exposure: args.exposure,

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -1,0 +1,73 @@
+//! tims-viewer — native GPU viewer for Bruker timsTOF raw data.
+//!
+//! Usage:
+//!   tims-viewer <path/to/run.d>      open a real Bruker .d dataset
+//!   tims-viewer DEMO                 synthetic point cloud (no Bruker data needed)
+//!   tims-viewer DEMO --budget 25000000
+
+mod app;
+mod camera;
+mod data;
+mod render;
+mod state;
+mod ui;
+
+use anyhow::Result;
+use clap::Parser;
+use winit::event_loop::{ControlFlow, EventLoop};
+
+use app::{App, Plan};
+use data::meta::MetaIndex;
+
+/// Command-line arguments.
+#[derive(Parser, Debug)]
+#[command(name = "tims-viewer", about = "Native GPU viewer for Bruker timsTOF raw data")]
+struct Args {
+    /// Path to a Bruker `.d` folder, or the literal `DEMO` for a synthetic cloud.
+    input: String,
+    /// On-GPU point budget (resident capacity). Larger = more detail, more VRAM.
+    #[arg(long)]
+    budget: Option<usize>,
+    /// Number of synthetic frames for DEMO.
+    #[arg(long, default_value_t = 800)]
+    demo_frames: usize,
+    /// Total synthetic points for DEMO (before downsampling to the budget).
+    #[arg(long, default_value_t = 30_000_000)]
+    demo_points: u64,
+}
+
+fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let args = Args::parse();
+
+    let (meta, is_demo) = if args.input.eq_ignore_ascii_case("DEMO") {
+        log::info!(
+            "DEMO mode: {} frames, {} synthetic points",
+            args.demo_frames,
+            args.demo_points
+        );
+        (MetaIndex::demo(args.demo_frames, args.demo_points), true)
+    } else {
+        log::info!("loading metadata from {}", args.input);
+        let meta = MetaIndex::load(&args.input)?;
+        log::info!(
+            "{} frames, ~{} points, RT [{:.1}, {:.1}] s, m/z [{:.1}, {:.1}], 1/K0 [{:.3}, {:.3}]",
+            meta.frames.len(),
+            meta.total_points_estimate,
+            meta.bounds.rt.min,
+            meta.bounds.rt.max,
+            meta.bounds.mz.min,
+            meta.bounds.mz.max,
+            meta.bounds.im.min,
+            meta.bounds.im.max,
+        );
+        (meta, false)
+    };
+
+    let plan = Plan::new(meta, is_demo, args.budget);
+    let event_loop = EventLoop::new()?;
+    event_loop.set_control_flow(ControlFlow::Poll);
+    let mut app = App::new(plan);
+    event_loop.run_app(&mut app)?;
+    Ok(())
+}

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -8,6 +8,7 @@
 mod app;
 mod camera;
 mod data;
+mod offscreen;
 mod render;
 mod state;
 mod ui;
@@ -34,6 +35,30 @@ struct Args {
     /// Total synthetic points for DEMO (before downsampling to the budget).
     #[arg(long, default_value_t = 30_000_000)]
     demo_points: u64,
+    /// Headless: render one frame to this PNG path and exit (no window needed).
+    #[arg(long)]
+    render_png: Option<String>,
+    /// With --render-png: render the volume raycaster instead of the point cloud.
+    #[arg(long)]
+    volume: bool,
+    /// With --render-png --volume: use maximum-intensity projection instead of composite.
+    #[arg(long)]
+    mip: bool,
+    /// MS level to render: all | ms1 | ms2.
+    #[arg(long, default_value = "all")]
+    ms: String,
+    /// Output image width / height for --render-png.
+    #[arg(long, default_value_t = 1280)]
+    width: u32,
+    #[arg(long, default_value_t = 800)]
+    height: u32,
+    /// Transfer-function overrides for --render-png (default from data percentiles).
+    #[arg(long)]
+    i_min: Option<f32>,
+    #[arg(long)]
+    i_max: Option<f32>,
+    #[arg(long)]
+    exposure: Option<f32>,
 }
 
 fn main() -> Result<()> {
@@ -65,6 +90,30 @@ fn main() -> Result<()> {
     };
 
     let plan = Plan::new(meta, is_demo, args.budget);
+
+    // Headless one-frame render mode (no window).
+    if let Some(path) = args.render_png {
+        let ms = match args.ms.to_ascii_lowercase().as_str() {
+            "ms1" | "1" => offscreen::MsFilter::Ms1,
+            "ms2" | "2" => offscreen::MsFilter::Ms2,
+            "all" => offscreen::MsFilter::All,
+            other => anyhow::bail!("--ms must be all|ms1|ms2, got '{other}'"),
+        };
+        let opts = offscreen::Options {
+            width: args.width,
+            height: args.height,
+            volume: args.volume,
+            mip: args.mip,
+            ms,
+            i_min: args.i_min,
+            i_max: args.i_max,
+            exposure: args.exposure,
+        };
+        offscreen::render_png(plan, std::path::Path::new(&path), &opts)?;
+        log::info!("wrote {}", path);
+        return Ok(());
+    }
+
     let event_loop = EventLoop::new()?;
     event_loop.set_control_flow(ControlFlow::Poll);
     let mut app = App::new(plan);

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -141,12 +141,22 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
                     pts.into_iter().filter(&keep).collect()
                 };
                 for p in &pts {
-                    grid.deposit(p.pos, p.intensity);
+                    // Deposit intensity*weight so density is downsample-invariant.
+                    grid.deposit(p.pos, p.intensity * p.weight);
                     if seen % sample_every == 0 && reservoir.len() < 200_000 {
                         reservoir.push(p.intensity);
                     }
                     seen += 1;
                 }
+                points.append(&queue, &pts);
+            }
+            Ok(LoadMsg::PeakChunk { points: pts }) => {
+                // Display-only peaks: append to the cloud, never to the volume density.
+                let pts: Vec<GpuPoint> = if opts.ms == MsFilter::All {
+                    pts
+                } else {
+                    pts.into_iter().filter(&keep).collect()
+                };
                 points.append(&queue, &pts);
             }
             Ok(LoadMsg::Stats { .. }) => {} // recomputed below from retained points

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -64,6 +64,22 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
         None,
     ))?;
 
+    // Validate output dimensions: nonzero (else invalid texture / infinite aspect) and
+    // within the device's max texture size (also bounds the row/size arithmetic below).
+    anyhow::ensure!(
+        opts.width > 0 && opts.height > 0,
+        "render dimensions must be > 0 (got {}x{})",
+        opts.width,
+        opts.height
+    );
+    let max_dim = limits.max_texture_dimension_2d;
+    anyhow::ensure!(
+        opts.width <= max_dim && opts.height <= max_dim,
+        "render dimensions {}x{} exceed the device max texture size {max_dim}",
+        opts.width,
+        opts.height
+    );
+
     let flags = adapter.get_downlevel_capabilities().flags;
     let supports_compaction = flags.contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
         && flags.contains(wgpu::DownlevelFlags::INDIRECT_EXECUTION);
@@ -105,6 +121,12 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
         MsFilter::Ms1 => p.flags & GpuPoint::MS2_FLAG == 0,
         MsFilter::Ms2 => p.flags & GpuPoint::MS2_FLAG != 0,
     };
+    // Reservoir of RETAINED intensities so the auto transfer range matches what is
+    // actually rendered (the loader's Stats span both MS levels).
+    let mut reservoir: Vec<f32> = Vec::new();
+    let sample_every = (capacity as usize / 200_000).max(1) as u64;
+    let mut seen: u64 = 0;
+    let mut done = false;
     loop {
         match loader.rx.recv() {
             Ok(LoadMsg::Chunk { points: pts, .. }) => {
@@ -117,18 +139,33 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
                 };
                 for p in &pts {
                     grid.deposit(p.pos, p.intensity);
+                    if seen % sample_every == 0 && reservoir.len() < 200_000 {
+                        reservoir.push(p.intensity);
+                    }
+                    seen += 1;
                 }
                 points.append(&queue, &pts);
             }
-            Ok(LoadMsg::Stats { i_min, i_max }) => {
-                state.i_min = i_min;
-                state.i_max = i_max;
+            Ok(LoadMsg::Stats { .. }) => {} // recomputed below from retained points
+            Ok(LoadMsg::Done { .. }) => {
+                done = true;
+                break;
             }
-            Ok(LoadMsg::Done { .. }) => break,
             Ok(LoadMsg::Error(e)) => anyhow::bail!("loader error: {e}"),
             Ok(LoadMsg::Progress(_)) => {}
             Err(_) => break,
         }
+    }
+    // A disconnect before Done means the loader thread died (e.g. panicked) — don't
+    // silently write a partial/empty image.
+    anyhow::ensure!(done, "loader thread ended before completing the load");
+
+    // Default transfer range from the retained intensities (p1/p99).
+    if !reservoir.is_empty() {
+        reservoir.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let pct = |q: f32| reservoir[(((reservoir.len() - 1) as f32) * q) as usize];
+        state.i_min = pct(0.01).max(1.0);
+        state.i_max = pct(0.99).max(state.i_min * 1.0001);
     }
     // Apply transfer-function overrides (e.g. raise i_min to threshold out noise).
     if let Some(v) = opts.i_min {

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -160,8 +160,14 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
     // silently write a partial/empty image.
     anyhow::ensure!(done, "loader thread ended before completing the load");
 
-    // Default transfer range from the retained intensities (p1/p99).
-    if !reservoir.is_empty() {
+    // Default transfer range. Volume density sums live in a different range than
+    // per-point intensity, so take it from the voxel density distribution; the point
+    // cloud uses the retained-intensity percentiles.
+    if opts.volume {
+        let (lo, hi) = grid.density_percentiles();
+        state.i_min = lo;
+        state.i_max = hi;
+    } else if !reservoir.is_empty() {
         reservoir.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let pct = |q: f32| reservoir[(((reservoir.len() - 1) as f32) * q) as usize];
         state.i_min = pct(0.01).max(1.0);

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -213,9 +213,11 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
     let camera = OrbitCamera::default();
     let aspect = opts.width as f32 / opts.height as f32;
     let cam_uniform = camera.to_uniform(aspect, [opts.width as f32, opts.height as f32]);
+    let params = state.params();
     points.update_camera(&queue, &cam_uniform);
-    points.update_params(&queue, &state.params());
+    points.update_params(&queue, &params);
     annotations.update_camera(&queue, &cam_uniform);
+    annotations.update_filter(&queue, params.filter_min, params.filter_max);
     if opts.volume {
         let mut vu = state.volume_uniform(camera.inv_view_proj(aspect));
         vu.density_scale = grid.density_scale();

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -1,0 +1,297 @@
+//! Headless one-frame renderer: load a run, render the point cloud or volume to an
+//! offscreen texture, and write a PNG. Works without a display (used for screenshots on
+//! headless machines and to preview the volume raycaster).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::app::Plan;
+use crate::camera::OrbitCamera;
+use crate::data::demo::DemoSource;
+use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
+use crate::data::point::GpuPoint;
+use crate::render::colormap::COLORMAP_NAMES;
+use crate::render::point_cloud::PointCloudRenderer;
+use crate::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
+use crate::state::{AppState, ViewMode, VolStyle};
+
+const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+
+/// Which MS level to render.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MsFilter {
+    All,
+    Ms1,
+    Ms2,
+}
+
+pub struct Options {
+    pub width: u32,
+    pub height: u32,
+    pub volume: bool,
+    pub mip: bool,
+    pub ms: MsFilter,
+    /// Optional transfer-function overrides (else taken from data percentiles).
+    pub i_min: Option<f32>,
+    pub i_max: Option<f32>,
+    pub exposure: Option<f32>,
+}
+
+/// Render one frame of `plan`'s run and write a PNG to `out`.
+pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::PRIMARY | wgpu::Backends::GL,
+        ..Default::default()
+    });
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        force_fallback_adapter: false,
+        compatible_surface: None,
+    }))
+    .ok_or_else(|| anyhow::anyhow!("no GPU adapter available for offscreen render"))?;
+    log::info!("offscreen adapter: {:?}", adapter.get_info());
+
+    let limits = adapter.limits();
+    let (device, queue) = pollster::block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            label: Some("offscreen-device"),
+            required_features: wgpu::Features::empty(),
+            required_limits: limits.clone(),
+            memory_hints: wgpu::MemoryHints::Performance,
+        },
+        None,
+    ))?;
+
+    let flags = adapter.get_downlevel_capabilities().flags;
+    let supports_compaction = flags.contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
+        && flags.contains(wgpu::DownlevelFlags::INDIRECT_EXECUTION);
+
+    let bytes_per_point = std::mem::size_of::<GpuPoint>() as u64;
+    let total = plan.meta.total_points_estimate;
+    let mut cap = plan
+        .budget
+        .min((limits.max_buffer_size / bytes_per_point) as usize)
+        .min((total as usize).max(1));
+    if supports_compaction {
+        cap = cap.min((limits.max_storage_buffer_binding_size as u64 / bytes_per_point) as usize);
+    }
+    let capacity = cap.max(1) as u32;
+
+    let mut points =
+        PointCloudRenderer::new(&device, &queue, COLOR_FORMAT, DEPTH_FORMAT, capacity, supports_compaction);
+    let volume = VolumeRenderer::new(&device, &queue, COLOR_FORMAT, DEPTH_FORMAT, VOLUME_DIMS);
+    let mut grid = VolumeGrid::new(VOLUME_DIMS);
+
+    let bounds = plan.meta.bounds;
+    let mut state = AppState::new(bounds, total, COLORMAP_NAMES.len() as u32);
+    state.capacity = capacity;
+    state.view_mode = if opts.volume { ViewMode::Volume } else { ViewMode::Points };
+    state.vol_style = if opts.mip { VolStyle::Mip } else { VolStyle::Composite };
+
+    // Load the whole run synchronously by draining the streaming loader.
+    let mode = if plan.is_demo {
+        LoaderMode::Demo(DemoSource::new(plan.meta.frames.len(), total))
+    } else {
+        LoaderMode::Real {
+            path: plan.meta.data_path.clone(),
+            frame_ids: plan.meta.frames.iter().map(|f| f.id).collect(),
+        }
+    };
+    let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize);
+    let keep = |p: &GpuPoint| match opts.ms {
+        MsFilter::All => true,
+        MsFilter::Ms1 => p.flags & GpuPoint::MS2_FLAG == 0,
+        MsFilter::Ms2 => p.flags & GpuPoint::MS2_FLAG != 0,
+    };
+    loop {
+        match loader.rx.recv() {
+            Ok(LoadMsg::Chunk { points: pts, .. }) => {
+                // Filter to the requested MS level at the source so both the volume grid
+                // and the point buffer render only that level.
+                let pts: Vec<GpuPoint> = if opts.ms == MsFilter::All {
+                    pts
+                } else {
+                    pts.into_iter().filter(&keep).collect()
+                };
+                for p in &pts {
+                    grid.deposit(p.pos, p.intensity);
+                }
+                points.append(&queue, &pts);
+            }
+            Ok(LoadMsg::Stats { i_min, i_max }) => {
+                state.i_min = i_min;
+                state.i_max = i_max;
+            }
+            Ok(LoadMsg::Done { .. }) => break,
+            Ok(LoadMsg::Error(e)) => anyhow::bail!("loader error: {e}"),
+            Ok(LoadMsg::Progress(_)) => {}
+            Err(_) => break,
+        }
+    }
+    // Apply transfer-function overrides (e.g. raise i_min to threshold out noise).
+    if let Some(v) = opts.i_min {
+        state.i_min = v;
+    }
+    if let Some(v) = opts.i_max {
+        state.i_max = v;
+    }
+    if let Some(v) = opts.exposure {
+        state.exposure = v;
+    }
+    log::info!(
+        "loaded {} points (i_min={:.0} i_max={:.0} exposure={})",
+        points.resident(),
+        state.i_min,
+        state.i_max,
+        state.exposure
+    );
+
+    // Camera + uniforms.
+    let camera = OrbitCamera::default();
+    let aspect = opts.width as f32 / opts.height as f32;
+    points.update_camera(&queue, &camera.to_uniform(aspect, [opts.width as f32, opts.height as f32]));
+    points.update_params(&queue, &state.params());
+    if opts.volume {
+        let mut vu = state.volume_uniform(camera.inv_view_proj(aspect));
+        vu.density_scale = grid.density_scale();
+        volume.update_uniform(&queue, &vu);
+        volume.upload(&queue, &grid.to_f16_scaled());
+    }
+
+    // Offscreen targets.
+    let color = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("offscreen-color"),
+        size: wgpu::Extent3d {
+            width: opts.width,
+            height: opts.height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: COLOR_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let depth = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("offscreen-depth"),
+        size: wgpu::Extent3d {
+            width: opts.width,
+            height: opts.height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: DEPTH_FORMAT,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let color_view = color.create_view(&Default::default());
+    let depth_view = depth.create_view(&Default::default());
+
+    // Padded readback buffer (bytes_per_row must be 256-aligned for texture->buffer).
+    let unpadded_bpr = opts.width * 4;
+    let padded_bpr = unpadded_bpr.div_ceil(256) * 256;
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback"),
+        size: (padded_bpr * opts.height) as u64,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let mut encoder =
+        device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("offscreen") });
+    if !opts.volume {
+        points.prepare(&queue, &mut encoder);
+    }
+    {
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("offscreen-scene"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &color_view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: 0.02,
+                        g: 0.02,
+                        b: 0.035,
+                        a: 1.0,
+                    }),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &depth_view,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        if opts.volume {
+            volume.render(&mut rpass);
+        } else {
+            points.render(&mut rpass, state.point_mode);
+        }
+    }
+    encoder.copy_texture_to_buffer(
+        wgpu::ImageCopyTexture {
+            texture: &color,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        wgpu::ImageCopyBuffer {
+            buffer: &readback,
+            layout: wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(padded_bpr),
+                rows_per_image: Some(opts.height),
+            },
+        },
+        wgpu::Extent3d {
+            width: opts.width,
+            height: opts.height,
+            depth_or_array_layers: 1,
+        },
+    );
+    queue.submit(std::iter::once(encoder.finish()));
+
+    // Map and read back.
+    let slice = readback.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |r| {
+        let _ = tx.send(r);
+    });
+    device.poll(wgpu::Maintain::Wait);
+    rx.recv()
+        .context("map_async channel closed")?
+        .context("buffer map failed")?;
+
+    let data = slice.get_mapped_range();
+    let mut rgba = Vec::with_capacity((opts.width * opts.height * 4) as usize);
+    for row in 0..opts.height {
+        let start = (row * padded_bpr) as usize;
+        rgba.extend_from_slice(&data[start..start + unpadded_bpr as usize]);
+    }
+    drop(data);
+    readback.unmap();
+
+    // Encode PNG (Rgba8UnormSrgb bytes are already sRGB).
+    let file = std::fs::File::create(out).with_context(|| format!("creating {}", out.display()))?;
+    let w = std::io::BufWriter::new(file);
+    let mut encoder = png::Encoder::new(w, opts.width, opts.height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    encoder.set_source_srgb(png::SrgbRenderingIntent::Perceptual);
+    let mut writer = encoder.write_header().context("png header")?;
+    writer.write_image_data(&rgba).context("png write")?;
+
+    Ok(())
+}

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -12,6 +12,7 @@ use crate::data::demo::DemoSource;
 use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
 use crate::data::point::GpuPoint;
 use crate::render::colormap::COLORMAP_NAMES;
+use crate::render::annotation::AnnotationRenderer;
 use crate::render::point_cloud::PointCloudRenderer;
 use crate::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
 use crate::state::{AppState, ViewMode, VolStyle};
@@ -33,6 +34,7 @@ pub struct Options {
     pub volume: bool,
     pub mip: bool,
     pub ms: MsFilter,
+    pub annotations: bool,
     /// Optional transfer-function overrides (else taken from data percentiles).
     pub i_min: Option<f32>,
     pub i_max: Option<f32>,
@@ -99,6 +101,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
         PointCloudRenderer::new(&device, &queue, COLOR_FORMAT, DEPTH_FORMAT, capacity, supports_compaction);
     let volume = VolumeRenderer::new(&device, &queue, COLOR_FORMAT, DEPTH_FORMAT, VOLUME_DIMS);
     let mut grid = VolumeGrid::new(VOLUME_DIMS);
+    let mut annotations = AnnotationRenderer::new(&device, COLOR_FORMAT, DEPTH_FORMAT);
 
     let bounds = plan.meta.bounds;
     let mut state = AppState::new(bounds, total, COLORMAP_NAMES.len() as u32);
@@ -147,6 +150,11 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
                 points.append(&queue, &pts);
             }
             Ok(LoadMsg::Stats { .. }) => {} // recomputed below from retained points
+            Ok(LoadMsg::Annotations { lines }) => {
+                if opts.annotations {
+                    annotations.upload(&device, &lines);
+                }
+            }
             Ok(LoadMsg::Done { .. }) => {
                 done = true;
                 break;
@@ -194,8 +202,10 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
     // Camera + uniforms.
     let camera = OrbitCamera::default();
     let aspect = opts.width as f32 / opts.height as f32;
-    points.update_camera(&queue, &camera.to_uniform(aspect, [opts.width as f32, opts.height as f32]));
+    let cam_uniform = camera.to_uniform(aspect, [opts.width as f32, opts.height as f32]);
+    points.update_camera(&queue, &cam_uniform);
     points.update_params(&queue, &state.params());
+    annotations.update_camera(&queue, &cam_uniform);
     if opts.volume {
         let mut vu = state.volume_uniform(camera.inv_view_proj(aspect));
         vu.density_scale = grid.density_scale();
@@ -281,6 +291,9 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
             volume.render(&mut rpass);
         } else {
             points.render(&mut rpass, state.point_mode);
+        }
+        if opts.annotations {
+            annotations.render(&mut rpass);
         }
     }
     encoder.copy_texture_to_buffer(

--- a/tims-viewer/src/render/annotation.rs
+++ b/tims-viewer/src/render/annotation.rs
@@ -1,0 +1,135 @@
+//! Annotation overlay renderer: line-list geometry (DDA precursor crosses / DIA
+//! isolation-window boxes) drawn over the scene, always visible (depth-test Always).
+
+use wgpu::util::DeviceExt;
+
+use super::uniforms::CameraUniform;
+
+pub struct AnnotationRenderer {
+    vbuf: Option<wgpu::Buffer>,
+    vcount: u32,
+    camera_buf: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    pipeline: wgpu::RenderPipeline,
+}
+
+impl AnnotationRenderer {
+    pub fn new(
+        device: &wgpu::Device,
+        color_format: wgpu::TextureFormat,
+        depth_format: wgpu::TextureFormat,
+    ) -> Self {
+        let camera_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("annotation-camera"),
+            contents: bytemuck::bytes_of(&CameraUniform::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let bind_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("annotation-bind-layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("annotation-bind-group"),
+            layout: &bind_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: camera_buf.as_entire_binding(),
+            }],
+        });
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("annotation-shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/annotation.wgsl").into()),
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("annotation-pipeline-layout"),
+            bind_group_layouts: &[&bind_layout],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("annotation-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: 12,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x3],
+                }],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: color_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineList,
+                ..Default::default()
+            },
+            // Scene pass owns a depth attachment; draw on top without testing/writing.
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: depth_format,
+                depth_write_enabled: false,
+                depth_compare: wgpu::CompareFunction::Always,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+        AnnotationRenderer {
+            vbuf: None,
+            vcount: 0,
+            camera_buf,
+            bind_group,
+            pipeline,
+        }
+    }
+
+    pub fn update_camera(&self, queue: &wgpu::Queue, cam: &CameraUniform) {
+        queue.write_buffer(&self.camera_buf, 0, bytemuck::bytes_of(cam));
+    }
+
+    /// Upload line-list vertices (pairs = segments). Recreates the buffer.
+    pub fn upload(&mut self, device: &wgpu::Device, verts: &[[f32; 3]]) {
+        if verts.is_empty() {
+            self.vbuf = None;
+            self.vcount = 0;
+            return;
+        }
+        let buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("annotation-vertices"),
+            contents: bytemuck::cast_slice(verts),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        self.vbuf = Some(buf);
+        self.vcount = verts.len() as u32;
+    }
+
+    pub fn render(&self, rpass: &mut wgpu::RenderPass<'_>) {
+        let Some(vbuf) = &self.vbuf else { return };
+        if self.vcount == 0 {
+            return;
+        }
+        rpass.set_pipeline(&self.pipeline);
+        rpass.set_bind_group(0, &self.bind_group, &[]);
+        rpass.set_vertex_buffer(0, vbuf.slice(..));
+        rpass.draw(0..self.vcount, 0..1);
+    }
+}

--- a/tims-viewer/src/render/annotation.rs
+++ b/tims-viewer/src/render/annotation.rs
@@ -1,14 +1,33 @@
 //! Annotation overlay renderer: line-list geometry (DDA precursor crosses / DIA
 //! isolation-window boxes) drawn over the scene, always visible (depth-test Always).
 
+use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 
 use super::uniforms::CameraUniform;
+
+/// Normalized-cube window the overlay is clipped to (xyz; w unused).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+struct FilterUniform {
+    min: [f32; 4],
+    max: [f32; 4],
+}
+
+impl Default for FilterUniform {
+    fn default() -> Self {
+        FilterUniform {
+            min: [-1.0, -1.0, -1.0, 0.0],
+            max: [1.0, 1.0, 1.0, 0.0],
+        }
+    }
+}
 
 pub struct AnnotationRenderer {
     vbuf: Option<wgpu::Buffer>,
     vcount: u32,
     camera_buf: wgpu::Buffer,
+    filter_buf: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
     pipeline: wgpu::RenderPipeline,
 }
@@ -24,26 +43,38 @@ impl AnnotationRenderer {
             contents: bytemuck::bytes_of(&CameraUniform::default()),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
+        let filter_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("annotation-filter"),
+            contents: bytemuck::bytes_of(&FilterUniform::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let uniform_entry = |binding| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::VERTEX,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
         let bind_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("annotation-bind-layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
+            entries: &[uniform_entry(0), uniform_entry(1)],
         });
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("annotation-bind-group"),
             layout: &bind_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: camera_buf.as_entire_binding(),
-            }],
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: camera_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: filter_buf.as_entire_binding(),
+                },
+            ],
         });
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("annotation-shader"),
@@ -97,6 +128,7 @@ impl AnnotationRenderer {
             vbuf: None,
             vcount: 0,
             camera_buf,
+            filter_buf,
             bind_group,
             pipeline,
         }
@@ -104,6 +136,15 @@ impl AnnotationRenderer {
 
     pub fn update_camera(&self, queue: &wgpu::Queue, cam: &CameraUniform) {
         queue.write_buffer(&self.camera_buf, 0, bytemuck::bytes_of(cam));
+    }
+
+    /// Set the normalized-cube window the overlay is clipped to.
+    pub fn update_filter(&self, queue: &wgpu::Queue, min: [f32; 4], max: [f32; 4]) {
+        queue.write_buffer(
+            &self.filter_buf,
+            0,
+            bytemuck::bytes_of(&FilterUniform { min, max }),
+        );
     }
 
     /// Upload line-list vertices (pairs = segments). Recreates the buffer.

--- a/tims-viewer/src/render/colormap.rs
+++ b/tims-viewer/src/render/colormap.rs
@@ -1,0 +1,120 @@
+//! Colormap lookup tables baked into a single 2D texture (256 wide × N maps tall).
+//!
+//! The point/volume shaders sample row `colormap_id` at column `t∈[0,1]` to map a
+//! normalized intensity to a perceptual color.
+
+/// Names in row order. Keep in sync with [`anchors`].
+pub const COLORMAP_NAMES: [&str; 4] = ["Viridis", "Inferno", "Turbo", "Grayscale"];
+
+/// Number of texels per colormap row.
+const LUT_WIDTH: usize = 256;
+
+/// Control-point anchors (sRGB 0..255) for each colormap; linearly interpolated.
+fn anchors(map: usize) -> &'static [[u8; 3]] {
+    match map {
+        0 => &[
+            [68, 1, 84],
+            [59, 82, 139],
+            [33, 144, 140],
+            [93, 201, 99],
+            [253, 231, 37],
+        ],
+        1 => &[
+            [0, 0, 4],
+            [87, 16, 110],
+            [188, 55, 84],
+            [249, 142, 9],
+            [252, 255, 164],
+        ],
+        2 => &[
+            [48, 18, 59],
+            [54, 125, 197],
+            [7, 193, 151],
+            [166, 228, 48],
+            [249, 189, 38],
+            [180, 4, 38],
+        ],
+        _ => &[[0, 0, 0], [255, 255, 255]],
+    }
+}
+
+/// Build the RGBA8 LUT pixel data, row-major (`width=256`, `height=N`).
+pub fn build_lut_rgba8() -> (Vec<u8>, u32, u32) {
+    let n = COLORMAP_NAMES.len();
+    let mut data = vec![0u8; LUT_WIDTH * n * 4];
+    for map in 0..n {
+        let a = anchors(map);
+        let segs = a.len() - 1;
+        for x in 0..LUT_WIDTH {
+            let t = x as f32 / (LUT_WIDTH - 1) as f32;
+            let fseg = t * segs as f32;
+            let seg = (fseg.floor() as usize).min(segs - 1);
+            let local = fseg - seg as f32;
+            let c0 = a[seg];
+            let c1 = a[seg + 1];
+            let lerp = |i: usize| {
+                (c0[i] as f32 + (c1[i] as f32 - c0[i] as f32) * local).round() as u8
+            };
+            let idx = (map * LUT_WIDTH + x) * 4;
+            data[idx] = lerp(0);
+            data[idx + 1] = lerp(1);
+            data[idx + 2] = lerp(2);
+            data[idx + 3] = 255;
+        }
+    }
+    (data, LUT_WIDTH as u32, n as u32)
+}
+
+/// Upload the LUT to a sampled 2D texture and return (texture, view, sampler).
+pub fn create_lut_texture(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+) -> (wgpu::Texture, wgpu::TextureView, wgpu::Sampler) {
+    let (data, width, height) = build_lut_rgba8();
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("colormap-lut"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        // sRGB so sampling returns linear color for correct blending.
+        format: wgpu::TextureFormat::Rgba8UnormSrgb,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    queue.write_texture(
+        wgpu::ImageCopyTexture {
+            texture: &texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        &data,
+        wgpu::ImageDataLayout {
+            offset: 0,
+            bytes_per_row: Some(width * 4),
+            rows_per_image: Some(height),
+        },
+        wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+    );
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("colormap-sampler"),
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        address_mode_w: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        mipmap_filter: wgpu::FilterMode::Nearest,
+        ..Default::default()
+    });
+    (texture, view, sampler)
+}

--- a/tims-viewer/src/render/mod.rs
+++ b/tims-viewer/src/render/mod.rs
@@ -1,5 +1,6 @@
 //! Rendering layer: GPU pipelines, uniforms, and colormaps.
 
+pub mod annotation;
 pub mod colormap;
 pub mod point_cloud;
 pub mod uniforms;

--- a/tims-viewer/src/render/mod.rs
+++ b/tims-viewer/src/render/mod.rs
@@ -3,3 +3,4 @@
 pub mod colormap;
 pub mod point_cloud;
 pub mod uniforms;
+pub mod volume;

--- a/tims-viewer/src/render/mod.rs
+++ b/tims-viewer/src/render/mod.rs
@@ -1,0 +1,5 @@
+//! Rendering layer: GPU pipelines, uniforms, and colormaps.
+
+pub mod colormap;
+pub mod point_cloud;
+pub mod uniforms;

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -1,0 +1,377 @@
+//! Point-cloud renderer: a pre-allocated instance buffer plus two pipelines
+//! (additive-density and structural-opaque) sharing one shader and bind group.
+
+use wgpu::util::DeviceExt;
+
+use crate::data::point::GpuPoint;
+
+use super::colormap;
+use super::uniforms::{CameraUniform, ParamsUniform};
+
+/// Render mode selector matching `ParamsUniform.render_mode`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PointMode {
+    AdditiveDensity,
+    StructuralOpaque,
+}
+
+pub struct PointCloudRenderer {
+    /// Instance buffer sized to the point budget.
+    instances: wgpu::Buffer,
+    capacity: u32,
+    resident: u32,
+
+    camera_buf: wgpu::Buffer,
+    params_buf: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+
+    pipeline_additive: wgpu::RenderPipeline,
+    pipeline_opaque: wgpu::RenderPipeline,
+
+    // Keep the LUT alive for the lifetime of the bind group.
+    _lut_texture: wgpu::Texture,
+}
+
+impl PointCloudRenderer {
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        color_format: wgpu::TextureFormat,
+        depth_format: wgpu::TextureFormat,
+        capacity: u32,
+    ) -> Self {
+        let instances = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("point-instances"),
+            size: capacity as u64 * std::mem::size_of::<GpuPoint>() as u64,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let camera_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("camera-uniform"),
+            contents: bytemuck::bytes_of(&CameraUniform::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let params_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("params-uniform"),
+            contents: bytemuck::bytes_of(&ParamsUniform::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let (lut_texture, lut_view, lut_sampler) = colormap::create_lut_texture(device, queue);
+
+        let bind_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("point-bind-layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("point-bind-group"),
+            layout: &bind_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: camera_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: params_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(&lut_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::Sampler(&lut_sampler),
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("point-cloud-shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("../shaders/point_cloud.wgsl").into(),
+            ),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("point-pipeline-layout"),
+            bind_group_layouts: &[&bind_layout],
+            push_constant_ranges: &[],
+        });
+
+        let additive_blend = wgpu::BlendState {
+            color: wgpu::BlendComponent {
+                src_factor: wgpu::BlendFactor::One,
+                dst_factor: wgpu::BlendFactor::One,
+                operation: wgpu::BlendOperation::Add,
+            },
+            alpha: wgpu::BlendComponent {
+                src_factor: wgpu::BlendFactor::One,
+                dst_factor: wgpu::BlendFactor::One,
+                operation: wgpu::BlendOperation::Add,
+            },
+        };
+
+        let make_pipeline = |blend: Option<wgpu::BlendState>, depth_write: bool, depth_cmp| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("point-pipeline"),
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[GpuPoint::layout()],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: color_format,
+                        blend,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    strip_index_format: None,
+                    front_face: wgpu::FrontFace::Ccw,
+                    cull_mode: None,
+                    polygon_mode: wgpu::PolygonMode::Fill,
+                    unclipped_depth: false,
+                    conservative: false,
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: depth_format,
+                    depth_write_enabled: depth_write,
+                    depth_compare: depth_cmp,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+                cache: None,
+            })
+        };
+
+        // Additive: order-independent, no depth writes, always blend.
+        let pipeline_additive =
+            make_pipeline(Some(additive_blend), false, wgpu::CompareFunction::Always);
+        // Opaque: depth-tested and depth-written for true 3D structure.
+        let pipeline_opaque =
+            make_pipeline(Some(wgpu::BlendState::REPLACE), true, wgpu::CompareFunction::Less);
+
+        PointCloudRenderer {
+            instances,
+            capacity,
+            resident: 0,
+            camera_buf,
+            params_buf,
+            bind_group,
+            pipeline_additive,
+            pipeline_opaque,
+            _lut_texture: lut_texture,
+        }
+    }
+
+    pub fn resident(&self) -> u32 {
+        self.resident
+    }
+
+    /// Total point capacity (used by region-refinement / reload, Phase 1.5).
+    #[allow(dead_code)]
+    pub fn capacity(&self) -> u32 {
+        self.capacity
+    }
+
+    /// Clear resident points (used by region-refinement / reload, Phase 1.5).
+    #[allow(dead_code)]
+    pub fn reset(&mut self) {
+        self.resident = 0;
+    }
+
+    /// Append packed points at the running offset, clamping to capacity. Returns the
+    /// number actually written.
+    pub fn append(&mut self, queue: &wgpu::Queue, points: &[GpuPoint]) -> usize {
+        if points.is_empty() || self.resident >= self.capacity {
+            return 0;
+        }
+        let room = (self.capacity - self.resident) as usize;
+        let n = points.len().min(room);
+        let stride = std::mem::size_of::<GpuPoint>() as u64;
+        let offset = self.resident as u64 * stride; // checked-range: resident <= capacity
+        queue.write_buffer(&self.instances, offset, bytemuck::cast_slice(&points[..n]));
+        self.resident += n as u32;
+        n
+    }
+
+    pub fn update_camera(&self, queue: &wgpu::Queue, cam: &CameraUniform) {
+        queue.write_buffer(&self.camera_buf, 0, bytemuck::bytes_of(cam));
+    }
+
+    pub fn update_params(&self, queue: &wgpu::Queue, params: &ParamsUniform) {
+        queue.write_buffer(&self.params_buf, 0, bytemuck::bytes_of(params));
+    }
+
+    pub fn render(&self, rpass: &mut wgpu::RenderPass<'_>, mode: PointMode) {
+        if self.resident == 0 {
+            return;
+        }
+        let pipeline = match mode {
+            PointMode::AdditiveDensity => &self.pipeline_additive,
+            PointMode::StructuralOpaque => &self.pipeline_opaque,
+        };
+        rpass.set_pipeline(pipeline);
+        rpass.set_bind_group(0, &self.bind_group, &[]);
+        rpass.set_vertex_buffer(0, self.instances.slice(..));
+        // 4 vertices per instance (triangle strip quad), one instance per point.
+        rpass.draw(0..4, 0..self.resident);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::point::GpuPoint;
+    use crate::render::uniforms::{CameraUniform, ParamsUniform};
+
+    /// Build both pipelines (forcing naga to compile the WGSL), upload points, and
+    /// render offscreen in both modes. Skips cleanly if no GPU adapter is available
+    /// (e.g. a headless CI box without a software rasterizer).
+    #[test]
+    fn offscreen_render_smoke() {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY | wgpu::Backends::GL,
+            ..Default::default()
+        });
+        let Some(adapter) = pollster::block_on(instance.request_adapter(
+            &wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            },
+        )) else {
+            eprintln!("no GPU adapter available; skipping offscreen render smoke test");
+            return;
+        };
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("smoke-device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                memory_hints: Default::default(),
+            },
+            None,
+        ))
+        .expect("request_device failed");
+
+        let color_format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let depth_format = wgpu::TextureFormat::Depth32Float;
+        // Pipeline creation here compiles the WGSL and validates bind/layout.
+        let mut r = PointCloudRenderer::new(&device, &queue, color_format, depth_format, 1024);
+
+        let pts: Vec<GpuPoint> = (0..200)
+            .map(|i| GpuPoint {
+                pos: [(i as f32 / 200.0) * 2.0 - 1.0, 0.0, 0.0],
+                intensity: 100.0 + i as f32,
+                weight: 1.0,
+                flags: (i % 2) as u32,
+                _pad: [0, 0],
+            })
+            .collect();
+        assert_eq!(r.append(&queue, &pts), 200);
+        r.update_camera(&queue, &CameraUniform::default());
+        r.update_params(&queue, &ParamsUniform::default());
+
+        let make_tex = |format, usage| {
+            device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                size: wgpu::Extent3d {
+                    width: 64,
+                    height: 64,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage,
+                view_formats: &[],
+            })
+        };
+        let color = make_tex(color_format, wgpu::TextureUsages::RENDER_ATTACHMENT);
+        let depth = make_tex(depth_format, wgpu::TextureUsages::RENDER_ATTACHMENT);
+        let cview = color.create_view(&Default::default());
+        let dview = depth.create_view(&Default::default());
+
+        for mode in [PointMode::AdditiveDensity, PointMode::StructuralOpaque] {
+            let mut enc =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            {
+                let mut rpass = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &cview,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                        view: &dview,
+                        depth_ops: Some(wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(1.0),
+                            store: wgpu::StoreOp::Store,
+                        }),
+                        stencil_ops: None,
+                    }),
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+                r.render(&mut rpass, mode);
+            }
+            queue.submit(std::iter::once(enc.finish()));
+            device.poll(wgpu::Maintain::Wait);
+        }
+    }
+}

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -1,12 +1,18 @@
 //! Point-cloud renderer: a pre-allocated instance buffer plus two pipelines
 //! (additive-density and structural-opaque) sharing one shader and bind group.
+//!
+//! When the device supports compute + indirect execution, a compaction pass culls each
+//! resident point (window + MS mask + frustum) into a compacted buffer and writes the
+//! indirect-draw count, so the draw call processes only the *visible* set instead of
+//! every resident instance. Otherwise it falls back to drawing all resident points and
+//! culling in the vertex shader (the Phase-1 path).
 
 use wgpu::util::DeviceExt;
 
 use crate::data::point::GpuPoint;
 
 use super::colormap;
-use super::uniforms::{CameraUniform, ParamsUniform};
+use super::uniforms::{CameraUniform, CompactionUniform, ParamsUniform};
 
 /// Render mode selector matching `ParamsUniform.render_mode`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -15,21 +21,37 @@ pub enum PointMode {
     StructuralOpaque,
 }
 
+const WORKGROUP_SIZE: u32 = 256;
+
 pub struct PointCloudRenderer {
-    /// Instance buffer sized to the point budget.
-    instances: wgpu::Buffer,
+    /// Master instance buffer (all resident points), sized to the budget.
+    master: wgpu::Buffer,
+    /// Compacted visible points written by the compute pass (compaction path only).
+    compacted: wgpu::Buffer,
+    /// Indirect draw args: [vertex_count, instance_count, first_vertex, first_instance].
+    draw_args: wgpu::Buffer,
+
     capacity: u32,
     resident: u32,
 
     camera_buf: wgpu::Buffer,
     params_buf: wgpu::Buffer,
+    compaction_buf: wgpu::Buffer,
     bind_group: wgpu::BindGroup,
 
     pipeline_additive: wgpu::RenderPipeline,
     pipeline_opaque: wgpu::RenderPipeline,
 
+    /// Present only when compaction is supported.
+    compute: Option<ComputeStage>,
+
     // Keep the LUT alive for the lifetime of the bind group.
     _lut_texture: wgpu::Texture,
+}
+
+struct ComputeStage {
+    pipeline: wgpu::ComputePipeline,
+    bind_group: wgpu::BindGroup,
 }
 
 impl PointCloudRenderer {
@@ -39,12 +61,32 @@ impl PointCloudRenderer {
         color_format: wgpu::TextureFormat,
         depth_format: wgpu::TextureFormat,
         capacity: u32,
+        supports_compaction: bool,
     ) -> Self {
-        let instances = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("point-instances"),
-            size: capacity as u64 * std::mem::size_of::<GpuPoint>() as u64,
-            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+        let point_bytes = capacity as u64 * std::mem::size_of::<GpuPoint>() as u64;
+        // Master is read as storage by the compute pass and (in fallback) drawn as a
+        // vertex buffer; mark both usages.
+        let master = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("point-master"),
+            size: point_bytes,
+            usage: wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
+        });
+        let compacted = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("point-compacted"),
+            size: point_bytes.max(std::mem::size_of::<GpuPoint>() as u64),
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+        let draw_args = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("point-draw-args"),
+            // vertex_count=4 (quad strip), instance_count=0, first_vertex=0, first_instance=0
+            contents: bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]),
+            usage: wgpu::BufferUsages::INDIRECT
+                | wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST,
         });
 
         let camera_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -57,32 +99,19 @@ impl PointCloudRenderer {
             contents: bytemuck::bytes_of(&ParamsUniform::default()),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
+        let compaction_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("compaction-uniform"),
+            contents: bytemuck::bytes_of(&CompactionUniform::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
 
         let (lut_texture, lut_view, lut_sampler) = colormap::create_lut_texture(device, queue);
 
         let bind_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("point-bind-layout"),
             entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
+                uniform_entry(0),
+                uniform_entry(1),
                 wgpu::BindGroupLayoutEntry {
                     binding: 2,
                     visibility: wgpu::ShaderStages::FRAGMENT,
@@ -127,9 +156,7 @@ impl PointCloudRenderer {
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("point-cloud-shader"),
-            source: wgpu::ShaderSource::Wgsl(
-                include_str!("../shaders/point_cloud.wgsl").into(),
-            ),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/point_cloud.wgsl").into()),
         });
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -197,18 +224,39 @@ impl PointCloudRenderer {
         let pipeline_additive =
             make_pipeline(Some(additive_blend), false, wgpu::CompareFunction::Always);
         // Opaque: depth-tested and depth-written for true 3D structure.
-        let pipeline_opaque =
-            make_pipeline(Some(wgpu::BlendState::REPLACE), true, wgpu::CompareFunction::Less);
+        let pipeline_opaque = make_pipeline(
+            Some(wgpu::BlendState::REPLACE),
+            true,
+            wgpu::CompareFunction::Less,
+        );
+
+        let compute = if supports_compaction {
+            Some(build_compute_stage(
+                device,
+                &master,
+                &compacted,
+                &draw_args,
+                &camera_buf,
+                &params_buf,
+                &compaction_buf,
+            ))
+        } else {
+            None
+        };
 
         PointCloudRenderer {
-            instances,
+            master,
+            compacted,
+            draw_args,
             capacity,
             resident: 0,
             camera_buf,
             params_buf,
+            compaction_buf,
             bind_group,
             pipeline_additive,
             pipeline_opaque,
+            compute,
             _lut_texture: lut_texture,
         }
     }
@@ -239,7 +287,7 @@ impl PointCloudRenderer {
         let n = points.len().min(room);
         let stride = std::mem::size_of::<GpuPoint>() as u64;
         let offset = self.resident as u64 * stride; // checked-range: resident <= capacity
-        queue.write_buffer(&self.instances, offset, bytemuck::cast_slice(&points[..n]));
+        queue.write_buffer(&self.master, offset, bytemuck::cast_slice(&points[..n]));
         self.resident += n as u32;
         n
     }
@@ -252,6 +300,36 @@ impl PointCloudRenderer {
         queue.write_buffer(&self.params_buf, 0, bytemuck::bytes_of(params));
     }
 
+    /// Run the compaction compute pass (if supported). Must be called on the encoder
+    /// BEFORE the scene render pass; uniforms must already be updated for this frame.
+    pub fn prepare(&self, queue: &wgpu::Queue, encoder: &mut wgpu::CommandEncoder) {
+        let Some(compute) = &self.compute else {
+            return;
+        };
+        if self.resident == 0 {
+            return;
+        }
+        // Reset the survivor counter every frame (atomicAdd accumulates otherwise);
+        // keep vertex_count=4 for the quad strip.
+        queue.write_buffer(&self.draw_args, 0, bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]));
+        queue.write_buffer(
+            &self.compaction_buf,
+            0,
+            bytemuck::bytes_of(&CompactionUniform {
+                point_count: self.resident,
+                _pad: [0; 3],
+            }),
+        );
+        let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("point-compaction"),
+            timestamp_writes: None,
+        });
+        cpass.set_pipeline(&compute.pipeline);
+        cpass.set_bind_group(0, &compute.bind_group, &[]);
+        let groups = self.resident.div_ceil(WORKGROUP_SIZE);
+        cpass.dispatch_workgroups(groups, 1, 1);
+    }
+
     pub fn render(&self, rpass: &mut wgpu::RenderPass<'_>, mode: PointMode) {
         if self.resident == 0 {
             return;
@@ -262,9 +340,128 @@ impl PointCloudRenderer {
         };
         rpass.set_pipeline(pipeline);
         rpass.set_bind_group(0, &self.bind_group, &[]);
-        rpass.set_vertex_buffer(0, self.instances.slice(..));
-        // 4 vertices per instance (triangle strip quad), one instance per point.
-        rpass.draw(0..4, 0..self.resident);
+        if self.compute.is_some() {
+            // Draw only the compacted visible set; count comes from the indirect args.
+            rpass.set_vertex_buffer(0, self.compacted.slice(..));
+            rpass.draw_indirect(&self.draw_args, 0);
+        } else {
+            // Fallback: draw all resident points, cull in the vertex shader.
+            rpass.set_vertex_buffer(0, self.master.slice(..));
+            rpass.draw(0..4, 0..self.resident);
+        }
+    }
+}
+
+fn uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+fn storage_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+fn compute_uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_compute_stage(
+    device: &wgpu::Device,
+    master: &wgpu::Buffer,
+    compacted: &wgpu::Buffer,
+    draw_args: &wgpu::Buffer,
+    camera_buf: &wgpu::Buffer,
+    params_buf: &wgpu::Buffer,
+    compaction_buf: &wgpu::Buffer,
+) -> ComputeStage {
+    let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("compaction-bind-layout"),
+        entries: &[
+            storage_entry(0, true),  // src
+            storage_entry(1, false), // dst
+            storage_entry(2, false), // draw_args
+            compute_uniform_entry(3),
+            compute_uniform_entry(4),
+            compute_uniform_entry(5),
+        ],
+    });
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("compaction-bind-group"),
+        layout: &layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: master.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: compacted.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: draw_args.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: camera_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 4,
+                resource: params_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 5,
+                resource: compaction_buf.as_entire_binding(),
+            },
+        ],
+    });
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("compaction-shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/compact.wgsl").into()),
+    });
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("compaction-pipeline-layout"),
+        bind_group_layouts: &[&layout],
+        push_constant_ranges: &[],
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("compaction-pipeline"),
+        layout: Some(&pipeline_layout),
+        module: &shader,
+        entry_point: "cs_main",
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    ComputeStage {
+        pipeline,
+        bind_group,
     }
 }
 
@@ -274,9 +471,9 @@ mod tests {
     use crate::data::point::GpuPoint;
     use crate::render::uniforms::{CameraUniform, ParamsUniform};
 
-    /// Build both pipelines (forcing naga to compile the WGSL), upload points, and
-    /// render offscreen in both modes. Skips cleanly if no GPU adapter is available
-    /// (e.g. a headless CI box without a software rasterizer).
+    /// Build the pipelines (forcing WGSL compilation for both the draw and, when
+    /// supported, the compaction compute shader), upload points, run prepare() +
+    /// render offscreen in both modes. Skips cleanly if no GPU adapter is available.
     #[test]
     fn offscreen_render_smoke() {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
@@ -304,10 +501,20 @@ mod tests {
         ))
         .expect("request_device failed");
 
+        let flags = adapter.get_downlevel_capabilities().flags;
+        let supports_compaction = flags.contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
+            && flags.contains(wgpu::DownlevelFlags::INDIRECT_EXECUTION);
+
         let color_format = wgpu::TextureFormat::Rgba8UnormSrgb;
         let depth_format = wgpu::TextureFormat::Depth32Float;
-        // Pipeline creation here compiles the WGSL and validates bind/layout.
-        let mut r = PointCloudRenderer::new(&device, &queue, color_format, depth_format, 1024);
+        let mut r = PointCloudRenderer::new(
+            &device,
+            &queue,
+            color_format,
+            depth_format,
+            1024,
+            supports_compaction,
+        );
 
         let pts: Vec<GpuPoint> = (0..200)
             .map(|i| GpuPoint {
@@ -319,7 +526,9 @@ mod tests {
             })
             .collect();
         assert_eq!(r.append(&queue, &pts), 200);
-        r.update_camera(&queue, &CameraUniform::default());
+        // Camera looking at the cube so the frustum cull keeps points.
+        let cam = crate::camera::OrbitCamera::default().to_uniform(1.0, [64.0, 64.0]);
+        r.update_camera(&queue, &cam);
         r.update_params(&queue, &ParamsUniform::default());
 
         let make_tex = |format, usage| {
@@ -346,6 +555,7 @@ mod tests {
         for mode in [PointMode::AdditiveDensity, PointMode::StructuralOpaque] {
             let mut enc =
                 device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            r.prepare(&queue, &mut enc);
             {
                 let mut rpass = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: None,

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -65,6 +65,10 @@ pub struct VolumeUniform {
     pub style: u32,
     pub colormap_id: u32,
     pub n_colormaps: u32,
+    /// Multiplier applied to the sampled (normalized) voxel value to recover raw
+    /// intensity before the transfer function (mirrors VolumeGrid::density_scale).
+    pub density_scale: f32,
+    pub _pad: [f32; 3],
 }
 
 impl Default for VolumeUniform {
@@ -78,6 +82,8 @@ impl Default for VolumeUniform {
             style: 0,
             colormap_id: 0,
             n_colormaps: 1,
+            density_scale: 1.0,
+            _pad: [0.0; 3],
         }
     }
 }

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -1,0 +1,67 @@
+//! GPU uniform structs shared between the renderers and WGSL shaders.
+
+use bytemuck::{Pod, Zeroable};
+
+/// Per-frame camera data. 16-byte aligned throughout.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct CameraUniform {
+    pub view_proj: [[f32; 4]; 4],
+    /// Camera right vector in world space (for billboard orientation).
+    pub right: [f32; 4],
+    /// Camera up vector in world space.
+    pub up: [f32; 4],
+    /// Framebuffer size in pixels (x, y) + padding.
+    pub viewport: [f32; 4],
+}
+
+impl Default for CameraUniform {
+    fn default() -> Self {
+        CameraUniform {
+            view_proj: glam::Mat4::IDENTITY.to_cols_array_2d(),
+            right: [1.0, 0.0, 0.0, 0.0],
+            up: [0.0, 1.0, 0.0, 0.0],
+            viewport: [1.0, 1.0, 0.0, 0.0],
+        }
+    }
+}
+
+/// Rendering parameters bound to the UI controls.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct ParamsUniform {
+    /// Normalized-cube window minimum (xyz) + unused w.
+    pub filter_min: [f32; 4],
+    /// Normalized-cube window maximum (xyz) + unused w.
+    pub filter_max: [f32; 4],
+    /// Transfer function: x=mode (0 lin/1 sqrt/2 log), y=i_min, z=i_max, w=exposure.
+    pub transfer: [f32; 4],
+    pub point_size: f32,
+    pub opacity: f32,
+    pub _pad0: f32,
+    pub _pad1: f32,
+    /// Bit mask: bit0 show MS1, bit1 show MS2.
+    pub ms_mask: u32,
+    pub colormap_id: u32,
+    /// 0 = additive density, 1 = structural opaque.
+    pub render_mode: u32,
+    pub n_colormaps: u32,
+}
+
+impl Default for ParamsUniform {
+    fn default() -> Self {
+        ParamsUniform {
+            filter_min: [-1.0, -1.0, -1.0, 0.0],
+            filter_max: [1.0, 1.0, 1.0, 0.0],
+            transfer: [2.0, 1.0, 1e5, 1.0],
+            point_size: 2.5,
+            opacity: 0.6,
+            _pad0: 0.0,
+            _pad1: 0.0,
+            ms_mask: 0b11,
+            colormap_id: 0,
+            render_mode: 0,
+            n_colormaps: 1,
+        }
+    }
+}

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -48,6 +48,14 @@ pub struct ParamsUniform {
     pub n_colormaps: u32,
 }
 
+/// Small uniform feeding the compaction compute pass (resident point count).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod, Zeroable)]
+pub struct CompactionUniform {
+    pub point_count: u32,
+    pub _pad: [u32; 3],
+}
+
 impl Default for ParamsUniform {
     fn default() -> Self {
         ParamsUniform {

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -48,6 +48,40 @@ pub struct ParamsUniform {
     pub n_colormaps: u32,
 }
 
+/// Uniform for the volume raycaster. 16-byte aligned throughout (128 bytes).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct VolumeUniform {
+    pub inv_view_proj: [[f32; 4]; 4],
+    /// Window box minimum in the normalized cube (xyz) + unused w.
+    pub box_min: [f32; 4],
+    /// Window box maximum (xyz) + unused w.
+    pub box_max: [f32; 4],
+    /// Transfer: x=mode (0 lin/1 sqrt/2 log), y=i_min, z=i_max, w=exposure.
+    pub transfer: [f32; 4],
+    /// Samples marched along the ray.
+    pub steps: u32,
+    /// 0 = front-to-back composite, 1 = maximum-intensity projection.
+    pub style: u32,
+    pub colormap_id: u32,
+    pub n_colormaps: u32,
+}
+
+impl Default for VolumeUniform {
+    fn default() -> Self {
+        VolumeUniform {
+            inv_view_proj: glam::Mat4::IDENTITY.to_cols_array_2d(),
+            box_min: [-1.0, -1.0, -1.0, 0.0],
+            box_max: [1.0, 1.0, 1.0, 0.0],
+            transfer: [2.0, 1.0, 1e5, 1.0],
+            steps: 256,
+            style: 0,
+            colormap_id: 0,
+            n_colormaps: 1,
+        }
+    }
+}
+
 /// Small uniform feeding the compaction compute pass (resident point count).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, Pod, Zeroable)]

--- a/tims-viewer/src/render/volume.rs
+++ b/tims-viewer/src/render/volume.rs
@@ -1,0 +1,424 @@
+//! Volume rendering: a CPU max-intensity voxel grid (built incrementally as points
+//! stream in) uploaded to an anisotropic R16Float 3D texture, plus a fullscreen-triangle
+//! raycaster that shares the point cloud's transfer-function + colormap.
+//!
+//! MVP semantics: each voxel stores the MAX intensity of points falling in it (nearest
+//! voxel). Max keeps voxel values in the same range as raw per-point intensity, so the
+//! identical transfer function (i_min/i_max/log) and colormap apply unchanged — one
+//! shared exposure model across points and volume. Trilinear cloud-in-cell *density*
+//! deposition is the documented Phase-3 refinement.
+
+use half::f16;
+
+use super::colormap;
+use super::uniforms::VolumeUniform;
+
+/// Anisotropic grid dimensions (m/z, 1/K0, RT). m/z gets the most bins (finest features).
+pub const VOLUME_DIMS: [u32; 3] = [256, 128, 192];
+
+/// CPU-side max-intensity voxel grid.
+pub struct VolumeGrid {
+    dims: [u32; 3],
+    /// Max intensity per voxel, indexed x + nx*(y + ny*z).
+    data: Vec<f32>,
+    dirty: bool,
+}
+
+impl VolumeGrid {
+    pub fn new(dims: [u32; 3]) -> Self {
+        let n = dims[0] as usize * dims[1] as usize * dims[2] as usize;
+        VolumeGrid {
+            dims,
+            data: vec![0.0; n],
+            dirty: false,
+        }
+    }
+
+    pub fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    pub fn clear_dirty(&mut self) {
+        self.dirty = false;
+    }
+
+    /// Deposit a point (normalized cube position in [-1,1], raw intensity) as a max into
+    /// its containing voxel.
+    #[inline]
+    pub fn deposit(&mut self, pos: [f32; 3], intensity: f32) {
+        let [nx, ny, nz] = self.dims;
+        let vx = voxel_index(pos[0], nx);
+        let vy = voxel_index(pos[1], ny);
+        let vz = voxel_index(pos[2], nz);
+        let idx = vx + nx as usize * (vy + ny as usize * vz);
+        let slot = &mut self.data[idx];
+        if intensity > *slot {
+            *slot = intensity;
+        }
+        self.dirty = true;
+    }
+
+    /// Convert to f16 for upload, clamping to the f16 max to avoid overflow/inf.
+    pub fn to_f16(&self) -> Vec<f16> {
+        const F16_MAX: f32 = 65504.0;
+        self.data
+            .iter()
+            .map(|&v| f16::from_f32(v.min(F16_MAX)))
+            .collect()
+    }
+}
+
+#[inline]
+fn voxel_index(norm: f32, dim: u32) -> usize {
+    // Map [-1, 1] -> [0, dim-1].
+    let t = (norm * 0.5 + 0.5).clamp(0.0, 1.0);
+    ((t * dim as f32) as u32).min(dim - 1) as usize
+}
+
+pub struct VolumeRenderer {
+    texture: wgpu::Texture,
+    dims: [u32; 3],
+    uniform_buf: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    pipeline: wgpu::RenderPipeline,
+    _lut_texture: wgpu::Texture,
+}
+
+impl VolumeRenderer {
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        color_format: wgpu::TextureFormat,
+        depth_format: wgpu::TextureFormat,
+        dims: [u32; 3],
+    ) -> Self {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("volume-texture"),
+            size: wgpu::Extent3d {
+                width: dims[0],
+                height: dims[1],
+                depth_or_array_layers: dims[2],
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D3,
+            format: wgpu::TextureFormat::R16Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("volume-sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        let (lut_texture, lut_view, lut_sampler) = colormap::create_lut_texture(device, queue);
+
+        let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("volume-uniform"),
+            size: std::mem::size_of::<VolumeUniform>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&uniform_buf, 0, bytemuck::bytes_of(&VolumeUniform::default()));
+
+        let bind_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("volume-bind-layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D3,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 4,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("volume-bind-group"),
+            layout: &bind_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: uniform_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(&lut_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: wgpu::BindingResource::Sampler(&lut_sampler),
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("volume-shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/volume.wgsl").into()),
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("volume-pipeline-layout"),
+            bind_group_layouts: &[&bind_layout],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("volume-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: color_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            // Scene pass owns a depth attachment; declare it but neither test nor write.
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: depth_format,
+                depth_write_enabled: false,
+                depth_compare: wgpu::CompareFunction::Always,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        VolumeRenderer {
+            texture,
+            dims,
+            uniform_buf,
+            bind_group,
+            pipeline,
+            _lut_texture: lut_texture,
+        }
+    }
+
+    pub fn update_uniform(&self, queue: &wgpu::Queue, u: &VolumeUniform) {
+        queue.write_buffer(&self.uniform_buf, 0, bytemuck::bytes_of(u));
+    }
+
+    /// Upload the (f16) grid into the 3D texture. `data` length must equal the grid.
+    pub fn upload(&self, queue: &wgpu::Queue, data: &[f16]) {
+        let [nx, ny, nz] = self.dims;
+        debug_assert_eq!(data.len(), nx as usize * ny as usize * nz as usize);
+        queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &self.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            bytemuck::cast_slice(data),
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(nx * 2), // R16Float = 2 bytes/texel
+                rows_per_image: Some(ny),
+            },
+            wgpu::Extent3d {
+                width: nx,
+                height: ny,
+                depth_or_array_layers: nz,
+            },
+        );
+    }
+
+    pub fn render(&self, rpass: &mut wgpu::RenderPass<'_>) {
+        rpass.set_pipeline(&self.pipeline);
+        rpass.set_bind_group(0, &self.bind_group, &[]);
+        rpass.draw(0..3, 0..1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::uniforms::VolumeUniform;
+
+    #[test]
+    fn voxel_index_maps_cube_to_dims() {
+        assert_eq!(voxel_index(-1.0, 8), 0);
+        assert_eq!(voxel_index(1.0, 8), 7); // clamped to dim-1, not 8
+        assert_eq!(voxel_index(0.0, 8), 4);
+        assert_eq!(voxel_index(2.0, 8), 7); // out-of-range clamps
+        assert_eq!(voxel_index(-9.0, 8), 0);
+    }
+
+    #[test]
+    fn grid_deposit_keeps_max_and_clamps_f16() {
+        let mut g = VolumeGrid::new([4, 4, 4]);
+        g.deposit([0.0, 0.0, 0.0], 100.0);
+        g.deposit([0.0, 0.0, 0.0], 50.0); // smaller -> ignored (max)
+        g.deposit([0.0, 0.0, 0.0], 1e9); // huge -> clamped to f16 max on convert
+        assert!(g.dirty());
+        let f = g.to_f16();
+        assert_eq!(f.len(), 64);
+        let center = f[voxel_index(0.0, 4) + 4 * (voxel_index(0.0, 4) + 4 * voxel_index(0.0, 4))];
+        assert!(center.to_f32() <= 65504.0 && center.to_f32() > 0.0);
+    }
+
+    /// Build the volume pipeline (compiles volume.wgsl), upload a grid, and raycast
+    /// offscreen in both styles. Skips if no GPU adapter is present.
+    #[test]
+    fn offscreen_volume_smoke() {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY | wgpu::Backends::GL,
+            ..Default::default()
+        });
+        let Some(adapter) = pollster::block_on(instance.request_adapter(
+            &wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            },
+        )) else {
+            eprintln!("no GPU adapter; skipping offscreen volume smoke test");
+            return;
+        };
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("vol-smoke-device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                memory_hints: Default::default(),
+            },
+            None,
+        ))
+        .expect("request_device failed");
+
+        let color_format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        let depth_format = wgpu::TextureFormat::Depth32Float;
+        let dims = [16u32, 16, 16];
+        let r = VolumeRenderer::new(&device, &queue, color_format, depth_format, dims);
+
+        let mut grid = VolumeGrid::new(dims);
+        for i in 0..16 {
+            let t = i as f32 / 15.0 * 2.0 - 1.0;
+            grid.deposit([t, 0.0, 0.0], 500.0 + i as f32 * 100.0);
+        }
+        r.upload(&queue, &grid.to_f16());
+        let cam = crate::camera::OrbitCamera::default();
+        let mut u = VolumeUniform {
+            inv_view_proj: cam.inv_view_proj(1.0),
+            ..Default::default()
+        };
+
+        let make_tex = |format, usage| {
+            device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                size: wgpu::Extent3d {
+                    width: 32,
+                    height: 32,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage,
+                view_formats: &[],
+            })
+        };
+        let color = make_tex(color_format, wgpu::TextureUsages::RENDER_ATTACHMENT);
+        let depth = make_tex(depth_format, wgpu::TextureUsages::RENDER_ATTACHMENT);
+        let cview = color.create_view(&Default::default());
+        let dview = depth.create_view(&Default::default());
+
+        for style in [0u32, 1] {
+            u.style = style;
+            r.update_uniform(&queue, &u);
+            let mut enc =
+                device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            {
+                let mut rpass = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &cview,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                        view: &dview,
+                        depth_ops: Some(wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(1.0),
+                            store: wgpu::StoreOp::Store,
+                        }),
+                        stencil_ops: None,
+                    }),
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+                r.render(&mut rpass);
+            }
+            queue.submit(std::iter::once(enc.finish()));
+            device.poll(wgpu::Maintain::Wait);
+        }
+    }
+}

--- a/tims-viewer/src/render/volume.rs
+++ b/tims-viewer/src/render/volume.rs
@@ -16,20 +16,34 @@ use super::uniforms::VolumeUniform;
 /// Anisotropic grid dimensions (m/z, 1/K0, RT). m/z gets the most bins (finest features).
 pub const VOLUME_DIMS: [u32; 3] = [256, 128, 192];
 
+/// Target maximum stored f16 value; the grid is normalized so its peak maps here,
+/// well under the f16 ceiling (65504) so no value is clamped/lost.
+const F16_TARGET_MAX: f32 = 60000.0;
+
 /// CPU-side max-intensity voxel grid.
 pub struct VolumeGrid {
     dims: [u32; 3],
     /// Max intensity per voxel, indexed x + nx*(y + ny*z).
     data: Vec<f32>,
+    /// Largest intensity deposited so far (drives the normalization scale).
+    max_intensity: f32,
     dirty: bool,
 }
 
 impl VolumeGrid {
     pub fn new(dims: [u32; 3]) -> Self {
-        let n = dims[0] as usize * dims[1] as usize * dims[2] as usize;
+        assert!(
+            dims.iter().all(|&d| d > 0),
+            "volume dims must be non-zero, got {dims:?}"
+        );
+        let n = (dims[0] as usize)
+            .checked_mul(dims[1] as usize)
+            .and_then(|m| m.checked_mul(dims[2] as usize))
+            .expect("volume dimensions overflow usize");
         VolumeGrid {
             dims,
             data: vec![0.0; n],
+            max_intensity: 0.0,
             dirty: false,
         }
     }
@@ -55,15 +69,26 @@ impl VolumeGrid {
         if intensity > *slot {
             *slot = intensity;
         }
+        if intensity > self.max_intensity {
+            self.max_intensity = intensity;
+        }
         self.dirty = true;
     }
 
-    /// Convert to f16 for upload, clamping to the f16 max to avoid overflow/inf.
-    pub fn to_f16(&self) -> Vec<f16> {
-        const F16_MAX: f32 = 65504.0;
+    /// Factor the shader multiplies the sampled (normalized) value by to recover raw
+    /// intensity. `>= 1`; chosen so the grid peak maps to `F16_TARGET_MAX`.
+    pub fn density_scale(&self) -> f32 {
+        (self.max_intensity / F16_TARGET_MAX).max(1.0)
+    }
+
+    /// Normalize by `density_scale` and convert to f16 — preserves the full intensity
+    /// range (incl. values far above 65504) instead of clamping it away. The shader
+    /// multiplies back by `density_scale` before applying the shared transfer function.
+    pub fn to_f16_scaled(&self) -> Vec<f16> {
+        let inv = 1.0 / self.density_scale();
         self.data
             .iter()
-            .map(|&v| f16::from_f32(v.min(F16_MAX)))
+            .map(|&v| f16::from_f32((v * inv).min(F16_TARGET_MAX)))
             .collect()
     }
 }
@@ -226,7 +251,21 @@ impl VolumeRenderer {
                 entry_point: "fs_main",
                 targets: &[Some(wgpu::ColorTargetState {
                     format: color_format,
-                    blend: None,
+                    // Premultiplied alpha: the composite fragment outputs (acc, alpha)
+                    // with acc already premultiplied, so low-opacity rays let the scene
+                    // clear color show through. MIP returns alpha=1 and stays opaque.
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                    }),
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
                 compilation_options: Default::default(),
@@ -313,12 +352,19 @@ mod tests {
         let mut g = VolumeGrid::new([4, 4, 4]);
         g.deposit([0.0, 0.0, 0.0], 100.0);
         g.deposit([0.0, 0.0, 0.0], 50.0); // smaller -> ignored (max)
-        g.deposit([0.0, 0.0, 0.0], 1e9); // huge -> clamped to f16 max on convert
+        g.deposit([0.0, 0.0, 0.0], 1e9); // huge -> normalized, not clamped away
         assert!(g.dirty());
-        let f = g.to_f16();
+        // Scale normalizes the 1e9 peak down under the f16 ceiling.
+        assert!(g.density_scale() > 1.0);
+        let f = g.to_f16_scaled();
         assert_eq!(f.len(), 64);
         let center = f[voxel_index(0.0, 4) + 4 * (voxel_index(0.0, 4) + 4 * voxel_index(0.0, 4))];
-        assert!(center.to_f32() <= 65504.0 && center.to_f32() > 0.0);
+        // Stored value is finite and well under the f16 ceiling; recovering raw
+        // intensity (value * density_scale) reconstructs the 1e9 peak.
+        let stored = center.to_f32();
+        assert!(stored > 0.0 && stored <= 65504.0);
+        let recovered = stored * g.density_scale();
+        assert!((recovered - 1e9).abs() / 1e9 < 0.02, "recovered {recovered}");
     }
 
     /// Build the volume pipeline (compiles volume.wgsl), upload a grid, and raycast
@@ -360,7 +406,7 @@ mod tests {
             let t = i as f32 / 15.0 * 2.0 - 1.0;
             grid.deposit([t, 0.0, 0.0], 500.0 + i as f32 * 100.0);
         }
-        r.upload(&queue, &grid.to_f16());
+        r.upload(&queue, &grid.to_f16_scaled());
         let cam = crate::camera::OrbitCamera::default();
         let mut u = VolumeUniform {
             inv_view_proj: cam.inv_view_proj(1.0),

--- a/tims-viewer/src/render/volume.rs
+++ b/tims-viewer/src/render/volume.rs
@@ -16,17 +16,17 @@ use super::uniforms::VolumeUniform;
 /// Anisotropic grid dimensions (m/z, 1/K0, RT). m/z gets the most bins (finest features).
 pub const VOLUME_DIMS: [u32; 3] = [256, 128, 192];
 
-/// Target maximum stored f16 value; the grid is normalized so its peak maps here,
-/// well under the f16 ceiling (65504) so no value is clamped/lost.
+/// Target peak stored f16 value; the grid is normalized so its densest voxel maps
+/// here, well under the f16 ceiling (65504) so nothing is clamped/lost.
 const F16_TARGET_MAX: f32 = 60000.0;
 
-/// CPU-side max-intensity voxel grid.
+/// CPU-side density voxel grid: trilinear cloud-in-cell accumulation of intensity.
 pub struct VolumeGrid {
     dims: [u32; 3],
-    /// Max intensity per voxel, indexed x + nx*(y + ny*z).
+    /// Accumulated density per voxel, indexed x + nx*(y + ny*z).
     data: Vec<f32>,
-    /// Largest intensity deposited so far (drives the normalization scale).
-    max_intensity: f32,
+    /// Largest accumulated voxel density (drives the normalization scale).
+    max_density: f32,
     dirty: bool,
 }
 
@@ -43,7 +43,7 @@ impl VolumeGrid {
         VolumeGrid {
             dims,
             data: vec![0.0; n],
-            max_intensity: 0.0,
+            max_density: 0.0,
             dirty: false,
         }
     }
@@ -56,34 +56,74 @@ impl VolumeGrid {
         self.dirty = false;
     }
 
-    /// Deposit a point (normalized cube position in [-1,1], raw intensity) as a max into
-    /// its containing voxel.
+    /// Deposit a point (normalized cube position in [-1,1], raw intensity) using
+    /// trilinear cloud-in-cell weighting: the intensity is split across the 8 nearest
+    /// voxels by their interpolation weights and ADDED. This is conservative (the 8
+    /// weights sum to 1, so total deposited == intensity) and avoids the blocky
+    /// aliasing of nearest-voxel binning. Edges clamp onto the boundary voxels.
     #[inline]
     pub fn deposit(&mut self, pos: [f32; 3], intensity: f32) {
         let [nx, ny, nz] = self.dims;
-        let vx = voxel_index(pos[0], nx);
-        let vy = voxel_index(pos[1], ny);
-        let vz = voxel_index(pos[2], nz);
-        let idx = vx + nx as usize * (vy + ny as usize * vz);
-        let slot = &mut self.data[idx];
-        if intensity > *slot {
-            *slot = intensity;
-        }
-        if intensity > self.max_intensity {
-            self.max_intensity = intensity;
-        }
+        // Cell-centered continuous coordinate in [-0.5, dim-0.5].
+        let g = |norm: f32, dim: u32| (norm * 0.5 + 0.5).clamp(0.0, 1.0) * dim as f32 - 0.5;
+        let (gx, gy, gz) = (g(pos[0], nx), g(pos[1], ny), g(pos[2], nz));
+        let split = |gc: f32, dim: u32| -> (usize, usize, f32) {
+            let base = gc.floor();
+            let frac = gc - base;
+            let lo = (base as i64).clamp(0, dim as i64 - 1) as usize;
+            let hi = ((base as i64) + 1).clamp(0, dim as i64 - 1) as usize;
+            (lo, hi, frac)
+        };
+        let (x0, x1, fx) = split(gx, nx);
+        let (y0, y1, fy) = split(gy, ny);
+        let (z0, z1, fz) = split(gz, nz);
+        let nxu = nx as usize;
+        let nyu = ny as usize;
+        let mut add = |x: usize, y: usize, z: usize, w: f32| {
+            let idx = x + nxu * (y + nyu * z);
+            let v = self.data[idx] + intensity * w;
+            self.data[idx] = v;
+            if v > self.max_density {
+                self.max_density = v;
+            }
+        };
+        add(x0, y0, z0, (1.0 - fx) * (1.0 - fy) * (1.0 - fz));
+        add(x1, y0, z0, fx * (1.0 - fy) * (1.0 - fz));
+        add(x0, y1, z0, (1.0 - fx) * fy * (1.0 - fz));
+        add(x1, y1, z0, fx * fy * (1.0 - fz));
+        add(x0, y0, z1, (1.0 - fx) * (1.0 - fy) * fz);
+        add(x1, y0, z1, fx * (1.0 - fy) * fz);
+        add(x0, y1, z1, (1.0 - fx) * fy * fz);
+        add(x1, y1, z1, fx * fy * fz);
         self.dirty = true;
     }
 
     /// Factor the shader multiplies the sampled (normalized) value by to recover raw
-    /// intensity. `>= 1`; chosen so the grid peak maps to `F16_TARGET_MAX`.
+    /// density, chosen so the densest voxel maps to `F16_TARGET_MAX`.
     pub fn density_scale(&self) -> f32 {
-        (self.max_intensity / F16_TARGET_MAX).max(1.0)
+        if self.max_density > 0.0 {
+            self.max_density / F16_TARGET_MAX
+        } else {
+            1.0
+        }
     }
 
-    /// Normalize by `density_scale` and convert to f16 — preserves the full intensity
-    /// range (incl. values far above 65504) instead of clamping it away. The shader
-    /// multiplies back by `density_scale` before applying the shared transfer function.
+    /// p1/p99 of the non-empty voxel densities — sensible default transfer range for
+    /// the volume (density sums live in a different range than per-point intensity).
+    pub fn density_percentiles(&self) -> (f32, f32) {
+        let mut nz: Vec<f32> = self.data.iter().copied().filter(|&v| v > 0.0).collect();
+        if nz.is_empty() {
+            return (1.0, 2.0);
+        }
+        nz.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let pct = |q: f32| nz[(((nz.len() - 1) as f32) * q) as usize];
+        let lo = pct(0.50).max(1e-6); // median: voxels below it are sparse fringe
+        let hi = pct(0.999).max(lo * 1.0001);
+        (lo, hi)
+    }
+
+    /// Normalize by `density_scale` and convert to f16. The shader multiplies back by
+    /// `density_scale` before the transfer function.
     pub fn to_f16_scaled(&self) -> Vec<f16> {
         let inv = 1.0 / self.density_scale();
         self.data
@@ -91,13 +131,6 @@ impl VolumeGrid {
             .map(|&v| f16::from_f32((v * inv).min(F16_TARGET_MAX)))
             .collect()
     }
-}
-
-#[inline]
-fn voxel_index(norm: f32, dim: u32) -> usize {
-    // Map [-1, 1] -> [0, dim-1].
-    let t = (norm * 0.5 + 0.5).clamp(0.0, 1.0);
-    ((t * dim as f32) as u32).min(dim - 1) as usize
 }
 
 pub struct VolumeRenderer {
@@ -339,32 +372,44 @@ mod tests {
     use crate::render::uniforms::VolumeUniform;
 
     #[test]
-    fn voxel_index_maps_cube_to_dims() {
-        assert_eq!(voxel_index(-1.0, 8), 0);
-        assert_eq!(voxel_index(1.0, 8), 7); // clamped to dim-1, not 8
-        assert_eq!(voxel_index(0.0, 8), 4);
-        assert_eq!(voxel_index(2.0, 8), 7); // out-of-range clamps
-        assert_eq!(voxel_index(-9.0, 8), 0);
+    fn trilinear_deposit_conserves_total() {
+        // Trilinear deposit splits intensity across the 8 nearest voxels with weights
+        // summing to 1, so the total grid mass equals the deposited intensity.
+        let mut g = VolumeGrid::new([8, 8, 8]);
+        g.deposit([0.13, -0.27, 0.61], 1000.0);
+        assert!(g.dirty());
+        let total: f32 = g.data.iter().sum();
+        assert!((total - 1000.0).abs() < 0.5, "total mass {total} != 1000");
+        // A second point at the same place doubles the local mass (additive density).
+        g.deposit([0.13, -0.27, 0.61], 1000.0);
+        let total2: f32 = g.data.iter().sum();
+        assert!((total2 - 2000.0).abs() < 1.0, "total mass {total2} != 2000");
     }
 
     #[test]
-    fn grid_deposit_keeps_max_and_clamps_f16() {
+    fn density_scale_and_f16_recover_peak() {
         let mut g = VolumeGrid::new([4, 4, 4]);
-        g.deposit([0.0, 0.0, 0.0], 100.0);
-        g.deposit([0.0, 0.0, 0.0], 50.0); // smaller -> ignored (max)
-        g.deposit([0.0, 0.0, 0.0], 1e9); // huge -> normalized, not clamped away
-        assert!(g.dirty());
-        // Scale normalizes the 1e9 peak down under the f16 ceiling.
-        assert!(g.density_scale() > 1.0);
+        // Deposit on an exact voxel center so its full intensity lands in one voxel.
+        g.deposit([0.0, 0.0, 0.0], 1e9);
+        assert!(g.density_scale() > 1.0); // huge peak -> scaled down for f16
         let f = g.to_f16_scaled();
         assert_eq!(f.len(), 64);
-        let center = f[voxel_index(0.0, 4) + 4 * (voxel_index(0.0, 4) + 4 * voxel_index(0.0, 4))];
-        // Stored value is finite and well under the f16 ceiling; recovering raw
-        // intensity (value * density_scale) reconstructs the 1e9 peak.
-        let stored = center.to_f32();
-        assert!(stored > 0.0 && stored <= 65504.0);
-        let recovered = stored * g.density_scale();
-        assert!((recovered - 1e9).abs() / 1e9 < 0.02, "recovered {recovered}");
+        let peak = f.iter().map(|h| h.to_f32()).fold(0.0f32, f32::max);
+        assert!(peak > 0.0 && peak <= 65504.0);
+        // Recovering raw density (stored * density_scale) reconstructs the peak.
+        let recovered = peak * g.density_scale();
+        assert!((recovered - g.max_density).abs() / g.max_density < 0.01);
+    }
+
+    #[test]
+    fn density_percentiles_are_ordered() {
+        let mut g = VolumeGrid::new([16, 16, 16]);
+        for i in 0..200 {
+            let t = (i as f32 / 200.0) * 2.0 - 1.0;
+            g.deposit([t, 0.0, 0.0], 100.0 + i as f32);
+        }
+        let (lo, hi) = g.density_percentiles();
+        assert!(lo > 0.0 && hi > lo, "percentiles lo={lo} hi={hi}");
     }
 
     /// Build the volume pipeline (compiles volume.wgsl), upload a grid, and raycast

--- a/tims-viewer/src/shaders/annotation.wgsl
+++ b/tims-viewer/src/shaders/annotation.wgsl
@@ -8,10 +8,20 @@ struct Camera {
     viewport  : vec4<f32>,
 };
 
+struct Filter {
+    min : vec4<f32>,
+    max : vec4<f32>,
+};
+
 @group(0) @binding(0) var<uniform> cam : Camera;
+@group(0) @binding(1) var<uniform> flt : Filter;
 
 @vertex
 fn vs_main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    // Clip annotations to the active window so narrowing a range filters them too.
+    if (any(pos < flt.min.xyz) || any(pos > flt.max.xyz)) {
+        return vec4<f32>(2.0, 2.0, 2.0, 1.0); // outside clip volume -> culled
+    }
     return cam.view_proj * vec4<f32>(pos, 1.0);
 }
 

--- a/tims-viewer/src/shaders/annotation.wgsl
+++ b/tims-viewer/src/shaders/annotation.wgsl
@@ -1,0 +1,22 @@
+// Annotation overlay: draws line-list geometry (DDA precursor crosses / DIA isolation
+// boxes) in the normalized cube, on top of the scene.
+
+struct Camera {
+    view_proj : mat4x4<f32>,
+    right     : vec4<f32>,
+    up        : vec4<f32>,
+    viewport  : vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> cam : Camera;
+
+@vertex
+fn vs_main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+    return cam.view_proj * vec4<f32>(pos, 1.0);
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    // Bright cyan, fully opaque so markers read clearly over points or volume.
+    return vec4<f32>(0.1, 0.95, 0.95, 1.0);
+}

--- a/tims-viewer/src/shaders/compact.wgsl
+++ b/tims-viewer/src/shaders/compact.wgsl
@@ -1,0 +1,91 @@
+// Compaction compute pass: cull each resident point against the active window, MS
+// mask, and camera frustum, and append survivors into a compacted buffer while
+// counting them into the indirect-draw args. The draw pass then renders only the
+// visible set via draw_indirect, instead of processing every resident instance.
+
+struct GpuPoint {
+    pos : vec3<f32>,
+    intensity : f32,
+    weight : f32,
+    flags : u32,
+    pad : vec2<u32>,
+};
+
+struct Camera {
+    view_proj : mat4x4<f32>,
+    right     : vec4<f32>,
+    up        : vec4<f32>,
+    viewport  : vec4<f32>,
+};
+
+struct Params {
+    filter_min : vec4<f32>,
+    filter_max : vec4<f32>,
+    transfer   : vec4<f32>,
+    point_size : f32,
+    opacity    : f32,
+    _pad0      : f32,
+    _pad1      : f32,
+    ms_mask     : u32,
+    colormap_id : u32,
+    render_mode : u32,
+    n_colormaps : u32,
+};
+
+// Layout matches wgpu's DrawIndirectArgs: vertex_count, instance_count, first_vertex,
+// first_instance. instance_count is the atomic survivor counter.
+struct DrawArgs {
+    vertex_count   : u32,
+    instance_count : atomic<u32>,
+    first_vertex   : u32,
+    first_instance : u32,
+};
+
+struct Compaction {
+    point_count : u32,
+    _p0 : u32,
+    _p1 : u32,
+    _p2 : u32,
+};
+
+@group(0) @binding(0) var<storage, read>       src : array<GpuPoint>;
+@group(0) @binding(1) var<storage, read_write> dst : array<GpuPoint>;
+@group(0) @binding(2) var<storage, read_write> draw_args : DrawArgs;
+@group(0) @binding(3) var<uniform> cam : Camera;
+@group(0) @binding(4) var<uniform> params : Params;
+@group(0) @binding(5) var<uniform> comp : Compaction;
+
+@compute @workgroup_size(256)
+fn cs_main(@builtin(global_invocation_id) gid : vec3<u32>) {
+    let i = gid.x;
+    if (i >= comp.point_count) {
+        return;
+    }
+    let p = src[i];
+
+    // Window filter (normalized cube).
+    if (any(p.pos < params.filter_min.xyz) || any(p.pos > params.filter_max.xyz)) {
+        return;
+    }
+
+    // MS-type mask.
+    let is_ms2 = (p.flags & 1u) != 0u;
+    let show = select((params.ms_mask & 1u) != 0u, (params.ms_mask & 2u) != 0u, is_ms2);
+    if (!show) {
+        return;
+    }
+
+    // Frustum cull (with a margin so splats near the edge aren't clipped early).
+    let clip = cam.view_proj * vec4<f32>(p.pos, 1.0);
+    if (clip.w <= 0.0) {
+        return;
+    }
+    let m = clip.w * 1.2;
+    if (clip.x < -m || clip.x > m || clip.y < -m || clip.y > m || clip.z < 0.0 || clip.z > clip.w) {
+        return;
+    }
+
+    // Append (slot is guaranteed < capacity because survivors <= resident <= capacity).
+    let slot = atomicAdd(&draw_args.instance_count, 1u);
+    dst[slot] = p;
+}

--- a/tims-viewer/src/shaders/point_cloud.wgsl
+++ b/tims-viewer/src/shaders/point_cloud.wgsl
@@ -1,0 +1,131 @@
+// Point-cloud splat shader: instanced screen-facing billboards with a shared
+// transfer-function + colormap, additive-density and structural-opaque modes.
+
+struct Camera {
+    view_proj : mat4x4<f32>,
+    right     : vec4<f32>,
+    up        : vec4<f32>,
+    viewport  : vec4<f32>,
+};
+
+struct Params {
+    filter_min : vec4<f32>,
+    filter_max : vec4<f32>,
+    transfer   : vec4<f32>, // mode, i_min, i_max, exposure
+    point_size : f32,
+    opacity    : f32,
+    _pad0      : f32,
+    _pad1      : f32,
+    ms_mask     : u32,
+    colormap_id : u32,
+    render_mode : u32,
+    n_colormaps : u32,
+};
+
+@group(0) @binding(0) var<uniform> cam : Camera;
+@group(0) @binding(1) var<uniform> params : Params;
+@group(0) @binding(2) var lut_tex : texture_2d<f32>;
+@group(0) @binding(3) var lut_smp : sampler;
+
+struct VsOut {
+    @builtin(position) clip : vec4<f32>,
+    @location(0) uv : vec2<f32>,
+    @location(1) intensity : f32,
+    @location(2) weight : f32,
+    @location(3) visible : f32,
+};
+
+fn transfer(i: f32) -> f32 {
+    let mode = params.transfer.x;
+    let imin = params.transfer.y;
+    let imax = params.transfer.z;
+    if (mode < 0.5) {
+        return clamp((i - imin) / max(imax - imin, 1e-6), 0.0, 1.0);
+    } else if (mode < 1.5) {
+        let a = sqrt(max(i, 0.0));
+        let lo = sqrt(max(imin, 0.0));
+        let hi = sqrt(max(imax, 0.0));
+        return clamp((a - lo) / max(hi - lo, 1e-6), 0.0, 1.0);
+    } else {
+        let a = log(max(i, 1.0));
+        let lo = log(max(imin, 1.0));
+        let hi = log(max(imax, 1.0));
+        return clamp((a - lo) / max(hi - lo, 1e-6), 0.0, 1.0);
+    }
+}
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vid : u32,
+    @location(0) pos : vec3<f32>,
+    @location(1) intensity : f32,
+    @location(2) weight : f32,
+    @location(3) flags : u32,
+) -> VsOut {
+    var out : VsOut;
+
+    // Window + MS-type filtering -> collapse off-screen if rejected.
+    let in_window =
+        all(pos >= params.filter_min.xyz) && all(pos <= params.filter_max.xyz);
+    let is_ms2 = (flags & 1u) != 0u;
+    let show = select((params.ms_mask & 1u) != 0u, (params.ms_mask & 2u) != 0u, is_ms2);
+    if (!in_window || !show) {
+        out.clip = vec4<f32>(2.0, 2.0, 2.0, 1.0); // outside clip volume -> culled
+        out.visible = 0.0;
+        out.uv = vec2<f32>(0.0, 0.0);
+        out.intensity = 0.0;
+        out.weight = 0.0;
+        return out;
+    }
+
+    // Quad corners for a 4-vertex triangle strip.
+    var corners = array<vec2<f32>, 4>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 1.0, -1.0),
+        vec2<f32>(-1.0,  1.0),
+        vec2<f32>( 1.0,  1.0),
+    );
+    let corner = corners[vid];
+
+    // World-space billboard so size attenuates with distance (perspective).
+    let half = params.point_size * 0.0015;
+    let world = pos + (corner.x * cam.right.xyz + corner.y * cam.up.xyz) * half;
+    out.clip = cam.view_proj * vec4<f32>(world, 1.0);
+    out.uv = corner;
+    out.intensity = intensity;
+    out.weight = weight;
+    out.visible = 1.0;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    if (in.visible < 0.5) {
+        discard;
+    }
+    let r = length(in.uv);
+    let falloff = 1.0 - smoothstep(0.0, 1.0, r);
+    if (falloff <= 0.0) {
+        discard;
+    }
+    let t = transfer(in.intensity);
+    let row = (f32(params.colormap_id) + 0.5) / f32(params.n_colormaps);
+    let color = textureSample(lut_tex, lut_smp, vec2<f32>(t, row)).rgb;
+
+    if (params.render_mode == 1u) {
+        // Structural opaque: round point via alpha cutout, depth-written.
+        if (falloff < 0.5) {
+            discard;
+        }
+        return vec4<f32>(color, 1.0);
+    }
+
+    // Additive density: weight by 1/p so brightness is invariant to the DOWNSAMPLE
+    // ratio, then scale by exposure so dense regions are tunable rather than blowing
+    // out. Note: with world-size billboards, integrated brightness still varies with
+    // camera distance (splat pixel-area ~ 1/dist^2) — that zoom dependence is the
+    // accepted cost of perspective size attenuation, addressed in Phase 1.5 if needed.
+    let exposure = params.transfer.w;
+    let contrib = falloff * params.opacity * exposure * in.weight;
+    return vec4<f32>(color * contrib, contrib);
+}

--- a/tims-viewer/src/shaders/volume.wgsl
+++ b/tims-viewer/src/shaders/volume.wgsl
@@ -12,6 +12,10 @@ struct Volume {
     style : u32,          // 0 = composite, 1 = MIP
     colormap_id : u32,
     n_colormaps : u32,
+    density_scale : f32,  // recover raw intensity from the normalized texture
+    _pad0 : f32,
+    _pad1 : f32,
+    _pad2 : f32,
 };
 
 @group(0) @binding(0) var<uniform> vol : Volume;
@@ -65,7 +69,15 @@ fn colormap(t: f32) -> vec3<f32> {
 
 // Robust ray/AABB slab test. Returns (t_enter, t_exit); a miss has t_exit < t_enter.
 fn intersect_box(o: vec3<f32>, dir: vec3<f32>, bmin: vec3<f32>, bmax: vec3<f32>) -> vec2<f32> {
-    let inv = 1.0 / dir;
+    // Nudge near-zero direction components so 1/dir stays finite — avoids 0*inf = NaN
+    // for box-boundary-parallel rays (common in axis/orthographic views).
+    let eps = 1e-7;
+    let safe = vec3<f32>(
+        select(dir.x, eps, abs(dir.x) < eps),
+        select(dir.y, eps, abs(dir.y) < eps),
+        select(dir.z, eps, abs(dir.z) < eps),
+    );
+    let inv = 1.0 / safe;
     let t0 = (bmin - o) * inv;
     let t1 = (bmax - o) * inv;
     let tmin = min(t0, t1);
@@ -101,7 +113,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
         for (var i = 0u; i < steps; i = i + 1u) {
             let p = o + dir * (t_enter + dt * (f32(i) + 0.5));
             let uvw = p * 0.5 + vec3<f32>(0.5);
-            let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r;
+            let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r * vol.density_scale;
             maxt = max(maxt, transfer(dens));
         }
         if (maxt <= 0.0) {
@@ -116,7 +128,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     for (var i = 0u; i < steps; i = i + 1u) {
         let p = o + dir * (t_enter + dt * (f32(i) + 0.5));
         let uvw = p * 0.5 + vec3<f32>(0.5);
-        let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r;
+        let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r * vol.density_scale;
         let tval = transfer(dens);
         if (tval > 0.0) {
             let col = colormap(tval);
@@ -132,5 +144,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     if (alpha <= 0.0) {
         discard;
     }
-    return vec4<f32>(acc, 1.0);
+    // Premultiplied (acc) with its coverage alpha, so the clear color shows through
+    // where the ray didn't accumulate full opacity (pipeline uses premultiplied blend).
+    return vec4<f32>(acc, alpha);
 }

--- a/tims-viewer/src/shaders/volume.wgsl
+++ b/tims-viewer/src/shaders/volume.wgsl
@@ -1,0 +1,136 @@
+// Volume raycaster: a fullscreen triangle whose fragment shader marches a ray through
+// the 3D intensity texture, sharing the point cloud's transfer-function + colormap.
+// Composite (front-to-back) and maximum-intensity-projection styles. The march is
+// clamped to the active window box, so range filtering works in volume mode too.
+
+struct Volume {
+    inv_view_proj : mat4x4<f32>,
+    box_min : vec4<f32>,
+    box_max : vec4<f32>,
+    transfer : vec4<f32>, // mode, i_min, i_max, exposure
+    steps : u32,
+    style : u32,          // 0 = composite, 1 = MIP
+    colormap_id : u32,
+    n_colormaps : u32,
+};
+
+@group(0) @binding(0) var<uniform> vol : Volume;
+@group(0) @binding(1) var vol_tex : texture_3d<f32>;
+@group(0) @binding(2) var vol_smp : sampler;
+@group(0) @binding(3) var lut_tex : texture_2d<f32>;
+@group(0) @binding(4) var lut_smp : sampler;
+
+struct VsOut {
+    @builtin(position) clip : vec4<f32>,
+    @location(0) ndc : vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vid : u32) -> VsOut {
+    // Fullscreen triangle.
+    var p = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 3.0, -1.0),
+        vec2<f32>(-1.0,  3.0),
+    );
+    var out : VsOut;
+    out.clip = vec4<f32>(p[vid], 0.0, 1.0);
+    out.ndc = p[vid];
+    return out;
+}
+
+fn transfer(i: f32) -> f32 {
+    let mode = vol.transfer.x;
+    let imin = vol.transfer.y;
+    let imax = vol.transfer.z;
+    if (mode < 0.5) {
+        return clamp((i - imin) / max(imax - imin, 1e-6), 0.0, 1.0);
+    } else if (mode < 1.5) {
+        let a = sqrt(max(i, 0.0));
+        let lo = sqrt(max(imin, 0.0));
+        let hi = sqrt(max(imax, 0.0));
+        return clamp((a - lo) / max(hi - lo, 1e-6), 0.0, 1.0);
+    } else {
+        let a = log(max(i, 1.0));
+        let lo = log(max(imin, 1.0));
+        let hi = log(max(imax, 1.0));
+        return clamp((a - lo) / max(hi - lo, 1e-6), 0.0, 1.0);
+    }
+}
+
+fn colormap(t: f32) -> vec3<f32> {
+    let row = (f32(vol.colormap_id) + 0.5) / f32(vol.n_colormaps);
+    return textureSampleLevel(lut_tex, lut_smp, vec2<f32>(t, row), 0.0).rgb;
+}
+
+// Robust ray/AABB slab test. Returns (t_enter, t_exit); a miss has t_exit < t_enter.
+fn intersect_box(o: vec3<f32>, dir: vec3<f32>, bmin: vec3<f32>, bmax: vec3<f32>) -> vec2<f32> {
+    let inv = 1.0 / dir;
+    let t0 = (bmin - o) * inv;
+    let t1 = (bmax - o) * inv;
+    let tmin = min(t0, t1);
+    let tmax = max(t0, t1);
+    let t_enter = max(max(tmin.x, tmin.y), tmin.z);
+    let t_exit = min(min(tmax.x, tmax.y), tmax.z);
+    return vec2<f32>(t_enter, t_exit);
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    // Reconstruct the world-space ray from the inverse view-projection.
+    let near = vol.inv_view_proj * vec4<f32>(in.ndc, 0.0, 1.0);
+    let far = vol.inv_view_proj * vec4<f32>(in.ndc, 1.0, 1.0);
+    let o = near.xyz / near.w;
+    let dir = normalize(far.xyz / far.w - o);
+
+    let hit = intersect_box(o, dir, vol.box_min.xyz, vol.box_max.xyz);
+    let t_enter = max(hit.x, 0.0);
+    let t_exit = hit.y;
+    if (t_exit <= t_enter) {
+        discard;
+    }
+
+    let steps = max(vol.steps, 1u);
+    let span = t_exit - t_enter;
+    let dt = span / f32(steps);
+    let exposure = vol.transfer.w;
+
+    if (vol.style == 1u) {
+        // Maximum-intensity projection.
+        var maxt = 0.0;
+        for (var i = 0u; i < steps; i = i + 1u) {
+            let p = o + dir * (t_enter + dt * (f32(i) + 0.5));
+            let uvw = p * 0.5 + vec3<f32>(0.5);
+            let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r;
+            maxt = max(maxt, transfer(dens));
+        }
+        if (maxt <= 0.0) {
+            discard;
+        }
+        return vec4<f32>(colormap(maxt), 1.0);
+    }
+
+    // Front-to-back composite.
+    var acc = vec3<f32>(0.0);
+    var alpha = 0.0;
+    for (var i = 0u; i < steps; i = i + 1u) {
+        let p = o + dir * (t_enter + dt * (f32(i) + 0.5));
+        let uvw = p * 0.5 + vec3<f32>(0.5);
+        let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r;
+        let tval = transfer(dens);
+        if (tval > 0.0) {
+            let col = colormap(tval);
+            // Opacity integrated over the step length so it's step-count independent.
+            let a = 1.0 - exp(-tval * exposure * dt * 40.0);
+            acc = acc + (1.0 - alpha) * a * col;
+            alpha = alpha + (1.0 - alpha) * a;
+            if (alpha > 0.99) {
+                break;
+            }
+        }
+    }
+    if (alpha <= 0.0) {
+        discard;
+    }
+    return vec4<f32>(acc, 1.0);
+}

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -1,0 +1,147 @@
+//! Application UI state and its mapping to GPU params.
+
+use crate::data::point::AxisBounds;
+use crate::render::point_cloud::PointMode;
+use crate::render::uniforms::ParamsUniform;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransferMode {
+    Linear,
+    Sqrt,
+    Log,
+}
+
+impl TransferMode {
+    fn as_f32(self) -> f32 {
+        match self {
+            TransferMode::Linear => 0.0,
+            TransferMode::Sqrt => 1.0,
+            TransferMode::Log => 2.0,
+        }
+    }
+}
+
+/// Inclusive real-unit window on one axis.
+#[derive(Clone, Copy, Debug)]
+pub struct Window {
+    pub min: f64,
+    pub max: f64,
+}
+
+pub struct AppState {
+    pub bounds: AxisBounds,
+
+    pub render_mode: PointMode,
+
+    // Transfer function / appearance
+    pub transfer: TransferMode,
+    pub i_min: f32,
+    pub i_max: f32,
+    pub exposure: f32,
+    pub colormap_id: u32,
+    pub n_colormaps: u32,
+    pub point_size: f32,
+    pub opacity: f32,
+
+    // Filters
+    pub show_ms1: bool,
+    pub show_ms2: bool,
+    pub rt_window: Window,
+    pub mz_window: Window,
+    pub im_window: Window,
+
+    // Readouts
+    pub fps: f32,
+    pub resident_points: u32,
+    pub capacity: u32,
+    pub total_estimate: u64,
+    pub load_progress: f32,
+    pub downsample_stride: u32,
+    /// Set if the loader thread ended before signaling completion (e.g. panic).
+    pub load_failed: bool,
+}
+
+impl AppState {
+    pub fn new(bounds: AxisBounds, total_estimate: u64, n_colormaps: u32) -> Self {
+        AppState {
+            bounds,
+            render_mode: PointMode::AdditiveDensity,
+            transfer: TransferMode::Log,
+            i_min: 1.0,
+            i_max: 1e5,
+            exposure: 1.0,
+            colormap_id: 0,
+            n_colormaps,
+            point_size: 2.5,
+            opacity: 0.5,
+            show_ms1: true,
+            show_ms2: true,
+            rt_window: Window {
+                min: bounds.rt.min,
+                max: bounds.rt.max,
+            },
+            mz_window: Window {
+                min: bounds.mz.min,
+                max: bounds.mz.max,
+            },
+            im_window: Window {
+                min: bounds.im.min,
+                max: bounds.im.max,
+            },
+            fps: 0.0,
+            resident_points: 0,
+            capacity: 0,
+            total_estimate,
+            load_progress: 0.0,
+            downsample_stride: 1,
+            load_failed: false,
+        }
+    }
+
+    pub fn reset_windows(&mut self) {
+        self.rt_window = Window {
+            min: self.bounds.rt.min,
+            max: self.bounds.rt.max,
+        };
+        self.mz_window = Window {
+            min: self.bounds.mz.min,
+            max: self.bounds.mz.max,
+        };
+        self.im_window = Window {
+            min: self.bounds.im.min,
+            max: self.bounds.im.max,
+        };
+    }
+
+    /// Build the GPU params uniform from the current UI state.
+    pub fn params(&self) -> ParamsUniform {
+        let fmin = self.bounds.normalize(
+            self.mz_window.min,
+            self.im_window.min,
+            self.rt_window.min,
+        );
+        let fmax = self.bounds.normalize(
+            self.mz_window.max,
+            self.im_window.max,
+            self.rt_window.max,
+        );
+        let ms_mask = (self.show_ms1 as u32) | ((self.show_ms2 as u32) << 1);
+        let render_mode = match self.render_mode {
+            PointMode::AdditiveDensity => 0,
+            PointMode::StructuralOpaque => 1,
+        };
+        ParamsUniform {
+            filter_min: [fmin[0], fmin[1], fmin[2], 0.0],
+            filter_max: [fmax[0], fmax[1], fmax[2], 0.0],
+            transfer: [self.transfer.as_f32(), self.i_min, self.i_max, self.exposure],
+            point_size: self.point_size,
+            opacity: self.opacity,
+            _pad0: 0.0,
+            _pad1: 0.0,
+            ms_mask,
+            colormap_id: self.colormap_id,
+            render_mode,
+            n_colormaps: self.n_colormaps.max(1),
+        }
+    }
+}

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -63,6 +63,8 @@ pub struct AppState {
     // Filters
     pub show_ms1: bool,
     pub show_ms2: bool,
+    /// Show the DDA-precursor / DIA-window annotation overlay.
+    pub show_annotations: bool,
     pub rt_window: Window,
     pub mz_window: Window,
     pub im_window: Window,
@@ -96,6 +98,7 @@ impl AppState {
             opacity: 0.5,
             show_ms1: true,
             show_ms2: true,
+            show_annotations: true,
             rt_window: Window {
                 min: bounds.rt.min,
                 max: bounds.rt.max,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -2,7 +2,21 @@
 
 use crate::data::point::AxisBounds;
 use crate::render::point_cloud::PointMode;
-use crate::render::uniforms::ParamsUniform;
+use crate::render::uniforms::{ParamsUniform, VolumeUniform};
+
+/// Top-level visualization mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ViewMode {
+    Points,
+    Volume,
+}
+
+/// Volume raycast style.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VolStyle {
+    Composite,
+    Mip,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TransferMode {
@@ -31,7 +45,10 @@ pub struct Window {
 pub struct AppState {
     pub bounds: AxisBounds,
 
-    pub render_mode: PointMode,
+    pub view_mode: ViewMode,
+    pub point_mode: PointMode,
+    pub vol_style: VolStyle,
+    pub vol_steps: u32,
 
     // Transfer function / appearance
     pub transfer: TransferMode,
@@ -65,7 +82,10 @@ impl AppState {
     pub fn new(bounds: AxisBounds, total_estimate: u64, n_colormaps: u32) -> Self {
         AppState {
             bounds,
-            render_mode: PointMode::AdditiveDensity,
+            view_mode: ViewMode::Points,
+            point_mode: PointMode::AdditiveDensity,
+            vol_style: VolStyle::Composite,
+            vol_steps: 256,
             transfer: TransferMode::Log,
             i_min: 1.0,
             i_max: 1e5,
@@ -126,7 +146,7 @@ impl AppState {
             self.rt_window.max,
         );
         let ms_mask = (self.show_ms1 as u32) | ((self.show_ms2 as u32) << 1);
-        let render_mode = match self.render_mode {
+        let render_mode = match self.point_mode {
             PointMode::AdditiveDensity => 0,
             PointMode::StructuralOpaque => 1,
         };
@@ -141,6 +161,34 @@ impl AppState {
             ms_mask,
             colormap_id: self.colormap_id,
             render_mode,
+            n_colormaps: self.n_colormaps.max(1),
+        }
+    }
+
+    /// Build the volume raycaster uniform; `inv_view_proj` comes from the camera.
+    pub fn volume_uniform(&self, inv_view_proj: [[f32; 4]; 4]) -> VolumeUniform {
+        let bmin = self.bounds.normalize(
+            self.mz_window.min,
+            self.im_window.min,
+            self.rt_window.min,
+        );
+        let bmax = self.bounds.normalize(
+            self.mz_window.max,
+            self.im_window.max,
+            self.rt_window.max,
+        );
+        let style = match self.vol_style {
+            VolStyle::Composite => 0,
+            VolStyle::Mip => 1,
+        };
+        VolumeUniform {
+            inv_view_proj,
+            box_min: [bmin[0], bmin[1], bmin[2], 0.0],
+            box_max: [bmax[0], bmax[1], bmax[2], 0.0],
+            transfer: [self.transfer.as_f32(), self.i_min, self.i_max, self.exposure],
+            steps: self.vol_steps.max(1),
+            style,
+            colormap_id: self.colormap_id,
             n_colormaps: self.n_colormaps.max(1),
         }
     }

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -190,6 +190,9 @@ impl AppState {
             style,
             colormap_id: self.colormap_id,
             n_colormaps: self.n_colormaps.max(1),
+            // Overwritten by the app from VolumeGrid::density_scale() each frame.
+            density_scale: 1.0,
+            _pad: [0.0; 3],
         }
     }
 }

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -1,0 +1,174 @@
+//! egui control panel.
+
+use crate::camera::{AxisView, OrbitCamera, Projection};
+use crate::render::colormap::COLORMAP_NAMES;
+use crate::render::point_cloud::PointMode;
+use crate::state::{AppState, TransferMode};
+
+/// Build the left control panel; mutates state and camera in place.
+pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera) {
+    egui::SidePanel::left("controls")
+        .resizable(true)
+        .default_width(280.0)
+        .show(ctx, |ui| {
+            ui.heading("tims-viewer");
+            ui.separator();
+
+            // ---- Readouts ----
+            ui.label(format!("FPS: {:.0}", state.fps));
+            ui.label(format!(
+                "Points: {} / {} (cap)",
+                fmt_count(state.resident_points as u64),
+                fmt_count(state.capacity as u64)
+            ));
+            ui.label(format!(
+                "Run estimate: {} (×{} downsample)",
+                fmt_count(state.total_estimate),
+                state.downsample_stride
+            ));
+            if state.load_failed {
+                ui.colored_label(egui::Color32::LIGHT_RED, "Load failed (see log)");
+            } else if state.load_progress < 1.0 {
+                ui.add(egui::ProgressBar::new(state.load_progress).show_percentage());
+            } else {
+                ui.label("Load complete");
+            }
+            ui.separator();
+
+            // ---- Render mode ----
+            ui.label("Render mode");
+            ui.horizontal(|ui| {
+                ui.radio_value(
+                    &mut state.render_mode,
+                    PointMode::AdditiveDensity,
+                    "Additive",
+                );
+                ui.radio_value(
+                    &mut state.render_mode,
+                    PointMode::StructuralOpaque,
+                    "Opaque",
+                );
+            });
+            ui.separator();
+
+            // ---- Intensity transfer function ----
+            ui.label("Intensity transfer");
+            ui.horizontal(|ui| {
+                ui.radio_value(&mut state.transfer, TransferMode::Linear, "Lin");
+                ui.radio_value(&mut state.transfer, TransferMode::Sqrt, "Sqrt");
+                ui.radio_value(&mut state.transfer, TransferMode::Log, "Log");
+            });
+            ui.add(
+                egui::Slider::new(&mut state.i_min, 1.0..=1e6)
+                    .logarithmic(true)
+                    .text("i_min"),
+            );
+            ui.add(
+                egui::Slider::new(&mut state.i_max, 10.0..=1e8)
+                    .logarithmic(true)
+                    .text("i_max"),
+            );
+            if state.i_max <= state.i_min {
+                state.i_max = state.i_min * 1.0001;
+            }
+            ui.add(
+                egui::Slider::new(&mut state.exposure, 0.001..=5.0)
+                    .logarithmic(true)
+                    .text("exposure"),
+            );
+
+            egui::ComboBox::from_label("colormap")
+                .selected_text(COLORMAP_NAMES[state.colormap_id as usize])
+                .show_ui(ui, |ui| {
+                    for (i, name) in COLORMAP_NAMES.iter().enumerate() {
+                        ui.selectable_value(&mut state.colormap_id, i as u32, *name);
+                    }
+                });
+            ui.separator();
+
+            // ---- Appearance ----
+            ui.add(egui::Slider::new(&mut state.point_size, 0.5..=12.0).text("point size"));
+            ui.add(egui::Slider::new(&mut state.opacity, 0.02..=1.0).text("opacity"));
+            ui.separator();
+
+            // ---- MS filter ----
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut state.show_ms1, "MS1");
+                ui.checkbox(&mut state.show_ms2, "MS2");
+            });
+            ui.separator();
+
+            // ---- Axis windows ----
+            ui.label("Windows (real units)");
+            axis_window(ui, "RT (s)", &mut state.rt_window, state.bounds.rt.min, state.bounds.rt.max);
+            axis_window(ui, "m/z (Th)", &mut state.mz_window, state.bounds.mz.min, state.bounds.mz.max);
+            axis_window(ui, "1/K0", &mut state.im_window, state.bounds.im.min, state.bounds.im.max);
+            if ui.button("Reset windows").clicked() {
+                state.reset_windows();
+            }
+            ui.separator();
+
+            // ---- Camera ----
+            ui.label("Camera");
+            ui.horizontal(|ui| {
+                if ui.button("Reset").clicked() {
+                    camera.reset();
+                }
+                let mut ortho = camera.projection == Projection::Orthographic;
+                if ui.checkbox(&mut ortho, "Ortho").changed() {
+                    camera.projection = if ortho {
+                        Projection::Orthographic
+                    } else {
+                        Projection::Perspective
+                    };
+                }
+            });
+            ui.horizontal(|ui| {
+                if ui.button("m/z view").clicked() {
+                    camera.set_axis_view(AxisView::Mz);
+                }
+                if ui.button("mob view").clicked() {
+                    camera.set_axis_view(AxisView::Mobility);
+                }
+                if ui.button("RT view").clicked() {
+                    camera.set_axis_view(AxisView::Rt);
+                }
+            });
+        });
+}
+
+fn axis_window(
+    ui: &mut egui::Ui,
+    label: &str,
+    win: &mut crate::state::Window,
+    lo: f64,
+    hi: f64,
+) {
+    ui.label(label);
+    ui.horizontal(|ui| {
+        ui.add(
+            egui::DragValue::new(&mut win.min)
+                .speed((hi - lo) / 500.0)
+                .range(lo..=hi),
+        );
+        ui.label("–");
+        ui.add(
+            egui::DragValue::new(&mut win.max)
+                .speed((hi - lo) / 500.0)
+                .range(lo..=hi),
+        );
+    });
+    if win.min > win.max {
+        win.max = win.min;
+    }
+}
+
+fn fmt_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1e6)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1e3)
+    } else {
+        n.to_string()
+    }
+}

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -3,7 +3,7 @@
 use crate::camera::{AxisView, OrbitCamera, Projection};
 use crate::render::colormap::COLORMAP_NAMES;
 use crate::render::point_cloud::PointMode;
-use crate::state::{AppState, TransferMode};
+use crate::state::{AppState, TransferMode, ViewMode, VolStyle};
 
 /// Build the left control panel; mutates state and camera in place.
 pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera) {
@@ -38,17 +38,34 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
             // ---- Render mode ----
             ui.label("Render mode");
             ui.horizontal(|ui| {
-                ui.radio_value(
-                    &mut state.render_mode,
-                    PointMode::AdditiveDensity,
-                    "Additive",
-                );
-                ui.radio_value(
-                    &mut state.render_mode,
-                    PointMode::StructuralOpaque,
-                    "Opaque",
-                );
+                ui.radio_value(&mut state.view_mode, ViewMode::Points, "Points");
+                ui.radio_value(&mut state.view_mode, ViewMode::Volume, "Volume");
             });
+            match state.view_mode {
+                ViewMode::Points => {
+                    ui.horizontal(|ui| {
+                        ui.radio_value(
+                            &mut state.point_mode,
+                            PointMode::AdditiveDensity,
+                            "Additive",
+                        );
+                        ui.radio_value(
+                            &mut state.point_mode,
+                            PointMode::StructuralOpaque,
+                            "Opaque",
+                        );
+                    });
+                }
+                ViewMode::Volume => {
+                    ui.horizontal(|ui| {
+                        ui.radio_value(&mut state.vol_style, VolStyle::Composite, "Composite");
+                        ui.radio_value(&mut state.vol_style, VolStyle::Mip, "MIP");
+                    });
+                    ui.add(
+                        egui::Slider::new(&mut state.vol_steps, 32..=1024).text("ray steps"),
+                    );
+                }
+            }
             ui.separator();
 
             // ---- Intensity transfer function ----

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -113,6 +113,7 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
                 ui.checkbox(&mut state.show_ms1, "MS1");
                 ui.checkbox(&mut state.show_ms2, "MS2");
             });
+            ui.checkbox(&mut state.show_annotations, "Annotations (precursors / DIA windows)");
             ui.separator();
 
             // ---- Axis windows ----


### PR DESCRIPTION
## What

A new workspace binary crate **`tims-viewer`** — a native, GPU-accelerated, real-time viewer for Bruker timsTOF raw data. It reads `rustdf`/`mscore` directly and streams 4D points (m/z, 1/K0 ion mobility, retention time; value = intensity) straight to the GPU, sidestepping the Python → Plotly → WebGL serialization wall that caps the existing tools (`imspy-vis`, `timsim` GUI) at ~30k–200k points.

## Phase 1 (point-cloud MVP)

- **Streaming loader** on a background thread + bounded crossbeam channel; the cloud builds progressively as data loads. Cancellable sends (no shutdown deadlock) and `Empty`-vs-`Disconnected` handling (loader death surfaced in the UI).
- **Scaling**: global systematic downsampling to a device-limit-derived point budget, with per-point `1/p` weight so additive-density brightness is invariant to the downsample ratio.
- **Two correct render modes**: additive-density (order-independent, exposure/tone-mapped) and structural-opaque (depth-tested).
- **Interaction**: orbit camera (orbit/pan/zoom, perspective + ortho, axis presets) and an egui panel — render mode, RT/m-z/1-K0 windows, transfer function (lin/sqrt/log) + colormap, point size/opacity, MS1/MS2 toggle, FPS/point/progress readouts.
- **`DEMO` mode** generates a synthetic LC-IMS-MS cloud, so the viewer runs with no Bruker data.
- Pinned, mutually-compatible dependency triple (`wgpu 22.1` / `winit 0.30.5` / `egui 0.29.1`); window created in `resumed`, full `SurfaceError` handling, egui texture set/free paired with surface acquisition.

## How to run

```bash
cargo run --release -p tims-viewer -- DEMO            # synthetic, no Bruker data
cargo run --release -p tims-viewer -- /path/to/run.d
```

## Tests

`cargo test -p tims-viewer` → **7 passing**, including a real **offscreen-GPU render** smoke test (compiles the WGSL + runs both pipelines), ceil-stride budget bound, cross-frame systematic-sampling bound over uneven frames, an end-to-end DEMO load, GpuPoint layout, and AxisTransform round-trip.

## Review

Two independent codex review passes (8 + 3 findings); all 11 addressed, and the second pass verified the first pass's fixes. Notable: global systematic sampling (bounded kept count + correct `1/p` weight), positional frame-id validation (rustdf indexes frames by position), and surface-error texture-leak / shutdown-deadlock fixes.

## Notes / scope

- Frame ids are validated as contiguous `1..=N` positional order (the viewer relies on rustdf's position-based frame indexing). The deeper fix would add `ORDER BY Id` inside rustdf's metadata query — out of scope here.
- Next phases (not in this PR): **1.5** GPU compaction / `draw_indirect` visible-set reduction (the real scaling lever); **2** volume raycasting; **3** stratified sampling, annotation overlays, screenshot export.