### PR TITLE
Thermo dispatch (post-#408): superimpose mode, ground-truth eval, Exploris, 150K-scale memory fixes

### DIFF
--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -602,10 +602,13 @@ impl PyActivationPolicy {
 /// profile / MS2 per-window fragments), and authors it into its slot. Returns
 /// `(scans, ms1, ms2, ms2_nonempty, overflow_cleared, checksum_valid)`. Requires
 /// the `thermo` feature; the DB must have been built from this template (frames
-/// 1:1 with template slots), else a structured error is raised.
+/// 1:1 with template slots), else a structured error is raised. `superimpose_ppm`
+/// `0` (default) replaces the template signal (pure simulated output); `>0` keeps
+/// the template's real signal and overlays simulated peaks on top (real⊕sim), using
+/// the value as the MS2 centroid merge tolerance in ppm.
 #[cfg(feature = "thermo")]
 #[pyfunction]
-#[pyo3(signature = (db_path, template_path, out_path, num_threads=4, quad_k=15.0, max_ms1_peaks=400, max_ms2_peaks=120, precursor_noise_ppm=0.0, fragment_noise_ppm=0.0))]
+#[pyo3(signature = (db_path, template_path, out_path, num_threads=4, quad_k=15.0, max_ms1_peaks=400, max_ms2_peaks=120, precursor_noise_ppm=0.0, fragment_noise_ppm=0.0, superimpose_ppm=0.0))]
 pub fn write_astral_raw(
     py: Python<'_>,
     db_path: &str,
@@ -617,10 +620,15 @@ pub fn write_astral_raw(
     max_ms2_peaks: usize,
     precursor_noise_ppm: f64,
     fragment_noise_ppm: f64,
+    superimpose_ppm: f64,
 ) -> PyResult<(usize, usize, usize, usize, usize, bool)> {
     use rustdf::sim::astral_dispatch::{write_astral_raw as run, AstralWriteOptions};
     use std::path::Path;
-    for (name, v) in [("precursor_noise_ppm", precursor_noise_ppm), ("fragment_noise_ppm", fragment_noise_ppm)] {
+    for (name, v) in [
+        ("precursor_noise_ppm", precursor_noise_ppm),
+        ("fragment_noise_ppm", fragment_noise_ppm),
+        ("superimpose_ppm", superimpose_ppm),
+    ] {
         if !v.is_finite() || v < 0.0 {
             return Err(PyValueError::new_err(format!("{name} must be finite and >= 0, got {v}")));
         }
@@ -632,6 +640,7 @@ pub fn write_astral_raw(
         max_ms2_peaks,
         precursor_noise_ppm,
         fragment_noise_ppm,
+        superimpose_ppm,
     };
     let s = py
         .allow_threads(|| {

--- a/packages/imspy-simulation/pyproject.toml
+++ b/packages/imspy-simulation/pyproject.toml
@@ -33,6 +33,7 @@ gui = [
 [project.scripts]
 timsim = "imspy_simulation.timsim.simulator:main"
 timsim-gui = "imspy_simulation.timsim.gui:main"
+timsim-eval = "imspy_simulation.timsim.groundtruth_eval:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/groundtruth_eval.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/groundtruth_eval.py
@@ -47,6 +47,73 @@ def _strip_mods(seq: str) -> str:
     return _UNIMOD.sub("", seq).replace("[", "").replace("]", "")
 
 
+# ----------------------------------------------------------------------------
+# Precursor-level FDP (peptidoform-aware). The bare-backbone metrics above are a
+# diagnostic; FDR is controlled per peptidoform+charge, so the realized FDP must
+# be measured on a canonical modified-sequence key consistent across the truth DB
+# (UNIMOD brackets), DiaNN (`(UniMod:n)` in Modified.Sequence) and alphaDIA
+# (stripped sequence + `mods` names + `mod_sites`). Validated: the same
+# peptidoform yields an identical key from all three sources.
+# ----------------------------------------------------------------------------
+
+# alphaDIA mod NAME (before '@') -> UNIMOD id.
+_MOD_NAME_TO_UNIMOD = {
+    "Oxidation": 35, "Carbamidomethyl": 4, "Acetyl": 1,
+    "Phospho": 21, "Deamidated": 7, "GlyGly": 121,
+}
+_INLINE_MOD = re.compile(r"[\(\[](?:UniMod|UNIMOD):(\d+)[\)\]]", re.I)
+
+
+def _il_norm(s: str) -> str:
+    """Collapse the isobaric I/L ambiguity (I->L) so mass-equal calls don't count
+    as backbone-distinct."""
+    return s.replace("I", "L")
+
+
+def _canon_inline(seq: str) -> tuple:
+    """Parse inline UNIMOD notation — ``M[UNIMOD:35]K`` (truth) or
+    ``M(UniMod:35)K`` (DiaNN) — into ``(stripped, {pos_1based: unimod_id})``.
+    A mod token before any residue is N-term (position 0)."""
+    mods, stripped, pos, i = {}, [], 0, 0
+    while i < len(seq):
+        m = _INLINE_MOD.match(seq, i)
+        if m:
+            mods[pos] = int(m.group(1))
+            i = m.end()
+        elif seq[i].isalpha():
+            pos += 1
+            stripped.append(seq[i])
+            i += 1
+        else:
+            i += 1
+    return "".join(stripped), mods
+
+
+def _canon_alphadia(stripped: str, mods_str, sites_str) -> tuple:
+    """alphaDIA (stripped, ``mods`` names, ``mod_sites`` 1-based) ->
+    ``(stripped, {pos: unimod_id})``. Unknown mod names map to -1 (a sentinel that
+    cannot match a truth id, so it counts as a peptidoform mismatch rather than
+    silently matching)."""
+    mods = {}
+    if isinstance(mods_str, str) and mods_str:
+        for nm, st in zip(mods_str.split(";"), str(sites_str).split(";")):
+            uid = _MOD_NAME_TO_UNIMOD.get(nm.split("@")[0], -1)
+            try:
+                mods[int(st)] = uid
+            except ValueError:
+                continue
+    return stripped, mods
+
+
+def _pf_key(stripped: str, mods: Dict[int, int], il: bool = True) -> str:
+    s = _il_norm(stripped) if il else stripped
+    return s + "/" + ";".join(f"{p}:{i}" for p, i in sorted(mods.items()))
+
+
+def _bb_key(stripped: str, il: bool = True) -> str:
+    return _il_norm(stripped) if il else stripped
+
+
 @dataclass
 class GroundTruthMetrics:
     identified: int                      # identified precursors matched to a simulated backbone+charge
@@ -209,13 +276,116 @@ def evaluate_run(db_path: str, report_path: str, engine: str = "diann") -> Groun
     return evaluate(load_simulated_truth(db_path), load_report(report_path, engine))
 
 
+def load_precursor_truth(db_path: str, il_normalize: bool = True) -> Dict[str, object]:
+    """Rendered-observable simulated precursors as canonical keys. 'Rendered-observable'
+    = a non-decoy ion that has >=1 fragment row (it was actually fragmented/rendered),
+    not mere DB membership. Returns sets of (backbone, charge) and (peptidoform, charge),
+    plus a {(backbone,charge): set(mod-id-multiset)} map to separate wrong-site
+    localization (right backbone + right mod composition, wrong position — unresolvable)
+    from genuine wrong-modification calls."""
+    con = sqlite3.connect(db_path)
+    df = pd.read_sql(
+        "SELECT DISTINCT i.sequence, i.charge FROM ions i "
+        "JOIN fragment_ions f ON i.ion_id = f.ion_id "
+        "JOIN peptides p ON i.peptide_id = p.peptide_id WHERE p.decoy = 0",
+        con,
+    )
+    con.close()
+    bb, pf = set(), set()
+    bb_multiset: Dict[tuple, set] = {}
+    for seq, ch in zip(df["sequence"], df["charge"]):
+        st, mods = _canon_inline(seq)
+        c = int(ch)
+        bk = (_bb_key(st, il_normalize), c)
+        bb.add(bk)
+        pf.add((_pf_key(st, mods, il_normalize), c))
+        bb_multiset.setdefault(bk, set()).add(tuple(sorted(mods.values())))
+    return {"bb": bb, "pf": pf, "bb_multiset": bb_multiset, "n": len(df)}
+
+
+def load_precursor_report(path: str, engine: str = "diann") -> pd.DataFrame:
+    """Normalize a report to per-row canonical keys + q-value, WITHOUT a q-filter (the
+    caller thresholds for the curve). Columns: bb, pf, charge, mod_multiset, q."""
+    engine = engine.lower()
+    rows = []
+    if engine == "diann":
+        d = pd.read_parquet(path) if path.endswith(".parquet") else pd.read_csv(path, sep="\t")
+        for ms, ch, q in zip(d["Modified.Sequence"].astype(str),
+                             d["Precursor.Charge"].astype(int), d["Q.Value"].astype(float)):
+            st, mods = _canon_inline(ms)
+            rows.append((_bb_key(st), _pf_key(st, mods), int(ch),
+                         tuple(sorted(mods.values())), float(q)))
+    elif engine == "alphadia":
+        a = pd.read_parquet(path) if path.endswith(".parquet") else pd.read_csv(path, sep="\t")
+        if "precursor.decoy" in a.columns:
+            a = a[a["precursor.decoy"] == 0]
+        for st, mo, si, ch, q in zip(a["precursor.sequence"].astype(str), a["precursor.mods"],
+                                     a["precursor.mod_sites"], a["precursor.charge"].astype(int),
+                                     a["precursor.qval"].astype(float)):
+            _, mods = _canon_alphadia(st, mo, si)
+            rows.append((_bb_key(st), _pf_key(st, mods), int(ch),
+                         tuple(sorted(mods.values())), float(q)))
+    else:
+        raise ValueError(f"unknown engine '{engine}' (expected 'diann' or 'alphadia')")
+    return pd.DataFrame(rows, columns=["bb", "pf", "charge", "mod_multiset", "q"])
+
+
+def precursor_fdp_breakdown(truth: Dict[str, object], report: pd.DataFrame,
+                            q_thresholds=(0.001, 0.005, 0.01, 0.02, 0.05)) -> list:
+    """Realized precursor FDP at each q threshold, dedup on (peptidoform, charge), with
+    the genuine / localization-ambiguous / wrong-backbone split. 'genuine' excludes
+    unresolvable localization (right backbone + same mod-id multiset, wrong site)."""
+    tbb, tpf, tms = truth["bb"], truth["pf"], truth["bb_multiset"]
+    out = []
+    for q in q_thresholds:
+        r = report[report["q"] <= q].drop_duplicates(subset=["pf", "charge"])
+        n = len(r)
+        correct = wrong_bb = wrong_mod = loc_ambig = 0
+        for bb, pf, ch, ms in zip(r["bb"], r["pf"], r["charge"], r["mod_multiset"]):
+            if (pf, ch) in tpf:
+                correct += 1
+            elif (bb, ch) not in tbb:
+                wrong_bb += 1
+            elif ms in tms.get((bb, ch), set()):
+                loc_ambig += 1          # right backbone + mod composition, wrong site
+            else:
+                wrong_mod += 1
+        genuine = wrong_bb + wrong_mod
+        bbr = report[report["q"] <= q].drop_duplicates(subset=["bb", "charge"])
+        nbb = len(bbr)
+        bb_false = sum((b, c) not in tbb for b, c in zip(bbr["bb"], bbr["charge"]))
+        out.append({
+            "q": q, "n_precursors": n,
+            "fdp_backbone": bb_false / nbb if nbb else float("nan"),
+            "fdp_peptidoform_strict": (n - correct) / n if n else float("nan"),
+            "fdp_peptidoform_genuine": genuine / n if n else float("nan"),
+            "localization_ambiguous": loc_ambig,
+            "wrong_backbone": wrong_bb, "wrong_mod_composition": wrong_mod,
+        })
+    return out
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Ground-truth eval of a TimSim run vs a DIA search report.")
     ap.add_argument("--db", required=True, help="path to synthetic_data.db")
     ap.add_argument("--report", required=True, help="path to the search report (DiaNN parquet/tsv, or alphaDIA)")
     ap.add_argument("--engine", default="diann", choices=["diann", "alphadia"])
     ap.add_argument("--out", default=None, help="optional path to write metrics JSON")
+    ap.add_argument("--precursor-fdp", action="store_true",
+                    help="precursor-level FDP-vs-q (peptidoform-aware) with the genuine / "
+                         "localization-ambiguous / wrong-backbone breakdown")
     a = ap.parse_args()
+    if a.precursor_fdp:
+        truth = load_precursor_truth(a.db)
+        report = load_precursor_report(a.report, a.engine)
+        bd = precursor_fdp_breakdown(truth, report)
+        payload = {"rendered_observable_precursors": truth["n"],
+                   "report_rows": int(len(report)), "engine": a.engine, "curve": bd}
+        print(json.dumps(payload, indent=2))
+        if a.out:
+            with open(a.out, "w") as f:
+                json.dump(payload, f, indent=2)
+        return
     m = evaluate_run(a.db, a.report, a.engine)
     print(m.to_json())
     if a.out:

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/groundtruth_eval.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/groundtruth_eval.py
@@ -1,0 +1,204 @@
+"""Ground-truth evaluation of a simulated run against a search-engine report.
+
+Given a TimSim ``synthetic_data.db`` (the ground truth: exactly which peptides, at
+which charges, retention times, and abundances were simulated) and a DIA search report
+(DiaNN or alphaDIA), compute the validation metrics:
+
+- **RT correlation**     — reported retention time vs simulated apex RT (Pearson +
+  median absolute error). Tests that the render places elution at the intended RT.
+- **Charge accuracy**    — fraction of identified precursors whose charge was actually
+  simulated for that peptide backbone.
+- **Empirical FDR**      — entrapment: identified backbones that were NOT simulated /
+  total identified. Validates the engine's FDR control on the data (meaningful only
+  when searching a library larger than the simulated set, e.g. the full proteome).
+- **Quant correlation**  — reported quantity vs simulated abundance
+  (``events × relative_abundance``), log10–log10 Pearson, across the dynamic range.
+- **Recall by abundance**— detection rate per simulated-abundance quartile (a flat
+  curve implies an interference/intensity-model ceiling; a rising curve implies a
+  realistic dynamic-range limit).
+
+Instrument-agnostic: works for Bruker, Astral, or Orbitrap runs alike — it only needs
+the DB + a report. See also the integration framework (``timsim.integration.eval``)
+for the CI-style pass/fail harness; this module is the reusable metric core.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from dataclasses import asdict, dataclass
+from typing import Dict, Optional
+
+import numpy as np
+import pandas as pd
+
+_UNIMOD = re.compile(r"\[UNIMOD:\d+\]")
+
+
+def _strip_mods(seq: str) -> str:
+    """Backbone (bare residues) of a UNIMOD-bracket sequence, e.g.
+    ``M[UNIMOD:35]C[UNIMOD:4]K`` -> ``MCK``."""
+    return _UNIMOD.sub("", seq).replace("[", "").replace("]", "")
+
+
+@dataclass
+class GroundTruthMetrics:
+    identified: int                      # identified precursors matched to a simulated backbone+charge
+    reported_total: int                  # total precursors in the report
+    simulated_ions: int                  # simulated (target) precursor ions
+    rt_pearson: float
+    rt_median_abs_error: float           # in the report's RT unit (minutes)
+    charge_accuracy: float               # of matched-backbone IDs, fraction at a simulated charge
+    empirical_fdr: float                 # identified backbones not in the simulated set / reported_total
+    empirical_fdr_n_false: int
+    quant_log_pearson: float
+    quant_log_spearman: float
+    quant_dynamic_range_orders: float
+    recall_by_abundance_quartile: Dict[str, float]
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+def load_simulated_truth(db_path: str) -> pd.DataFrame:
+    """Load the simulated (non-decoy) precursor ions with backbone, charge, apex RT
+    (converted seconds->minutes), and abundance (``events × relative_abundance``)."""
+    con = sqlite3.connect(db_path)
+    df = pd.read_sql(
+        "SELECT i.sequence, i.charge, i.relative_abundance, "
+        "p.events, p.retention_time_gru_predictor AS rt_s "
+        "FROM ions i JOIN peptides p ON i.peptide_id = p.peptide_id "
+        "WHERE p.decoy = 0",
+        con,
+    )
+    con.close()
+    df["bb"] = df["sequence"].map(_strip_mods)
+    df["sim_rt"] = df["rt_s"] / 60.0                      # DB stores seconds; reports use minutes
+    df["sim_quantity"] = df["events"] * df["relative_abundance"]
+    return df
+
+
+def load_report(path: str, engine: str = "diann") -> pd.DataFrame:
+    """Normalize a search report to columns: ``bb, charge, rt, quantity``.
+
+    engine='diann': a DiaNN ``report.parquet``/``.tsv``
+    (Stripped.Sequence, Precursor.Charge, RT, Precursor.Quantity).
+    engine='alphadia': an alphaDIA ``precursor.tsv``/parquet
+    (sequence, charge, rt, ...)."""
+    engine = engine.lower()
+    if engine == "diann":
+        r = pd.read_parquet(path) if path.endswith(".parquet") else pd.read_csv(path, sep="\t")
+        return pd.DataFrame({
+            "bb": r["Stripped.Sequence"].astype(str),
+            "charge": r["Precursor.Charge"].astype(int),
+            "rt": r["RT"].astype(float),
+            "quantity": r.get("Precursor.Quantity", pd.Series(np.nan, index=r.index)).astype(float),
+        })
+    if engine == "alphadia":
+        r = pd.read_parquet(path) if path.endswith(".parquet") else pd.read_csv(path, sep="\t")
+        # alphaDIA precursor table: sequence (stripped), charge, rt (seconds), intensity
+        seq_col = next(c for c in ("sequence", "Sequence", "stripped_sequence") if c in r.columns)
+        rt_col = next((c for c in ("rt", "rt_observed", "rt_calibrated") if c in r.columns), None)
+        q_col = next((c for c in ("intensity", "quantity", "sum_b_ion_intensity") if c in r.columns), None)
+        rt = r[rt_col].astype(float) if rt_col else pd.Series(np.nan, index=r.index)
+        if rt_col and rt.max() > 200:   # heuristic: alphaDIA rt in seconds -> minutes
+            rt = rt / 60.0
+        return pd.DataFrame({
+            "bb": r[seq_col].map(_strip_mods),
+            "charge": r["charge"].astype(int),
+            "rt": rt,
+            "quantity": r[q_col].astype(float) if q_col else pd.Series(np.nan, index=r.index),
+        })
+    raise ValueError(f"unknown engine '{engine}' (expected 'diann' or 'alphadia')")
+
+
+def evaluate(truth: pd.DataFrame, report: pd.DataFrame) -> GroundTruthMetrics:
+    """Compute ground-truth metrics from a simulated-truth frame and a normalized report."""
+    from scipy.stats import pearsonr, spearmanr
+
+    sim_bb = set(truth["bb"])
+    sim_bc = set(zip(truth["bb"], truth["charge"]))
+    bb_charges: Dict[str, set] = {}
+    for b, c in zip(truth["bb"], truth["charge"]):
+        bb_charges.setdefault(b, set()).add(int(c))
+    sim_rt = dict(zip(truth["bb"], truth["sim_rt"]))            # apex RT per backbone
+    sim_q = truth.groupby(["bb", "charge"])["sim_quantity"].sum().to_dict()
+
+    n = len(report)
+    rep_pairs = list(zip(report["bb"], report["charge"]))
+    false_bb = [b not in sim_bb for b in report["bb"]]
+    empirical_fdr = float(np.mean(false_bb)) if n else 0.0
+
+    matched = report[report["bb"].isin(sim_bb)].copy()
+    # RT correlation on matched backbones
+    matched["sim_rt"] = matched["bb"].map(sim_rt)
+    rt_ok = matched.dropna(subset=["rt", "sim_rt"])
+    if len(rt_ok) >= 2 and rt_ok["rt"].std() > 0 and rt_ok["sim_rt"].std() > 0:
+        rt_pearson = float(pearsonr(rt_ok["rt"], rt_ok["sim_rt"])[0])
+        rt_mae = float(np.median(np.abs(rt_ok["rt"] - rt_ok["sim_rt"])))
+    else:
+        rt_pearson, rt_mae = float("nan"), float("nan")
+    # charge accuracy
+    charge_acc = float(np.mean([
+        c in bb_charges.get(b, set()) for b, c in zip(matched["bb"], matched["charge"])
+    ])) if len(matched) else float("nan")
+    # quant correlation (log-log) on matched backbone+charge with positive quantity
+    matched["sim_q"] = [sim_q.get((b, c)) for b, c in zip(matched["bb"], matched["charge"])]
+    q = matched.dropna(subset=["sim_q", "quantity"])
+    q = q[(q["sim_q"] > 0) & (q["quantity"] > 0)]
+    if len(q) >= 2:
+        lr, ls = np.log10(q["quantity"].values), np.log10(q["sim_q"].values)
+        quant_p = float(pearsonr(lr, ls)[0])
+        quant_s = float(spearmanr(lr, ls)[0])
+        dyn = float(np.log10(q["sim_q"].max() / q["sim_q"].min()))
+    else:
+        quant_p = quant_s = dyn = float("nan")
+    # recall by simulated-abundance quartile (over all simulated ions)
+    ident_pairs = set(rep_pairs)
+    t = truth.copy()
+    t["found"] = [(b, c) in ident_pairs for b, c in zip(t["bb"], t["charge"])]
+    recall_q: Dict[str, float] = {}
+    if len(t) >= 4:
+        t["q"] = pd.qcut(t["sim_quantity"].rank(method="first"), 4,
+                         labels=["Q1_low", "Q2", "Q3", "Q4_high"])
+        recall_q = {str(k): round(float(v), 4)
+                    for k, v in t.groupby("q", observed=True)["found"].mean().items()}
+
+    return GroundTruthMetrics(
+        identified=int(sum((b, c) in sim_bc for b, c in rep_pairs)),
+        reported_total=n,
+        simulated_ions=len(truth),
+        rt_pearson=rt_pearson,
+        rt_median_abs_error=rt_mae,
+        charge_accuracy=charge_acc,
+        empirical_fdr=empirical_fdr,
+        empirical_fdr_n_false=int(sum(false_bb)),
+        quant_log_pearson=quant_p,
+        quant_log_spearman=quant_s,
+        quant_dynamic_range_orders=dyn,
+        recall_by_abundance_quartile=recall_q,
+    )
+
+
+def evaluate_run(db_path: str, report_path: str, engine: str = "diann") -> GroundTruthMetrics:
+    """Convenience: load DB + report and evaluate."""
+    return evaluate(load_simulated_truth(db_path), load_report(report_path, engine))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Ground-truth eval of a TimSim run vs a DIA search report.")
+    ap.add_argument("--db", required=True, help="path to synthetic_data.db")
+    ap.add_argument("--report", required=True, help="path to the search report (DiaNN parquet/tsv, or alphaDIA)")
+    ap.add_argument("--engine", default="diann", choices=["diann", "alphadia"])
+    ap.add_argument("--out", default=None, help="optional path to write metrics JSON")
+    a = ap.parse_args()
+    m = evaluate_run(a.db, a.report, a.engine)
+    print(m.to_json())
+    if a.out:
+        with open(a.out, "w") as f:
+            f.write(m.to_json())
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/groundtruth_eval.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/groundtruth_eval.py
@@ -8,9 +8,14 @@ which charges, retention times, and abundances were simulated) and a DIA search 
   median absolute error). Tests that the render places elution at the intended RT.
 - **Charge accuracy**    — fraction of identified precursors whose charge was actually
   simulated for that peptide backbone.
-- **Empirical FDR**      — entrapment: identified backbones that were NOT simulated /
-  total identified. Validates the engine's FDR control on the data (meaningful only
-  when searching a library larger than the simulated set, e.g. the full proteome).
+- **FDP** (false discovery proportion) — identified backbones NOT in the simulated set
+  / total identified. This is the *realized* false fraction measured against the
+  COMPLETE ground truth (we know exactly what was simulated) — NOT an FDR estimate, and
+  NOT entrapment. (FDR is the expected FDP an estimator targets; entrapment estimates
+  FDR by spiking known non-target sequences as a separate axis — neither is needed here
+  since the truth is known.) Meaningful only when the search space exceeds the simulated
+  set (library-free / full proteome); assumes the run has no blank/noise-derived real
+  IDs (true today — only simulated-peptide signal is rendered).
 - **Quant correlation**  — reported quantity vs simulated abundance
   (``events × relative_abundance``), log10–log10 Pearson, across the dynamic range.
 - **Recall by abundance**— detection rate per simulated-abundance quartile (a flat
@@ -50,8 +55,8 @@ class GroundTruthMetrics:
     rt_pearson: float
     rt_median_abs_error: float           # in the report's RT unit (minutes)
     charge_accuracy: float               # of matched-backbone IDs, fraction at a simulated charge
-    empirical_fdr: float                 # identified backbones not in the simulated set / reported_total
-    empirical_fdr_n_false: int
+    fdp: float                           # false discovery PROPORTION: backbones not simulated / reported_total
+    n_false_discoveries: int             # reported IDs whose backbone was never simulated
     quant_log_pearson: float
     quant_log_spearman: float
     quant_dynamic_range_orders: float
@@ -96,19 +101,32 @@ def load_report(path: str, engine: str = "diann") -> pd.DataFrame:
             "quantity": r.get("Precursor.Quantity", pd.Series(np.nan, index=r.index)).astype(float),
         })
     if engine == "alphadia":
+        # alphaDIA `precursors.parquet`: dotted columns (precursor.sequence [stripped],
+        # precursor.charge, precursor.rt.observed [seconds], precursor.intensity [often
+        # NaN in the precursor table — quant lives in precursor.matrix], precursor.decoy,
+        # precursor.qval). Fall back to bare names for older/other layouts.
         r = pd.read_parquet(path) if path.endswith(".parquet") else pd.read_csv(path, sep="\t")
-        # alphaDIA precursor table: sequence (stripped), charge, rt (seconds), intensity
-        seq_col = next(c for c in ("sequence", "Sequence", "stripped_sequence") if c in r.columns)
-        rt_col = next((c for c in ("rt", "rt_observed", "rt_calibrated") if c in r.columns), None)
-        q_col = next((c for c in ("intensity", "quantity", "sum_b_ion_intensity") if c in r.columns), None)
-        rt = r[rt_col].astype(float) if rt_col else pd.Series(np.nan, index=r.index)
-        if rt_col and rt.max() > 200:   # heuristic: alphaDIA rt in seconds -> minutes
+        col = lambda *names: next((c for c in names if c in r.columns), None)
+        seq_c = col("precursor.sequence", "sequence", "Sequence", "stripped_sequence")
+        chg_c = col("precursor.charge", "charge")
+        rt_c = col("precursor.rt.observed", "precursor.rt.calibrated", "rt_observed", "rt")
+        q_c = col("precursor.intensity", "intensity", "quantity")
+        dec_c = col("precursor.decoy", "decoy")
+        qv_c = col("precursor.qval", "qval", "q_value")
+        if seq_c is None or chg_c is None:
+            raise ValueError(f"alphaDIA report missing sequence/charge columns; saw {list(r.columns)[:12]}")
+        if dec_c is not None:
+            r = r[r[dec_c] == 0]
+        if qv_c is not None:
+            r = r[r[qv_c] <= 0.01]
+        rt = r[rt_c].astype(float) if rt_c else pd.Series(np.nan, index=r.index)
+        if rt_c is not None and len(rt) and rt.max() > 200:   # seconds -> minutes
             rt = rt / 60.0
         return pd.DataFrame({
-            "bb": r[seq_col].map(_strip_mods),
-            "charge": r["charge"].astype(int),
-            "rt": rt,
-            "quantity": r[q_col].astype(float) if q_col else pd.Series(np.nan, index=r.index),
+            "bb": r[seq_c].map(_strip_mods),
+            "charge": r[chg_c].astype(int),
+            "rt": rt.values,
+            "quantity": r[q_c].astype(float).values if q_c else np.full(len(r), np.nan),
         })
     raise ValueError(f"unknown engine '{engine}' (expected 'diann' or 'alphadia')")
 
@@ -127,8 +145,13 @@ def evaluate(truth: pd.DataFrame, report: pd.DataFrame) -> GroundTruthMetrics:
 
     n = len(report)
     rep_pairs = list(zip(report["bb"], report["charge"]))
+    # FDP: a reported peptide whose backbone was never simulated is a realized false
+    # discovery (its signal is not in the .raw). NOTE: assumes no blank/noise-derived
+    # real IDs (true while only simulated signal is rendered). I/L isobars make this a
+    # mild upper bound (an L-variant of a simulated I-peptide is mass-equal but counts
+    # false under exact string match).
     false_bb = [b not in sim_bb for b in report["bb"]]
-    empirical_fdr = float(np.mean(false_bb)) if n else 0.0
+    fdp = float(np.mean(false_bb)) if n else 0.0
 
     matched = report[report["bb"].isin(sim_bb)].copy()
     # RT correlation on matched backbones
@@ -172,8 +195,8 @@ def evaluate(truth: pd.DataFrame, report: pd.DataFrame) -> GroundTruthMetrics:
         rt_pearson=rt_pearson,
         rt_median_abs_error=rt_mae,
         charge_accuracy=charge_acc,
-        empirical_fdr=empirical_fdr,
-        empirical_fdr_n_false=int(sum(false_bb)),
+        fdp=fdp,
+        n_false_discoveries=int(sum(false_bb)),
         quant_log_pearson=quant_p,
         quant_log_spearman=quant_s,
         quant_dynamic_range_orders=dyn,

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/register_prediction_set.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/register_prediction_set.py
@@ -37,7 +37,22 @@ DEFAULT_PREDICTION_SET_ID = 0
 INSTRUMENT_ACTIVATION = {
     "bruker_timstof": {"activation_method": "hcd", "energy_unit": "ev"},
     "orbitrap_astral": {"activation_method": "hcd", "energy_unit": "nce"},
+    "orbitrap_exploris": {"activation_method": "hcd", "energy_unit": "nce"},
 }
+
+#: Thermo instruments simulated via the build-from-template path (a Thermo ``.raw``
+#: template's per-scan schedule + windows become the acquisition; each rendered frame
+#: is authored into its slot). These share the SAME physics — no ion mobility, HCD with
+#: NCE — and the same dispatch; they differ only in the MS2 detector packet format
+#: (Astral ASTMS vs classic-Orbitrap FTMS centroids), which the ``.raw`` writer detects
+#: and authors automatically. Gate the build-from-template branches on membership here
+#: (not ``== 'orbitrap_astral'``) so the family is extensible.
+THERMO_TEMPLATE_INSTRUMENTS = frozenset({"orbitrap_astral", "orbitrap_exploris"})
+
+
+def is_thermo_template_instrument(instrument) -> bool:
+    """True if ``instrument`` uses the Thermo build-from-template path (Astral/Orbitrap)."""
+    return str(instrument or "").lower() in THERMO_TEMPLATE_INSTRUMENTS
 
 
 def resolve_instrument_activation(instrument: str) -> tuple[str, str]:

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_frame_distributions_emg.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_frame_distributions_emg.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from scipy.special import erfcx
@@ -163,6 +163,45 @@ def estimate_mu_from_mode_emg(mode: ArrayLike, sigma: ArrayLike, lambda_: ArrayL
     return mode + np.sqrt(2)*sigma*erfcxinv(1/(lambda_*sigma)*np.sqrt(2/np.pi))-np.power(sigma,2)*lambda_
 
 
+def _emg_project_slice(
+        frames_np, times_np, mus, sigmas, lambdas, noise_levels,
+        target_p, step_size, rt_cycle_length, n_steps, num_threads,
+        remove_epsilon, add_noise,
+) -> Tuple[List[int], List[int], List[str], List[str]]:
+    """Project ONE slice of peptides to (first_idx, last_idx, occurrence_json,
+    abundance_json), replicating the per-peptide steps of
+    ``simulate_frame_distributions_emg`` exactly.
+
+    The per-(peptide, frame) EMG projection is deterministic and peptide-local (no
+    cross-peptide coupling — see the streaming design notes), so calling this over
+    slices is output-equivalent to one full-array call while bounding peak memory to
+    the slice. Noise levels are passed IN (pre-drawn for all peptides) so batching
+    does not perturb the global RNG stream.
+    """
+    occurrences = ims.calculate_frame_occurrences_emg_par(
+        times_np, mus, sigmas, lambdas, target_p, step_size,
+        num_threads=num_threads, n_steps=n_steps,
+    )
+    abundances = ims.calculate_frame_abundances_emg_par(
+        frames_np, times_np, occurrences, mus, sigmas, lambdas, rt_cycle_length,
+        num_threads=num_threads, n_steps=n_steps,
+    )
+    # remove_epsilon filter on the unrounded f64 abundances (membership + values)
+    occurrences = [list(np.array(o)[np.array(a) > remove_epsilon]) for o, a in zip(occurrences, abundances)]
+    abundances = [list(np.array(a)[np.array(a) > remove_epsilon]) for a in abundances]
+    first = [(-1 if len(o) == 0 else o[0]) for o in occurrences]
+    last = [(-1 if len(o) == 0 else o[-1]) for o in occurrences]
+    if add_noise:
+        abundances = [add_uniform_noise(np.array(a), nl) for a, nl in zip(abundances, noise_levels)]
+        abundances = [a / np.sum(a) for a in abundances]
+    occ_json = [python_list_to_json_string(o, as_float=False) for o in occurrences]
+    ab_json = [
+        python_list_to_json_string(np.nan_to_num(np.array(a), nan=0.0).tolist(), as_float=True)
+        for a in abundances
+    ]
+    return first, last, occ_json, ab_json
+
+
 def simulate_frame_distributions_emg(
         peptides: pd.DataFrame,
         frames: pd.DataFrame,
@@ -186,6 +225,7 @@ def simulate_frame_distributions_emg(
         lambdas: np.ndarray = None,
         gradient_length: float = None,
         remove_epsilon: float = 1e-4,
+        batch_size: Optional[int] = 25000,
 ) -> pd.DataFrame:
     """Simulate frame distributions for peptides.
 
@@ -251,73 +291,41 @@ def simulate_frame_distributions_emg(
     peptide_rt['rt_sigma'] = sigmas
     peptide_rt['rt_lambda'] = lambdas
     
-    occurrences = ims.calculate_frame_occurrences_emg_par(
-        times_np,
-        mus,
-        sigmas,
-        lambdas,
-        target_p,
-        step_size,
-        num_threads=num_threads,
-        n_steps=n_steps,
-    )
-
-    abundances = ims.calculate_frame_abundances_emg_par(
-        frames_np,
-        times_np,
-        occurrences,
-        mus,
-        sigmas,
-        lambdas,
-        rt_cycle_length,
-        num_threads=num_threads,
-        n_steps=n_steps,
-    )
+    # Pre-draw ALL per-peptide noise levels here (one np.random.uniform(0,2,n) call,
+    # exactly as the original did over the full set) so batching cannot perturb the
+    # global RNG stream — the EMG/Rust projection calls between here and the original
+    # draw site consume no np.random state.
+    all_noise_levels = np.random.uniform(0.0, 2.0, n) if add_noise else None
 
     if verbose:
         print("Serializing frame distributions to json ...")
 
-    # filter occurrences and abundances
-    occurrences = [list(np.array(occurrence)[np.array(abundance) > remove_epsilon]) for occurrence, abundance in zip(occurrences, abundances)]
-    abundances = [list(np.array(abundance)[np.array(abundance) > remove_epsilon]) for abundance in abundances]
-
-    # this could now fail, if all values are removed because they are below remove_epsilon
-
-    first_occurrence, last_occurrence = [], []
-
-    for oc, ab in zip(occurrences, abundances):
-        if len(oc) == 0 or len(ab) == 0:
-            first_occurrence.append(-1)
-            last_occurrence.append(-1)
-        else:
-            first_occurrence.append(oc[0])
-            last_occurrence.append(oc[-1])
+    # Project in batches to bound peak memory. The per-(peptide, frame) projection is
+    # deterministic and peptide-local, so chunking is output-equivalent to one full
+    # call; on dense-frame templates (e.g. Astral nDIA, ~2000 frames/peptide) holding
+    # all peptides' profiles + their copies at once OOMs. batch_size=None disables it.
+    bs = batch_size if (batch_size and n > batch_size) else n
+    first_occurrence: List[int] = []
+    last_occurrence: List[int] = []
+    occurrence_json: List[str] = []
+    abundance_json: List[str] = []
+    for s in range(0, n, bs):
+        e = min(s + bs, n)
+        noise_slice = None if all_noise_levels is None else all_noise_levels[s:e]
+        f, l, oj, aj = _emg_project_slice(
+            frames_np, times_np, mus[s:e], sigmas[s:e], lambdas[s:e], noise_slice,
+            target_p, step_size, rt_cycle_length, n_steps, num_threads,
+            remove_epsilon, add_noise,
+        )
+        first_occurrence.extend(f)
+        last_occurrence.extend(l)
+        occurrence_json.extend(oj)
+        abundance_json.extend(aj)
 
     peptide_rt['frame_occurrence_start'] = first_occurrence
     peptide_rt['frame_occurrence_end'] = last_occurrence
-
-    peptide_rt['frame_occurrence'] = occurrences
-
-    if add_noise:
-        # TODO: make noise model configurable
-        noise_levels = np.random.uniform(0.0, 2.0, len(abundances))
-        abundances = [add_uniform_noise(np.array(abundance), noise_level) for abundance, noise_level in zip(abundances, noise_levels)]
-        # Normalize frame abundance
-        abundances = [frame_abundance / np.sum(frame_abundance) for frame_abundance in abundances]
-
-    peptide_rt['frame_abundance'] = [list(x) for x in abundances]
-
-    peptide_rt['frame_occurrence'] = peptide_rt['frame_occurrence'].apply(
-        lambda r: python_list_to_json_string(r, as_float=False)
-    )
-
-    # replace NaN values with 0.0 in frame abundance
-    peptide_rt['frame_abundance'] = [np.nan_to_num(np.array(x), nan=0.0).tolist() for x in abundances]
-
-    peptide_rt['frame_abundance'] = peptide_rt['frame_abundance'].apply(
-        lambda r: python_list_to_json_string(r, as_float=True)
-    )
-
+    peptide_rt['frame_occurrence'] = occurrence_json
+    peptide_rt['frame_abundance'] = abundance_json
     peptide_rt['rt_mu'] = mus
 
     # print how many rows get removed, if any

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_frame_distributions_emg.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_frame_distributions_emg.py
@@ -302,9 +302,14 @@ def simulate_frame_distributions_emg(
 
     # Project in batches to bound peak memory. The per-(peptide, frame) projection is
     # deterministic and peptide-local, so chunking is output-equivalent to one full
-    # call; on dense-frame templates (e.g. Astral nDIA, ~2000 frames/peptide) holding
-    # all peptides' profiles + their copies at once OOMs. batch_size=None disables it.
-    bs = batch_size if (batch_size and n > batch_size) else n
+    # call (the peptide-iteration order is preserved, so even the noise path —
+    # add_uniform_noise, which is Numba-jitted and draws Numba's RNG in peptide order —
+    # is byte-identical for a fixed RNG state). On dense-frame templates (e.g. Astral
+    # nDIA, ~2000 frames/peptide) holding all peptides' profiles + their copies at once
+    # OOMs. batch_size=None disables batching.
+    if batch_size is not None and batch_size <= 0:
+        raise ValueError(f"batch_size must be a positive int or None, got {batch_size}")
+    bs = batch_size if (batch_size and n > batch_size) else max(n, 1)  # max(n,1): n==0 safe
     first_occurrence: List[int] = []
     last_occurrence: List[int] = []
     occurrence_json: List[str] = []

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import math
 
 # Silence verbose package outputs before importing them
 os.environ["WANDB_SILENT"] = "true"
@@ -405,6 +406,10 @@ def get_default_settings() -> dict:
         'mz_noise_uniform': False,
         'add_real_data_noise': False,
         'superimpose_on_reference': False,
+        # MS2 centroid merge tolerance (ppm) used when superimposing simulated peaks
+        # onto a Thermo .raw template's real signal (Astral/Orbitrap Overlay mode).
+        # Ignored for the Bruker path and when superimpose_on_reference is False.
+        'superimpose_merge_ppm': 15.0,
         'reference_noise_intensity_max': 30,
         'down_sample_factor': 0.5,
 
@@ -568,6 +573,28 @@ class SimulationConfig:
         # Validate superimpose_on_reference is DIA-only
         if self._config.get('superimpose_on_reference', False) and self._config.get('acquisition_type') == 'DDA':
             raise ValueError("superimpose_on_reference is only supported for DIA acquisition mode")
+
+        # For a Thermo build-from-template run, superimposition uses an MS2 centroid
+        # merge tolerance (ppm). A 0/negative tolerance would silently fall back to
+        # Replace (overwrite, destroying the reference signal the user asked to keep),
+        # so require a strictly-positive, finite tolerance when superimposing onto a
+        # Thermo template. (The Bruker path ignores this key.)
+        if self._config.get('superimpose_on_reference', False) and is_thermo:
+            raw_ppm = self._config.get('superimpose_merge_ppm')
+            # Coerce ONCE; reject bool (float(True)==1.0 would slip through) and any
+            # non-numeric value with the contextual error, not a bare float() exception.
+            merge_ppm = None
+            if not isinstance(raw_ppm, bool):
+                try:
+                    merge_ppm = float(raw_ppm)
+                except (TypeError, ValueError):
+                    merge_ppm = None
+            if merge_ppm is None or not math.isfinite(merge_ppm) or merge_ppm <= 0.0:
+                raise ValueError(
+                    "superimpose_on_reference on a Thermo template requires "
+                    f"superimpose_merge_ppm > 0 (got {raw_ppm!r}); a 0/negative tolerance "
+                    "would overwrite the reference signal instead of overlaying onto it"
+                )
 
         # Validate p_charge
         p_charge = self._config.get('p_charge', 0.8)
@@ -1621,10 +1648,20 @@ def main():
             logger.info(
                 f"  m/z noise: precursor {prec_noise_ppm} ppm, fragment {frag_noise_ppm} ppm (Gaussian)"
             )
+        # Superimpose simulated peaks onto the template's real signal (real⊕sim)
+        # instead of replacing it. 0 ppm = Replace (default, pure simulated output);
+        # >0 ppm = Overlay with that MS2 centroid merge tolerance.
+        superimpose_ppm = float(config.superimpose_merge_ppm) if config.superimpose_on_reference else 0.0
+        if superimpose_ppm:
+            logger.info(
+                f"  superimpose: overlaying simulated peaks on the template's real "
+                f"signal (merge tolerance {superimpose_ppm} ppm)"
+            )
         scans, n_ms1, n_ms2, n_ms2_nz, n_cleared, ok = (
             imspy_connector.py_acquisition.write_astral_raw(
                 db_path, thermo_template_path(config), out_raw, num_threads,
                 precursor_noise_ppm=prec_noise_ppm, fragment_noise_ppm=frag_noise_ppm,
+                superimpose_ppm=superimpose_ppm,
             )
         )
         logger.info(

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -340,9 +340,12 @@ def get_default_settings() -> dict:
         # the fragment-model compatibility guard, and the prediction-set provenance.
         # Default 'bruker_timstof' preserves current behaviour exactly.
         'instrument': 'bruker_timstof',
-        # P6e(b): for instrument='orbitrap_astral', the Thermo .raw template the run
-        # is built from — its real per-scan schedule + windows become the
-        # acquisition (no Bruker reference). Required for an Astral run.
+        # Build-from-template: for any Thermo instrument (orbitrap_astral,
+        # orbitrap_exploris), the Thermo .raw template the run is built from — its real
+        # per-scan schedule + windows become the acquisition (no Bruker reference).
+        # `template_path` is the generic name; `astral_template_path` is the historical
+        # alias (both accepted; see thermo_template_path()). Required for a Thermo run.
+        'template_path': None,
         'astral_template_path': None,
 
         'sigma_lower_rt': None,
@@ -467,15 +470,26 @@ def get_default_settings() -> dict:
     }
 
 
+def thermo_template_path(config) -> "str | None":
+    """The Thermo ``.raw`` template path for a build-from-template run.
+
+    Accepts the generic ``template_path`` and the historical ``astral_template_path``
+    alias (the latter takes precedence if both are set)."""
+    get = config.get if isinstance(config, dict) else (lambda k, d=None: getattr(config, k, d))
+    return get('astral_template_path', None) or get('template_path', None)
+
+
 def astral_nce_override(config) -> "float | None":
     """The DIA-window NCE override to apply for this run (P6d).
 
-    Returns the configured normalized collision energy ONLY for an Orbitrap Astral
-    run; ``None`` (i.e. ignore it, keep the reference eV windows) for Bruker — so a
-    stray ``collision_energy_nce`` on a Bruker config can never silently replace eV
-    windows with an NCE while provenance still labels them eV."""
+    Returns the configured normalized collision energy ONLY for a Thermo
+    build-from-template run (Astral/Orbitrap); ``None`` (i.e. ignore it, keep the
+    reference eV windows) for Bruker — so a stray ``collision_energy_nce`` on a Bruker
+    config can never silently replace eV windows with an NCE while provenance still
+    labels them eV."""
+    from .jobs.register_prediction_set import is_thermo_template_instrument
     instrument = str(getattr(config, 'instrument', 'bruker_timstof')).lower()
-    if instrument == 'orbitrap_astral':
+    if is_thermo_template_instrument(instrument):
         return getattr(config, 'collision_energy_nce', None)
     return None
 
@@ -520,15 +534,19 @@ class SimulationConfig:
         if self._config.get('from_findings') and self._config.get('from_existing'):
             raise ValueError("Cannot use both 'from_findings' and 'from_existing' at the same time")
 
-        # An Astral run is built from a Thermo .raw template, NOT a Bruker
-        # reference .d — so it requires astral_template_path in place of
-        # reference_path (the lean, Bruker-independent build-from-template path).
+        # A Thermo build-from-template run (Astral/Orbitrap) is built from a Thermo .raw
+        # template, NOT a Bruker reference .d — so it requires a template path in place
+        # of reference_path (the lean, Bruker-independent build-from-template path).
+        from .jobs.register_prediction_set import is_thermo_template_instrument
         instrument = str(self._config.get('instrument', 'bruker_timstof')).lower()
-        ref_key = 'astral_template_path' if instrument == 'orbitrap_astral' else 'reference_path'
+        is_thermo = is_thermo_template_instrument(instrument)
+        # For a Thermo run the template path may be given as `template_path` or the
+        # `astral_template_path` alias; require at least one (validated below).
+        ref_key = 'reference_path'
         if self._config.get('from_findings'):
-            required = ['save_path', ref_key, 'findings_path']
+            required = ['save_path', 'findings_path'] if is_thermo else ['save_path', ref_key, 'findings_path']
         else:
-            required = ['save_path', ref_key, 'fasta_path']
+            required = ['save_path', 'fasta_path'] if is_thermo else ['save_path', ref_key, 'fasta_path']
         missing = [key for key in required if not self._config.get(key)]
 
         if missing:
@@ -590,54 +608,54 @@ class SimulationConfig:
                 f"unknown instrument '{instrument}'. Supported: "
                 f"{sorted(INSTRUMENT_ACTIVATION)}."
             )
-        if instrument == 'orbitrap_astral':
-            # Astral is a DIA, no-IMS, NCE instrument. DDA-PASEF CE is Bruker
-            # scan-driven, and the run MUST supply a genuine normalized collision
-            # energy — otherwise the reference-derived Bruker eV windows would be
-            # silently mislabelled as NCE and fed to the NCE predictor.
+        if is_thermo:
+            # Thermo build-from-template instruments (Astral/Orbitrap) are DIA, no-IMS,
+            # NCE. DDA-PASEF CE is Bruker scan-driven, and the run MUST supply a genuine
+            # normalized collision energy — otherwise reference-derived Bruker eV
+            # windows would be silently mislabelled as NCE and fed to the NCE predictor.
             if self._config.get('acquisition_type') == 'DDA':
                 raise ValueError(
-                    "instrument 'orbitrap_astral' does not support DDA acquisition "
+                    f"instrument '{instrument}' does not support DDA acquisition "
                     "(DDA-PASEF collision energy is Bruker scan-driven). Use DIA."
                 )
             # collision_energy_nce is OPTIONAL for the build-from-template path: the
-            # Astral template already supplies a genuine per-window NCE, which is
-            # used by default. If set, it OVERRIDES every window with that single
-            # NCE (a deliberate manual choice); if set, it must be positive.
+            # template already supplies a genuine per-window NCE, used by default. If
+            # set, it OVERRIDES every window with that single NCE (a deliberate manual
+            # choice); if set, it must be positive.
             nce = self._config.get('collision_energy_nce')
             if nce is not None and not (isinstance(nce, (int, float)) and nce > 0):
                 raise ValueError(
                     "collision_energy_nce, if set, must be a positive normalized "
                     "collision energy (e.g. 27); it overrides the template's "
-                    "per-window NCE for an Astral run."
+                    "per-window NCE for a Thermo build-from-template run."
                 )
-            # The Astral MS2 render is deterministic; precursor survival is a
-            # stochastic (per-scan random fraction) feature. Refuse rather than
-            # silently drop the configured survival signal (it is not modelled on
-            # the Astral path yet).
+            # The Thermo MS2 render is deterministic; precursor survival is a stochastic
+            # (per-scan random fraction) feature. Refuse rather than silently drop the
+            # configured survival signal (it is not modelled on this path yet).
             if self._config.get('precursor_survival_max', 0.0) and float(
                 self._config.get('precursor_survival_max', 0.0)
             ) > 0.0:
                 raise ValueError(
-                    "instrument 'orbitrap_astral' does not support precursor_survival_* "
-                    "(the Astral MS2 render is deterministic; survival is stochastic). "
-                    "Set precursor_survival_min/max to 0 for an Astral run."
+                    f"instrument '{instrument}' does not support precursor_survival_* "
+                    "(the Thermo MS2 render is deterministic; survival is stochastic). "
+                    "Set precursor_survival_min/max to 0 for a Thermo run."
                 )
-            # Build-from-template: an Astral run is built from a Thermo .raw template
-            # (its real per-scan schedule + windows become the acquisition).
-            template = self._config.get('astral_template_path')
+            # Build-from-template: the run is built from a Thermo .raw template (its real
+            # per-scan schedule + windows become the acquisition). Accept either
+            # `template_path` or the `astral_template_path` alias.
+            template = thermo_template_path(self._config)
             if not template:
                 raise ValueError(
-                    "instrument 'orbitrap_astral' requires 'astral_template_path' "
-                    "(a Thermo .raw whose per-scan schedule + windows the run is "
-                    "built from)."
+                    f"instrument '{instrument}' requires 'template_path' (or the "
+                    "'astral_template_path' alias): a Thermo .raw whose per-scan "
+                    "schedule + windows the run is built from."
                 )
             if not os.path.exists(template):
-                raise FileNotFoundError(f"astral_template_path does not exist: {template}")
-            # The Astral .raw writer + dispatch live behind the connector's 'thermo'
-            # feature, which the published wheels disable (the Thermo writer
-            # dependency is private). Fail fast at config load instead of an
-            # AttributeError after a full simulation.
+                raise FileNotFoundError(f"template_path does not exist: {template}")
+            # The Thermo .raw writer + dispatch live behind the connector's 'thermo'
+            # feature, which the published wheels disable (the Thermo writer dependency
+            # is private). Fail fast at config load instead of an AttributeError after a
+            # full simulation.
             try:
                 import imspy_connector
                 thermo_ok = bool(imspy_connector.py_acquisition.has_thermo())
@@ -645,10 +663,10 @@ class SimulationConfig:
                 thermo_ok = False
             if not thermo_ok:
                 raise ValueError(
-                    "instrument 'orbitrap_astral' requires imspy-connector built with "
-                    "the 'thermo' feature (maturin build --release --features thermo, "
-                    "then reinstall). The published wheels disable it because the "
-                    "Thermo .raw writer dependency is private."
+                    f"instrument '{instrument}' requires imspy-connector built with the "
+                    "'thermo' feature (maturin build --release --features thermo, then "
+                    "reinstall). The published wheels disable it because the Thermo .raw "
+                    "writer dependency is private."
                 )
 
     def __getattr__(self, name: str):
@@ -994,16 +1012,19 @@ def main():
         logger.info(f"  Output path: {save_path}")
         logger.info("")
 
+    from .jobs.register_prediction_set import is_thermo_template_instrument
     instrument = str(getattr(config, 'instrument', 'bruker_timstof')).lower()
-    if instrument == 'orbitrap_astral':
-        # Build-from-template (P6e option b): NO Bruker reference. The Astral
-        # template's real per-scan schedule + windows become the acquisition, so
-        # the trunk is simulated on the template's true non-uniform timeline.
+    if is_thermo_template_instrument(instrument):
+        # Build-from-template (P6e option b): NO Bruker reference. The Thermo template's
+        # real per-scan schedule + windows become the acquisition, so the trunk is
+        # simulated on the template's true non-uniform timeline. Same path for Astral
+        # and classic Orbitrap — the .raw writer handles the MS2 detector format.
         from .jobs.astral_acquisition import AstralAcquisitionBuilder
-        logger.info(f"  Astral build-from-template: {config.astral_template_path}")
+        _template = thermo_template_path(config)
+        logger.info(f"  Thermo build-from-template ({instrument}): {_template}")
         acquisition_builder = AstralAcquisitionBuilder(
             str(Path(save_path) / name),
-            config.astral_template_path,
+            _template,
             round_collision_energy=config.round_collision_energy,
             collision_energy_decimals=config.collision_energy_decimals,
             # Optional override: if set, forces a single NCE across all windows;
@@ -1095,7 +1116,7 @@ def main():
             # change to the Bruker path.
             rescale_gradient = (
                 acquisition_builder.gradient_length
-                if instrument == 'orbitrap_astral'
+                if is_thermo_template_instrument(instrument)
                 else config.gradient_length
             )
             if not config.silent_mode:
@@ -1175,7 +1196,7 @@ def main():
         rt_max = peptides['retention_time_gru_predictor'].max()
         grad = (
             acquisition_builder.gradient_length
-            if instrument == 'orbitrap_astral'
+            if is_thermo_template_instrument(instrument)
             else config.gradient_length
         )
         if abs(rt_max - grad) / grad > 0.05:
@@ -1581,12 +1602,13 @@ def main():
     )
 
     # JOB 10: vendor output.
-    if instrument == 'orbitrap_astral':
-        # The trunk is now simulated on the Astral template's timeline + windows
-        # (fragments at per-window NCE). Author a Thermo .raw from the template
-        # (render each frame -> its template slot) — NOT a Bruker .d.
+    if is_thermo_template_instrument(instrument):
+        # The trunk is simulated on the Thermo template's timeline + windows (fragments
+        # at per-window NCE). Author a Thermo .raw from the template (render each frame
+        # -> its template slot) — NOT a Bruker .d. Same dispatch for Astral and classic
+        # Orbitrap; the writer authors the template's native MS2 centroid format.
         import imspy_connector
-        logger.info(section_header("Authoring Astral .raw", use_unicode))
+        logger.info(section_header(f"Authoring Thermo .raw ({instrument})", use_unicode))
         db_path = acquisition_builder.synthetics_handle.database_path
         out_raw = str(Path(save_path) / f"{name}.raw")
         # Recording-stage m/z noise (Gaussian, ppm). Respect the same toggles the
@@ -1601,7 +1623,7 @@ def main():
             )
         scans, n_ms1, n_ms2, n_ms2_nz, n_cleared, ok = (
             imspy_connector.py_acquisition.write_astral_raw(
-                db_path, config.astral_template_path, out_raw, num_threads,
+                db_path, thermo_template_path(config), out_raw, num_threads,
                 precursor_noise_ppm=prec_noise_ppm, fragment_noise_ppm=frag_noise_ppm,
             )
         )

--- a/packages/imspy-simulation/tests/test_fragment_predictor_capability_p6d.py
+++ b/packages/imspy-simulation/tests/test_fragment_predictor_capability_p6d.py
@@ -282,3 +282,50 @@ def test_prosit_hcd_live_koina_contract():
     assert iv.shape == (1, 174)
     # A real Prosit HCD spectrum has several non-zero fragments.
     assert (iv > 0).sum() >= 3
+
+
+def test_orbitrap_exploris_uses_thermo_template_path():
+    """ORBI production config: orbitrap_exploris routes through the SAME
+    build-from-template path as Astral (no-IMS, HCD-NCE), via the generic
+    `template_path` (with `astral_template_path` as alias)."""
+    from imspy_simulation.timsim.jobs.register_prediction_set import (
+        resolve_instrument_activation,
+        is_thermo_template_instrument,
+    )
+    from imspy_simulation.timsim.simulator import thermo_template_path, astral_nce_override
+
+    # registry: exploris shares the Astral activation/unit + the thermo-template family
+    assert resolve_instrument_activation("orbitrap_exploris") == ("hcd", "nce")
+    assert is_thermo_template_instrument("orbitrap_exploris")
+    assert is_thermo_template_instrument("orbitrap_astral")
+    assert not is_thermo_template_instrument("bruker_timstof")
+
+    # template path resolves from either the generic key or the historical alias
+    assert thermo_template_path({"template_path": "/b.raw"}) == "/b.raw"
+    assert thermo_template_path({"astral_template_path": "/a.raw"}) == "/a.raw"
+    # alias wins when both set (back-compat precedence)
+    assert thermo_template_path({"template_path": "/b.raw", "astral_template_path": "/a.raw"}) == "/a.raw"
+
+    # NCE override applies to exploris (a Thermo run), ignored for Bruker
+    assert astral_nce_override(
+        _config_with(instrument="orbitrap_exploris", collision_energy_nce=28.0)
+    ) == 28.0
+    assert astral_nce_override(
+        _config_with(instrument="bruker_timstof", collision_energy_nce=28.0)
+    ) is None
+
+
+def test_orbitrap_exploris_validate_requires_template(tmp_path):
+    """An exploris run requires a template_path and is DIA-only, like Astral."""
+    import pytest
+
+    def exploris(**o):
+        o.setdefault("acquisition_type", "DIA")
+        return _config_with(instrument="orbitrap_exploris", **o)
+
+    # missing template -> error mentioning template_path
+    with pytest.raises(ValueError, match="template_path"):
+        exploris(template_path=None)._validate()
+    # DDA rejected
+    with pytest.raises(ValueError, match="does not support DDA"):
+        exploris(acquisition_type="DDA", template_path=__file__)._validate()

--- a/packages/imspy-simulation/tests/test_frame_distribution_chunking.py
+++ b/packages/imspy-simulation/tests/test_frame_distribution_chunking.py
@@ -1,0 +1,70 @@
+"""Phase 0 streaming: batching the EMG frame-distribution projection must not change
+its output.
+
+The per-(peptide, frame) EMG projection is deterministic and peptide-local, so
+chunking the projection (to bound peak memory on dense-frame templates like the Astral
+nDIA grid, ~2000 frames/peptide) must be output-equivalent to a single full-array call:
+
+- noise OFF (the default): byte-identical occurrence + abundance.
+- noise ON: structurally identical (same occurrence, same per-peptide length, same
+  normalization) but a different random noise realization — `add_uniform_noise` draws
+  np.random per frame, so reordering the stream changes values (statistical
+  equivalence, not byte parity — by design).
+"""
+import json
+
+import numpy as np
+import pandas as pd
+
+from imspy_simulation.timsim.jobs.simulate_frame_distributions_emg import (
+    simulate_frame_distributions_emg,
+)
+
+# Dense-frame fixture mimicking the Astral nDIA template (many frames / short gradient).
+_F, _T, _N = 6000, 300.0, 1500
+_FRAMES = pd.DataFrame({"frame_id": np.arange(1, _F + 1), "time": np.linspace(0, _T, _F)})
+_KW = dict(
+    frames=_FRAMES, sigma_lower_rt=None, sigma_upper_rt=None, sigma_alpha_rt=4,
+    sigma_beta_rt=4, k_lower_rt=0, k_upper_rt=10, k_alpha_rt=1, k_beta_rt=20,
+    target_p=0.999, step_size=0.001, rt_cycle_length=_T / _F, n_steps=1000,
+    num_threads=4, gradient_length=_T, remove_epsilon=1e-4, verbose=False,
+)
+
+
+def _peptides():
+    rt = np.random.RandomState(7).uniform(5, _T - 5, _N)
+    return pd.DataFrame({"peptide_id": np.arange(_N), "retention_time_gru_predictor": rt})
+
+
+def _run(batch_size, add_noise):
+    np.random.seed(123)  # fix sigma/k/mu sampling so only batching differs
+    out = simulate_frame_distributions_emg(
+        peptides=_peptides(), add_noise=add_noise, batch_size=batch_size, **_KW
+    )
+    return out.sort_values("peptide_id").reset_index(drop=True)
+
+
+def test_chunking_byte_identical_noise_off():
+    full = _run(batch_size=None, add_noise=False)
+    chunked = _run(batch_size=200, add_noise=False)
+    assert len(full) == len(chunked)
+    assert full["frame_occurrence"].tolist() == chunked["frame_occurrence"].tolist()
+    assert full["frame_abundance"].tolist() == chunked["frame_abundance"].tolist()
+    assert full["frame_occurrence_start"].tolist() == chunked["frame_occurrence_start"].tolist()
+    assert full["frame_occurrence_end"].tolist() == chunked["frame_occurrence_end"].tolist()
+
+
+def test_chunking_structurally_equivalent_noise_on():
+    full = _run(batch_size=None, add_noise=True)
+    chunked = _run(batch_size=200, add_noise=True)
+    assert len(full) == len(chunked)
+    # occurrence (frame membership) is deterministic -> identical even with noise
+    assert full["frame_occurrence"].tolist() == chunked["frame_occurrence"].tolist()
+    fa, fb = full["frame_abundance"].tolist(), chunked["frame_abundance"].tolist()
+    for sa, sb in zip(fa, fb):
+        va, vb = np.array(json.loads(sa)), np.array(json.loads(sb))
+        assert len(va) == len(vb)                       # same structure
+        # both normalized to ~1; values are different random noise realizations, so
+        # they do NOT match each other tightly (statistical equivalence, by design).
+        assert abs(va.sum() - 1.0) < 0.05
+        assert abs(vb.sum() - 1.0) < 0.05

--- a/packages/imspy-simulation/tests/test_frame_distribution_chunking.py
+++ b/packages/imspy-simulation/tests/test_frame_distribution_chunking.py
@@ -6,19 +6,26 @@ chunking the projection (to bound peak memory on dense-frame templates like the 
 nDIA grid, ~2000 frames/peptide) must be output-equivalent to a single full-array call:
 
 - noise OFF (the default): byte-identical occurrence + abundance.
-- noise ON: structurally identical (same occurrence, same per-peptide length, same
-  normalization) but a different random noise realization — `add_uniform_noise` draws
-  np.random per frame, so reordering the stream changes values (statistical
-  equivalence, not byte parity — by design).
+- noise ON: also byte-identical, PROVIDED both RNGs are seeded. `add_uniform_noise`
+  is Numba-jitted and draws Numba's RNG (which `np.random.seed` does NOT reset — a
+  jitted seeder does). Batching preserves peptide-iteration order, so with the same
+  Numba RNG state the noise draws are identical; the apparent non-determinism without
+  a Numba seed is Numba's un-seeded stream, not a batching effect.
 """
 import json
 
 import numpy as np
 import pandas as pd
+from numba import njit
 
 from imspy_simulation.timsim.jobs.simulate_frame_distributions_emg import (
     simulate_frame_distributions_emg,
 )
+
+
+@njit
+def _seed_numba(s):  # Python np.random.seed does not reset Numba's nopython RNG
+    np.random.seed(s)
 
 # Dense-frame fixture mimicking the Astral nDIA template (many frames / short gradient).
 _F, _T, _N = 6000, 300.0, 1500
@@ -37,34 +44,42 @@ def _peptides():
 
 
 def _run(batch_size, add_noise):
-    np.random.seed(123)  # fix sigma/k/mu sampling so only batching differs
+    np.random.seed(123)   # fix sigma/k/mu sampling + Python-RNG draws
+    _seed_numba(123)      # fix add_uniform_noise's Numba RNG so only batching differs
     out = simulate_frame_distributions_emg(
         peptides=_peptides(), add_noise=add_noise, batch_size=batch_size, **_KW
     )
     return out.sort_values("peptide_id").reset_index(drop=True)
 
 
+def _assert_byte_identical(full, chunked):
+    assert len(full) == len(chunked)
+    for col in ("frame_occurrence", "frame_abundance",
+                "frame_occurrence_start", "frame_occurrence_end"):
+        assert full[col].tolist() == chunked[col].tolist(), col
+
+
 def test_chunking_byte_identical_noise_off():
-    full = _run(batch_size=None, add_noise=False)
-    chunked = _run(batch_size=200, add_noise=False)
-    assert len(full) == len(chunked)
-    assert full["frame_occurrence"].tolist() == chunked["frame_occurrence"].tolist()
-    assert full["frame_abundance"].tolist() == chunked["frame_abundance"].tolist()
-    assert full["frame_occurrence_start"].tolist() == chunked["frame_occurrence_start"].tolist()
-    assert full["frame_occurrence_end"].tolist() == chunked["frame_occurrence_end"].tolist()
+    _assert_byte_identical(_run(batch_size=None, add_noise=False),
+                           _run(batch_size=200, add_noise=False))
 
 
-def test_chunking_structurally_equivalent_noise_on():
-    full = _run(batch_size=None, add_noise=True)
-    chunked = _run(batch_size=200, add_noise=True)
-    assert len(full) == len(chunked)
-    # occurrence (frame membership) is deterministic -> identical even with noise
-    assert full["frame_occurrence"].tolist() == chunked["frame_occurrence"].tolist()
-    fa, fb = full["frame_abundance"].tolist(), chunked["frame_abundance"].tolist()
-    for sa, sb in zip(fa, fb):
-        va, vb = np.array(json.loads(sa)), np.array(json.loads(sb))
-        assert len(va) == len(vb)                       # same structure
-        # both normalized to ~1; values are different random noise realizations, so
-        # they do NOT match each other tightly (statistical equivalence, by design).
-        assert abs(va.sum() - 1.0) < 0.05
-        assert abs(vb.sum() - 1.0) < 0.05
+def test_chunking_byte_identical_noise_on():
+    # With both RNGs seeded, batching is byte-identical even with noise (peptide order
+    # is preserved, so Numba's per-frame noise stream is identical).
+    _assert_byte_identical(_run(batch_size=None, add_noise=True),
+                           _run(batch_size=200, add_noise=True))
+
+
+def test_zero_peptides_does_not_crash():
+    np.random.seed(0)
+    empty = pd.DataFrame({"peptide_id": pd.Series([], dtype=int),
+                          "retention_time_gru_predictor": pd.Series([], dtype=float)})
+    out = simulate_frame_distributions_emg(peptides=empty, add_noise=False, batch_size=200, **_KW)
+    assert len(out) == 0
+
+
+def test_nonpositive_batch_size_rejected():
+    import pytest
+    with pytest.raises(ValueError):
+        simulate_frame_distributions_emg(peptides=_peptides(), add_noise=False, batch_size=0, **_KW)

--- a/packages/imspy-simulation/tests/test_groundtruth_eval.py
+++ b/packages/imspy-simulation/tests/test_groundtruth_eval.py
@@ -1,0 +1,74 @@
+"""Unit tests for the ground-truth eval metric core (engine/instrument-agnostic)."""
+import numpy as np
+import pandas as pd
+
+from imspy_simulation.timsim.groundtruth_eval import evaluate, _strip_mods
+
+
+def _truth():
+    # 4 simulated precursors over 3 backbones; B is simulated at z2 AND z3.
+    return pd.DataFrame({
+        "bb":           ["AAAK", "BBBR", "BBBR", "CCCK"],
+        "charge":       [2,      2,      3,      2],
+        "sim_rt":       [5.0,    10.0,   10.0,   15.0],   # minutes
+        "sim_quantity": [1e3,    1e5,    1e4,    1e7],
+    })
+
+
+def test_strip_mods():
+    assert _strip_mods("M[UNIMOD:35]C[UNIMOD:4]K") == "MCK"
+    assert _strip_mods("[UNIMOD:1]PEPK") == "PEPK"
+
+
+def test_perfect_report_metrics():
+    truth = _truth()
+    # report identifies AAAK/z2, BBBR/z2, CCCK/z2 — all real, correct charges, exact RT,
+    # quantity proportional to simulated abundance (log-correlated).
+    report = pd.DataFrame({
+        "bb":       ["AAAK", "BBBR", "CCCK"],
+        "charge":   [2,      2,      2],
+        "rt":       [5.0,    10.0,   15.0],
+        "quantity": [2e3,    2e5,    2e7],   # 2x sim -> perfect log-log correlation
+    })
+    m = evaluate(truth, report)
+    assert m.identified == 3 and m.reported_total == 3 and m.simulated_ions == 4
+    assert m.empirical_fdr == 0.0 and m.empirical_fdr_n_false == 0
+    assert m.charge_accuracy == 1.0
+    assert m.rt_pearson > 0.999 and m.rt_median_abs_error < 1e-9
+    assert m.quant_log_pearson > 0.999
+
+
+def test_entrapment_fdr_and_charge_error():
+    truth = _truth()
+    # 4 reported: 2 real (AAAK/z2, BBBR/z3), 1 wrong-charge (CCCK/z4 — backbone real,
+    # charge not simulated), 1 entrapment false (XXXK not simulated at all).
+    report = pd.DataFrame({
+        "bb":       ["AAAK", "BBBR", "CCCK", "XXXK"],
+        "charge":   [2,      3,      4,      2],
+        "rt":       [5.0,    10.0,   15.0,   20.0],
+        "quantity": [1e3,    1e4,    1e7,    1e2],
+    })
+    m = evaluate(truth, report)
+    # empirical FDR = backbones not simulated / total = 1 (XXXK) / 4
+    assert m.empirical_fdr_n_false == 1
+    assert abs(m.empirical_fdr - 0.25) < 1e-9
+    # matched-backbone IDs = AAAK,BBBR,CCCK (3); CCCK@z4 not a simulated charge -> 2/3
+    assert abs(m.charge_accuracy - (2 / 3)) < 1e-9
+    # only backbone+charge that match a simulated ion count as 'identified': AAAK/z2, BBBR/z3
+    assert m.identified == 2
+
+
+def test_recall_by_abundance_rises_with_quantity():
+    # 8 simulated precursors spanning abundance; report finds only the brightest 4.
+    truth = pd.DataFrame({
+        "bb": [f"PEP{i}K" for i in range(8)],
+        "charge": [2] * 8,
+        "sim_rt": list(np.linspace(1, 30, 8)),
+        "sim_quantity": [10 ** e for e in range(8)],   # 1e0 .. 1e7
+    })
+    bright = [f"PEP{i}K" for i in range(4, 8)]          # top-4 abundance
+    report = pd.DataFrame({"bb": bright, "charge": [2] * 4,
+                           "rt": [1.0] * 4, "quantity": [1e6] * 4})
+    m = evaluate(truth, report)
+    q = m.recall_by_abundance_quartile
+    assert q["Q1_low"] == 0.0 and q["Q4_high"] == 1.0   # detection tracks abundance

--- a/packages/imspy-simulation/tests/test_groundtruth_eval.py
+++ b/packages/imspy-simulation/tests/test_groundtruth_eval.py
@@ -32,13 +32,13 @@ def test_perfect_report_metrics():
     })
     m = evaluate(truth, report)
     assert m.identified == 3 and m.reported_total == 3 and m.simulated_ions == 4
-    assert m.empirical_fdr == 0.0 and m.empirical_fdr_n_false == 0
+    assert m.fdp == 0.0 and m.n_false_discoveries == 0
     assert m.charge_accuracy == 1.0
     assert m.rt_pearson > 0.999 and m.rt_median_abs_error < 1e-9
     assert m.quant_log_pearson > 0.999
 
 
-def test_entrapment_fdr_and_charge_error():
+def test_fdp_and_charge_error():
     truth = _truth()
     # 4 reported: 2 real (AAAK/z2, BBBR/z3), 1 wrong-charge (CCCK/z4 — backbone real,
     # charge not simulated), 1 entrapment false (XXXK not simulated at all).
@@ -49,9 +49,9 @@ def test_entrapment_fdr_and_charge_error():
         "quantity": [1e3,    1e4,    1e7,    1e2],
     })
     m = evaluate(truth, report)
-    # empirical FDR = backbones not simulated / total = 1 (XXXK) / 4
-    assert m.empirical_fdr_n_false == 1
-    assert abs(m.empirical_fdr - 0.25) < 1e-9
+    # FDP = backbones not simulated / total = 1 (XXXK) / 4
+    assert m.n_false_discoveries == 1
+    assert abs(m.fdp - 0.25) < 1e-9
     # matched-backbone IDs = AAAK,BBBR,CCCK (3); CCCK@z4 not a simulated charge -> 2/3
     assert abs(m.charge_accuracy - (2 / 3)) < 1e-9
     # only backbone+charge that match a simulated ion count as 'identified': AAAK/z2, BBBR/z3

--- a/packages/imspy-simulation/tests/test_groundtruth_eval.py
+++ b/packages/imspy-simulation/tests/test_groundtruth_eval.py
@@ -2,7 +2,57 @@
 import numpy as np
 import pandas as pd
 
-from imspy_simulation.timsim.groundtruth_eval import evaluate, _strip_mods
+from imspy_simulation.timsim.groundtruth_eval import (
+    evaluate, _strip_mods,
+    _canon_inline, _canon_alphadia, _pf_key, _bb_key,
+    precursor_fdp_breakdown,
+)
+
+
+def test_canonical_peptidoform_consistent_across_sources():
+    # The SAME peptidoform must yield an identical canonical key whether it comes from
+    # the truth DB (UNIMOD brackets), DiaNN ((UniMod:n) parens), or alphaDIA
+    # (stripped + mod names + 1-based sites). Oxidation@M == UNIMOD:35 at residue 11.
+    st_t, m_t = _canon_inline("AAALLAKQAEM[UNIMOD:35]EVK")     # truth
+    st_d, m_d = _canon_inline("AAALLAKQAEM(UniMod:35)EVK")     # DiaNN
+    st_a, m_a = _canon_alphadia("AAALLAKQAEMEVK", "Oxidation@M", "11")  # alphaDIA
+    assert _pf_key(st_t, m_t) == _pf_key(st_d, m_d) == _pf_key(st_a, m_a) == "AAALLAKQAEMEVK/11:35"
+    # I/L normalization collapses the isobaric ambiguity at backbone + peptidoform level.
+    assert _bb_key("PEPTIDEK") == _bb_key("PEPTLDEK") == "PEPTLDEK"
+    # Unknown alphaDIA mod -> -1 sentinel (cannot match a real truth id).
+    _, m_u = _canon_alphadia("PEPK", "Glubbery@P", "1")
+    assert m_u == {1: -1}
+
+
+def test_precursor_fdp_breakdown_buckets():
+    # Truth: PEPTLDEK/z2 with oxidation at M-less... use a clear case.
+    # Simulated peptidoforms: ACDEK/z2 (no mod), MCDEK/z2 with ox@M1.
+    truth = {
+        "bb": {("ACDEK", 2), ("MCDEK", 2)},
+        "pf": {("ACDEK/", 2), ("MCDEK/1:35", 2)},
+        "bb_multiset": {("ACDEK", 2): {()}, ("MCDEK", 2): {(35,)}},
+        "n": 2,
+    }
+    # Report: 1 correct, 1 wrong-backbone (genuine FP), 1 right-bb+ox wrong SITE
+    # (localization-ambiguous: MCDEK has ox, but reported on... only one M, so emulate
+    # via a 2-M backbone), 1 right-bb wrong-mod-composition (genuine).
+    truth["bb"].add(("MMDEK", 2)); truth["pf"].add(("MMDEK/1:35", 2))
+    truth["bb_multiset"][("MMDEK", 2)] = {(35,)}
+    report = pd.DataFrame({
+        "bb":  ["ACDEK",   "ZZZEK",      "MMDEK",      "MMDEK"],
+        "pf":  ["ACDEK/",  "ZZZEK/",     "MMDEK/2:35", "MMDEK/1:4"],
+        "charge":       [2,        2,            2,            2],
+        "mod_multiset": [(),       (),           (35,),        (4,)],
+        "q":            [0.001,    0.001,        0.001,        0.001],
+    })
+    bd = precursor_fdp_breakdown(truth, report, q_thresholds=(0.01,))[0]
+    assert bd["n_precursors"] == 4
+    assert bd["wrong_backbone"] == 1           # ZZZEK
+    assert bd["localization_ambiguous"] == 1   # MMDEK ox wrong site (right mod multiset)
+    assert bd["wrong_mod_composition"] == 1    # MMDEK carbamidomethyl (not a simulated mod set)
+    # strict counts all 3 non-correct; genuine excludes the localization-ambiguous one.
+    assert abs(bd["fdp_peptidoform_strict"] - 3 / 4) < 1e-9
+    assert abs(bd["fdp_peptidoform_genuine"] - 2 / 4) < 1e-9
 
 
 def _truth():

--- a/rustdf/src/sim/acquisition.rs
+++ b/rustdf/src/sim/acquisition.rs
@@ -267,6 +267,18 @@ mod thermo {
                     ),
                 ));
             }
+            // Overlay with no simulated peaks is a true no-op: leave the template
+            // slot's REAL signal byte-identical. Don't round-trip it through
+            // overlay_profile/overlay_centroids, which re-canonicalize the packet
+            // (and could merge near-coincident real centroids within merge_tol_ppm).
+            // Replace with no peaks still clears the slot (pure-simulated, zero-
+            // residual) — that path falls through below.
+            if scan.peaks.is_empty() {
+                if let WriteMode::Overlay { .. } = self.mode {
+                    self.cursor += 1;
+                    return Ok(());
+                }
+            }
             if is_profile {
                 // Advance the cursor only after authoring succeeds, so a failed
                 // write doesn't permanently consume the slot.
@@ -534,5 +546,94 @@ mod tests {
         assert!(cents.len() >= base_cents + 1, "MS2 real centroids not retained / sim not added");
         eprintln!("thermo_overlay OK: MS1 {}->{} pts (+sim), MS2 {}->{} centroids",
             base_pts, prof.point_count(), base_cents, cents.len());
+    }
+
+    // Gated: an EMPTY overlay must be a true no-op — the template's real signal is
+    // left untouched. The short-circuit returns before `self.raw` is mutated, so the
+    // packet bytes are never round-tripped through overlay/author (which would
+    // re-canonicalize and could merge near-coincident real centroids). We assert the
+    // DECODED signal is bit-identical (exact equality: nothing is recomputed, so the
+    // decode of an untouched packet is deterministic). This is the contract the
+    // dispatch's overflow fallback relies on in Overlay mode (an overflowing slot is
+    // re-authored empty and must keep its real signal).
+    #[test]
+    fn overlay_empty_is_noop() {
+        let template = match std::env::var("TIMSIM_ASTRAL_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP overlay_empty_is_noop: set TIMSIM_ASTRAL_TEMPLATE=<astral .raw>");
+                return;
+            }
+        };
+        let out = std::env::temp_dir().join("rustdf_overlay_empty_noop.raw");
+
+        // Baseline: decoded MS1 profile + MS2 centroids of the first NON-EMPTY
+        // profile/centroid scans (a vacuous empty scan would make the invariant
+        // trivially hold), straight from the untouched template.
+        let base = thermorawfile::RawFile::open(&template).unwrap();
+        let (mut prof_scan, mut cent_scan) = (None, None);
+        for i in 0..base.index.len() {
+            let scan = base.first_scan + i as u32;
+            let pkt = (base.data_addr + base.index[i].offset) as usize;
+            let psize = u32::from_le_bytes(base.bytes[pkt + 4..pkt + 8].try_into().unwrap());
+            if psize > 0 && prof_scan.is_none()
+                && base.profile(scan).map(|p| p.point_count() > 0).unwrap_or(false)
+            {
+                prof_scan = Some(scan);
+            }
+            if psize == 0 && cent_scan.is_none() && !base.centroid_peaks(scan).is_empty() {
+                cent_scan = Some(scan);
+            }
+            if prof_scan.is_some() && cent_scan.is_some() { break; }
+        }
+        let prof_scan = prof_scan.expect("template has no non-empty MS1 profile scan");
+        let cent_scan = cent_scan.expect("template has no non-empty MS2 centroid scan");
+        let cal = base.calibration_at_event(base.scantrailer_addr as usize + 4).unwrap();
+        let profile_points = |rf: &thermorawfile::RawFile, scan: u32| -> Vec<(f64, f32)> {
+            let p = rf.profile(scan).unwrap();
+            let mut v = Vec::with_capacity(p.point_count());
+            for c in &p.chunks {
+                for j in 0..c.signal.len() {
+                    v.push((p.mz_of_bin(c.first_bin + j as u32, &cal), c.signal[j]));
+                }
+            }
+            v
+        };
+        let base_prof = profile_points(&base, prof_scan);
+        let base_cents: Vec<(f64, f32)> =
+            base.centroid_peaks(cent_scan).iter().map(|p| (p.mz, p.intensity)).collect();
+        assert!(!base_prof.is_empty(), "picked an empty MS1 profile — test would be vacuous");
+        assert!(!base_cents.is_empty(), "picked an empty MS2 centroid — test would be vacuous");
+
+        // Walk every slot in order, authoring an EMPTY descriptor in Overlay mode.
+        // A complete pass exercises the finalize path; Overlay is exempt from the
+        // zero-residual check, and every empty author short-circuits.
+        let mut w = ThermoRawWriter::from_template(&template, &out)
+            .expect("open")
+            .with_mode(WriteMode::Overlay { merge_tol_ppm: 20.0 });
+        for &(_, is_profile) in w.manifest().to_vec().iter() {
+            w.write_scan(&ScanDescriptor {
+                ms_level: if is_profile { 1 } else { 2 },
+                retention_time: 0.0,
+                isolation: None,
+                peaks: Vec::new(),
+            })
+            .expect("empty overlay author");
+        }
+        w.finalize().expect("finalize");
+
+        let rf = thermorawfile::RawFile::open(&out).unwrap();
+        assert!(rf.checksum_valid(), "checksum invalid");
+        let out_prof = profile_points(&rf, prof_scan);
+        let out_cents: Vec<(f64, f32)> =
+            rf.centroid_peaks(cent_scan).iter().map(|p| (p.mz, p.intensity)).collect();
+        // Real signal bit-identical — empty overlay touched nothing (exact equality:
+        // the packet is never mutated, so the decode is deterministic).
+        assert_eq!(out_prof, base_prof, "MS1 profile changed under empty overlay");
+        assert_eq!(out_cents, base_cents, "MS2 centroids changed under empty overlay");
+        eprintln!(
+            "overlay_empty_is_noop OK: MS1 {} pts + MS2 {} centroids unchanged across full empty pass",
+            base_prof.len(), base_cents.len()
+        );
     }
 }

--- a/rustdf/src/sim/astral_dispatch.rs
+++ b/rustdf/src/sim/astral_dispatch.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use mscore::data::spectrum::MzSpectrum;
 use mscore::timstof::quadrupole::WindowTransmission;
 
-use crate::sim::acquisition::{AcquisitionWriter, ScanDescriptor, ThermoRawWriter};
+use crate::sim::acquisition::{AcquisitionWriter, ScanDescriptor, ThermoRawWriter, WriteMode};
 use crate::sim::dia::TimsTofSyntheticsFrameBuilderDIA;
 use crate::sim::handle::TimsTofSyntheticsDataHandle;
 use crate::sim::scheme::DataMode;
@@ -48,6 +48,14 @@ pub struct AstralWriteOptions {
     pub precursor_noise_ppm: f64,
     /// Gaussian m/z noise (≈ppm at 3σ) applied to MS2 fragment peaks. 0 = off.
     pub fragment_noise_ppm: f64,
+    /// Superimpose simulated peaks onto the template's REAL signal (real⊕sim)
+    /// instead of replacing it; the value is the MS2 centroid merge tolerance in
+    /// ppm. `0` (default) = `WriteMode::Replace` (overwrite, zero-residual). `>0` =
+    /// `WriteMode::Overlay { merge_tol_ppm }` — the template's real signal is kept
+    /// and simulated peaks are added on top (the "reference run = layout + real
+    /// noise" workflow). On a packet-budget overflow in Overlay mode the slot keeps
+    /// the template signal untouched (no clear).
+    pub superimpose_ppm: f64,
 }
 
 impl Default for AstralWriteOptions {
@@ -59,6 +67,7 @@ impl Default for AstralWriteOptions {
             max_ms2_peaks: 120,
             precursor_noise_ppm: 0.0,
             fragment_noise_ppm: 0.0,
+            superimpose_ppm: 0.0,
         }
     }
 }
@@ -114,6 +123,20 @@ pub fn write_astral_raw(
 ) -> Result<AstralWriteSummary, String> {
     use thermorawfile::RawFile;
 
+    // Validate at the Rust entry point too (not only the PyO3 boundary), so a
+    // direct Rust caller can't smuggle in a non-finite/negative tolerance: a NaN
+    // would silently fall to Replace (the `> 0.0` test is false) and `inf` would
+    // select Overlay only to fail deep in the first MS2 author.
+    for (name, v) in [
+        ("precursor_noise_ppm", opts.precursor_noise_ppm),
+        ("fragment_noise_ppm", opts.fragment_noise_ppm),
+        ("superimpose_ppm", opts.superimpose_ppm),
+    ] {
+        if !v.is_finite() || v < 0.0 {
+            return Err(format!("{name} must be finite and >= 0, got {v}"));
+        }
+    }
+
     let builder = TimsTofSyntheticsFrameBuilderDIA::new(db_path, false, opts.num_threads)
         .map_err(|e| format!("open Astral DB: {e}"))?;
     let handle = TimsTofSyntheticsDataHandle::new(db_path)
@@ -145,6 +168,12 @@ pub fn write_astral_raw(
         .ok_or("template has no MS1 calibration")?;
     let mut writer = ThermoRawWriter::from_template(template_path, out_path)
         .map_err(|e| format!("open writer: {e}"))?;
+    // Replace (default) overwrites the template's signal — pure simulated output,
+    // zero-residual. Overlay keeps the template's real signal and adds simulated
+    // peaks on top (real⊕sim); the ppm is the MS2 centroid merge tolerance.
+    if opts.superimpose_ppm > 0.0 {
+        writer = writer.with_mode(WriteMode::Overlay { merge_tol_ppm: opts.superimpose_ppm });
+    }
     let manifest: Vec<(u32, bool)> = writer.manifest().to_vec();
 
     // Frames are 1:1 with template slots, in scan order (the Astral builder built
@@ -206,7 +235,10 @@ pub fn write_astral_raw(
         };
 
         // Author; on a residual packet-budget overflow, consume the slot with an
-        // empty (cleared) scan so the schedule + checksum stay intact. Count a
+        // empty payload so the schedule + checksum stay intact. In Replace mode that
+        // clears the slot (empty output); in Overlay mode an empty payload is a
+        // true no-op (write_scan short-circuits) that leaves the template's real
+        // signal byte-identical — so an overflowing slot keeps real noise. Count a
         // non-empty MS2 only when its actual (non-empty) payload was authored — a
         // cleared scan is empty in the output and must not be counted.
         let had_peaks = !desc.peaks.is_empty();

--- a/rustdf/src/sim/handle.rs
+++ b/rustdf/src/sim/handle.rs
@@ -1437,12 +1437,17 @@ impl TimsTofSyntheticsDataHandle {
 
         for peptide in peptides.iter() {
             let peptide_id = peptide.peptide_id;
-            let frame_occurrence = peptide.frame_distribution.occurrence.clone();
-            let frame_abundance = peptide.frame_distribution.abundance.clone();
-
-            for (frame_id, abundance) in frame_occurrence.iter().zip(frame_abundance.iter()) {
+            // Borrow the per-peptide occurrence/abundance vectors instead of cloning
+            // them — the loop only copies the scalar peptide_id (u32) and abundance
+            // (f32) into the map, so the clones were pure transient garbage (~300M
+            // elements copied at 150K peptides). Output is identical.
+            for (frame_id, abundance) in peptide
+                .frame_distribution
+                .occurrence
+                .iter()
+                .zip(peptide.frame_distribution.abundance.iter())
+            {
                 // only insert if the abundance is greater than 1e-6
-
                 if *abundance > 1e-6 {
                     let (occurrences, abundances) = frame_to_abundances
                         .entry(*frame_id)


### PR DESCRIPTION
Follow-up increment on `feature/instrument-dispatch-p1` after #408 (Orbitrap Astral
build-from-template) was merged. Seven commits, no changes to the Bruker byte-default.

## Thermo `.raw` superimposition (Overlay mode)
Wire `WriteMode::Overlay` into the build-from-template writer so a run can keep the
template's **real** signal and add simulated peaks on top (real⊕sim), instead of only
replacing it. Replace stays the byte-default; superimposition is opt-in via
`config.superimpose_on_reference` + `superimpose_merge_ppm` (default 15 ppm).
- `AstralWriteOptions.superimpose_ppm` (0 = Replace, >0 = Overlay merge tolerance);
  validated finite/≥0 at both the Rust entry point and the PyO3 boundary.
- `write_scan` short-circuits an empty Overlay author (advances the cursor, leaves the
  template packet untouched) so the overflow fallback keeps real signal byte-identical
  rather than re-canonicalising it. Gated `overlay_empty_is_noop` test proves the
  decoded MS1 profile + MS2 centroids are unchanged (exact equality).
- Reject a non-positive/non-finite tolerance when superimposing (would silently fall
  back to Replace and overwrite the reference).

## Standalone ground-truth eval (`timsim-eval`)
New `imspy_simulation.timsim.groundtruth_eval` — engine/instrument-agnostic eval of a
simulated run against a DiaNN/alphaDIA report: RT correlation, charge accuracy, **FDP**
(realized false-discovery proportion vs the complete ground truth), quant correlation,
and recall-by-abundance. (`empirical_fdr` renamed to `fdp` — it is a realized proportion
measured against known truth, not an FDR estimate or entrapment.)

## Generalize Thermo build-from-template to `orbitrap_exploris`
Replace the hardcoded `orbitrap_astral` checks with a `THERMO_TEMPLATE_INSTRUMENTS`
family (`is_thermo_template_instrument`) + generic `template_path` key. One trunk now
renders to Bruker `.d`, Astral `.raw`, and classic Orbitrap `.raw`.

## 150K-scale memory fixes
- Batch the EMG frame-distribution projection (default 25k) to bound peak RSS;
  output-equivalent (byte-identical noise-off; noise-on byte-identical with Numba RNG
  seeded). Zero-peptide guard + byte-parity tests.
- Borrow per-peptide vectors in `build_frame_to_abundances` instead of cloning.

These (Phase 0 batching + borrow cleanup) let a 150K-peptide run complete end-to-end
within 31 GB (render peak ~19 GB).

## Testing
- `cargo test --features thermo` incl. gated `thermo_overlay` / `overlay_empty_is_noop`
  against real Astral + Orbitrap templates.
- Both Codex review rounds on the superimpose change actioned.
- Frame-dist batching byte-parity (noise on/off) + eval-module unit tests.