### PR TITLE
timsim from_findings: optional shared reference_median to preserve cross-sample ratios

### DIFF
--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/load_findings.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/load_findings.py
@@ -63,6 +63,7 @@ def load_findings(
     inverse_mobility_std_mean: float,
     intensity_multiplier: float,
     verbose: bool,
+    reference_median: float | None = None,
 ) -> FindingsResult:
     """Read a standardized findings table and build TimSim DataFrames.
 
@@ -82,6 +83,13 @@ def load_findings(
         intensity_multiplier: User-facing knob applied *after* the
             auto-scaling (e.g. 10.0 for 10x brighter, 0.1 for 10x dimmer).
         verbose: Whether to log progress.
+        reference_median: Optional fixed intensity median used as the
+            event-scaling denominator instead of this sample's own median.
+            Default None = per-sample median (legacy behaviour). Pass the
+            SAME value to every condition of a multi-sample experiment to
+            preserve cross-sample (e.g. A/B) intensity ratios — otherwise the
+            per-sample median differs between conditions and silently rescales
+            every cross-sample ratio by median(condition_i)/median(condition_j).
 
     Returns:
         FindingsResult with peptides, proteins, ions (if charge provided),
@@ -155,11 +163,13 @@ def load_findings(
             )
 
         peptides = _build_peptides_from_ions(ions, deduped, upscale_factor,
-                                              intensity_multiplier, has_rt, verbose)
+                                              intensity_multiplier, has_rt, verbose,
+                                              reference_median)
     else:
         # No ions to build — peptides directly from deduped rows
         peptides = _build_peptides_no_charge(deduped, upscale_factor,
-                                              intensity_multiplier, has_rt, verbose)
+                                              intensity_multiplier, has_rt, verbose,
+                                              reference_median)
         ions = None
 
     if len(peptides) == 0:
@@ -429,6 +439,7 @@ def _build_peptides_from_ions(
     intensity_multiplier: float,
     has_rt: bool,
     verbose: bool,
+    reference_median: float | None = None,
 ) -> pd.DataFrame:
     """Build peptides from the surviving ion set (charge path).
 
@@ -466,10 +477,11 @@ def _build_peptides_from_ions(
     peptide_intensities = ions.groupby("sequence")["relative_abundance"].first()  # placeholder
     # Recompute from deduped to include all charge-state intensities
     ion_intensity_by_seq = deduped[deduped["sequence"].isin(surviving_set)].groupby("sequence")["intensity"].sum()
-    median_intensity = _safe_median(ion_intensity_by_seq)
+    median_intensity = reference_median if reference_median else _safe_median(ion_intensity_by_seq)
 
     if verbose:
-        logger.info(f"  Intensity scaling: median={median_intensity:.0f} -> "
+        src = "reference (shared)" if reference_median else "per-sample"
+        logger.info(f"  Intensity scaling: median={median_intensity:.0f} ({src}) -> "
                      f"upscale_factor={upscale_factor}")
 
     peptide_rows = []
@@ -521,15 +533,17 @@ def _build_peptides_no_charge(
     intensity_multiplier: float,
     has_rt: bool,
     verbose: bool,
+    reference_median: float | None = None,
 ) -> pd.DataFrame:
     """Build peptides when charge column is absent (each row = one peptide)."""
     unique_proteins = deduped["protein"].unique()
     protein_name_to_id = {name: idx for idx, name in enumerate(unique_proteins)}
 
-    median_intensity = _safe_median(deduped["intensity"])
+    median_intensity = reference_median if reference_median else _safe_median(deduped["intensity"])
 
     if verbose:
-        logger.info(f"  Intensity scaling: median={median_intensity:.0f} -> "
+        src = "reference (shared)" if reference_median else "per-sample"
+        logger.info(f"  Intensity scaling: median={median_intensity:.0f} ({src}) -> "
                      f"upscale_factor={upscale_factor}")
 
     peptide_rows = []

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/load_findings.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/load_findings.py
@@ -87,14 +87,22 @@ def load_findings(
             event-scaling denominator instead of this sample's own median.
             Default None = per-sample median (legacy behaviour). Pass the
             SAME value to every condition of a multi-sample experiment to
-            preserve cross-sample (e.g. A/B) intensity ratios — otherwise the
-            per-sample median differs between conditions and silently rescales
-            every cross-sample ratio by median(condition_i)/median(condition_j).
+            preserve cross-sample (e.g. A/B) intensity ratios — otherwise each
+            condition divides by its own median, so (events = intensity/median)
+            any cross-sample ratio events_i/events_j is silently scaled by
+            median_j/median_i, which is != 1 when the conditions' intensity
+            distributions differ. Must be finite and > 0.
 
     Returns:
         FindingsResult with peptides, proteins, ions (if charge provided),
         and flags indicating which optional columns were present.
     """
+    if reference_median is not None and not (
+        np.isfinite(reference_median) and reference_median > 0
+    ):
+        raise ValueError(
+            f"reference_median must be a finite positive number, got {reference_median!r}"
+        )
 
     # ------------------------------------------------------------------
     # 1. Read and validate the input table
@@ -477,10 +485,10 @@ def _build_peptides_from_ions(
     peptide_intensities = ions.groupby("sequence")["relative_abundance"].first()  # placeholder
     # Recompute from deduped to include all charge-state intensities
     ion_intensity_by_seq = deduped[deduped["sequence"].isin(surviving_set)].groupby("sequence")["intensity"].sum()
-    median_intensity = reference_median if reference_median else _safe_median(ion_intensity_by_seq)
+    median_intensity = reference_median if reference_median is not None else _safe_median(ion_intensity_by_seq)
 
     if verbose:
-        src = "reference (shared)" if reference_median else "per-sample"
+        src = "reference (shared)" if reference_median is not None else "per-sample"
         logger.info(f"  Intensity scaling: median={median_intensity:.0f} ({src}) -> "
                      f"upscale_factor={upscale_factor}")
 
@@ -539,10 +547,10 @@ def _build_peptides_no_charge(
     unique_proteins = deduped["protein"].unique()
     protein_name_to_id = {name: idx for idx, name in enumerate(unique_proteins)}
 
-    median_intensity = reference_median if reference_median else _safe_median(deduped["intensity"])
+    median_intensity = reference_median if reference_median is not None else _safe_median(deduped["intensity"])
 
     if verbose:
-        src = "reference (shared)" if reference_median else "per-sample"
+        src = "reference (shared)" if reference_median is not None else "per-sample"
         logger.info(f"  Intensity scaling: median={median_intensity:.0f} ({src}) -> "
                      f"upscale_factor={upscale_factor}")
 

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -290,6 +290,10 @@ def get_default_settings() -> dict:
         'from_findings': False,
         'findings_path': None,
         'intensity_multiplier': 1.0,
+        # Shared event-scaling denominator across conditions; None = per-sample
+        # median (legacy). Set the SAME value for every condition (A/B/...) of a
+        # multi-sample experiment to preserve cross-sample intensity ratios.
+        'findings_reference_median': None,
         'use_bruker_sdk': True,
 
         # Peptide digestion
@@ -1016,6 +1020,7 @@ def main():
             inverse_mobility_std_mean=config.inverse_mobility_std_mean,
             intensity_multiplier=config.intensity_multiplier,
             verbose=not config.silent_mode,
+            reference_median=config.findings_reference_median,
         )
         peptides = findings_result.peptides
         proteins = findings_result.proteins

--- a/packages/imspy-simulation/tests/test_load_findings.py
+++ b/packages/imspy-simulation/tests/test_load_findings.py
@@ -615,3 +615,51 @@ class TestRegressions:
 
         assert events_10x > events_1x
         assert events_10x == pytest.approx(events_1x * 10, rel=0.01)
+
+
+# ---------------------------------------------------------------------------
+# reference_median: shared event-scaling denominator preserves cross-sample ratios
+# ---------------------------------------------------------------------------
+
+class TestReferenceMedian:
+    """events = intensity / median * upscale. With the per-sample median, two
+    conditions whose intensity distributions differ rescale cross-sample ratios
+    by median_j/median_i. A shared reference_median removes that."""
+
+    SHARED = "SHAREDPEPTIDEK"          # present in both samples
+    _FILLERS = ["AAAAAAAK", "DDDDDDDK", "EEEEEEEK"]
+
+    def _events(self, tmp_path, name, shared_int, filler_int, reference_median):
+        # no charge column -> simplest (no_charge) path; wide ranges so nothing is filtered
+        df = pd.DataFrame({
+            "protein": ["P0"] + [f"P{i+1}" for i in range(len(self._FILLERS))],
+            "sequence": [self.SHARED] + self._FILLERS,
+            "intensity": [float(shared_int)] + [float(filler_int)] * len(self._FILLERS),
+        })
+        path = tmp_path / f"{name}.tsv"
+        df.to_csv(path, sep="\t", index=False)
+        res = load_findings(str(path), rt_lower=0.0, rt_upper=1e9, mz_lower=0.0,
+                            mz_upper=1e9, im_lower=0.0, im_upper=2.0,
+                            upscale_factor=100_000, inverse_mobility_std_mean=0.009,
+                            intensity_multiplier=1.0, verbose=False,
+                            reference_median=reference_median)
+        pep = res.peptides.set_index("sequence")
+        return float(pep.loc[self.SHARED, "events"])
+
+    def test_shared_reference_preserves_ratio(self, tmp_path):
+        # A: shared=100, fillers=50 (median 50); B: shared=300, fillers=200 (median 200)
+        # seed ratio B/A for the shared peptide = 3.0
+        ea = self._events(tmp_path, "A", 100, 50, reference_median=100.0)
+        eb = self._events(tmp_path, "B", 300, 200, reference_median=100.0)
+        assert eb / ea == pytest.approx(3.0, rel=0.01)
+
+    def test_per_sample_median_distorts_ratio(self, tmp_path):
+        # legacy behaviour (reference_median=None): ratio scaled by median_A/median_B = 50/200
+        ea = self._events(tmp_path, "A", 100, 50, reference_median=None)
+        eb = self._events(tmp_path, "B", 300, 200, reference_median=None)
+        assert eb / ea == pytest.approx(3.0 * 50.0 / 200.0, rel=0.01)  # = 0.75, NOT 3.0
+
+    @pytest.mark.parametrize("bad", [0.0, -1.0, float("nan"), float("inf")])
+    def test_invalid_reference_raises(self, tmp_path, bad):
+        with pytest.raises(ValueError, match="reference_median"):
+            self._events(tmp_path, "x", 100, 50, reference_median=bad)


### PR DESCRIPTION
## Problem
`load_findings` scales events by **each sample's own** median intensity:
```
events = total_intensity / median_intensity * upscale_factor * intensity_multiplier
```
For a multi-condition experiment (e.g. an A/B spike-in benchmark), Sample A and B have different intensity distributions, so `median_A != median_B` and **every cross-sample ratio is silently rescaled by `median(A)/median(B)`**.

Measured on an A/B plasma benchmark (PlasmaBENCH), this distorted the *simulated ground-truth* ratios uniformly:

| species | nominal A/B | simulated (blueprint) |
|---|---|---|
| yeast | 3.0 | ~2.1 |
| E. coli | 0.5 | ~0.35 |
| human | 1.0 | **~0.74** |

A single factor (= `median(A)/median(B)` ≈ 0.74) explains all three species — the human=0.74 (should be 1.0) is the smoking gun. (It was hidden in analyses that human-anchor the ratios, since a uniform factor cancels; it surfaces wherever the truth ratios are used directly or anchored on an external reference.)

## Fix
Add an optional `reference_median` parameter (config key `findings_reference_median`, **default `None` = unchanged per-sample behaviour**). Pass the **same** value to every condition of a multi-sample experiment → they share one event-scaling denominator → cross-sample (A/B) intensity ratios are preserved. Absolute per-sample brightness then reflects real composition differences (calibrate via `intensity_multiplier`).

## Compatibility
Fully backward-compatible: with `reference_median=None` (the default) behaviour is identical to before. Only the verbose log line gains a `(per-sample)`/`(reference shared)` tag.

## Files
- `load_findings.py`: `reference_median` param threaded into both `_build_peptides_from_ions` and `_build_peptides_no_charge`.
- `simulator.py`: `findings_reference_median` config default + passed to `load_findings`.