### PR TITLE
Multi-vendor simulation (SCIEX/Waters/Thermo/Bruker) + mzPROV provenance signing

### DIFF
--- a/imspy_connector/Cargo.toml
+++ b/imspy_connector/Cargo.toml
@@ -23,3 +23,5 @@ rustc-hash = "2.1.0"
 # time). Off by default: the core connector + Bruker scheme path stay unaffected.
 thermo = ["rustdf/thermo"]
 sciex = ["rustdf/sciex"]
+# Open mzML output writer (mzdata); no private repo needed.
+mzml = ["rustdf/mzml"]

--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -650,6 +650,40 @@ pub fn write_astral_raw(
     Ok((s.scans, s.ms1, s.ms2, s.ms2_nonempty, s.overflow_cleared, s.checksum_valid))
 }
 
+/// Render a no-IM DIA `synthetic_data.db` to open **mzML** (the SCIEX / vendor-neutral
+/// output). Walks the DB frames, renders MS1 (precursor marginal) + MS2 (per-window
+/// fragments), and writes mzML via mzdata. Returns `(scans, ms1, ms2, ms2_nonempty)`.
+/// Requires the `mzml` feature.
+#[cfg(feature = "mzml")]
+#[pyfunction]
+#[pyo3(signature = (db_path, out_path, num_threads=4, quad_k=15.0))]
+pub fn render_dia_mzml(
+    py: Python<'_>,
+    db_path: &str,
+    out_path: &str,
+    num_threads: usize,
+    quad_k: f64,
+) -> PyResult<(usize, usize, usize, usize)> {
+    use std::path::Path;
+    let s = py
+        .allow_threads(|| {
+            rustdf::sim::mzml::render_db_to_mzml(
+                Path::new(db_path),
+                Path::new(out_path),
+                num_threads,
+                quad_k,
+            )
+        })
+        .map_err(PyValueError::new_err)?;
+    Ok((s.scans, s.ms1, s.ms2, s.ms2_nonempty))
+}
+
+/// Whether the connector was built with the `mzml` feature (open mzML writer).
+#[pyfunction]
+pub fn has_mzml() -> bool {
+    cfg!(feature = "mzml")
+}
+
 #[pymodule]
 pub fn py_acquisition(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAcquisitionScheme>()?;
@@ -665,5 +699,8 @@ pub fn py_acquisition(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(accurate_scan_projection, m)?)?;
     m.add_function(wrap_pyfunction!(has_thermo, m)?)?;
     m.add_function(wrap_pyfunction!(has_sciex, m)?)?;
+    #[cfg(feature = "mzml")]
+    m.add_function(wrap_pyfunction!(render_dia_mzml, m)?)?;
+    m.add_function(wrap_pyfunction!(has_mzml, m)?)?;
     Ok(())
 }

--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -111,6 +111,48 @@ impl PyAcquisitionScheme {
         Ok(Self { inner })
     }
 
+    /// Synthesize the per-frame SWATH schedule for a SCIEX `.wiff` over the gradient —
+    /// the SCIEX analogue of `thermo_frame_schedule`. Reads the `.wiff` SWATH method,
+    /// then expands the cycle (MS1 + one MS2 frame per window) over `num_cycles`. Returns
+    /// rows `(scan, retention_time_s, ms_level, isolation_center_mz, isolation_width_mz,
+    /// collision_energy)`; MS1 rows have `None` isolation/CE.
+    #[cfg(feature = "sciex")]
+    #[staticmethod]
+    #[pyo3(signature = (path, cycle_time_s, gradient_length_s, *, ce_intercept=None, ce_slope_per_mz=None))]
+    pub fn sciex_frame_schedule(
+        py: Python<'_>,
+        path: &str,
+        cycle_time_s: f64,
+        gradient_length_s: f64,
+        ce_intercept: Option<f64>,
+        ce_slope_per_mz: Option<f64>,
+    ) -> PyResult<Vec<(u32, f64, u8, Option<f64>, Option<f64>, Option<f64>)>> {
+        use rustdf::sim::scheme::CollisionEnergyPolicy;
+        let ce = match (ce_intercept, ce_slope_per_mz) {
+            (Some(intercept), Some(slope_per_mz)) => {
+                CollisionEnergyPolicy::Linear { intercept, slope_per_mz }
+            }
+            (None, None) => CollisionEnergyPolicy::Unknown,
+            _ => {
+                return Err(PyValueError::new_err(
+                    "supply both ce_intercept and ce_slope_per_mz, or neither",
+                ))
+            }
+        };
+        let rows = py
+            .allow_threads(|| {
+                AcquisitionScheme::from_sciex_wiff(path, cycle_time_s, gradient_length_s, ce)
+                    .map(|s| s.dia_frame_schedule())
+            })
+            .map_err(PyErr::from)?;
+        if rows.is_empty() {
+            return Err(PyValueError::new_err(
+                "empty SWATH schedule (check cycle_time_s/gradient_length_s)",
+            ));
+        }
+        Ok(rows)
+    }
+
     /// Instrument kind (canonical enum variant name, e.g. `"TimsTofDia"`).
     #[getter]
     pub fn instrument(&self) -> String {

--- a/imspy_connector/src/py_simulation.rs
+++ b/imspy_connector/src/py_simulation.rs
@@ -605,6 +605,54 @@ impl PyTimsTofLazyFrameBuilderDDA {
     }
 }
 
+/// Decode a batch of Prosit intensity vectors into DiaNN/Spectronaut transitions and
+/// write/append them to a `.tsv` — the fast (rayon-parallel, Rust) replacement for a
+/// per-peptide Python decode loop. `prosit_flat` is row-major (peptide `i` is
+/// `prosit_flat[i*n_cols..(i+1)*n_cols]`). The caller supplies the cheap string columns
+/// (`modpep_diann` in `(UniMod:n)` form, the stripped `PeptideSequence`). With
+/// `append=False` the file is truncated and a header written; `append=True` appends rows
+/// (for chunked builds). Returns `(transitions_written, precursors_written)`.
+#[pyfunction]
+#[pyo3(signature = (out_path, modified_sequences, modpep_diann, stripped, charges, prosit_flat, n_cols, precursor_mz, retention_time, protein_ids, genes, min_fragments=3, append=false))]
+#[allow(clippy::too_many_arguments)]
+pub fn write_spectral_library_tsv(
+    py: Python<'_>,
+    out_path: &str,
+    modified_sequences: Vec<String>,
+    modpep_diann: Vec<String>,
+    stripped: Vec<String>,
+    charges: Vec<i32>,
+    prosit_flat: Vec<f64>,
+    n_cols: usize,
+    precursor_mz: Vec<f64>,
+    retention_time: Vec<f64>,
+    protein_ids: Vec<String>,
+    genes: Vec<String>,
+    min_fragments: usize,
+    append: bool,
+) -> PyResult<(usize, usize)> {
+    use pyo3::exceptions::PyValueError;
+    use std::path::Path;
+    py.allow_threads(|| {
+        rustdf::sim::library::build_spectral_library_tsv(
+            Path::new(out_path),
+            &modified_sequences,
+            &modpep_diann,
+            &stripped,
+            &charges,
+            &prosit_flat,
+            n_cols,
+            &precursor_mz,
+            &retention_time,
+            &protein_ids,
+            &genes,
+            min_fragments,
+            append,
+        )
+    })
+    .map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
 #[pymodule]
 pub fn py_simulation(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyIsotopeTransmissionConfig>()?;
@@ -614,5 +662,6 @@ pub fn py_simulation(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTimsTofSyntheticsFrameBuilderDDA>()?;
     m.add_class::<PyTimsTofLazyFrameBuilderDIA>()?;
     m.add_class::<PyTimsTofLazyFrameBuilderDDA>()?;
+    m.add_function(wrap_pyfunction!(write_spectral_library_tsv, m)?)?;
     Ok(())
 }

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/grid.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/grid.py
@@ -58,8 +58,14 @@ import toml
 
 
 def _drop_none(d: dict) -> dict:
-    """TOML has no null; drop keys whose value is None (e.g. an unset window_step)."""
-    return {k: v for k, v in d.items() if v is not None}
+    """TOML has no null; drop keys whose value is None (e.g. an unset window_step),
+    recursing into nested tables so a None buried in a sub-table can't reach toml.dump."""
+    out = {}
+    for k, v in d.items():
+        if v is None:
+            continue
+        out[k] = _drop_none(v) if isinstance(v, dict) else v
+    return out
 
 
 def expand(spec: dict) -> dict[str, dict]:
@@ -89,6 +95,17 @@ def expand(spec: dict) -> dict[str, dict]:
         cfg.setdefault("save_path", os.path.join(save_root, label))
         cfg.setdefault("experiment_name", label.upper().replace("_", "-"))
         out[label] = _drop_none(cfg)
+    # Two cells writing to the same save_path would clobber each other's output (can
+    # happen if cells set/override save_path, or labels collide post-normalisation).
+    by_save_path: dict[str, str] = {}
+    for label, cfg in out.items():
+        sp = cfg["save_path"]
+        if sp in by_save_path:
+            raise ValueError(
+                f"cells {by_save_path[sp]!r} and {label!r} resolve to the same "
+                f"save_path {sp!r}; give them distinct save_path / labels"
+            )
+        by_save_path[sp] = label
     return out
 
 
@@ -107,18 +124,21 @@ def write_configs(expanded: dict[str, dict], out_dir: str) -> dict[str, str]:
 def manifest_for(spec: dict, eval_filename: str = "eval.json") -> dict:
     """Build the ``multi_vendor`` manifest for this grid.
 
-    Each cell's ``eval_json`` points at ``<save_root>/<label>/<eval_filename>`` (where the
-    per-cell ``groundtruth_eval`` JSON is expected). ``q`` carries through from the spec.
+    Derived from ``expand(spec)`` so it shares the same validation (missing instrument,
+    duplicate labels, save_path collisions) and the SAME resolved ``save_path`` as the
+    written configs — each cell's ``eval_json`` is ``<resolved save_path>/<eval_filename>``,
+    so the manifest can't drift from where the run actually wrote its output. ``q`` carries
+    through from the spec.
     """
-    save_root = spec.get("save_root", "grid")
+    expanded = expand(spec)
+    cell_by_label = {c["label"]: c for c in spec.get("cells", [])}
     vendors = []
-    for cell in spec.get("cells", []):
-        label = cell["label"]
-        cfg = {**spec.get("base", {}), **cell.get("config", {})}
+    for label, cfg in expanded.items():
+        cell = cell_by_label[label]
         vendors.append({
-            "instrument": cfg.get("instrument", label),
+            "instrument": cfg["instrument"],
             "engine": cell.get("engine", "?"),
-            "eval_json": os.path.join(save_root, label, eval_filename),
+            "eval_json": os.path.join(cfg["save_path"], eval_filename),
             "source": cell.get("source", "live"),
         })
     return {"q": spec.get("q", 0.01), "vendors": vendors}

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/grid.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/grid.py
@@ -1,0 +1,150 @@
+"""Multi-vendor benchmark *test grid*: expand one shared base config + per-vendor
+cells into matched per-vendor TimSim configs, and emit the manifest the
+``multi_vendor`` consolidator consumes.
+
+The point of the grid is a fair, reproducible cross-vendor comparison: every cell
+shares the bulk of the configuration (FASTA, peptide counts, m/z noise) so the only
+differences are the instrument and its acquisition source. A grid spec (JSON)::
+
+    {
+      "save_root": "/tmp/grid",
+      "base": {                       # shared across every cell
+        "fasta_path": "/data/human.fasta",
+        "acquisition_type": "DIA",
+        "num_peptides_total": 30000,
+        "num_sample_peptides": 5000,
+        "num_threads": 6,
+        "apply_fragmentation": true
+      },
+      "cells": [
+        {"label": "bruker", "engine": "diann",
+         "config": {"instrument": "bruker_timstof", "reference_path": "/data/ref.d",
+                    "gradient_length": 1800}},
+        {"label": "thermo", "engine": "alphadia",
+         "config": {"instrument": "orbitrap_exploris", "template_path": "/data/tmpl.raw",
+                    "intensity_model": "prosit_hcd", "gradient_length": 2700}},
+        {"label": "sciex", "engine": "alphadia",
+         "config": {"instrument": "sciex_zenotof", "template_path": "/data/m.wiff",
+                    "intensity_model": "prosit_hcd", "gradient_length": 1800}},
+        {"label": "waters", "engine": "diann",
+         "config": {"instrument": "waters_synapt_xs", "intensity_model": "prosit_hcd",
+                    "gradient_length": 1800, "waters_cycle_time_s": 1.5}}
+      ]
+    }
+
+``expand`` merges ``base`` + each cell's ``config`` into a full TimSim config (adding
+``save_path = <save_root>/<label>`` and ``experiment_name``). ``write_configs`` writes
+``<label>.toml`` per cell. ``manifest_for`` produces the ``multi_vendor`` manifest whose
+each cell's ``eval_json`` points at ``<save_root>/<label>/eval.json`` — the JSON you
+produce by running, per cell::
+
+    timsim <out_dir>/<label>.toml                          # sim -> output + synthetic_data.db
+    <engine> on the output                                 # DiaNN (.d/.mzML) | alphaDIA (.raw/.mzML)
+    python -m imspy_simulation.timsim.groundtruth_eval \\
+        --db <save_root>/<label>/<EXP>/synthetic_data.db --report <report> \\
+        --engine <engine> --precursor-fdp --out <save_root>/<label>/eval.json
+
+Then ``python -m imspy_simulation.timsim.benchmark.multi_vendor --manifest <manifest>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Optional
+
+import toml
+
+
+def _drop_none(d: dict) -> dict:
+    """TOML has no null; drop keys whose value is None (e.g. an unset window_step)."""
+    return {k: v for k, v in d.items() if v is not None}
+
+
+def expand(spec: dict) -> dict[str, dict]:
+    """Merge ``base`` + each cell's ``config`` into a full per-cell TimSim config.
+
+    Adds ``save_path = <save_root>/<label>`` and a derived ``experiment_name`` unless
+    the cell sets its own. Cell config overrides base on key collision.
+    """
+    save_root = spec.get("save_root", "grid")
+    base = spec.get("base", {})
+    cells = spec.get("cells", [])
+    if not cells:
+        raise ValueError("grid spec has no 'cells'")
+    out: dict[str, dict] = {}
+    seen = set()
+    for cell in cells:
+        label = cell.get("label")
+        if not label:
+            raise ValueError(f"cell missing 'label': {cell!r}")
+        if label in seen:
+            raise ValueError(f"duplicate cell label {label!r}")
+        seen.add(label)
+        cfg = dict(base)
+        cfg.update(cell.get("config", {}))
+        if "instrument" not in cfg:
+            raise ValueError(f"cell {label!r} has no 'instrument' (in cell.config or base)")
+        cfg.setdefault("save_path", os.path.join(save_root, label))
+        cfg.setdefault("experiment_name", label.upper().replace("_", "-"))
+        out[label] = _drop_none(cfg)
+    return out
+
+
+def write_configs(expanded: dict[str, dict], out_dir: str) -> dict[str, str]:
+    """Write one ``<label>.toml`` per cell into ``out_dir``; return {label: path}."""
+    os.makedirs(out_dir, exist_ok=True)
+    paths: dict[str, str] = {}
+    for label, cfg in expanded.items():
+        path = os.path.join(out_dir, f"{label}.toml")
+        with open(path, "w") as fh:
+            toml.dump(cfg, fh)
+        paths[label] = path
+    return paths
+
+
+def manifest_for(spec: dict, eval_filename: str = "eval.json") -> dict:
+    """Build the ``multi_vendor`` manifest for this grid.
+
+    Each cell's ``eval_json`` points at ``<save_root>/<label>/<eval_filename>`` (where the
+    per-cell ``groundtruth_eval`` JSON is expected). ``q`` carries through from the spec.
+    """
+    save_root = spec.get("save_root", "grid")
+    vendors = []
+    for cell in spec.get("cells", []):
+        label = cell["label"]
+        cfg = {**spec.get("base", {}), **cell.get("config", {})}
+        vendors.append({
+            "instrument": cfg.get("instrument", label),
+            "engine": cell.get("engine", "?"),
+            "eval_json": os.path.join(save_root, label, eval_filename),
+            "source": cell.get("source", "live"),
+        })
+    return {"q": spec.get("q", 0.01), "vendors": vendors}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--spec", required=True, help="path to the grid spec JSON")
+    ap.add_argument("--out-dir", required=True, help="directory to write the per-cell TOML configs")
+    ap.add_argument("--write-manifest", help="optional path to write the multi_vendor manifest JSON")
+    args = ap.parse_args(argv)
+
+    with open(args.spec) as fh:
+        spec = json.load(fh)
+    expanded = expand(spec)
+    paths = write_configs(expanded, args.out_dir)
+    print(f"wrote {len(paths)} grid configs to {args.out_dir}:")
+    for label, p in paths.items():
+        print(f"  {label:10s} -> {p}  (instrument={expanded[label]['instrument']})")
+    if args.write_manifest:
+        manifest = manifest_for(spec)
+        with open(args.write_manifest, "w") as fh:
+            json.dump(manifest, fh, indent=2)
+        print(f"wrote consolidation manifest -> {args.write_manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/multi_vendor.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/multi_vendor.py
@@ -1,0 +1,179 @@
+"""Multi-vendor TimSim benchmark: consolidate per-vendor ground-truth eval results
+into one side-by-side recall / FDP table.
+
+TimSim simulates DIA data for four instrument families, each searched by an
+independent engine and scored against the known ground truth:
+
+    Bruker timsTOF (.d)   Thermo Astral/Orbitrap (.raw)
+    SCIEX ZenoTOF (mzML)  Waters Synapt XS SONAR (mzML)
+
+This module does NOT run simulators or search engines (those are external and
+host-specific). It reads the JSON emitted by ``groundtruth_eval`` (one per vendor)
+and renders a comparison table, so the multi-vendor validation story lives in one
+reproducible place. Vendors with no fresh eval JSON can be carried as ``recorded``
+entries (a prior validated run) with explicit provenance, kept distinct from
+freshly-evaluated rows by the ``source`` column.
+
+Per-vendor generation recipe (each produces one eval JSON consumed here)::
+
+    1. timsim <vendor>.toml                       # -> .d/.raw/.mzML + synthetic_data.db
+    2. <engine> on the output                     # DiaNN (.d/.mzML), alphaDIA (.raw/.mzML)
+    3. python -m imspy_simulation.timsim.groundtruth_eval \\
+         --db <synthetic_data.db> --report <engine report> \\
+         --engine <diann|alphadia> --precursor-fdp --out <vendor>.json
+
+A manifest (JSON) lists the vendors to consolidate::
+
+    {
+      "q": 0.01,
+      "vendors": [
+        {"instrument": "sciex_zenotof",  "engine": "alphadia", "eval_json": "/path/sciex.json"},
+        {"instrument": "waters_synapt_xs","engine": "diann",   "eval_json": "/path/waters.json"},
+        {"instrument": "bruker_timstof", "engine": "diann", "source": "recorded",
+         "recorded": {"observable": 0, "ids": 0, "recall_pct": 0.0,
+                      "fdp_backbone": 0.0, "fdp_peptidoform": 0.0},
+         "note": "prior validated run <ref>"}
+      ]
+    }
+
+    python -m imspy_simulation.timsim.benchmark.multi_vendor --manifest m.json --out table.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+# Display metadata per supported instrument (output format the render produces).
+VENDOR_META = {
+    "bruker_timstof": ("Bruker timsTOF", ".d (TDF)"),
+    "orbitrap_astral": ("Thermo Astral", ".raw"),
+    "orbitrap_exploris": ("Thermo Orbitrap", ".raw"),
+    "sciex_zenotof": ("SCIEX ZenoTOF", "mzML"),
+    "waters_synapt_xs": ("Waters Synapt XS SONAR", "mzML"),
+}
+
+
+@dataclass
+class VendorRow:
+    instrument: str
+    display: str
+    output: str
+    engine: str
+    observable: Optional[int]
+    ids: Optional[int]
+    recall_pct: Optional[float]
+    fdp_backbone: Optional[float]
+    fdp_peptidoform: Optional[float]
+    source: str
+    note: str = ""
+
+
+def summarize_eval(eval_json_path: str, q: float = 0.01) -> dict:
+    """Extract the recall / FDP summary at q-threshold ``q`` from a groundtruth_eval JSON.
+
+    Picks the curve point whose ``q`` is closest to the requested threshold (the eval
+    samples a fixed grid; an exact match is used when present).
+    """
+    with open(eval_json_path) as fh:
+        data = json.load(fh)
+    curve = data.get("curve") or []
+    if not curve:
+        raise ValueError(f"{eval_json_path}: no 'curve' in eval JSON")
+    point = min(curve, key=lambda r: abs(float(r["q"]) - q))
+    observable = data.get("rendered_observable_precursors")
+    ids = point.get("n_precursors")
+    recall = (100.0 * ids / observable) if (observable and ids is not None) else None
+    return {
+        "observable": observable,
+        "ids": ids,
+        "recall_pct": recall,
+        "fdp_backbone": point.get("fdp_backbone"),
+        "fdp_peptidoform": point.get("fdp_peptidoform_genuine"),
+        "q": point.get("q"),
+        "engine": data.get("engine"),
+    }
+
+
+def build_rows(manifest: dict) -> list[VendorRow]:
+    q = float(manifest.get("q", 0.01))
+    rows: list[VendorRow] = []
+    for v in manifest.get("vendors", []):
+        instrument = v["instrument"]
+        display, output = VENDOR_META.get(instrument, (instrument, "?"))
+        engine = v.get("engine", "?")
+        if v.get("eval_json"):
+            s = summarize_eval(v["eval_json"], q=q)
+            rows.append(VendorRow(
+                instrument=instrument, display=display, output=output,
+                engine=engine or s.get("engine") or "?",
+                observable=s["observable"], ids=s["ids"], recall_pct=s["recall_pct"],
+                fdp_backbone=s["fdp_backbone"], fdp_peptidoform=s["fdp_peptidoform"],
+                source=v.get("source", "live"), note=v.get("note", ""),
+            ))
+        elif v.get("recorded"):
+            r = v["recorded"]
+            rows.append(VendorRow(
+                instrument=instrument, display=display, output=output, engine=engine,
+                observable=r.get("observable"), ids=r.get("ids"),
+                recall_pct=r.get("recall_pct"),
+                fdp_backbone=r.get("fdp_backbone"), fdp_peptidoform=r.get("fdp_peptidoform"),
+                source=v.get("source", "recorded"), note=v.get("note", ""),
+            ))
+        else:
+            raise ValueError(f"vendor {instrument!r} has neither 'eval_json' nor 'recorded'")
+    return rows
+
+
+def _fmt_pct(x: Optional[float]) -> str:
+    return "—" if x is None else f"{x:.1f}%"
+
+
+def _fmt_fdp(x: Optional[float]) -> str:
+    return "—" if x is None else f"{x * 100:.2f}%"
+
+
+def render_markdown(rows: list[VendorRow], q: float = 0.01) -> str:
+    head = (
+        f"# TimSim multi-vendor benchmark (q = {q:g})\n\n"
+        "| Vendor | Output | Engine | Observable | IDs @FDR | Recall | FDP (backbone) | FDP (peptidoform) | Source |\n"
+        "|---|---|---|---:|---:|---:|---:|---:|---|\n"
+    )
+    body = "".join(
+        f"| {r.display} | {r.output} | {r.engine} | "
+        f"{'—' if r.observable is None else r.observable} | "
+        f"{'—' if r.ids is None else r.ids} | {_fmt_pct(r.recall_pct)} | "
+        f"{_fmt_fdp(r.fdp_backbone)} | {_fmt_fdp(r.fdp_peptidoform)} | {r.source} |\n"
+        for r in rows
+    )
+    notes = [f"- **{r.display}**: {r.note}" for r in rows if r.note]
+    tail = ("\n" + "\n".join(notes) + "\n") if notes else ""
+    return head + body + tail
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--manifest", required=True, help="path to the vendor manifest JSON")
+    ap.add_argument("--out", help="optional path to write the Markdown table")
+    ap.add_argument("--json-out", help="optional path to write the consolidated JSON")
+    args = ap.parse_args(argv)
+
+    with open(args.manifest) as fh:
+        manifest = json.load(fh)
+    q = float(manifest.get("q", 0.01))
+    rows = build_rows(manifest)
+    table = render_markdown(rows, q=q)
+    print(table)
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(table)
+    if args.json_out:
+        with open(args.json_out, "w") as fh:
+            json.dump({"q": q, "vendors": [asdict(r) for r in rows]}, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/multi_vendor.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/benchmark/multi_vendor.py
@@ -74,15 +74,22 @@ class VendorRow:
 def summarize_eval(eval_json_path: str, q: float = 0.01) -> dict:
     """Extract the recall / FDP summary at q-threshold ``q`` from a groundtruth_eval JSON.
 
-    Picks the curve point whose ``q`` is closest to the requested threshold (the eval
-    samples a fixed grid; an exact match is used when present).
+    FDR-threshold semantics: report the curve point with the LARGEST ``q`` that is still
+    ``<= q`` (i.e. the most IDs that pass at or below the requested FDR) — never a point
+    above the threshold, which would overstate IDs/recall. If the curve starts above
+    ``q`` (no point qualifies), fall back to the smallest-``q`` point; the returned ``q``
+    reflects which point was actually used.
     """
     with open(eval_json_path) as fh:
         data = json.load(fh)
     curve = data.get("curve") or []
     if not curve:
         raise ValueError(f"{eval_json_path}: no 'curve' in eval JSON")
-    point = min(curve, key=lambda r: abs(float(r["q"]) - q))
+    at_or_below = [r for r in curve if float(r["q"]) <= q + 1e-12]
+    if at_or_below:
+        point = max(at_or_below, key=lambda r: float(r["q"]))
+    else:
+        point = min(curve, key=lambda r: float(r["q"]))
     observable = data.get("rendered_observable_precursors")
     ids = point.get("n_precursors")
     recall = (100.0 * ids / observable) if (observable and ids is not None) else None
@@ -103,7 +110,7 @@ def build_rows(manifest: dict) -> list[VendorRow]:
     for v in manifest.get("vendors", []):
         instrument = v["instrument"]
         display, output = VENDOR_META.get(instrument, (instrument, "?"))
-        engine = v.get("engine", "?")
+        engine = v.get("engine")  # may be None -> fall back to the eval JSON's engine
         if v.get("eval_json"):
             s = summarize_eval(v["eval_json"], q=q)
             rows.append(VendorRow(
@@ -116,7 +123,7 @@ def build_rows(manifest: dict) -> list[VendorRow]:
         elif v.get("recorded"):
             r = v["recorded"]
             rows.append(VendorRow(
-                instrument=instrument, display=display, output=output, engine=engine,
+                instrument=instrument, display=display, output=output, engine=engine or "?",
                 observable=r.get("observable"), ids=r.get("ids"),
                 recall_pct=r.get("recall_pct"),
                 fdp_backbone=r.get("fdp_backbone"), fdp_peptidoform=r.get("fdp_peptidoform"),
@@ -125,6 +132,11 @@ def build_rows(manifest: dict) -> list[VendorRow]:
         else:
             raise ValueError(f"vendor {instrument!r} has neither 'eval_json' nor 'recorded'")
     return rows
+
+
+def _cell(s) -> str:
+    """Sanitize a string for a Markdown table cell (escape pipes, flatten newlines)."""
+    return str(s).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
 
 
 def _fmt_pct(x: Optional[float]) -> str:
@@ -142,13 +154,13 @@ def render_markdown(rows: list[VendorRow], q: float = 0.01) -> str:
         "|---|---|---|---:|---:|---:|---:|---:|---|\n"
     )
     body = "".join(
-        f"| {r.display} | {r.output} | {r.engine} | "
+        f"| {_cell(r.display)} | {_cell(r.output)} | {_cell(r.engine)} | "
         f"{'—' if r.observable is None else r.observable} | "
         f"{'—' if r.ids is None else r.ids} | {_fmt_pct(r.recall_pct)} | "
-        f"{_fmt_fdp(r.fdp_backbone)} | {_fmt_fdp(r.fdp_peptidoform)} | {r.source} |\n"
+        f"{_fmt_fdp(r.fdp_backbone)} | {_fmt_fdp(r.fdp_peptidoform)} | {_cell(r.source)} |\n"
         for r in rows
     )
-    notes = [f"- **{r.display}**: {r.note}" for r in rows if r.note]
+    notes = [f"- **{_cell(r.display)}**: {_cell(r.note)}" for r in rows if r.note]
     tail = ("\n" + "\n".join(notes) + "\n") if notes else ""
     return head + body + tail
 

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
@@ -13,140 +13,27 @@ testable on its own; the acquisition builder consumes its output.
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Tuple
+from typing import Optional
 
 import numpy as np
-import pandas as pd
 
-# A schedule row: (scan, rt_s, ms_level, center_mz|None, width_mz|None, ce|None)
-ScheduleRow = Tuple[int, float, int, Optional[float], Optional[float], Optional[float]]
+# The schedule->tables transform and the duck-typed Bruker-reference stand-ins are
+# instrument-neutral (the SCIEX build-from-.wiff path reuses them verbatim), so they
+# live in the shared module. Imported here under both the canonical neutral names and
+# the original ``*astral*`` / ``_Astral*`` names so existing call sites and tests keep
+# working.
+from .template_acquisition_common import (
+    ScheduleRow,
+    TemplateHelperHandle,
+    TemplateTdfWriterStub,
+    build_frame_tables_from_schedule,
+    build_synthetic_scan_table,
+)
 
-
-def build_synthetic_scan_table(
-    num_scans: int = 451,
-    im_lower: float = 0.6,
-    im_upper: float = 1.6,
-) -> pd.DataFrame:
-    """A synthetic mobility (scan) grid for an Astral run — NO Bruker reference.
-
-    Astral has no ion mobility, and the render marginalises the mobility axis away
-    (P6c/P6e), so the actual 1/K0 values do not affect Astral output — but the
-    simulation pipeline still projects ion-mobility distributions onto a scan grid,
-    so it needs SOME grid. We provide a plausible descending 1/K0 grid (the Bruker
-    `scans` table is descending scan index with ascending mobility) without reading
-    a reference `.d`. This is the key decoupling primitive for the lean Astral
-    acquisition path (option b): it removes the `TDFWriter.helper_handle` dependency.
-    """
-    if num_scans < 1:
-        raise ValueError("num_scans must be >= 1")
-    if not (im_lower < im_upper):
-        raise ValueError("im_lower must be < im_upper")
-    # Descending scan index (Bruker convention), ascending inverse mobility.
-    scans = np.arange(num_scans, dtype=np.int64)[::-1]
-    mobilities = np.linspace(im_lower, im_upper, num_scans, dtype=np.float64)
-    return pd.DataFrame({"scan": scans, "mobility": mobilities})
-
-
-def build_astral_frame_tables(
-    schedule: Sequence[ScheduleRow],
-    *,
-    num_scans: int = 1,
-    ce_decimals: int = 2,
-) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, List[int]]:
-    """Build the Astral acquisition tables from a template scan schedule.
-
-    Each template scan becomes one frame (``frame_id`` 1..N in scan order), timed
-    at its REAL retention time. MS1 scans are precursor frames (``ms_type`` 0); MS2
-    scans are fragment frames (``ms_type`` 9) carrying the template's isolation
-    window + collision energy. Distinct (center, width, CE) windows are assigned
-    window-group ids; because Astral has no ion mobility, each window spans the
-    FULL scan range ``[0, num_scans-1]`` so the (mobility-indexed) transmission
-    degenerates to pure m/z gating.
-
-    Returns ``(frame_table, dia_ms_ms_windows, frames_to_window_groups,
-    frame_to_template_scan)`` where the last is a list mapping ``frame_id-1`` ->
-    the template scan number (so the writer can author each frame into its slot).
-    """
-    if not schedule:
-        raise ValueError("empty template schedule")
-
-    frames = []
-    fragment_rows = []  # (frame_id, window_key)
-    frame_to_template_scan: List[int] = []
-    # Deterministic window-group assignment: first occurrence order.
-    window_key_to_group: dict[Tuple[float, float, float], int] = {}
-    window_group_meta: dict[int, Tuple[float, float, float]] = {}
-
-    n_ms1 = 0
-    for idx, row in enumerate(schedule):
-        scan, rt, ms_level, center, width, ce = row
-        frame_id = idx + 1
-        frame_to_template_scan.append(int(scan))
-        is_ms1 = ms_level <= 1
-        ms_type = 0 if is_ms1 else 9
-        frames.append({"frame_id": frame_id, "time": float(rt), "ms_type": ms_type})
-        if is_ms1:
-            n_ms1 += 1
-            continue
-        # MS2: resolve / assign its window group.
-        if center is None or width is None:
-            raise ValueError(f"MS2 scan {scan} (frame {frame_id}) has no isolation window")
-        ce_val = round(float(ce), ce_decimals) if ce is not None else 0.0
-        key = (round(float(center), 4), round(float(width), 4), ce_val)
-        group = window_key_to_group.get(key)
-        if group is None:
-            group = len(window_key_to_group) + 1  # 1-based window-group ids
-            window_key_to_group[key] = group
-            window_group_meta[group] = key
-        fragment_rows.append({"frame": frame_id, "window_group": group})
-
-    if n_ms1 == 0:
-        raise ValueError("template schedule has no MS1 scans")
-    if not fragment_rows:
-        raise ValueError("template schedule has no MS2 scans")
-
-    frame_table = pd.DataFrame(frames)
-    frames_to_window_groups = pd.DataFrame(fragment_rows)
-
-    # One dia_ms_ms_windows row per window group. Astral has no mobility, so the
-    # window spans the whole scan range (mobility transmission -> pure m/z gating).
-    win_rows = []
-    for group, (center, width, ce_val) in sorted(window_group_meta.items()):
-        win_rows.append(
-            {
-                "window_group": group,
-                "scan_start": 0,
-                "scan_end": int(max(num_scans - 1, 0)),
-                "isolation_mz": center,
-                "isolation_width": width,
-                "collision_energy": ce_val,
-            }
-        )
-    dia_ms_ms_windows = pd.DataFrame(win_rows)
-
-    return frame_table, dia_ms_ms_windows, frames_to_window_groups, frame_to_template_scan
-
-
-class _AstralHelperHandle:
-    """Minimal stand-in for a Bruker reference's ``helper_handle`` — exposes only
-    the m/z + ion-mobility ranges the distribution jobs read. Astral has no IMS;
-    the mobility range is synthetic (marginalised away at render)."""
-
-    def __init__(self, mz_lower, mz_upper, im_lower, im_upper, num_scans):
-        self.mz_lower = mz_lower
-        self.mz_upper = mz_upper
-        self.im_lower = im_lower
-        self.im_upper = im_upper
-        self.num_scans = num_scans
-
-
-class _AstralTdfWriterStub:
-    """Stand-in for the Bruker ``TDFWriter``: the Astral path writes a Thermo
-    ``.raw`` (not a ``.d``), so only the reference ranges are needed during
-    simulation, never the binary writer."""
-
-    def __init__(self, helper_handle):
-        self.helper_handle = helper_handle
+# Backward-compatible aliases (the function/classes moved to template_acquisition_common).
+build_astral_frame_tables = build_frame_tables_from_schedule
+_AstralHelperHandle = TemplateHelperHandle
+_AstralTdfWriterStub = TemplateTdfWriterStub
 
 
 class AstralAcquisitionBuilder:
@@ -211,11 +98,11 @@ class AstralAcquisitionBuilder:
             )
 
         # Round (and window-group) collision energies at the configured precision —
-        # do it ONCE inside build_astral_frame_tables so grouping and the stored CE
-        # use the same values (no premature truncation). round_collision_energy=False
+        # do it ONCE inside build_frame_tables_from_schedule so grouping and the stored
+        # CE use the same values (no premature truncation). round_collision_energy=False
         # keeps full precision (grouped at 6 dp to avoid float over-splitting).
         ce_decimals = collision_energy_decimals if round_collision_energy else 6
-        ft, win, f2g, f2scan = build_astral_frame_tables(
+        ft, win, f2g, f2scan = build_frame_tables_from_schedule(
             schedule, num_scans=num_scans, ce_decimals=ce_decimals
         )
         # Optional manual override: force a single NCE across all windows. Off by
@@ -238,8 +125,8 @@ class AstralAcquisitionBuilder:
             mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())
         if mz_upper is None:
             mz_upper = float(win["isolation_mz"].max() + win["isolation_width"].max())
-        self.tdf_writer = _AstralTdfWriterStub(
-            _AstralHelperHandle(mz_lower, mz_upper, im_lower, im_upper, num_scans)
+        self.tdf_writer = TemplateTdfWriterStub(
+            TemplateHelperHandle(mz_lower, mz_upper, im_lower, im_upper, num_scans)
         )
 
         for name, tbl in (

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/register_prediction_set.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/register_prediction_set.py
@@ -41,6 +41,10 @@ INSTRUMENT_ACTIVATION = {
     # SCIEX ZenoTOF SWATH: beam-type CID (HCD-like); rolling CE is modelled and fed to the
     # prosit_hcd NCE predictor as NCE for now (true SCIEX CE is in volts — a refinement).
     "sciex_zenotof": {"activation_method": "hcd", "energy_unit": "nce"},
+    # Waters Synapt XS SONAR: scanning-quadrupole DIA, beam-type CID (HCD-like); rolling CE
+    # is modelled and fed to the prosit_hcd NCE predictor as NCE for now (true Waters CE is a
+    # voltage ramp — a refinement, same as SCIEX).
+    "waters_synapt_xs": {"activation_method": "hcd", "energy_unit": "nce"},
 }
 
 #: Thermo instruments simulated via the build-from-template path (a Thermo ``.raw``
@@ -68,6 +72,18 @@ SCIEX_INSTRUMENTS = frozenset({"sciex_zenotof"})
 def is_sciex_instrument(instrument) -> bool:
     """True if ``instrument`` uses the SCIEX build-from-.wiff path (ZenoTOF SWATH -> mzML)."""
     return str(instrument or "").lower() in SCIEX_INSTRUMENTS
+
+
+#: Waters instruments simulated via the build-from-parameters path: SONAR is a
+#: scanning-quadrupole DIA fully described by its scan range + window + cycle, so the
+#: schedule is SYNTHESIZED from parameters (no vendor file is read), no ion mobility is
+#: modelled, and the render output is open mzML. HCD-like (beam-type CID) physics.
+WATERS_INSTRUMENTS = frozenset({"waters_synapt_xs"})
+
+
+def is_waters_instrument(instrument) -> bool:
+    """True if ``instrument`` uses the Waters SONAR build-from-parameters path (-> mzML)."""
+    return str(instrument or "").lower() in WATERS_INSTRUMENTS
 
 
 def resolve_instrument_activation(instrument: str) -> tuple[str, str]:

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/register_prediction_set.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/register_prediction_set.py
@@ -38,6 +38,9 @@ INSTRUMENT_ACTIVATION = {
     "bruker_timstof": {"activation_method": "hcd", "energy_unit": "ev"},
     "orbitrap_astral": {"activation_method": "hcd", "energy_unit": "nce"},
     "orbitrap_exploris": {"activation_method": "hcd", "energy_unit": "nce"},
+    # SCIEX ZenoTOF SWATH: beam-type CID (HCD-like); rolling CE is modelled and fed to the
+    # prosit_hcd NCE predictor as NCE for now (true SCIEX CE is in volts — a refinement).
+    "sciex_zenotof": {"activation_method": "hcd", "energy_unit": "nce"},
 }
 
 #: Thermo instruments simulated via the build-from-template path (a Thermo ``.raw``
@@ -53,6 +56,18 @@ THERMO_TEMPLATE_INSTRUMENTS = frozenset({"orbitrap_astral", "orbitrap_exploris"}
 def is_thermo_template_instrument(instrument) -> bool:
     """True if ``instrument`` uses the Thermo build-from-template path (Astral/Orbitrap)."""
     return str(instrument or "").lower() in THERMO_TEMPLATE_INSTRUMENTS
+
+
+#: SCIEX instruments simulated via the build-from-.wiff path: the .wiff SWATH method
+#: (windows + TOF cal) becomes the acquisition, the schedule is SYNTHESIZED (the .wiff
+#: has no timing), and the render output is open mzML (the proprietary .wiff.scan is not
+#: authored). No ion mobility; HCD-like (beam-type CID) physics.
+SCIEX_INSTRUMENTS = frozenset({"sciex_zenotof"})
+
+
+def is_sciex_instrument(instrument) -> bool:
+    """True if ``instrument`` uses the SCIEX build-from-.wiff path (ZenoTOF SWATH -> mzML)."""
+    return str(instrument or "").lower() in SCIEX_INSTRUMENTS
 
 
 def resolve_instrument_activation(instrument: str) -> tuple[str, str]:

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
@@ -6,7 +6,7 @@ per-scan timing, so — unlike the Thermo build-from-template path which reads t
 template's real schedule — we SYNTHESIZE a SWATH frame schedule from the windows plus a
 caller-supplied cycle time + gradient (and a rolling-CE model). The Rust scheme layer does
 the expansion (``PyAcquisitionScheme.sciex_frame_schedule``); from there the acquisition
-tables are built by the SAME ``build_astral_frame_tables`` transform the Astral path uses,
+tables are built by the SAME ``build_frame_tables_from_schedule`` transform the Astral path uses,
 so the trunk renders identically. Output is open mzML (``render_dia_mzml``), since the
 proprietary ``.wiff.scan`` spectra are not authored.
 """
@@ -17,10 +17,10 @@ from typing import Optional
 
 import numpy as np
 
-from .astral_acquisition import (
-    _AstralHelperHandle,
-    _AstralTdfWriterStub,
-    build_astral_frame_tables,
+from .template_acquisition_common import (
+    TemplateHelperHandle,
+    TemplateTdfWriterStub,
+    build_frame_tables_from_schedule,
     build_synthetic_scan_table,
 )
 
@@ -92,7 +92,7 @@ class SciexAcquisitionBuilder:
             )
 
         ce_decimals = collision_energy_decimals if round_collision_energy else 6
-        ft, win, f2g, f2scan = build_astral_frame_tables(
+        ft, win, f2g, f2scan = build_frame_tables_from_schedule(
             schedule, num_scans=num_scans, ce_decimals=ce_decimals
         )
 
@@ -111,8 +111,8 @@ class SciexAcquisitionBuilder:
             mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())
         if mz_upper is None:
             mz_upper = float(win["isolation_mz"].max() + win["isolation_width"].max())
-        self.tdf_writer = _AstralTdfWriterStub(
-            _AstralHelperHandle(mz_lower, mz_upper, im_lower, im_upper, num_scans)
+        self.tdf_writer = TemplateTdfWriterStub(
+            TemplateHelperHandle(mz_lower, mz_upper, im_lower, im_upper, num_scans)
         )
 
         for name, tbl in (

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
@@ -83,6 +83,27 @@ class SciexAcquisitionBuilder:
             ce_slope_per_mz=ce_slope_per_mz,
         )
         schedule = list(sched)
+
+        # Rolling CE must stay strictly positive (and known) across the synthesized
+        # windows: a None CE silently becomes 0, and a non-positive NCE conditions
+        # fragment-intensity prediction to empty/unphysical MS2. The .wiff windows +
+        # rolling-CE model are resolved in Rust; verify the result here (parity with
+        # the Waters SONAR builder). MS2 rows are ms_level != 1.
+        ms2_ce = [r[5] for r in schedule if r[2] != 1]
+        if ms2_ce:
+            if any(c is None for c in ms2_ce):
+                raise ValueError(
+                    "SCIEX schedule has windows with unknown collision energy (some .wiff "
+                    "window centers fell outside the rolling-CE model); supply a CE model "
+                    "covering the full SWATH precursor m/z range"
+                )
+            if min(ms2_ce) <= 0.0:
+                raise ValueError(
+                    f"SCIEX rolling-CE model (intercept={ce_intercept}, slope={ce_slope_per_mz}) "
+                    f"yields non-positive collision energy (min {min(ms2_ce):.4f}) over the SWATH "
+                    "windows; supply a CE model positive across the precursor m/z range"
+                )
+
         if verbose:
             n_ms1 = sum(1 for r in schedule if r[2] == 1)
             print(

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
@@ -1,0 +1,130 @@
+"""SCIEX ZenoTOF SWATH build-from-.wiff acquisition (the SCIEX analogue of
+``AstralAcquisitionBuilder``).
+
+A SCIEX ``.wiff`` method carries the SWATH isolation windows + TOF calibration but NO
+per-scan timing, so — unlike the Thermo build-from-template path which reads the
+template's real schedule — we SYNTHESIZE a SWATH frame schedule from the windows plus a
+caller-supplied cycle time + gradient (and a rolling-CE model). The Rust scheme layer does
+the expansion (``PyAcquisitionScheme.sciex_frame_schedule``); from there the acquisition
+tables are built by the SAME ``build_astral_frame_tables`` transform the Astral path uses,
+so the trunk renders identically. Output is open mzML (``render_dia_mzml``), since the
+proprietary ``.wiff.scan`` spectra are not authored.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .astral_acquisition import (
+    _AstralHelperHandle,
+    _AstralTdfWriterStub,
+    build_astral_frame_tables,
+    build_synthetic_scan_table,
+)
+
+
+class SciexAcquisitionBuilder:
+    """Lean SCIEX ZenoTOF SWATH acquisition — NO Bruker reference / TDF.
+
+    Synthesizes the frame table + DIA windows from a SCIEX ``.wiff`` SWATH method
+    (``sciex_frame_schedule``) and a supplied cycle time / gradient / rolling-CE model,
+    then writes the four acquisition tables to ``synthetic_data.db``. Duck-types the
+    slice of the Bruker acquisition-builder interface the simulator reads
+    (``synthetics_handle``, ``frame_table``, ``scan_table``, ``tdf_writer.helper_handle``
+    ranges, ``gradient_length``, ``rt_cycle_length``, ``path``). The render output is mzML
+    (the proprietary ``.wiff.scan`` is not authored).
+    """
+
+    def __init__(
+        self,
+        path: str,
+        wiff_path: str,
+        *,
+        cycle_time_s: float = 3.5,
+        gradient_length_s: float = 1800.0,
+        ce_intercept: Optional[float] = 5.0,
+        ce_slope_per_mz: Optional[float] = 0.045,
+        num_scans: int = 451,
+        im_lower: float = 0.6,
+        im_upper: float = 1.6,
+        mz_lower: Optional[float] = None,
+        mz_upper: Optional[float] = None,
+        round_collision_energy: bool = True,
+        collision_energy_decimals: int = 2,
+        verbose: bool = True,
+    ) -> None:
+        import imspy_connector
+        from imspy_simulation.experiment import SyntheticExperimentDataHandle
+
+        # SCIEX rolling CE is not stored in the .wiff; without a model the schedule's CE
+        # is Unknown -> 0, which conditions fragment-intensity prediction (empty/unrealistic
+        # MS2). Require an explicit linear rolling-CE model for a SCIEX run.
+        if ce_intercept is None or ce_slope_per_mz is None:
+            raise ValueError(
+                "SCIEX requires a rolling-CE model: pass both ce_intercept and "
+                "ce_slope_per_mz (CE = intercept + slope_per_mz * precursor_mz)"
+            )
+
+        self.path = path
+        self.wiff_path = wiff_path
+        self.acquisition_name = "dia"
+        self.synthetics_handle = SyntheticExperimentDataHandle(database_path=path)
+
+        # Synthesize the SWATH schedule (Rust): 1 MS1 + N windows per cycle, expanded
+        # over the gradient at `cycle_time_s`. CE is the rolling-CE linear model (vs
+        # m/z); supply both coefficients or neither (left Unknown -> CE 0).
+        sched = imspy_connector.py_acquisition.PyAcquisitionScheme.sciex_frame_schedule(
+            wiff_path,
+            cycle_time_s,
+            gradient_length_s,
+            ce_intercept=ce_intercept,
+            ce_slope_per_mz=ce_slope_per_mz,
+        )
+        schedule = list(sched)
+        if verbose:
+            n_ms1 = sum(1 for r in schedule if r[2] == 1)
+            print(
+                f"SCIEX SWATH build-from-.wiff: {len(schedule)} frames "
+                f"({gradient_length_s / 60.0:.1f} min, cycle {cycle_time_s}s, "
+                f"{n_ms1} cycles)"
+            )
+
+        ce_decimals = collision_energy_decimals if round_collision_energy else 6
+        ft, win, f2g, f2scan = build_astral_frame_tables(
+            schedule, num_scans=num_scans, ce_decimals=ce_decimals
+        )
+
+        self.frame_table = ft
+        self.scan_table = build_synthetic_scan_table(num_scans, im_lower, im_upper)
+        self.dia_ms_ms_windows = win
+        self.frames_to_window_groups = f2g
+        self.frame_to_template_scan = f2scan  # synthetic (1..N); no real .wiff slots
+        self.num_frames = len(ft)
+        self.gradient_length = float(ft["time"].max())
+        diffs = np.diff(ft["time"].values)
+        positive = diffs[diffs > 0]
+        self.rt_cycle_length = float(np.median(positive)) if positive.size else 0.0
+
+        if mz_lower is None:
+            mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())
+        if mz_upper is None:
+            mz_upper = float(win["isolation_mz"].max() + win["isolation_width"].max())
+        self.tdf_writer = _AstralTdfWriterStub(
+            _AstralHelperHandle(mz_lower, mz_upper, im_lower, im_upper, num_scans)
+        )
+
+        for name, tbl in (
+            ("frames", ft),
+            ("scans", self.scan_table),
+            ("dia_ms_ms_info", f2g),
+            ("dia_ms_ms_windows", win),
+        ):
+            self.synthetics_handle.create_table(table_name=name, table=tbl)
+
+    def __repr__(self) -> str:
+        return (
+            f"SciexAcquisitionBuilder(path={self.path}, frames={self.num_frames}, "
+            f"windows={len(self.dia_ms_ms_windows)}, gradient={self.gradient_length:.1f}s)"
+        )

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/template_acquisition_common.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/template_acquisition_common.py
@@ -1,0 +1,151 @@
+"""Instrument-neutral primitives shared by every build-from-template acquisition
+builder (Thermo ``.raw`` Astral/Orbitrap and SCIEX ``.wiff`` ZenoTOF SWATH).
+
+A build-from-template run does NOT read a Bruker reference ``.d``: it turns a
+vendor template's (or synthesized) per-scan schedule into the four TimSim
+acquisition tables, and feeds the distribution jobs only the m/z + ion-mobility
+ranges they need. The transform and the two duck-typed stand-ins below are the
+same regardless of vendor, so they live here once and are imported by each
+builder (``astral_acquisition``, ``sciex_acquisition``).
+
+A schedule row is ``(scan, rt_s, ms_level, center_mz|None, width_mz|None,
+ce|None)`` — isolation/CE are ``None`` for MS1. This module is a pure data
+transform (no connector / no DB), so it is unit-testable on its own.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+# A schedule row: (scan, rt_s, ms_level, center_mz|None, width_mz|None, ce|None)
+ScheduleRow = Tuple[int, float, int, Optional[float], Optional[float], Optional[float]]
+
+
+def build_synthetic_scan_table(
+    num_scans: int = 451,
+    im_lower: float = 0.6,
+    im_upper: float = 1.6,
+) -> pd.DataFrame:
+    """A synthetic mobility (scan) grid for a build-from-template run — NO Bruker reference.
+
+    Astral/Orbitrap/ZenoTOF have no ion mobility, and the render marginalises the
+    mobility axis away, so the actual 1/K0 values do not affect the output — but the
+    simulation pipeline still projects ion-mobility distributions onto a scan grid,
+    so it needs SOME grid. We provide a plausible descending 1/K0 grid (the Bruker
+    ``scans`` table is descending scan index with ascending mobility) without reading
+    a reference ``.d``. This is the key decoupling primitive for the lean
+    build-from-template path: it removes the ``TDFWriter.helper_handle`` dependency.
+    """
+    if num_scans < 1:
+        raise ValueError("num_scans must be >= 1")
+    if not (im_lower < im_upper):
+        raise ValueError("im_lower must be < im_upper")
+    # Descending scan index (Bruker convention), ascending inverse mobility.
+    scans = np.arange(num_scans, dtype=np.int64)[::-1]
+    mobilities = np.linspace(im_lower, im_upper, num_scans, dtype=np.float64)
+    return pd.DataFrame({"scan": scans, "mobility": mobilities})
+
+
+def build_frame_tables_from_schedule(
+    schedule: Sequence[ScheduleRow],
+    *,
+    num_scans: int = 1,
+    ce_decimals: int = 2,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, List[int]]:
+    """Build the DIA acquisition tables from a per-scan template schedule.
+
+    Each schedule scan becomes one frame (``frame_id`` 1..N in scan order), timed
+    at its retention time. MS1 scans are precursor frames (``ms_type`` 0); MS2
+    scans are fragment frames (``ms_type`` 9) carrying the isolation window +
+    collision energy. Distinct (center, width, CE) windows are assigned
+    window-group ids; because these instruments have no ion mobility, each window
+    spans the FULL scan range ``[0, num_scans-1]`` so the (mobility-indexed)
+    transmission degenerates to pure m/z gating.
+
+    Returns ``(frame_table, dia_ms_ms_windows, frames_to_window_groups,
+    frame_to_template_scan)`` where the last is a list mapping ``frame_id-1`` ->
+    the template scan number (so the writer can author each frame into its slot).
+    """
+    if not schedule:
+        raise ValueError("empty template schedule")
+
+    frames = []
+    fragment_rows = []  # (frame_id, window_key)
+    frame_to_template_scan: List[int] = []
+    # Deterministic window-group assignment: first occurrence order.
+    window_key_to_group: dict[Tuple[float, float, float], int] = {}
+    window_group_meta: dict[int, Tuple[float, float, float]] = {}
+
+    n_ms1 = 0
+    for idx, row in enumerate(schedule):
+        scan, rt, ms_level, center, width, ce = row
+        frame_id = idx + 1
+        frame_to_template_scan.append(int(scan))
+        is_ms1 = ms_level <= 1
+        ms_type = 0 if is_ms1 else 9
+        frames.append({"frame_id": frame_id, "time": float(rt), "ms_type": ms_type})
+        if is_ms1:
+            n_ms1 += 1
+            continue
+        # MS2: resolve / assign its window group.
+        if center is None or width is None:
+            raise ValueError(f"MS2 scan {scan} (frame {frame_id}) has no isolation window")
+        ce_val = round(float(ce), ce_decimals) if ce is not None else 0.0
+        key = (round(float(center), 4), round(float(width), 4), ce_val)
+        group = window_key_to_group.get(key)
+        if group is None:
+            group = len(window_key_to_group) + 1  # 1-based window-group ids
+            window_key_to_group[key] = group
+            window_group_meta[group] = key
+        fragment_rows.append({"frame": frame_id, "window_group": group})
+
+    if n_ms1 == 0:
+        raise ValueError("template schedule has no MS1 scans")
+    if not fragment_rows:
+        raise ValueError("template schedule has no MS2 scans")
+
+    frame_table = pd.DataFrame(frames)
+    frames_to_window_groups = pd.DataFrame(fragment_rows)
+
+    # One dia_ms_ms_windows row per window group. No mobility, so the window spans
+    # the whole scan range (mobility transmission -> pure m/z gating).
+    win_rows = []
+    for group, (center, width, ce_val) in sorted(window_group_meta.items()):
+        win_rows.append(
+            {
+                "window_group": group,
+                "scan_start": 0,
+                "scan_end": int(max(num_scans - 1, 0)),
+                "isolation_mz": center,
+                "isolation_width": width,
+                "collision_energy": ce_val,
+            }
+        )
+    dia_ms_ms_windows = pd.DataFrame(win_rows)
+
+    return frame_table, dia_ms_ms_windows, frames_to_window_groups, frame_to_template_scan
+
+
+class TemplateHelperHandle:
+    """Minimal stand-in for a Bruker reference's ``helper_handle`` — exposes only
+    the m/z + ion-mobility ranges the distribution jobs read. These instruments
+    have no IMS; the mobility range is synthetic (marginalised away at render)."""
+
+    def __init__(self, mz_lower, mz_upper, im_lower, im_upper, num_scans):
+        self.mz_lower = mz_lower
+        self.mz_upper = mz_upper
+        self.im_lower = im_lower
+        self.im_upper = im_upper
+        self.num_scans = num_scans
+
+
+class TemplateTdfWriterStub:
+    """Stand-in for the Bruker ``TDFWriter``: a build-from-template path writes a
+    Thermo ``.raw`` or open mzML (not a ``.d``), so only the reference ranges are
+    needed during simulation, never the binary writer."""
+
+    def __init__(self, helper_handle):
+        self.helper_handle = helper_handle

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/waters_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/waters_acquisition.py
@@ -20,6 +20,7 @@ marginalises mobility away; Waters TWIMS drift-time/CCS is out of scope for v0).
 
 from __future__ import annotations
 
+import math
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -48,13 +49,16 @@ def build_sonar_schedule(
     """Synthesize a SONAR DIA schedule: 1 MS1 + N quad windows per cycle.
 
     Windows are laid from ``mz_start``: center ``i`` = ``mz_start + window_width/2
-    + i*window_step``, count chosen so the last window's upper edge reaches
-    ``mz_end``. ``window_step == window_width`` gives contiguous (non-overlapping)
-    windows; a smaller step gives the overlapping SONAR scan. Each cycle is 1 MS1
-    survey followed by the windows, evenly spaced across ``cycle_time_s``, repeated
-    over the gradient. Collision energy is the rolling-CE linear model
-    ``ce_intercept + ce_slope_per_mz * center`` (modelled as NCE for the
-    HCD-like beam-type CID, as for SCIEX).
+    + i*window_step``. Endpoint policy: the window count is chosen with ``ceil`` so
+    the windows FULLY COVER ``[mz_start, mz_end]`` (no gap); the last window may
+    extend slightly past ``mz_end`` rather than leave the top of the range
+    uncovered. ``window_step == window_width`` gives contiguous (non-overlapping)
+    windows; a smaller step gives the overlapping SONAR scan (``window_step >
+    window_width`` would leave gaps and is rejected). Each cycle is 1 MS1 survey
+    followed by the windows, evenly spaced across ``cycle_time_s``, repeated over
+    the gradient. Collision energy is the rolling-CE linear model
+    ``ce_intercept + ce_slope_per_mz * center`` (modelled as NCE for the HCD-like
+    beam-type CID, as for SCIEX).
 
     Returns ``(schedule_rows, window_centers, n_cycles)``.
     """
@@ -64,10 +68,35 @@ def build_sonar_schedule(
         raise ValueError("window_width and window_step must be > 0")
     if cycle_time_s <= 0.0:
         raise ValueError("cycle_time_s must be > 0")
+    if not math.isfinite(gradient_length_s) or gradient_length_s <= 0.0:
+        raise ValueError(f"gradient_length_s must be finite and > 0, got {gradient_length_s!r}")
 
     span = mz_end - mz_start
-    n_windows = max(1, int(round((span - window_width) / window_step)) + 1)
+    if window_width > span:
+        raise ValueError(
+            f"window_width ({window_width}) must be <= the m/z span ({span}); a window "
+            f"wider than the scanned range is not a valid SONAR geometry"
+        )
+    if window_step > window_width:
+        raise ValueError(
+            f"window_step ({window_step}) must be <= window_width ({window_width}); a "
+            f"larger step would leave uncovered gaps between windows"
+        )
+
+    # ceil (with a float-noise epsilon) so windows fully cover [mz_start, mz_end];
+    # the last window may overshoot mz_end slightly rather than leave a gap.
+    n_steps = max(0, math.ceil((span - window_width) / window_step - 1e-9))
+    n_windows = n_steps + 1
     centers = [round(mz_start + window_width / 2.0 + i * window_step, 4) for i in range(n_windows)]
+
+    # Rolling CE must stay strictly positive across all windows (a non-positive NCE
+    # would condition fragment-intensity prediction to empty/unphysical MS2).
+    min_ce = min(ce_intercept + ce_slope_per_mz * c for c in centers)
+    if min_ce <= 0.0:
+        raise ValueError(
+            f"rolling-CE model yields non-positive collision energy (min {min_ce:.4f}) over "
+            f"windows {centers[0]}..{centers[-1]}; supply a CE model positive across the range"
+        )
 
     n_events = 1 + n_windows  # MS1 + windows
     n_cycles = max(1, int(gradient_length_s / cycle_time_s))
@@ -149,6 +178,8 @@ class WatersSonarAcquisitionBuilder:
             ce_slope_per_mz=ce_slope_per_mz,
         )
         if verbose:
+            # window_step > window_width is rejected in build_sonar_schedule, so
+            # step == width is contiguous and step < width is overlapping.
             overlap = "contiguous" if window_step >= window_width else f"overlapping step {window_step}"
             print(
                 f"Waters SONAR build-from-parameters: {len(centers)} windows "

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/waters_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/waters_acquisition.py
@@ -1,0 +1,200 @@
+"""Waters SONAR build-from-parameters acquisition (the Waters analogue of
+``SciexAcquisitionBuilder``).
+
+SONAR is Waters' scanning-quadrupole DIA: the quadrupole continuously scans a
+narrow (~20 Da) transmission window across a fixed precursor m/z range, synced
+with the TOF pushes, so the acquisition is fully described by a few parameters
+(scan range, window width/step, cycle time) — there is no per-scan timing or
+windowing to read from a vendor file. We therefore SYNTHESIZE the SONAR schedule
+directly in Python (no template needed, unlike the Thermo/SCIEX build-from-file
+paths) and feed it to the SAME ``build_frame_tables_from_schedule`` transform the
+Astral/SCIEX paths use. Output is open mzML (``render_dia_mzml``).
+
+Measured scheme of a real SONAR run (PXD028735, Synapt XS): quad scans 400-900
+m/z, 20 Da window, ~200 bins/cycle (2.5 Da step, ~8x overlap), 0.5 s/cycle. The
+default here lays CONTIGUOUS 20 Da windows (a clean, light, directly-searchable
+"normal DIA" scheme); set ``window_step`` < ``window_width`` to reproduce the
+faithful overlapping bin scan. No ion mobility is modelled (the render
+marginalises mobility away; Waters TWIMS drift-time/CCS is out of scope for v0).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from .template_acquisition_common import (
+    TemplateHelperHandle,
+    TemplateTdfWriterStub,
+    build_frame_tables_from_schedule,
+    build_synthetic_scan_table,
+)
+
+ScheduleRow = Tuple[int, float, int, Optional[float], Optional[float], Optional[float]]
+
+
+def build_sonar_schedule(
+    *,
+    mz_start: float,
+    mz_end: float,
+    window_width: float,
+    window_step: float,
+    cycle_time_s: float,
+    gradient_length_s: float,
+    ce_intercept: float,
+    ce_slope_per_mz: float,
+) -> Tuple[List[ScheduleRow], List[float], int]:
+    """Synthesize a SONAR DIA schedule: 1 MS1 + N quad windows per cycle.
+
+    Windows are laid from ``mz_start``: center ``i`` = ``mz_start + window_width/2
+    + i*window_step``, count chosen so the last window's upper edge reaches
+    ``mz_end``. ``window_step == window_width`` gives contiguous (non-overlapping)
+    windows; a smaller step gives the overlapping SONAR scan. Each cycle is 1 MS1
+    survey followed by the windows, evenly spaced across ``cycle_time_s``, repeated
+    over the gradient. Collision energy is the rolling-CE linear model
+    ``ce_intercept + ce_slope_per_mz * center`` (modelled as NCE for the
+    HCD-like beam-type CID, as for SCIEX).
+
+    Returns ``(schedule_rows, window_centers, n_cycles)``.
+    """
+    if not (mz_end > mz_start):
+        raise ValueError(f"mz_end must be > mz_start (got {mz_start}..{mz_end})")
+    if window_width <= 0.0 or window_step <= 0.0:
+        raise ValueError("window_width and window_step must be > 0")
+    if cycle_time_s <= 0.0:
+        raise ValueError("cycle_time_s must be > 0")
+
+    span = mz_end - mz_start
+    n_windows = max(1, int(round((span - window_width) / window_step)) + 1)
+    centers = [round(mz_start + window_width / 2.0 + i * window_step, 4) for i in range(n_windows)]
+
+    n_events = 1 + n_windows  # MS1 + windows
+    n_cycles = max(1, int(gradient_length_s / cycle_time_s))
+    dt = cycle_time_s / n_events
+
+    schedule: List[ScheduleRow] = []
+    scan = 0
+    for c in range(n_cycles):
+        cycle_start = c * cycle_time_s
+        scan += 1
+        schedule.append((scan, cycle_start, 1, None, None, None))  # MS1 survey
+        for i, center in enumerate(centers):
+            scan += 1
+            rt = cycle_start + (i + 1) * dt
+            ce = ce_intercept + ce_slope_per_mz * center
+            schedule.append((scan, rt, 2, center, window_width, ce))
+    return schedule, centers, n_cycles
+
+
+class WatersSonarAcquisitionBuilder:
+    """Lean Waters SONAR acquisition — NO Bruker reference / TDF, NO vendor template.
+
+    Synthesizes the frame table + DIA windows from SONAR scan parameters and a
+    rolling-CE model (``build_sonar_schedule``), then writes the four acquisition
+    tables to ``synthetic_data.db``. Duck-types the slice of the Bruker
+    acquisition-builder interface the simulator reads (``synthetics_handle``,
+    ``frame_table``, ``scan_table``, ``tdf_writer.helper_handle`` ranges,
+    ``gradient_length``, ``rt_cycle_length``, ``path``). The render output is mzML.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        mz_start: float = 400.0,
+        mz_end: float = 900.0,
+        window_width: float = 20.0,
+        window_step: Optional[float] = None,
+        cycle_time_s: float = 0.5,
+        gradient_length_s: float = 1800.0,
+        ce_intercept: Optional[float] = 5.0,
+        ce_slope_per_mz: Optional[float] = 0.04,
+        num_scans: int = 451,
+        im_lower: float = 0.6,
+        im_upper: float = 1.6,
+        mz_lower: Optional[float] = None,
+        mz_upper: Optional[float] = None,
+        round_collision_energy: bool = True,
+        collision_energy_decimals: int = 2,
+        verbose: bool = True,
+    ) -> None:
+        from imspy_simulation.experiment import SyntheticExperimentDataHandle
+
+        # SONAR CE is a voltage ramp not stored anywhere here; without a model the
+        # schedule's CE would be 0, conditioning fragment-intensity prediction to
+        # empty/unrealistic MS2. Require an explicit linear rolling-CE model.
+        if ce_intercept is None or ce_slope_per_mz is None:
+            raise ValueError(
+                "Waters SONAR requires a rolling-CE model: pass both ce_intercept and "
+                "ce_slope_per_mz (CE = intercept + slope_per_mz * window_center_mz)"
+            )
+        # Default to contiguous (non-overlapping) windows; window_step < window_width
+        # reproduces the faithful overlapping SONAR quad scan.
+        if window_step is None:
+            window_step = window_width
+
+        self.path = path
+        self.acquisition_name = "dia"
+        self.synthetics_handle = SyntheticExperimentDataHandle(database_path=path)
+
+        schedule, centers, n_cycles = build_sonar_schedule(
+            mz_start=mz_start,
+            mz_end=mz_end,
+            window_width=window_width,
+            window_step=window_step,
+            cycle_time_s=cycle_time_s,
+            gradient_length_s=gradient_length_s,
+            ce_intercept=ce_intercept,
+            ce_slope_per_mz=ce_slope_per_mz,
+        )
+        if verbose:
+            overlap = "contiguous" if window_step >= window_width else f"overlapping step {window_step}"
+            print(
+                f"Waters SONAR build-from-parameters: {len(centers)} windows "
+                f"({mz_start:.0f}-{mz_end:.0f} m/z, {window_width} Da, {overlap}), "
+                f"{n_cycles} cycles x {cycle_time_s}s ({gradient_length_s / 60.0:.1f} min), "
+                f"{len(schedule)} frames"
+            )
+
+        ce_decimals = collision_energy_decimals if round_collision_energy else 6
+        ft, win, f2g, f2scan = build_frame_tables_from_schedule(
+            schedule, num_scans=num_scans, ce_decimals=ce_decimals
+        )
+
+        self.frame_table = ft
+        self.scan_table = build_synthetic_scan_table(num_scans, im_lower, im_upper)
+        self.dia_ms_ms_windows = win
+        self.frames_to_window_groups = f2g
+        self.frame_to_template_scan = f2scan  # synthetic (1..N); no real vendor slots
+        self.num_frames = len(ft)
+        self.gradient_length = float(ft["time"].max())
+        diffs = np.diff(ft["time"].values)
+        positive = diffs[diffs > 0]
+        self.rt_cycle_length = float(np.median(positive)) if positive.size else 0.0
+
+        if mz_lower is None:
+            mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())
+        if mz_upper is None:
+            mz_upper = float(win["isolation_mz"].max() + win["isolation_width"].max())
+        self.tdf_writer = _waters_writer_stub(mz_lower, mz_upper, im_lower, im_upper, num_scans)
+
+        for name, tbl in (
+            ("frames", ft),
+            ("scans", self.scan_table),
+            ("dia_ms_ms_info", f2g),
+            ("dia_ms_ms_windows", win),
+        ):
+            self.synthetics_handle.create_table(table_name=name, table=tbl)
+
+    def __repr__(self) -> str:
+        return (
+            f"WatersSonarAcquisitionBuilder(path={self.path}, frames={self.num_frames}, "
+            f"windows={len(self.dia_ms_ms_windows)}, gradient={self.gradient_length:.1f}s)"
+        )
+
+
+def _waters_writer_stub(mz_lower, mz_upper, im_lower, im_upper, num_scans):
+    return TemplateTdfWriterStub(
+        TemplateHelperHandle(mz_lower, mz_upper, im_lower, im_upper, num_scans)
+    )

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -413,6 +413,14 @@ def get_default_settings() -> dict:
         'reference_noise_intensity_max': 30,
         'down_sample_factor': 0.5,
 
+        # mzPROV provenance sidecar (Ed25519-signed self-disclosure: "this IS TimSim
+        # simulated data", binds the output to the config + a signing key). Emitted for
+        # the Bruker .d path; mzprov v0 canonicalizes .d/mzML, not vendor .raw, so Thermo
+        # .raw runs skip it. Requires the optional `mzprov` package (import-guarded).
+        'emit_provenance': True,
+        'provenance_embed': False,        # False = JSON sidecar; True = embed in analysis.tdf
+        'provenance_key_path': None,      # None = default ~/.config/timsim/keys/ (auto-gen)
+
         # Fragment intensity model
         'fragment_intensity_model': None,  # None/"prosit" or "peptdeep"
 
@@ -919,6 +927,42 @@ BRUKER timsTOF instrument. All configuration is provided via a TOML file.
              "'accurate' uses the improved projection."
     )
     return parser
+
+
+def emit_provenance_sidecar(d_path, db_path, config_path, experiment_name,
+                            embed, key_path, logger) -> None:
+    """Write an mzPROV Ed25519-signed provenance sidecar for a Bruker .d output —
+    tamper-evident self-disclosure that this is TimSim-simulated data, bound to the
+    config and a signing key. Import-guarded: a missing `mzprov` package or any signing
+    error is logged as a warning and never fails the run. mzprov v0 canonicalizes
+    .d/mzML only (not vendor .raw), so callers gate this to the Bruker path."""
+    try:
+        from mzprov.sign import sign_simulation_output
+    except ImportError:
+        logger.warning(
+            "  provenance: `mzprov` not installed — skipping sidecar "
+            "(pip install the mzprov python implementation to enable)"
+        )
+        return
+    try:
+        from imspy_simulation import __version__ as _sim_version
+    except Exception:
+        _sim_version = "unknown"
+    try:
+        gt = db_path if (db_path and os.path.exists(db_path)) else None
+        out = sign_simulation_output(
+            d_path=d_path,
+            ground_truth_path=gt,
+            config_path=config_path,
+            experiment_name=experiment_name,
+            simulator_version=_sim_version,
+            private_key_path=key_path,
+            embed=embed,
+        )
+        logger.info(f"  provenance: mzPROV sidecar -> {out}"
+                    + (" (embedded in .d)" if embed else ""))
+    except Exception as e:
+        logger.warning(f"  provenance: mzPROV signing failed (non-fatal): {e}")
 
 
 # ----------------------------------------------------------------------
@@ -1701,6 +1745,19 @@ def main():
             quad_transmission_max_isotopes=config.quad_transmission_max_isotopes,
             superimpose_on_reference=config.superimpose_on_reference,
         )
+        # mzPROV provenance: sign the authored Bruker .d (self-disclosure that this is
+        # TimSim-simulated data). Bruker-only — mzprov v0 doesn't canonicalize vendor
+        # .raw, so the Thermo build-from-template branch above is intentionally skipped.
+        if config.emit_provenance:
+            emit_provenance_sidecar(
+                d_path=os.path.join(save_path, name, f"{name}.d"),
+                db_path=str(Path(acquisition_builder.path) / 'synthetic_data.db'),
+                config_path=cli_args.config,
+                experiment_name=name,
+                embed=config.provenance_embed,
+                key_path=config.provenance_key_path,
+                logger=logger,
+            )
 
     # Collect final statistics
     stats.n_proteins = len(proteins) if proteins is not None else 0

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -799,22 +799,50 @@ class SimulationConfig:
                 raise ValueError(
                     f"waters_mz_end must be > waters_mz_start (got {mz_start}..{mz_end})"
                 )
-            if self._config.get('waters_window_width') <= 0.0:
+            width = self._config.get('waters_window_width')
+            if width <= 0.0:
+                raise ValueError(f"waters_window_width must be > 0, got {width!r}")
+            # A window wider than the scanned span is not a valid SONAR geometry.
+            if width > (mz_end - mz_start):
                 raise ValueError(
-                    f"waters_window_width must be > 0, got {self._config.get('waters_window_width')!r}"
+                    f"waters_window_width ({width}) must be <= the m/z span "
+                    f"({mz_end - mz_start}); a window wider than the scanned range "
+                    "is not a valid SONAR geometry"
                 )
             if self._config.get('waters_cycle_time_s') <= 0.0:
                 raise ValueError(
                     f"waters_cycle_time_s must be > 0, got {self._config.get('waters_cycle_time_s')!r}"
                 )
-            # window_step is optional (None -> contiguous); if set it must be finite/positive.
+            # gradient_length drives the cycle count; a non-finite/non-positive value would
+            # silently collapse to a single cycle (or crash mid-build). Fail fast.
+            grad = self._config.get('gradient_length')
+            if isinstance(grad, bool) or not isinstance(grad, (int, float)) or not math.isfinite(grad) or grad <= 0.0:
+                raise ValueError(f"gradient_length must be a finite number > 0, got {grad!r}")
+            # window_step is optional (None -> contiguous); if set it must be finite, positive,
+            # and <= window_width (a larger step would leave uncovered gaps between windows).
             step = self._config.get('waters_window_step')
-            if step is not None and (
-                isinstance(step, bool) or not isinstance(step, (int, float))
-                or not math.isfinite(step) or step <= 0.0
-            ):
+            if step is not None:
+                if (isinstance(step, bool) or not isinstance(step, (int, float))
+                        or not math.isfinite(step) or step <= 0.0):
+                    raise ValueError(
+                        f"waters_window_step, if set, must be a finite number > 0, got {step!r}"
+                    )
+                if step > width:
+                    raise ValueError(
+                        f"waters_window_step ({step}) must be <= waters_window_width ({width}); "
+                        "a larger step would leave uncovered gaps between windows"
+                    )
+            # Rolling CE must stay strictly positive across the scanned range, else fragment
+            # prediction is conditioned on a non-positive NCE (empty/unphysical MS2). Check the
+            # range ends (CE is linear in m/z, so the minimum is at one end).
+            ce_b = self._config.get('waters_ce_intercept')
+            ce_m = self._config.get('waters_ce_slope_per_mz')
+            ce_ends = (ce_b + ce_m * mz_start, ce_b + ce_m * mz_end)
+            if min(ce_ends) <= 0.0:
                 raise ValueError(
-                    f"waters_window_step, if set, must be a finite number > 0, got {step!r}"
+                    f"waters rolling-CE model (intercept={ce_b}, slope={ce_m}) yields a "
+                    f"non-positive collision energy over {mz_start}..{mz_end} m/z "
+                    f"(ends {ce_ends[0]:.3f}, {ce_ends[1]:.3f}); use a positive CE model"
                 )
             # The mzML renderer lives behind the connector's 'mzml' feature; fail fast.
             try:

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -414,10 +414,11 @@ def get_default_settings() -> dict:
         'down_sample_factor': 0.5,
 
         # mzPROV provenance (Ed25519-signed self-disclosure: "this IS TimSim simulated
-        # data", binds the output to the config + a signing key). Emitted for the Bruker .d
-        # path (structural canonicalization) AND the SCIEX/Waters mzML paths (mzML content
-        # canonicalization). Thermo .raw is not yet signed (mzprov v0 has no vendor-.raw
-        # canonicalization). Requires the optional `mzprov` package (import-guarded).
+        # data", binds the output to the config + a signing key). Emitted for ALL four
+        # vendors: Bruker .d (structural canonicalization), SCIEX/Waters mzML (mzML content
+        # canonicalization), and Thermo .raw (opaque whole-file content hash, sidecar-only —
+        # a vendor binary can't be embedded). Requires the optional `mzprov` package
+        # (with .raw support); import-guarded.
         'emit_provenance': True,
         # True (default): EMBED the signed envelope INTO the output itself — the .d's
         # analysis.tdf (a provenance table) or the mzML's fileContent — so provenance
@@ -1159,6 +1160,39 @@ def emit_provenance_sidecar_mzml(mzml_path, config_path, experiment_name,
                     + (" (embedded in mzML)" if embed else ""))
     except Exception as e:
         logger.warning(f"  provenance: mzPROV mzML signing failed (non-fatal): {e}")
+
+
+def emit_provenance_sidecar_raw(raw_path, config_path, experiment_name, key_path, logger) -> None:
+    """Write an mzPROV Ed25519-signed provenance sidecar for a Thermo .raw output. A vendor
+    .raw is an opaque proprietary binary with no safe injection point, so this is ALWAYS a
+    JSON sidecar (regardless of the run's embed preference) and the attestation is an opaque
+    whole-file content hash (sensitive to any byte change). Uses mzprov's ``sign_raw_output``.
+    Import-guarded (covers both a missing ``mzprov`` and an older ``mzprov`` without raw
+    support): any failure is logged as a warning and never fails the run."""
+    try:
+        from mzprov.sign import sign_raw_output
+    except ImportError:
+        logger.warning(
+            "  provenance: `mzprov` (with .raw support) not available — skipping .raw "
+            "sidecar (pip install/upgrade the mzprov python implementation to enable)"
+        )
+        return
+    try:
+        from imspy_simulation import __version__ as _sim_version
+    except Exception:
+        _sim_version = "unknown"
+    try:
+        out = sign_raw_output(
+            raw_path=raw_path,
+            config_path=config_path,
+            experiment_name=experiment_name,
+            tool_name="TimSim",
+            tool_version=_sim_version,
+            private_key_path=key_path,
+        )
+        logger.info(f"  provenance: mzPROV .raw sidecar -> {out}")
+    except Exception as e:
+        logger.warning(f"  provenance: mzPROV .raw signing failed (non-fatal): {e}")
 
 
 # ----------------------------------------------------------------------
@@ -1956,6 +1990,16 @@ def main():
         if not ok:
             raise RuntimeError(
                 f"authored Astral .raw failed checksum validation: {out_raw}"
+            )
+        # mzPROV provenance: sign the authored .raw. Always a JSON sidecar (a vendor
+        # .raw can't be embedded into), so the run's embed preference does not apply here.
+        if config.emit_provenance:
+            emit_provenance_sidecar_raw(
+                raw_path=out_raw,
+                config_path=cli_args.config,
+                experiment_name=name,
+                key_path=config.provenance_key_path,
+                logger=logger,
             )
     elif is_sciex_instrument(instrument):
         # SCIEX ZenoTOF SWATH: render the synthesized DIA frames to open mzML (the

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -421,6 +421,13 @@ def get_default_settings() -> dict:
         'provenance_embed': False,        # False = JSON sidecar; True = embed in analysis.tdf
         'provenance_key_path': None,      # None = default ~/.config/timsim/keys/ (auto-gen)
 
+        # SCIEX ZenoTOF SWATH build-from-.wiff (instrument=sciex_zenotof; template_path = .wiff).
+        # The .wiff method has no per-scan timing, so the SWATH schedule is synthesized from
+        # these + gradient_length. Rolling CE = ce_intercept + ce_slope_per_mz * precursor_mz.
+        'sciex_cycle_time_s': 3.5,
+        'sciex_ce_intercept': 5.0,
+        'sciex_ce_slope_per_mz': 0.045,
+
         # Fragment intensity model
         'fragment_intensity_model': None,  # None/"prosit" or "peptdeep"
 
@@ -550,16 +557,20 @@ class SimulationConfig:
         # A Thermo build-from-template run (Astral/Orbitrap) is built from a Thermo .raw
         # template, NOT a Bruker reference .d — so it requires a template path in place
         # of reference_path (the lean, Bruker-independent build-from-template path).
-        from .jobs.register_prediction_set import is_thermo_template_instrument
+        from .jobs.register_prediction_set import (
+            is_thermo_template_instrument, is_sciex_instrument,
+        )
         instrument = str(self._config.get('instrument', 'bruker_timstof')).lower()
         is_thermo = is_thermo_template_instrument(instrument)
-        # For a Thermo run the template path may be given as `template_path` or the
-        # `astral_template_path` alias; require at least one (validated below).
+        # Template-based runs (Thermo .raw OR SCIEX .wiff) build from a vendor template
+        # instead of a Bruker reference .d, so they need a `template_path` (or the
+        # `astral_template_path` alias) rather than `reference_path`.
+        is_template_based = is_thermo or is_sciex_instrument(instrument)
         ref_key = 'reference_path'
         if self._config.get('from_findings'):
-            required = ['save_path', 'findings_path'] if is_thermo else ['save_path', ref_key, 'findings_path']
+            required = ['save_path', 'findings_path'] if is_template_based else ['save_path', ref_key, 'findings_path']
         else:
-            required = ['save_path', 'fasta_path'] if is_thermo else ['save_path', ref_key, 'fasta_path']
+            required = ['save_path', 'fasta_path'] if is_template_based else ['save_path', ref_key, 'fasta_path']
         missing = [key for key in required if not self._config.get(key)]
 
         if missing:
@@ -1083,7 +1094,7 @@ def main():
         logger.info(f"  Output path: {save_path}")
         logger.info("")
 
-    from .jobs.register_prediction_set import is_thermo_template_instrument
+    from .jobs.register_prediction_set import is_thermo_template_instrument, is_sciex_instrument
     instrument = str(getattr(config, 'instrument', 'bruker_timstof')).lower()
     if is_thermo_template_instrument(instrument):
         # Build-from-template (P6e option b): NO Bruker reference. The Thermo template's
@@ -1101,6 +1112,25 @@ def main():
             # Optional override: if set, forces a single NCE across all windows;
             # otherwise the template's genuine per-window NCE is used.
             collision_energy_nce=astral_nce_override(config),
+            verbose=not config.silent_mode,
+        )
+    elif is_sciex_instrument(instrument):
+        # Build-from-.wiff (SCIEX ZenoTOF SWATH): the .wiff SWATH method (windows + TOF
+        # cal) becomes the acquisition; the schedule is SYNTHESIZED (the .wiff has no
+        # timing) from gradient_length + sciex_cycle_time_s + a rolling-CE model. Output
+        # is open mzML (the proprietary .wiff.scan is not authored).
+        from .jobs.sciex_acquisition import SciexAcquisitionBuilder
+        _wiff = thermo_template_path(config)
+        logger.info(f"  SCIEX build-from-.wiff ({instrument}): {_wiff}")
+        acquisition_builder = SciexAcquisitionBuilder(
+            str(Path(save_path) / name),
+            _wiff,
+            cycle_time_s=config.sciex_cycle_time_s,
+            gradient_length_s=config.gradient_length,
+            ce_intercept=config.sciex_ce_intercept,
+            ce_slope_per_mz=config.sciex_ce_slope_per_mz,
+            round_collision_energy=config.round_collision_energy,
+            collision_energy_decimals=config.collision_energy_decimals,
             verbose=not config.silent_mode,
         )
     else:
@@ -1628,6 +1658,7 @@ def main():
     from .jobs.register_prediction_set import (
         register_prediction_set,
         resolve_instrument_activation,
+        is_sciex_instrument,
     )
     # Normalize once (lower-case) so the later exact dispatch comparison can't be
     # fooled by a case variant like 'ORBITRAP_ASTRAL'.
@@ -1717,6 +1748,26 @@ def main():
             raise RuntimeError(
                 f"authored Astral .raw failed checksum validation: {out_raw}"
             )
+    elif is_sciex_instrument(instrument):
+        # SCIEX ZenoTOF SWATH: render the synthesized DIA frames to open mzML (the
+        # proprietary .wiff.scan spectra are not authored). mzML is readable by
+        # DiaNN/alphaDIA and mzprov-signable.
+        import imspy_connector
+        logger.info(section_header(f"Rendering mzML ({instrument})", use_unicode))
+        db_path = acquisition_builder.synthetics_handle.database_path
+        out_mzml = str(Path(save_path) / f"{name}.mzML")
+        if not imspy_connector.py_acquisition.has_mzml():
+            raise RuntimeError(
+                "connector built without the `mzml` feature — rebuild with "
+                "`maturin build --features mzml` to render SCIEX mzML output"
+            )
+        scans, n_ms1, n_ms2, n_ms2_nz = imspy_connector.py_acquisition.render_dia_mzml(
+            db_path, out_mzml, num_threads
+        )
+        logger.info(
+            f"  SCIEX mzML -> {out_mzml}: {scans} scans | {n_ms1} MS1 | "
+            f"{n_ms2} MS2 ({n_ms2_nz} non-empty)"
+        )
     else:
         logger.info(section_header("Assembling Frames", use_unicode))
         assemble_frames(

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -428,6 +428,19 @@ def get_default_settings() -> dict:
         'sciex_ce_intercept': 5.0,
         'sciex_ce_slope_per_mz': 0.045,
 
+        # Waters SONAR build-from-parameters (instrument=waters_synapt_xs; NO template file).
+        # SONAR is a scanning-quadrupole DIA fully described by these; the schedule is
+        # synthesized from them + gradient_length. window_step=None -> contiguous windows
+        # (set < window_width for the faithful overlapping quad scan). Rolling CE = intercept
+        # + slope_per_mz * window_center_mz.
+        'waters_mz_start': 400.0,
+        'waters_mz_end': 900.0,
+        'waters_window_width': 20.0,
+        'waters_window_step': None,
+        'waters_cycle_time_s': 0.5,
+        'waters_ce_intercept': 5.0,
+        'waters_ce_slope_per_mz': 0.04,
+
         # Fragment intensity model
         'fragment_intensity_model': None,  # None/"prosit" or "peptdeep"
 
@@ -558,14 +571,16 @@ class SimulationConfig:
         # template, NOT a Bruker reference .d — so it requires a template path in place
         # of reference_path (the lean, Bruker-independent build-from-template path).
         from .jobs.register_prediction_set import (
-            is_thermo_template_instrument, is_sciex_instrument,
+            is_thermo_template_instrument, is_sciex_instrument, is_waters_instrument,
         )
         instrument = str(self._config.get('instrument', 'bruker_timstof')).lower()
         is_thermo = is_thermo_template_instrument(instrument)
-        # Template-based runs (Thermo .raw OR SCIEX .wiff) build from a vendor template
-        # instead of a Bruker reference .d, so they need a `template_path` (or the
-        # `astral_template_path` alias) rather than `reference_path`.
-        is_template_based = is_thermo or is_sciex_instrument(instrument)
+        # Reference-free runs build WITHOUT a Bruker reference .d: Thermo .raw and SCIEX
+        # .wiff build from a vendor template, Waters SONAR is fully synthesized from
+        # parameters. None of them require `reference_path`. (Thermo/SCIEX still require a
+        # `template_path`/`astral_template_path` file, validated per-instrument below;
+        # Waters requires no file at all.)
+        is_template_based = is_thermo or is_sciex_instrument(instrument) or is_waters_instrument(instrument)
         ref_key = 'reference_path'
         if self._config.get('from_findings'):
             required = ['save_path', 'findings_path'] if is_template_based else ['save_path', ref_key, 'findings_path']
@@ -758,6 +773,60 @@ class SimulationConfig:
                     f"instrument '{instrument}' requires imspy-connector built with the "
                     "'mzml' feature (maturin build --release --features mzml, then "
                     "reinstall) to render SCIEX SWATH output to open mzML."
+                )
+
+        if is_waters_instrument(instrument):
+            # Waters SONAR is build-from-parameters: DIA-only (scanning-quadrupole cycle),
+            # no IMS, no vendor file required. DDA has no meaning on this path.
+            if self._config.get('acquisition_type') == 'DDA':
+                raise ValueError(
+                    f"instrument '{instrument}' does not support DDA acquisition "
+                    "(SONAR is a scanning-quadrupole DIA cycle). Use DIA."
+                )
+            # The SONAR scan geometry + rolling-CE model must be finite/positive: a
+            # non-finite/degenerate value would yield an empty or unphysical window scheme
+            # or condition fragment-intensity prediction to empty MS2.
+            mz_start = self._config.get('waters_mz_start')
+            mz_end = self._config.get('waters_mz_end')
+            for key in (
+                'waters_mz_start', 'waters_mz_end', 'waters_window_width',
+                'waters_cycle_time_s', 'waters_ce_intercept', 'waters_ce_slope_per_mz',
+            ):
+                val = self._config.get(key)
+                if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(val):
+                    raise ValueError(f"{key} must be a finite number, got {val!r}")
+            if not (mz_end > mz_start):
+                raise ValueError(
+                    f"waters_mz_end must be > waters_mz_start (got {mz_start}..{mz_end})"
+                )
+            if self._config.get('waters_window_width') <= 0.0:
+                raise ValueError(
+                    f"waters_window_width must be > 0, got {self._config.get('waters_window_width')!r}"
+                )
+            if self._config.get('waters_cycle_time_s') <= 0.0:
+                raise ValueError(
+                    f"waters_cycle_time_s must be > 0, got {self._config.get('waters_cycle_time_s')!r}"
+                )
+            # window_step is optional (None -> contiguous); if set it must be finite/positive.
+            step = self._config.get('waters_window_step')
+            if step is not None and (
+                isinstance(step, bool) or not isinstance(step, (int, float))
+                or not math.isfinite(step) or step <= 0.0
+            ):
+                raise ValueError(
+                    f"waters_window_step, if set, must be a finite number > 0, got {step!r}"
+                )
+            # The mzML renderer lives behind the connector's 'mzml' feature; fail fast.
+            try:
+                import imspy_connector
+                mzml_ok = bool(imspy_connector.py_acquisition.has_mzml())
+            except Exception:
+                mzml_ok = False
+            if not mzml_ok:
+                raise ValueError(
+                    f"instrument '{instrument}' requires imspy-connector built with the "
+                    "'mzml' feature (maturin build --release --features mzml, then "
+                    "reinstall) to render Waters SONAR output to open mzML."
                 )
 
     def __getattr__(self, name: str):
@@ -1139,7 +1208,9 @@ def main():
         logger.info(f"  Output path: {save_path}")
         logger.info("")
 
-    from .jobs.register_prediction_set import is_thermo_template_instrument, is_sciex_instrument
+    from .jobs.register_prediction_set import (
+        is_thermo_template_instrument, is_sciex_instrument, is_waters_instrument,
+    )
     instrument = str(getattr(config, 'instrument', 'bruker_timstof')).lower()
     if is_thermo_template_instrument(instrument):
         # Build-from-template (P6e option b): NO Bruker reference. The Thermo template's
@@ -1174,6 +1245,27 @@ def main():
             gradient_length_s=config.gradient_length,
             ce_intercept=config.sciex_ce_intercept,
             ce_slope_per_mz=config.sciex_ce_slope_per_mz,
+            round_collision_energy=config.round_collision_energy,
+            collision_energy_decimals=config.collision_energy_decimals,
+            verbose=not config.silent_mode,
+        )
+    elif is_waters_instrument(instrument):
+        # Build-from-parameters (Waters SONAR): NO vendor file. SONAR is a scanning-
+        # quadrupole DIA fully described by its scan range + window + cycle, so the
+        # schedule is SYNTHESIZED from those + gradient_length + a rolling-CE model.
+        # Output is open mzML.
+        from .jobs.waters_acquisition import WatersSonarAcquisitionBuilder
+        logger.info(f"  Waters SONAR build-from-parameters ({instrument})")
+        acquisition_builder = WatersSonarAcquisitionBuilder(
+            str(Path(save_path) / name),
+            mz_start=config.waters_mz_start,
+            mz_end=config.waters_mz_end,
+            window_width=config.waters_window_width,
+            window_step=config.waters_window_step,
+            cycle_time_s=config.waters_cycle_time_s,
+            gradient_length_s=config.gradient_length,
+            ce_intercept=config.waters_ce_intercept,
+            ce_slope_per_mz=config.waters_ce_slope_per_mz,
             round_collision_energy=config.round_collision_energy,
             collision_energy_decimals=config.collision_energy_decimals,
             verbose=not config.silent_mode,
@@ -1704,6 +1796,7 @@ def main():
         register_prediction_set,
         resolve_instrument_activation,
         is_sciex_instrument,
+        is_waters_instrument,
     )
     # Normalize once (lower-case) so the later exact dispatch comparison can't be
     # fooled by a case variant like 'ORBITRAP_ASTRAL'.
@@ -1811,6 +1904,27 @@ def main():
         )
         logger.info(
             f"  SCIEX mzML -> {out_mzml}: {scans} scans | {n_ms1} MS1 | "
+            f"{n_ms2} MS2 ({n_ms2_nz} non-empty)"
+        )
+    elif is_waters_instrument(instrument):
+        # Waters SONAR: render the synthesized scanning-quadrupole DIA frames to open mzML
+        # (no proprietary Waters .raw is authored). Unlike a real SONAR->mzML conversion
+        # (whose isolation windows ProteoWizard leaves full-range), we write correct per-
+        # window isolation, so the output is proper "normal DIA" mzML for DiaNN.
+        import imspy_connector
+        logger.info(section_header(f"Rendering mzML ({instrument})", use_unicode))
+        db_path = acquisition_builder.synthetics_handle.database_path
+        out_mzml = str(Path(save_path) / f"{name}.mzML")
+        if not imspy_connector.py_acquisition.has_mzml():
+            raise RuntimeError(
+                "connector built without the `mzml` feature — rebuild with "
+                "`maturin build --features mzml` to render Waters SONAR mzML output"
+            )
+        scans, n_ms1, n_ms2, n_ms2_nz = imspy_connector.py_acquisition.render_dia_mzml(
+            db_path, out_mzml, num_threads
+        )
+        logger.info(
+            f"  Waters SONAR mzML -> {out_mzml}: {scans} scans | {n_ms1} MS1 | "
             f"{n_ms2} MS2 ({n_ms2_nz} non-empty)"
         )
     else:

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -415,8 +415,9 @@ def get_default_settings() -> dict:
 
         # mzPROV provenance sidecar (Ed25519-signed self-disclosure: "this IS TimSim
         # simulated data", binds the output to the config + a signing key). Emitted for
-        # the Bruker .d path; mzprov v0 canonicalizes .d/mzML, not vendor .raw, so Thermo
-        # .raw runs skip it. Requires the optional `mzprov` package (import-guarded).
+        # the Bruker .d path (structural canonicalization) AND the SCIEX/Waters mzML paths
+        # (mzML content canonicalization). Thermo .raw is not yet signed (mzprov v0 has no
+        # vendor-.raw canonicalization). Requires the optional `mzprov` package (import-guarded).
         'emit_provenance': True,
         'provenance_embed': False,        # False = JSON sidecar; True = embed in analysis.tdf
         'provenance_key_path': None,      # None = default ~/.config/timsim/keys/ (auto-gen)
@@ -1116,6 +1117,43 @@ def emit_provenance_sidecar(d_path, db_path, config_path, experiment_name,
                     + (" (embedded in .d)" if embed else ""))
     except Exception as e:
         logger.warning(f"  provenance: mzPROV signing failed (non-fatal): {e}")
+
+
+def emit_provenance_sidecar_mzml(mzml_path, config_path, experiment_name,
+                                 embed, key_path, logger) -> None:
+    """Write an mzPROV Ed25519-signed provenance sidecar for an mzML output (the SCIEX
+    and Waters open-format paths) — tamper-evident self-disclosure that this is TimSim-
+    simulated data, bound to the config + a signing key. Uses mzprov's first-class mzML
+    signer (``sign_mzml_output``), which canonicalizes the mzML content (config + mzML
+    content hash; note v0 does not bind the ground-truth DB the way the .d path does).
+    Import-guarded: a missing ``mzprov`` package or any signing error is logged as a
+    warning and never fails the run."""
+    try:
+        from mzprov.sign import sign_mzml_output
+    except ImportError:
+        logger.warning(
+            "  provenance: `mzprov` not installed — skipping mzML sidecar "
+            "(pip install the mzprov python implementation to enable)"
+        )
+        return
+    try:
+        from imspy_simulation import __version__ as _sim_version
+    except Exception:
+        _sim_version = "unknown"
+    try:
+        out = sign_mzml_output(
+            mzml_path=mzml_path,
+            config_path=config_path,
+            experiment_name=experiment_name,
+            tool_name="TimSim",
+            tool_version=_sim_version,
+            private_key_path=key_path,
+            embed=embed,
+        )
+        logger.info(f"  provenance: mzPROV mzML sidecar -> {out}"
+                    + (" (embedded in mzML)" if embed else ""))
+    except Exception as e:
+        logger.warning(f"  provenance: mzPROV mzML signing failed (non-fatal): {e}")
 
 
 # ----------------------------------------------------------------------
@@ -1934,6 +1972,17 @@ def main():
             f"  SCIEX mzML -> {out_mzml}: {scans} scans | {n_ms1} MS1 | "
             f"{n_ms2} MS2 ({n_ms2_nz} non-empty)"
         )
+        # mzPROV provenance: sign the rendered mzML (self-disclosure that this is
+        # TimSim-simulated data) via mzprov's mzML signer.
+        if config.emit_provenance:
+            emit_provenance_sidecar_mzml(
+                mzml_path=out_mzml,
+                config_path=cli_args.config,
+                experiment_name=name,
+                embed=config.provenance_embed,
+                key_path=config.provenance_key_path,
+                logger=logger,
+            )
     elif is_waters_instrument(instrument):
         # Waters SONAR: render the synthesized scanning-quadrupole DIA frames to open mzML
         # (no proprietary Waters .raw is authored). Unlike a real SONAR->mzML conversion
@@ -1955,6 +2004,17 @@ def main():
             f"  Waters SONAR mzML -> {out_mzml}: {scans} scans | {n_ms1} MS1 | "
             f"{n_ms2} MS2 ({n_ms2_nz} non-empty)"
         )
+        # mzPROV provenance: sign the rendered mzML (self-disclosure that this is
+        # TimSim-simulated data) via mzprov's mzML signer.
+        if config.emit_provenance:
+            emit_provenance_sidecar_mzml(
+                mzml_path=out_mzml,
+                config_path=cli_args.config,
+                experiment_name=name,
+                embed=config.provenance_embed,
+                key_path=config.provenance_key_path,
+                logger=logger,
+            )
     else:
         logger.info(section_header("Assembling Frames", use_unicode))
         assemble_frames(

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -715,6 +715,51 @@ class SimulationConfig:
                     "writer dependency is private."
                 )
 
+        if is_sciex_instrument(instrument):
+            # SCIEX ZenoTOF SWATH is build-from-.wiff: DIA-only (the schedule is a
+            # synthesized SWATH cycle), no IMS. DDA has no meaning on this path.
+            if self._config.get('acquisition_type') == 'DDA':
+                raise ValueError(
+                    f"instrument '{instrument}' does not support DDA acquisition "
+                    "(SCIEX SWATH is a DIA cycle). Use DIA."
+                )
+            # Build-from-.wiff: the run is built from a SCIEX .wiff SWATH method (its
+            # windows + TOF cal become the acquisition; the schedule is synthesized).
+            # Accept either `template_path` or the `astral_template_path` alias.
+            template = thermo_template_path(self._config)
+            if not template:
+                raise ValueError(
+                    f"instrument '{instrument}' requires 'template_path' (or the "
+                    "'astral_template_path' alias): a SCIEX .wiff whose SWATH windows "
+                    "the run is built from."
+                )
+            if not os.path.exists(template):
+                raise FileNotFoundError(f"template_path does not exist: {template}")
+            # The rolling-CE model must be finite/positive: CE = intercept + slope*mz
+            # conditions fragment-intensity prediction, and a non-finite/negative value
+            # would silently yield empty or unphysical MS2.
+            for key in ('sciex_cycle_time_s', 'sciex_ce_intercept', 'sciex_ce_slope_per_mz'):
+                val = self._config.get(key)
+                if isinstance(val, bool) or not isinstance(val, (int, float)) or not math.isfinite(val):
+                    raise ValueError(f"{key} must be a finite number, got {val!r}")
+            if self._config.get('sciex_cycle_time_s') <= 0.0:
+                raise ValueError(
+                    f"sciex_cycle_time_s must be > 0, got {self._config.get('sciex_cycle_time_s')!r}"
+                )
+            # The mzML renderer lives behind the connector's 'mzml' feature; fail fast at
+            # config load instead of an AttributeError after a full simulation.
+            try:
+                import imspy_connector
+                mzml_ok = bool(imspy_connector.py_acquisition.has_mzml())
+            except Exception:
+                mzml_ok = False
+            if not mzml_ok:
+                raise ValueError(
+                    f"instrument '{instrument}' requires imspy-connector built with the "
+                    "'mzml' feature (maturin build --release --features mzml, then "
+                    "reinstall) to render SCIEX SWATH output to open mzML."
+                )
+
     def __getattr__(self, name: str):
         """Allow attribute-style access to configuration values."""
         if name.startswith('_'):

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/simulator.py
@@ -413,13 +413,18 @@ def get_default_settings() -> dict:
         'reference_noise_intensity_max': 30,
         'down_sample_factor': 0.5,
 
-        # mzPROV provenance sidecar (Ed25519-signed self-disclosure: "this IS TimSim
-        # simulated data", binds the output to the config + a signing key). Emitted for
-        # the Bruker .d path (structural canonicalization) AND the SCIEX/Waters mzML paths
-        # (mzML content canonicalization). Thermo .raw is not yet signed (mzprov v0 has no
-        # vendor-.raw canonicalization). Requires the optional `mzprov` package (import-guarded).
+        # mzPROV provenance (Ed25519-signed self-disclosure: "this IS TimSim simulated
+        # data", binds the output to the config + a signing key). Emitted for the Bruker .d
+        # path (structural canonicalization) AND the SCIEX/Waters mzML paths (mzML content
+        # canonicalization). Thermo .raw is not yet signed (mzprov v0 has no vendor-.raw
+        # canonicalization). Requires the optional `mzprov` package (import-guarded).
         'emit_provenance': True,
-        'provenance_embed': False,        # False = JSON sidecar; True = embed in analysis.tdf
+        # True (default): EMBED the signed envelope INTO the output itself — the .d's
+        # analysis.tdf (a provenance table) or the mzML's fileContent — so provenance
+        # travels with the file and no extra file is produced. False: write a sibling
+        # `<name>.provenance.json` sidecar instead. (A vendor .raw can't be embedded; that
+        # path would fall back to a sidecar.)
+        'provenance_embed': True,
         'provenance_key_path': None,      # None = default ~/.config/timsim/keys/ (auto-gen)
 
         # SCIEX ZenoTOF SWATH build-from-.wiff (instrument=sciex_zenotof; template_path = .wiff).

--- a/packages/imspy-simulation/tests/test_benchmark_grid.py
+++ b/packages/imspy-simulation/tests/test_benchmark_grid.py
@@ -1,0 +1,68 @@
+"""The multi-vendor benchmark test grid: config expansion + manifest generation."""
+
+import os
+
+import pytest
+import toml
+
+from imspy_simulation.timsim.benchmark.grid import expand, write_configs, manifest_for
+
+
+def _spec():
+    return {
+        "save_root": "/tmp/grid",
+        "q": 0.01,
+        "base": {"fasta_path": "/d/h.fasta", "acquisition_type": "DIA",
+                 "num_sample_peptides": 5000, "waters_window_step": None},
+        "cells": [
+            {"label": "bruker", "engine": "diann",
+             "config": {"instrument": "bruker_timstof", "reference_path": "/d/ref.d",
+                        "gradient_length": 1800}},
+            {"label": "waters", "engine": "diann",
+             "config": {"instrument": "waters_synapt_xs", "gradient_length": 1800}},
+        ],
+    }
+
+
+def test_expand_merges_base_and_cell_and_adds_paths():
+    ex = expand(_spec())
+    assert set(ex) == {"bruker", "waters"}
+    b = ex["bruker"]
+    assert b["instrument"] == "bruker_timstof"          # from cell
+    assert b["fasta_path"] == "/d/h.fasta"              # from base
+    assert b["num_sample_peptides"] == 5000             # from base
+    assert b["save_path"] == "/tmp/grid/bruker"         # derived
+    assert b["experiment_name"] == "BRUKER"             # derived from label
+    # None-valued base keys (e.g. unset window_step) are dropped (TOML has no null).
+    assert "waters_window_step" not in ex["waters"]
+
+
+def test_expand_rejects_bad_specs():
+    with pytest.raises(ValueError):
+        expand({"cells": []})  # no cells
+    with pytest.raises(ValueError):
+        expand({"cells": [{"engine": "diann", "config": {"instrument": "x"}}]})  # no label
+    with pytest.raises(ValueError):
+        expand({"cells": [{"label": "a", "config": {}}]})  # no instrument
+    with pytest.raises(ValueError):
+        expand({"cells": [{"label": "a", "config": {"instrument": "x"}},
+                          {"label": "a", "config": {"instrument": "y"}}]})  # dup label
+
+
+def test_write_configs_are_valid_toml(tmp_path):
+    ex = expand(_spec())
+    paths = write_configs(ex, str(tmp_path))
+    assert set(paths) == {"bruker", "waters"}
+    loaded = toml.load(paths["bruker"])
+    assert loaded["instrument"] == "bruker_timstof"
+    assert loaded["save_path"] == "/tmp/grid/bruker"
+    assert os.path.exists(paths["waters"])
+
+
+def test_manifest_points_eval_jsons_under_save_root():
+    m = manifest_for(_spec())
+    assert m["q"] == 0.01
+    by_instr = {v["instrument"]: v for v in m["vendors"]}
+    assert by_instr["bruker_timstof"]["eval_json"] == "/tmp/grid/bruker/eval.json"
+    assert by_instr["bruker_timstof"]["engine"] == "diann"
+    assert by_instr["waters_synapt_xs"]["eval_json"] == "/tmp/grid/waters/eval.json"

--- a/packages/imspy-simulation/tests/test_benchmark_grid.py
+++ b/packages/imspy-simulation/tests/test_benchmark_grid.py
@@ -66,3 +66,31 @@ def test_manifest_points_eval_jsons_under_save_root():
     assert by_instr["bruker_timstof"]["eval_json"] == "/tmp/grid/bruker/eval.json"
     assert by_instr["bruker_timstof"]["engine"] == "diann"
     assert by_instr["waters_synapt_xs"]["eval_json"] == "/tmp/grid/waters/eval.json"
+
+
+def test_manifest_follows_an_overridden_save_path():
+    # An explicit save_path must be honoured by the manifest (no drift from the run).
+    spec = {"save_root": "/tmp/grid", "cells": [
+        {"label": "w", "engine": "diann",
+         "config": {"instrument": "waters_synapt_xs", "save_path": "/custom/out"}},
+    ]}
+    m = manifest_for(spec)
+    assert m["vendors"][0]["eval_json"] == "/custom/out/eval.json"
+
+
+def test_expand_rejects_colliding_save_paths():
+    spec = {"save_root": "/tmp/grid", "cells": [
+        {"label": "a", "config": {"instrument": "x", "save_path": "/same"}},
+        {"label": "b", "config": {"instrument": "y", "save_path": "/same"}},
+    ]}
+    with pytest.raises(ValueError, match="save_path"):
+        expand(spec)
+
+
+def test_drop_none_is_recursive():
+    spec = {"save_root": "/tmp/g", "cells": [
+        {"label": "w", "config": {"instrument": "waters_synapt_xs",
+                                  "models": {"a": 1, "b": None}}},
+    ]}
+    cfg = expand(spec)["w"]
+    assert cfg["models"] == {"a": 1}  # nested None dropped

--- a/packages/imspy-simulation/tests/test_multi_vendor_benchmark.py
+++ b/packages/imspy-simulation/tests/test_multi_vendor_benchmark.py
@@ -1,0 +1,69 @@
+"""The multi-vendor benchmark consolidator: eval-JSON summary + table rendering."""
+
+import json
+
+import pytest
+
+from imspy_simulation.timsim.benchmark.multi_vendor import (
+    summarize_eval,
+    build_rows,
+    render_markdown,
+)
+
+
+def _write_eval(tmp_path, name, observable, curve):
+    p = tmp_path / name
+    p.write_text(json.dumps({"rendered_observable_precursors": observable,
+                             "engine": "diann", "curve": curve}))
+    return str(p)
+
+
+def test_summarize_eval_picks_the_requested_q_and_computes_recall(tmp_path):
+    path = _write_eval(tmp_path, "w.json", 1000, [
+        {"q": 0.001, "n_precursors": 700, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+        {"q": 0.01, "n_precursors": 800, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+        {"q": 0.05, "n_precursors": 810, "fdp_backbone": 0.01, "fdp_peptidoform_genuine": 0.0},
+    ])
+    s = summarize_eval(path, q=0.01)
+    assert s["observable"] == 1000 and s["ids"] == 800
+    assert s["recall_pct"] == pytest.approx(80.0)
+    assert s["fdp_backbone"] == 0.0
+
+
+def test_summarize_eval_nearest_q_when_no_exact_match(tmp_path):
+    path = _write_eval(tmp_path, "w.json", 100, [
+        {"q": 0.005, "n_precursors": 40, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+        {"q": 0.02, "n_precursors": 60, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+    ])
+    # request 0.01 -> nearest grid point is 0.005 (|.005|<|.01|) ... actually 0.005 dist .005, 0.02 dist .01
+    s = summarize_eval(path, q=0.01)
+    assert s["q"] == 0.005
+
+
+def test_build_rows_handles_live_and_recorded(tmp_path):
+    path = _write_eval(tmp_path, "sciex.json", 6049, [
+        {"q": 0.01, "n_precursors": 4957, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+    ])
+    manifest = {"q": 0.01, "vendors": [
+        {"instrument": "sciex_zenotof", "engine": "alphadia", "eval_json": path, "source": "live"},
+        {"instrument": "bruker_timstof", "engine": "diann", "source": "recorded",
+         "recorded": {"fdp_backbone": 0.0075, "fdp_peptidoform": 0.0085}, "note": "prior run"},
+    ]}
+    rows = build_rows(manifest)
+    assert [r.instrument for r in rows] == ["sciex_zenotof", "bruker_timstof"]
+    live = rows[0]
+    assert live.ids == 4957 and live.recall_pct == pytest.approx(81.9, abs=0.1)
+    assert live.display == "SCIEX ZenoTOF" and live.output == "mzML"
+    rec = rows[1]
+    assert rec.ids is None and rec.fdp_backbone == 0.0075 and rec.source == "recorded"
+
+    md = render_markdown(rows, q=0.01)
+    assert "SCIEX ZenoTOF" in md and "Waters" not in md
+    assert "81.9%" in md and "0.00%" in md   # live recall + FDP
+    assert "0.75%" in md                       # recorded FDP rendered as percent
+    assert "prior run" in md                   # note rendered
+
+
+def test_missing_metrics_source_raises():
+    with pytest.raises(ValueError):
+        build_rows({"vendors": [{"instrument": "waters_synapt_xs", "engine": "diann"}]})

--- a/packages/imspy-simulation/tests/test_multi_vendor_benchmark.py
+++ b/packages/imspy-simulation/tests/test_multi_vendor_benchmark.py
@@ -30,14 +30,36 @@ def test_summarize_eval_picks_the_requested_q_and_computes_recall(tmp_path):
     assert s["fdp_backbone"] == 0.0
 
 
-def test_summarize_eval_nearest_q_when_no_exact_match(tmp_path):
+def test_summarize_eval_picks_largest_q_at_or_below_target(tmp_path):
+    # FDR semantics: never report a point ABOVE the requested threshold. With points
+    # below (0.001, 0.005) and above (0.02) the target 0.01, pick 0.005 (largest <= 0.01),
+    # NOT the numerically-nearest 0.02.
     path = _write_eval(tmp_path, "w.json", 100, [
+        {"q": 0.001, "n_precursors": 30, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
         {"q": 0.005, "n_precursors": 40, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
-        {"q": 0.02, "n_precursors": 60, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+        {"q": 0.02, "n_precursors": 90, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
     ])
-    # request 0.01 -> nearest grid point is 0.005 (|.005|<|.01|) ... actually 0.005 dist .005, 0.02 dist .01
     s = summarize_eval(path, q=0.01)
-    assert s["q"] == 0.005
+    assert s["q"] == 0.005 and s["ids"] == 40
+
+
+def test_summarize_eval_falls_back_when_curve_starts_above_target(tmp_path):
+    # No point at/below 0.01 -> fall back to the smallest q (best available), and report it.
+    path = _write_eval(tmp_path, "w.json", 100, [
+        {"q": 0.02, "n_precursors": 60, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+        {"q": 0.05, "n_precursors": 80, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+    ])
+    s = summarize_eval(path, q=0.01)
+    assert s["q"] == 0.02
+
+
+def test_build_rows_engine_falls_back_to_eval_json(tmp_path):
+    # Manifest omits 'engine' -> use the engine recorded in the eval JSON ('diann').
+    path = _write_eval(tmp_path, "w.json", 100, [
+        {"q": 0.01, "n_precursors": 50, "fdp_backbone": 0.0, "fdp_peptidoform_genuine": 0.0},
+    ])
+    rows = build_rows({"vendors": [{"instrument": "waters_synapt_xs", "eval_json": path}]})
+    assert rows[0].engine == "diann"
 
 
 def test_build_rows_handles_live_and_recorded(tmp_path):

--- a/packages/imspy-simulation/tests/test_template_acquisition_common.py
+++ b/packages/imspy-simulation/tests/test_template_acquisition_common.py
@@ -1,0 +1,40 @@
+"""The instrument-neutral build-from-template primitives live in
+``template_acquisition_common`` and are shared by the Astral (.raw) and SCIEX
+(.wiff) acquisition builders. These tests lock that contract: the canonical
+names exist, the ``astral_acquisition`` back-compat aliases still point at them
+(the existing Astral test + any external import depend on it), and SCIEX imports
+the same objects.
+"""
+
+from imspy_simulation.timsim.jobs import astral_acquisition as A
+from imspy_simulation.timsim.jobs import sciex_acquisition as S
+from imspy_simulation.timsim.jobs import template_acquisition_common as C
+
+
+def test_canonical_symbols_exist():
+    assert callable(C.build_frame_tables_from_schedule)
+    assert callable(C.build_synthetic_scan_table)
+    assert C.TemplateHelperHandle is not None
+    assert C.TemplateTdfWriterStub is not None
+
+
+def test_astral_backcompat_aliases_point_at_shared_objects():
+    # The function/classes moved out of astral_acquisition; the old names must
+    # still resolve to the SAME objects (zero-churn for existing callers/tests).
+    assert A.build_astral_frame_tables is C.build_frame_tables_from_schedule
+    assert A._AstralHelperHandle is C.TemplateHelperHandle
+    assert A._AstralTdfWriterStub is C.TemplateTdfWriterStub
+
+
+def test_sciex_uses_the_shared_transform():
+    # SciexAcquisitionBuilder imports the shared transform (not a private copy).
+    assert S.build_frame_tables_from_schedule is C.build_frame_tables_from_schedule
+    assert S.TemplateHelperHandle is C.TemplateHelperHandle
+
+
+def test_stub_handles_carry_the_ranges_jobs_read():
+    handle = C.TemplateHelperHandle(100.0, 1700.0, 0.6, 1.6, 451)
+    writer = C.TemplateTdfWriterStub(handle)
+    assert writer.helper_handle is handle
+    assert (handle.mz_lower, handle.mz_upper) == (100.0, 1700.0)
+    assert (handle.im_lower, handle.im_upper, handle.num_scans) == (0.6, 1.6, 451)

--- a/packages/imspy-simulation/tests/test_waters_acquisition.py
+++ b/packages/imspy-simulation/tests/test_waters_acquisition.py
@@ -63,6 +63,18 @@ def test_each_cycle_is_ms1_then_windows_with_rolling_ce():
     assert times == sorted(times)
 
 
+def test_non_divisible_span_is_fully_covered_via_ceil():
+    # span 510 (400-910) is NOT divisible by 20: ceil must add a window so the last
+    # window's upper edge reaches/exceeds mz_end (full coverage, slight overshoot allowed).
+    _, centers, _ = _schedule(mz_end=910.0)  # span 510, width/step 20
+    last_upper = centers[-1] + 20.0 / 2.0
+    assert last_upper >= 910.0  # no gap at the top of the range
+    # exactly-divisible span must NOT overshoot (float-noise epsilon guards this).
+    _, centers2, _ = _schedule()  # span 500
+    assert centers2[-1] + 10.0 == 900.0
+    assert len(centers2) == 25
+
+
 def test_invalid_geometry_raises():
     with pytest.raises(ValueError):
         _schedule(mz_end=300.0)  # end <= start
@@ -70,6 +82,26 @@ def test_invalid_geometry_raises():
         _schedule(window_width=0.0)
     with pytest.raises(ValueError):
         _schedule(cycle_time_s=0.0)
+
+
+def test_degenerate_geometry_rejected():
+    # window wider than the scanned span.
+    with pytest.raises(ValueError, match="span"):
+        _schedule(window_width=600.0)  # span is 500
+    # step larger than width would leave gaps.
+    with pytest.raises(ValueError, match="gap"):
+        _schedule(window_width=20.0, window_step=25.0)
+    # non-positive / non-finite gradient.
+    with pytest.raises(ValueError):
+        _schedule(gradient_length_s=0.0)
+    with pytest.raises(ValueError):
+        _schedule(gradient_length_s=float("inf"))
+
+
+def test_non_positive_rolling_ce_rejected():
+    # intercept/slope that drive CE <= 0 over the window range must be rejected.
+    with pytest.raises(ValueError, match="collision energy"):
+        _schedule(ce_intercept=-100.0, ce_slope_per_mz=0.0)
 
 
 def test_instrument_registered_as_waters_hcd_nce():

--- a/packages/imspy-simulation/tests/test_waters_acquisition.py
+++ b/packages/imspy-simulation/tests/test_waters_acquisition.py
@@ -1,0 +1,80 @@
+"""Waters SONAR build-from-parameters schedule synthesis.
+
+These tests exercise the pure-Python ``build_sonar_schedule`` (no connector / no DB)
+and the instrument registration. The full builder (which writes to a DB) is covered
+by the simulator smoke path, not here.
+"""
+
+import math
+
+import pytest
+
+from imspy_simulation.timsim.jobs.waters_acquisition import build_sonar_schedule
+from imspy_simulation.timsim.jobs.register_prediction_set import (
+    is_waters_instrument,
+    resolve_instrument_activation,
+)
+
+
+def _schedule(**kw):
+    params = dict(
+        mz_start=400.0, mz_end=900.0, window_width=20.0, window_step=20.0,
+        cycle_time_s=0.5, gradient_length_s=5.0,
+        ce_intercept=5.0, ce_slope_per_mz=0.04,
+    )
+    params.update(kw)
+    return build_sonar_schedule(**params)
+
+
+def test_contiguous_windows_tile_the_range():
+    _, centers, _ = _schedule()
+    # 400-900 / 20 Da contiguous -> 25 windows, centered 410..890.
+    assert len(centers) == 25
+    assert centers[0] == 410.0
+    assert centers[-1] == 890.0
+    # contiguous: consecutive centers differ by exactly the width.
+    assert all(round(b - a, 6) == 20.0 for a, b in zip(centers, centers[1:]))
+
+
+def test_overlapping_step_increases_window_count():
+    # step 2.5 Da (the faithful SONAR quad scan) -> many more, overlapping windows.
+    _, centers, _ = _schedule(window_step=2.5)
+    assert len(centers) > 150  # ~193 for 400-900/20@2.5
+    # first window still starts at the range floor.
+    assert centers[0] == 410.0
+
+
+def test_each_cycle_is_ms1_then_windows_with_rolling_ce():
+    schedule, centers, n_cycles = _schedule(gradient_length_s=1.0)  # 2 cycles @ 0.5s
+    assert n_cycles == 2
+    # one cycle = 1 MS1 + len(centers) MS2.
+    per_cycle = 1 + len(centers)
+    assert len(schedule) == per_cycle * n_cycles
+    # first row of each cycle is MS1 (ms_level 1, no window/CE).
+    for c in range(n_cycles):
+        scan, rt, ms_level, center, width, ce = schedule[c * per_cycle]
+        assert ms_level == 1 and center is None and width is None and ce is None
+    # an MS2 row carries the window + rolling CE = intercept + slope*center.
+    scan, rt, ms_level, center, width, ce = schedule[1]
+    assert ms_level == 2 and width == 20.0
+    assert math.isclose(ce, 5.0 + 0.04 * center)
+    # retention times are non-decreasing.
+    times = [r[1] for r in schedule]
+    assert times == sorted(times)
+
+
+def test_invalid_geometry_raises():
+    with pytest.raises(ValueError):
+        _schedule(mz_end=300.0)  # end <= start
+    with pytest.raises(ValueError):
+        _schedule(window_width=0.0)
+    with pytest.raises(ValueError):
+        _schedule(cycle_time_s=0.0)
+
+
+def test_instrument_registered_as_waters_hcd_nce():
+    assert is_waters_instrument("waters_synapt_xs")
+    assert is_waters_instrument("WATERS_SYNAPT_XS")  # case-insensitive
+    assert not is_waters_instrument("bruker_timstof")
+    method, unit = resolve_instrument_activation("waters_synapt_xs")
+    assert method == "hcd" and unit == "nce"

--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -43,12 +43,17 @@ polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
 thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "9f4c0affe60a639759883fb569d3c9f5f7601856", optional = true }
 # SCIEX .wiff method reader (private repo; only built with the `sciex` feature)
 sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "ef7c0cd7e59d3b51160e446cbe3af240d230668d", optional = true }
+# Open mzML writer (Joshua Klein's mzdata); only built with the `mzml` feature. The
+# vendor-neutral output path: render -> mzML (readable by DiaNN/alphaDIA, mzprov-signable).
+# Used for SCIEX, whose proprietary .wiff.scan spectra are not authored.
+mzdata = { version = "0.63", optional = true }
 
 [features]
-# Off by default: enable the Thermo .raw / SCIEX .wiff extractors + writers.
-# Each requires build-time access to its private repo.
+# Off by default: enable the Thermo .raw / SCIEX .wiff extractors + writers, or the
+# open mzML writer. Each vendor extractor needs build-time access to its private repo.
 thermo = ["dep:thermorawfile"]
 sciex = ["dep:sciexwiff"]
+mzml = ["dep:mzdata"]
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/rustdf/src/sim/library.rs
+++ b/rustdf/src/sim/library.rs
@@ -69,6 +69,15 @@ pub fn build_spectral_library_tsv(
             ));
         }
     }
+    // The Prosit intensity vector reshapes to 29 fragment positions x 2 termini x 3
+    // charges = 174; any other width makes `reshape_prosit_array` panic.
+    const PROSIT_VEC_LEN: usize = 174;
+    if n_cols != PROSIT_VEC_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("n_cols must be {PROSIT_VEC_LEN} (Prosit vector width), got {n_cols}"),
+        ));
+    }
     if prosit_flat.len() != n * n_cols {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -82,10 +91,14 @@ pub fn build_spectral_library_tsv(
     }
 
     // Decode each peptide independently; emit a String block of tsv rows (empty if the
-    // precursor is skipped). Pure per-item work -> embarrassingly parallel.
+    // precursor is skipped). Pure per-item work -> embarrassingly parallel. The decode
+    // kernel PANICS on edge cases (peptides >30 residues overrun Prosit's 29-position
+    // array; malformed sequences fail to parse); an uncaught panic in a rayon worker
+    // would abort the whole process, so each peptide's work is caught and skipped.
     let blocks: Vec<String> = (0..n)
         .into_par_iter()
         .map(|i| {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let intensities = prosit_flat[i * n_cols..(i + 1) * n_cols].to_vec();
             let pep = PeptideSequence::new(modified_sequences[i].clone(), None);
             let coll = pep.associate_with_predicted_intensities(
@@ -137,6 +150,8 @@ pub fn build_spectral_library_tsv(
                 ));
             }
             block
+            }))
+            .unwrap_or_else(|_| String::new())
         })
         .collect();
 

--- a/rustdf/src/sim/library.rs
+++ b/rustdf/src/sim/library.rs
@@ -24,6 +24,27 @@ pub const LIBRARY_HEADER: &str = "ProteinId\tGenes\tModifiedPeptide\tPeptideSequ
 PrecursorCharge\tPrecursorMz\tTr_recalibrated\tFragmentType\tFragmentCharge\t\
 FragmentSeriesNumber\tProductMz\tLibraryIntensity";
 
+/// Prosit's fragment array holds 29 positions = a 30-residue peptide's b/y ions; a
+/// longer peptide overruns it and the decode kernel panics.
+const PROSIT_MAX_RESIDUES: usize = 30;
+
+/// Count backbone residues in a UNIMOD-bracket modified sequence, ignoring the
+/// `[UNIMOD:n]` tokens (and any other bracketed annotation). Cheap, allocation-free —
+/// used to skip over-length peptides before the panic-prone decode kernel.
+fn stripped_residue_count(modified_sequence: &str) -> usize {
+    let mut count = 0usize;
+    let mut in_bracket = false;
+    for c in modified_sequence.bytes() {
+        match c {
+            b'[' => in_bracket = true,
+            b']' => in_bracket = false,
+            b'A'..=b'Z' if !in_bracket => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
 /// Decode one batch of peptides (parallel) and write/append their transitions to
 /// `out_path` as a DiaNN-style `.tsv`.
 ///
@@ -92,13 +113,18 @@ pub fn build_spectral_library_tsv(
 
     // Decode each peptide independently; emit a String block of tsv rows (empty if the
     // precursor is skipped). Pure per-item work -> embarrassingly parallel. The decode
-    // kernel PANICS on edge cases (peptides >30 residues overrun Prosit's 29-position
-    // array; malformed sequences fail to parse); an uncaught panic in a rayon worker
-    // would abort the whole process, so each peptide's work is caught and skipped.
+    // kernel PANICS on peptides >30 residues (they overrun Prosit's fixed 29-position
+    // fragment array). The workspace builds with panic="abort", so catch_unwind cannot
+    // recover — we PREVENT the panic by skipping over-length (and empty) peptides up
+    // front. (Inputs are validated UNIMOD sequences from the DB/digest, so malformed
+    // sequences are not expected here.)
     let blocks: Vec<String> = (0..n)
         .into_par_iter()
         .map(|i| {
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let n_res = stripped_residue_count(&modified_sequences[i]);
+            if n_res == 0 || n_res > PROSIT_MAX_RESIDUES {
+                return String::new();
+            }
             let intensities = prosit_flat[i * n_cols..(i + 1) * n_cols].to_vec();
             let pep = PeptideSequence::new(modified_sequences[i].clone(), None);
             let coll = pep.associate_with_predicted_intensities(
@@ -150,8 +176,6 @@ pub fn build_spectral_library_tsv(
                 ));
             }
             block
-            }))
-            .unwrap_or_else(|_| String::new())
         })
         .collect();
 
@@ -184,6 +208,30 @@ mod tests {
 
     fn one(s: &str) -> Vec<String> {
         vec![s.to_string()]
+    }
+
+    #[test]
+    fn stripped_residue_count_ignores_mods() {
+        assert_eq!(stripped_residue_count("PEPTIDEK"), 8);
+        assert_eq!(stripped_residue_count("M[UNIMOD:35]PEPK"), 5);
+        assert_eq!(stripped_residue_count("[UNIMOD:1]ACDEK"), 5);
+        assert_eq!(stripped_residue_count("C[UNIMOD:4]C[UNIMOD:4]K"), 3);
+    }
+
+    #[test]
+    fn over_length_peptide_is_skipped_not_panicked() {
+        // A 35-residue peptide overruns Prosit's 29-position array; the decode kernel
+        // would panic (and panic=abort kills the process), so it must be skipped BEFORE
+        // the kernel. Build with one over-length peptide -> header only, no crash.
+        let out = std::env::temp_dir().join("rustdf_lib_overlen.tsv");
+        let long = "ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQR"; // 35 residues
+        assert_eq!(stripped_residue_count(long), 35);
+        let (n_trans, n_prec) = build_spectral_library_tsv(
+            &out, &one(long), &one(long), &one(long), &[2],
+            &vec![0.1; 174], 174, &[700.0], &[10.0], &one("P"), &one("G"), 3, false,
+        )
+        .expect("must not panic on over-length peptide");
+        assert_eq!((n_trans, n_prec), (0, 0), "over-length peptide skipped");
     }
 
     #[test]

--- a/rustdf/src/sim/library.rs
+++ b/rustdf/src/sim/library.rs
@@ -1,0 +1,221 @@
+//! Fast spectral-library writer: decode Prosit intensity vectors into a DiaNN/
+//! Spectronaut-style transition `.tsv` in parallel.
+//!
+//! The per-peptide decode (`PeptideSequence::associate_with_predicted_intensities`)
+//! is already a Rust kernel in `mscore`; the slow part of a Python library builder is
+//! calling it millions of times across the PyO3 boundary and assembling a giant
+//! DataFrame. This does the whole batch in Rust with `rayon` and streams the rows
+//! straight to disk — turning a multi-hour build into seconds.
+//!
+//! The caller (Python) supplies the cheap string columns it already has
+//! (`ModifiedPeptide` in DiaNN `(UniMod:n)` form, the stripped `PeptideSequence`) so
+//! this module needs no mod-notation regex; ordinals come from the fragment ion's own
+//! `amino_acid_count()`.
+
+use std::fs::OpenOptions;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+
+use mscore::data::peptide::{FragmentType, PeptideSequence};
+use rayon::prelude::*;
+
+/// DiaNN/Spectronaut transition columns, in output order.
+pub const LIBRARY_HEADER: &str = "ProteinId\tGenes\tModifiedPeptide\tPeptideSequence\t\
+PrecursorCharge\tPrecursorMz\tTr_recalibrated\tFragmentType\tFragmentCharge\t\
+FragmentSeriesNumber\tProductMz\tLibraryIntensity";
+
+/// Decode one batch of peptides (parallel) and write/append their transitions to
+/// `out_path` as a DiaNN-style `.tsv`.
+///
+/// Per precursor: b/y ions are read off the reshaped Prosit array, intensities are
+/// renormalised to max=1, non-finite / non-positive intensities and m/z are dropped,
+/// and a precursor with fewer than `min_fragments` surviving fragments is skipped
+/// entirely (it emits no rows). Returns `(transitions_written, precursors_written)`.
+///
+/// `prosit_flat` is row-major: peptide `i`'s vector is `prosit_flat[i*n_cols..(i+1)*n_cols]`.
+/// All metadata slices must have the same length (the peptide count); `n_cols` is the
+/// Prosit vector width (174). With `append=false` the file is truncated and the header
+/// written first; with `append=true` rows are appended (no header) — for chunked builds.
+#[allow(clippy::too_many_arguments)]
+pub fn build_spectral_library_tsv(
+    out_path: &Path,
+    modified_sequences: &[String],
+    modpep_diann: &[String],
+    stripped: &[String],
+    charges: &[i32],
+    prosit_flat: &[f64],
+    n_cols: usize,
+    precursor_mz: &[f64],
+    retention_time: &[f64],
+    protein_ids: &[String],
+    genes: &[String],
+    min_fragments: usize,
+    append: bool,
+) -> io::Result<(usize, usize)> {
+    let n = modified_sequences.len();
+    for (name, len) in [
+        ("modpep_diann", modpep_diann.len()),
+        ("stripped", stripped.len()),
+        ("charges", charges.len()),
+        ("precursor_mz", precursor_mz.len()),
+        ("retention_time", retention_time.len()),
+        ("protein_ids", protein_ids.len()),
+        ("genes", genes.len()),
+    ] {
+        if len != n {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("column '{name}' length {len} != peptide count {n}"),
+            ));
+        }
+    }
+    if prosit_flat.len() != n * n_cols {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "prosit_flat length {} != peptides {} * n_cols {}",
+                prosit_flat.len(),
+                n,
+                n_cols
+            ),
+        ));
+    }
+
+    // Decode each peptide independently; emit a String block of tsv rows (empty if the
+    // precursor is skipped). Pure per-item work -> embarrassingly parallel.
+    let blocks: Vec<String> = (0..n)
+        .into_par_iter()
+        .map(|i| {
+            let intensities = prosit_flat[i * n_cols..(i + 1) * n_cols].to_vec();
+            let pep = PeptideSequence::new(modified_sequences[i].clone(), None);
+            let coll = pep.associate_with_predicted_intensities(
+                charges[i],
+                FragmentType::B,
+                intensities,
+                true,
+                true,
+            );
+            // Gather surviving fragments and the per-precursor max for renormalisation.
+            let mut frags: Vec<(String, i32, usize, f64, f64)> = Vec::new();
+            let mut max_i = 0.0_f64;
+            for series in &coll.peptide_ions {
+                for ion in series.n_ions.iter().chain(series.c_ions.iter()) {
+                    let inten = ion.ion.intensity;
+                    let mz = ion.mz();
+                    if !inten.is_finite() || inten <= 0.0 || !mz.is_finite() {
+                        continue;
+                    }
+                    let ordinal = ion.ion.sequence.amino_acid_count();
+                    if inten > max_i {
+                        max_i = inten;
+                    }
+                    frags.push((ion.kind.to_string(), ion.ion.charge, ordinal, mz, inten));
+                }
+            }
+            if frags.len() < min_fragments || max_i <= 0.0 {
+                return String::new();
+            }
+            let mut block = String::with_capacity(frags.len() * 80);
+            for (kind, fch, ord, mz, inten) in &frags {
+                // ProteinId Genes ModifiedPeptide PeptideSequence PrecursorCharge
+                // PrecursorMz Tr FragmentType FragmentCharge FragmentSeriesNumber
+                // ProductMz LibraryIntensity
+                block.push_str(&format!(
+                    "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+                    protein_ids[i],
+                    genes[i],
+                    modpep_diann[i],
+                    stripped[i],
+                    charges[i],
+                    precursor_mz[i],
+                    retention_time[i],
+                    kind,
+                    fch,
+                    ord,
+                    mz,
+                    inten / max_i,
+                ));
+            }
+            block
+        })
+        .collect();
+
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .append(append)
+        .truncate(!append)
+        .open(out_path)?;
+    let mut w = BufWriter::new(file);
+    if !append {
+        writeln!(w, "{LIBRARY_HEADER}")?;
+    }
+    let (mut n_trans, mut n_prec) = (0usize, 0usize);
+    for block in &blocks {
+        if block.is_empty() {
+            continue;
+        }
+        n_prec += 1;
+        n_trans += block.as_bytes().iter().filter(|&&b| b == b'\n').count();
+        w.write_all(block.as_bytes())?;
+    }
+    w.flush()?;
+    Ok((n_trans, n_prec))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn one(s: &str) -> Vec<String> {
+        vec![s.to_string()]
+    }
+
+    #[test]
+    fn rejects_mismatched_column_lengths() {
+        let dir = std::env::temp_dir().join("rustdf_lib_badcols.tsv");
+        // charges has 2 entries but everything else has 1 -> error, no file contract.
+        let r = build_spectral_library_tsv(
+            &dir,
+            &one("PEPTIDEK"),
+            &one("PEPTIDEK"),
+            &one("PEPTIDEK"),
+            &[2, 3],
+            &vec![0.0; 174],
+            174,
+            &[500.0],
+            &[10.0],
+            &one("P"),
+            &one("G"),
+            3,
+            false,
+        );
+        assert!(r.is_err(), "mismatched column lengths must error");
+    }
+
+    #[test]
+    fn rejects_wrong_prosit_flat_size() {
+        let dir = std::env::temp_dir().join("rustdf_lib_badflat.tsv");
+        let r = build_spectral_library_tsv(
+            &dir, &one("PEPK"), &one("PEPK"), &one("PEPK"), &[2],
+            &vec![0.0; 100], 174, &[500.0], &[10.0], &one("P"), &one("G"), 3, false,
+        );
+        assert!(r.is_err(), "prosit_flat length != n*n_cols must error");
+    }
+
+    #[test]
+    fn all_zero_intensities_emit_header_only() {
+        // A zero Prosit vector -> every fragment intensity 0 -> precursor skipped
+        // (< min_fragments). Replace mode still writes the header and an empty body.
+        let out = std::env::temp_dir().join("rustdf_lib_zero.tsv");
+        let (n_trans, n_prec) = build_spectral_library_tsv(
+            &out, &one("PEPTIDEK"), &one("PEPTIDEK"), &one("PEPTIDEK"), &[2],
+            &vec![0.0; 174], 174, &[500.0], &[10.0], &one("P"), &one("G"), 3, false,
+        )
+        .expect("write");
+        assert_eq!((n_trans, n_prec), (0, 0));
+        let body = std::fs::read_to_string(&out).expect("read");
+        assert!(body.starts_with("ProteinId\t"), "header present");
+        assert_eq!(body.lines().count(), 1, "header only, no transition rows");
+    }
+}

--- a/rustdf/src/sim/mod.rs
+++ b/rustdf/src/sim/mod.rs
@@ -7,6 +7,8 @@ pub mod dia;
 pub mod handle;
 pub mod lazy_builder;
 pub mod library;
+#[cfg(feature = "mzml")]
+pub mod mzml;
 pub mod precursor;
 pub mod projector;
 pub mod scheme;

--- a/rustdf/src/sim/mod.rs
+++ b/rustdf/src/sim/mod.rs
@@ -6,6 +6,7 @@ pub mod dda;
 pub mod dia;
 pub mod handle;
 pub mod lazy_builder;
+pub mod library;
 pub mod precursor;
 pub mod projector;
 pub mod scheme;

--- a/rustdf/src/sim/mzml.rs
+++ b/rustdf/src/sim/mzml.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::path::Path;
 
 use mzdata::io::MzMLWriter;
+use mzdata::meta::DissociationMethodTerm;
 use mzdata::prelude::*;
 use mzdata::spectrum::bindata::{ArrayType, BinaryDataArrayType, DataArray};
 use mzdata::spectrum::{
@@ -63,52 +64,83 @@ pub fn write_scans_mzml(scans: &[MzMlScan], out_path: &Path) -> io::Result<usize
     let file = File::create(out_path)?;
     let mut writer = MzMLWriter::new(file);
     for (i, s) in scans.iter().enumerate() {
-        let mut arrays = BinaryArrayMap::new();
-        arrays.add(DataArray::wrap(
-            &ArrayType::MZArray,
-            BinaryDataArrayType::Float64,
-            f64_le_bytes(&s.mz),
-        ));
-        arrays.add(DataArray::wrap(
-            &ArrayType::IntensityArray,
-            BinaryDataArrayType::Float32,
-            f32_le_bytes(&s.intensity),
-        ));
-
-        let mut desc = SpectrumDescription::default();
-        desc.id = format!("scan={}", i + 1);
-        desc.index = i;
-        desc.ms_level = s.ms_level;
-        desc.polarity = ScanPolarity::Positive;
-        desc.signal_continuity = SignalContinuity::Centroid;
-
-        // Scan start time: mzML stores it in minutes.
-        let mut scan_event = ScanEvent::default();
-        scan_event.start_time = s.retention_time_s / 60.0;
-        desc.acquisition.scans.push(scan_event);
-
-        if let Some(iso) = &s.isolation {
-            let mut prec = Precursor::default();
-            prec.isolation_window = IsolationWindow {
-                target: iso.center_mz as f32,
-                lower_bound: iso.lower_mz as f32,
-                upper_bound: iso.upper_mz as f32,
-                ..Default::default()
-            };
-            let mut ion = SelectedIon::default();
-            ion.mz = iso.center_mz;
-            prec.ions.push(ion);
-            let mut activation = Activation::default();
-            activation.energy = iso.collision_energy as f32;
-            prec.activation = activation;
-            desc.precursor.push(prec);
-        }
-
-        let spectrum = RawSpectrum::new(desc, arrays);
-        writer.write(&spectrum)?;
+        write_one_scan(&mut writer, i, s)?;
     }
     writer.close()?;
     Ok(scans.len())
+}
+
+/// Build the mzML spectrum for one scan and write it to an open writer. Shared by the
+/// in-memory `write_scans_mzml` and the streaming `render_db_to_mzml` (which writes each
+/// frame as it is rendered rather than buffering them all).
+fn write_one_scan<W: io::Write>(
+    writer: &mut MzMLWriter<W>,
+    index: usize,
+    s: &MzMlScan,
+) -> io::Result<()> {
+    if s.mz.len() != s.intensity.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "scan {index}: m/z ({}) and intensity ({}) length mismatch",
+                s.mz.len(),
+                s.intensity.len()
+            ),
+        ));
+    }
+    let mut arrays = BinaryArrayMap::new();
+    arrays.add(DataArray::wrap(
+        &ArrayType::MZArray,
+        BinaryDataArrayType::Float64,
+        f64_le_bytes(&s.mz),
+    ));
+    arrays.add(DataArray::wrap(
+        &ArrayType::IntensityArray,
+        BinaryDataArrayType::Float32,
+        f32_le_bytes(&s.intensity),
+    ));
+
+    let mut desc = SpectrumDescription::default();
+    desc.id = format!("scan={}", index + 1);
+    desc.index = index;
+    desc.ms_level = s.ms_level;
+    desc.polarity = ScanPolarity::Positive;
+    desc.signal_continuity = SignalContinuity::Centroid;
+
+    // Scan start time: mzML stores it in minutes.
+    let mut scan_event = ScanEvent::default();
+    scan_event.start_time = s.retention_time_s / 60.0;
+    desc.acquisition.scans.push(scan_event);
+
+    if let Some(iso) = &s.isolation {
+        let mut prec = Precursor::default();
+        // mzdata stores isolation bounds as ABSOLUTE m/z (its writer converts to mzML
+        // lower/upper OFFSETS); pass absolute lower/upper.
+        prec.isolation_window = IsolationWindow {
+            target: iso.center_mz as f32,
+            lower_bound: iso.lower_mz as f32,
+            upper_bound: iso.upper_mz as f32,
+            ..Default::default()
+        };
+        let mut ion = SelectedIon::default();
+        ion.mz = iso.center_mz;
+        prec.ions.push(ion);
+        let mut activation = Activation::default();
+        // Declare the dissociation method (HCD / beam-type CID) so the <activation> is
+        // not just a bare energy. NOTE: mzdata serialises `energy` as PSI-MS "collision
+        // energy" (eV); our value is the model's NCE/CE as supplied — downstream search
+        // engines key on fragments, not this field, but the unit caveat stands.
+        activation
+            .methods_mut()
+            .push(DissociationMethodTerm::BeamTypeCollisionInducedDissociation);
+        activation.energy = iso.collision_energy as f32;
+        prec.activation = activation;
+        desc.precursor.push(prec);
+    }
+
+    let spectrum = RawSpectrum::new(desc, arrays);
+    writer.write(&spectrum)?;
+    Ok(())
 }
 
 /// Outcome of a DB → mzML render.
@@ -177,8 +209,11 @@ pub fn render_db_to_mzml(
         .collect();
     frame_ids.sort_unstable();
 
-    let (mut ms1, mut ms2, mut ms2_nonempty) = (0usize, 0usize, 0usize);
-    let mut scans: Vec<MzMlScan> = Vec::with_capacity(frame_ids.len());
+    // Stream: open the writer and emit each frame as it is rendered, so peak memory is
+    // one scan, not the whole run (a 28k-frame run is a ~1.5 GB mzML).
+    let file = std::fs::File::create(out_path).map_err(|e| format!("create {out_path:?}: {e}"))?;
+    let mut writer = MzMLWriter::new(file);
+    let (mut ms1, mut ms2, mut ms2_nonempty, mut total) = (0usize, 0usize, 0usize, 0usize);
     for frame_id in frame_ids {
         let desc = if prec_set.contains(&frame_id) {
             let ev = builder
@@ -204,17 +239,18 @@ pub fn render_db_to_mzml(
         if isolation.is_some() && !desc.peaks.is_empty() {
             ms2_nonempty += 1;
         }
-        scans.push(MzMlScan {
+        let scan = MzMlScan {
             ms_level: desc.ms_level,
             retention_time_s: desc.retention_time,
             mz: desc.peaks.iter().map(|(m, _)| *m).collect(),
             intensity: desc.peaks.iter().map(|(_, i)| *i).collect(),
             isolation,
-        });
+        };
+        write_one_scan(&mut writer, total, &scan).map_err(|e| format!("write scan {total}: {e}"))?;
+        total += 1;
     }
-
-    write_scans_mzml(&scans, out_path).map_err(|e| format!("write mzML: {e}"))?;
-    Ok(MzMlWriteSummary { scans: scans.len(), ms1, ms2, ms2_nonempty })
+    writer.close().map_err(|e| format!("close mzML: {e}"))?;
+    Ok(MzMlWriteSummary { scans: total, ms1, ms2, ms2_nonempty })
 }
 
 #[cfg(test)]

--- a/rustdf/src/sim/mzml.rs
+++ b/rustdf/src/sim/mzml.rs
@@ -1,0 +1,164 @@
+//! Open **mzML** output via Joshua Klein's `mzdata` (`MzMLWriter`).
+//!
+//! The vendor-neutral output path: a stream of rendered scans (m/z + intensity, MS
+//! level, retention time, optional MS2 isolation window + collision energy) is written
+//! as standards-compliant mzML — readable by DiaNN/alphaDIA and signable by mzprov.
+//! Used for SCIEX, whose proprietary `.wiff.scan` spectra are not authored; reusable as
+//! a general open-format output for any instrument.
+
+#![cfg(feature = "mzml")]
+
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+use mzdata::io::MzMLWriter;
+use mzdata::prelude::*;
+use mzdata::spectrum::bindata::{ArrayType, BinaryDataArrayType, DataArray};
+use mzdata::spectrum::{
+    Activation, BinaryArrayMap, IsolationWindow, Precursor, RawSpectrum, ScanEvent,
+    ScanPolarity, SelectedIon, SignalContinuity, SpectrumDescription,
+};
+
+/// One MS2 isolation window + applied collision energy.
+#[derive(Clone, Debug)]
+pub struct MzMlIsolation {
+    pub center_mz: f64,
+    pub lower_mz: f64,
+    pub upper_mz: f64,
+    pub collision_energy: f64,
+}
+
+/// One vendor-neutral scan to serialise (centroided peak list).
+#[derive(Clone, Debug)]
+pub struct MzMlScan {
+    pub ms_level: u8,
+    pub retention_time_s: f64,
+    pub mz: Vec<f64>,
+    pub intensity: Vec<f32>,
+    /// Present for MS2: the precursor isolation window + CE.
+    pub isolation: Option<MzMlIsolation>,
+}
+
+fn f64_le_bytes(v: &[f64]) -> Vec<u8> {
+    let mut b = Vec::with_capacity(v.len() * 8);
+    for x in v {
+        b.extend_from_slice(&x.to_le_bytes());
+    }
+    b
+}
+
+fn f32_le_bytes(v: &[f32]) -> Vec<u8> {
+    let mut b = Vec::with_capacity(v.len() * 4);
+    for x in v {
+        b.extend_from_slice(&x.to_le_bytes());
+    }
+    b
+}
+
+/// Write a stream of scans to `out_path` as mzML. Scans are written in order;
+/// returns the number written. Spectra are centroid peak lists; MS2 spectra carry
+/// their isolation window (target + lower/upper bound) and collision energy.
+pub fn write_scans_mzml(scans: &[MzMlScan], out_path: &Path) -> io::Result<usize> {
+    let file = File::create(out_path)?;
+    let mut writer = MzMLWriter::new(file);
+    for (i, s) in scans.iter().enumerate() {
+        let mut arrays = BinaryArrayMap::new();
+        arrays.add(DataArray::wrap(
+            &ArrayType::MZArray,
+            BinaryDataArrayType::Float64,
+            f64_le_bytes(&s.mz),
+        ));
+        arrays.add(DataArray::wrap(
+            &ArrayType::IntensityArray,
+            BinaryDataArrayType::Float32,
+            f32_le_bytes(&s.intensity),
+        ));
+
+        let mut desc = SpectrumDescription::default();
+        desc.id = format!("scan={}", i + 1);
+        desc.index = i;
+        desc.ms_level = s.ms_level;
+        desc.polarity = ScanPolarity::Positive;
+        desc.signal_continuity = SignalContinuity::Centroid;
+
+        // Scan start time: mzML stores it in minutes.
+        let mut scan_event = ScanEvent::default();
+        scan_event.start_time = s.retention_time_s / 60.0;
+        desc.acquisition.scans.push(scan_event);
+
+        if let Some(iso) = &s.isolation {
+            let mut prec = Precursor::default();
+            prec.isolation_window = IsolationWindow {
+                target: iso.center_mz as f32,
+                lower_bound: iso.lower_mz as f32,
+                upper_bound: iso.upper_mz as f32,
+                ..Default::default()
+            };
+            let mut ion = SelectedIon::default();
+            ion.mz = iso.center_mz;
+            prec.ions.push(ion);
+            let mut activation = Activation::default();
+            activation.energy = iso.collision_energy as f32;
+            prec.activation = activation;
+            desc.precursor.push(prec);
+        }
+
+        let spectrum = RawSpectrum::new(desc, arrays);
+        writer.write(&spectrum)?;
+    }
+    writer.close()?;
+    Ok(scans.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mzdata::io::MzMLReader;
+
+    #[test]
+    fn write_read_roundtrip() {
+        let scans = vec![
+            MzMlScan {
+                ms_level: 1,
+                retention_time_s: 60.0,
+                mz: vec![400.1, 500.2, 600.3],
+                intensity: vec![1000.0, 2000.0, 1500.0],
+                isolation: None,
+            },
+            MzMlScan {
+                ms_level: 2,
+                retention_time_s: 61.5,
+                mz: vec![150.1, 250.2, 410.3],
+                intensity: vec![500.0, 800.0, 300.0],
+                isolation: Some(MzMlIsolation {
+                    center_mz: 500.0,
+                    lower_mz: 495.0,
+                    upper_mz: 505.0,
+                    collision_energy: 27.0,
+                }),
+            },
+        ];
+        let out = std::env::temp_dir().join("rustdf_mzml_roundtrip.mzML");
+        let n = write_scans_mzml(&scans, &out).expect("write mzML");
+        assert_eq!(n, 2);
+
+        // Read it back with mzdata and confirm the content survived the round-trip.
+        let mut reader = MzMLReader::open_path(&out).expect("reopen mzML");
+        let read: Vec<_> = (&mut reader).collect();
+        assert_eq!(read.len(), 2, "spectrum count");
+
+        let ms1 = &read[0];
+        assert_eq!(ms1.ms_level(), 1);
+        assert!((ms1.start_time() - 1.0).abs() < 1e-6, "MS1 RT 60s -> 1.0 min");
+        let p1 = ms1.peaks();
+        assert_eq!(p1.len(), 3, "MS1 peak count");
+
+        let ms2 = &read[1];
+        assert_eq!(ms2.ms_level(), 2);
+        let prec = ms2.precursor().expect("MS2 precursor");
+        assert!((prec.isolation_window.target - 500.0).abs() < 1e-3, "isolation target");
+        assert!((prec.isolation_window.lower_bound - 495.0).abs() < 1e-3);
+        assert_eq!(ms2.peaks().len(), 3, "MS2 peak count");
+    }
+}

--- a/rustdf/src/sim/mzml.rs
+++ b/rustdf/src/sim/mzml.rs
@@ -181,15 +181,27 @@ pub fn render_db_to_mzml(
     let wg = handle
         .read_window_group_settings()
         .map_err(|e| format!("read windows: {e}"))?;
-    let by_group: HashMap<u32, (f64, f64, f64)> = wg
-        .iter()
-        .map(|w| {
-            (
-                w.window_group,
-                (w.isolation_mz as f64, w.isolation_width as f64, w.collision_energy as f64),
-            )
-        })
-        .collect();
+    // One window per group is the no-IM DIA invariant; reject conflicting duplicate rows
+    // (silently keeping the last would mis-render) and non-positive widths.
+    let mut by_group: HashMap<u32, (f64, f64, f64)> = HashMap::new();
+    for w in &wg {
+        let v = (w.isolation_mz as f64, w.isolation_width as f64, w.collision_energy as f64);
+        if v.1 <= 0.0 {
+            return Err(format!(
+                "window_group {} has non-positive isolation width {}",
+                w.window_group, v.1
+            ));
+        }
+        if let Some(prev) = by_group.insert(w.window_group, v) {
+            if prev != v {
+                return Err(format!(
+                    "conflicting dia_ms_ms_windows rows for window_group {}: {prev:?} vs {v:?} \
+                     (render_db_to_mzml expects one window per group, no-IM DIA)",
+                    w.window_group
+                ));
+            }
+        }
+    }
     let f2g = handle
         .read_frame_to_window_group()
         .map_err(|e| format!("read frame->group: {e}"))?;

--- a/rustdf/src/sim/mzml.rs
+++ b/rustdf/src/sim/mzml.rs
@@ -111,6 +111,112 @@ pub fn write_scans_mzml(scans: &[MzMlScan], out_path: &Path) -> io::Result<usize
     Ok(scans.len())
 }
 
+/// Outcome of a DB → mzML render.
+#[derive(Debug, Clone)]
+pub struct MzMlWriteSummary {
+    pub scans: usize,
+    pub ms1: usize,
+    pub ms2: usize,
+    pub ms2_nonempty: usize,
+}
+
+/// Render a no-IM DIA `synthetic_data.db` to mzML — the vendor-neutral output used for
+/// SCIEX SWATH (and any no-IM DIA scheme). MS1 frames are rendered via the precursor
+/// marginal; MS2 frames via the per-window fragment kernel (gated by the DB window's m/z
+/// + CE). This is the open-format analogue of `astral_dispatch::write_astral_raw`: same
+/// render kernels, mzML out instead of a vendor `.raw`. Returns counts.
+pub fn render_db_to_mzml(
+    db_path: &Path,
+    out_path: &Path,
+    num_threads: usize,
+    quad_k: f64,
+) -> Result<MzMlWriteSummary, String> {
+    use std::collections::HashMap;
+
+    use mscore::timstof::quadrupole::WindowTransmission;
+
+    use crate::sim::acquisition::ScanDescriptor;
+    use crate::sim::dia::TimsTofSyntheticsFrameBuilderDIA;
+    use crate::sim::handle::TimsTofSyntheticsDataHandle;
+    use crate::sim::scheme::DataMode;
+
+    let builder = TimsTofSyntheticsFrameBuilderDIA::new(db_path, false, num_threads)
+        .map_err(|e| format!("open DB: {e}"))?;
+    let handle =
+        TimsTofSyntheticsDataHandle::new(db_path).map_err(|e| format!("open DB handle: {e}"))?;
+
+    // frame -> (center, width, ce) for MS2 frames, via the DB window tables.
+    let wg = handle
+        .read_window_group_settings()
+        .map_err(|e| format!("read windows: {e}"))?;
+    let by_group: HashMap<u32, (f64, f64, f64)> = wg
+        .iter()
+        .map(|w| {
+            (
+                w.window_group,
+                (w.isolation_mz as f64, w.isolation_width as f64, w.collision_energy as f64),
+            )
+        })
+        .collect();
+    let f2g = handle
+        .read_frame_to_window_group()
+        .map_err(|e| format!("read frame->group: {e}"))?;
+    let mut frame_window: HashMap<u32, (f64, f64, f64)> = HashMap::new();
+    for r in &f2g {
+        if let Some(&w) = by_group.get(&r.window_group) {
+            frame_window.insert(r.frame_id, w);
+        }
+    }
+
+    let prec_set = &builder.precursor_frame_builder.precursor_frame_id_set;
+    let mut frame_ids: Vec<u32> = builder
+        .precursor_frame_builder
+        .frames
+        .iter()
+        .map(|f| f.frame_id)
+        .collect();
+    frame_ids.sort_unstable();
+
+    let (mut ms1, mut ms2, mut ms2_nonempty) = (0usize, 0usize, 0usize);
+    let mut scans: Vec<MzMlScan> = Vec::with_capacity(frame_ids.len());
+    for frame_id in frame_ids {
+        let desc = if prec_set.contains(&frame_id) {
+            let ev = builder
+                .precursor_frame_builder
+                .render_precursor_scan(frame_id, DataMode::Centroid);
+            ms1 += 1;
+            ScanDescriptor::from_rendered_event(&ev, 0.0)?
+        } else {
+            let (center, width, ce) = *frame_window
+                .get(&frame_id)
+                .ok_or_else(|| format!("MS2 frame {frame_id} has no window in the DB tables"))?;
+            let wt = WindowTransmission::new(center, width, quad_k);
+            let ev = builder.render_fragment_scan(frame_id, &wt, ce, DataMode::Centroid);
+            ms2 += 1;
+            ScanDescriptor::from_rendered_event(&ev, ce)?
+        };
+        let isolation = desc.isolation.map(|w| MzMlIsolation {
+            center_mz: w.center_mz,
+            lower_mz: w.center_mz - w.width_mz / 2.0,
+            upper_mz: w.center_mz + w.width_mz / 2.0,
+            collision_energy: w.collision_energy,
+        });
+        if isolation.is_some() && !desc.peaks.is_empty() {
+            ms2_nonempty += 1;
+        }
+        scans.push(MzMlScan {
+            ms_level: desc.ms_level,
+            retention_time_s: desc.retention_time,
+            mz: desc.peaks.iter().map(|(m, _)| *m).collect(),
+            intensity: desc.peaks.iter().map(|(_, i)| *i).collect(),
+            isolation,
+        });
+    }
+
+    write_scans_mzml(&scans, out_path).map_err(|e| format!("write mzML: {e}"))?;
+    Ok(MzMlWriteSummary { scans: scans.len(), ms1, ms2, ms2_nonempty })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,5 +266,31 @@ mod tests {
         assert!((prec.isolation_window.target - 500.0).abs() < 1e-3, "isolation target");
         assert!((prec.isolation_window.lower_bound - 495.0).abs() < 1e-3);
         assert_eq!(ms2.peaks().len(), 3, "MS2 peak count");
+    }
+
+    // Gated: set TIMSIM_DIA_DB to a no-IM DIA synthetic_data.db (e.g. an Orbitrap/SCIEX
+    // run) to render it to mzML and confirm it reads back.
+    #[test]
+    fn render_db_to_mzml_roundtrip() {
+        let db = match std::env::var("TIMSIM_DIA_DB") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP render_db_to_mzml_roundtrip: set TIMSIM_DIA_DB=<synthetic_data.db>");
+                return;
+            }
+        };
+        let out = std::env::temp_dir().join("rustdf_render_db.mzML");
+        let s = render_db_to_mzml(std::path::Path::new(&db), &out, 4, 15.0).expect("render mzML");
+        assert!(s.ms1 > 0 && s.ms2 > 0, "expected MS1 + MS2 scans, got {s:?}");
+        let mut reader = MzMLReader::open_path(&out).expect("reopen mzML");
+        let n_ms1 = (&mut reader).filter(|sp| sp.ms_level() == 1).count();
+        let mut reader2 = MzMLReader::open_path(&out).expect("reopen mzML 2");
+        let n_total = (&mut reader2).count();
+        assert_eq!(n_total, s.scans, "round-trip scan count");
+        assert_eq!(n_ms1, s.ms1, "round-trip MS1 count");
+        eprintln!(
+            "render_db_to_mzml OK: {} scans ({} MS1, {} MS2, {} non-empty MS2) -> mzML reads back {}",
+            s.scans, s.ms1, s.ms2, s.ms2_nonempty, n_total
+        );
     }
 }

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -409,6 +409,52 @@ impl AcquisitionScheme {
         }
     }
 
+    /// Expand a `FixedCycleTime` DIA scheme into a per-frame schedule over the whole
+    /// gradient — the synthesized analogue of `thermo_frame_schedule` for schemes that
+    /// carry no per-scan timing (e.g. a SCIEX `.wiff` SWATH method). Each cycle emits its
+    /// events (MS1 then one MS2 frame per window) at evenly-spaced times within the
+    /// cycle. Rows are `(scan, retention_time_s, ms_level, isolation_center_mz,
+    /// isolation_width_mz, collision_energy)`; the MS1 row's isolation/CE are `None`, and
+    /// a window's CE is resolved from its `CollisionEnergyPolicy` at the window center
+    /// (`None` if the policy is `Unknown`). Empty unless `repeat` is `FixedCycleTime`.
+    pub fn dia_frame_schedule(
+        &self,
+    ) -> Vec<(u32, f64, u8, Option<f64>, Option<f64>, Option<f64>)> {
+        let (cycle_time_s, start_time_s) = match self.repeat {
+            RepeatPolicy::FixedCycleTime { cycle_time_s, start_time_s, .. } => {
+                (cycle_time_s, start_time_s)
+            }
+            _ => return Vec::new(),
+        };
+        let n_cycles = self.num_cycles().unwrap_or(0);
+        let n_events = self.cycle.len();
+        if n_cycles == 0 || n_events == 0 {
+            return Vec::new();
+        }
+        let per_event_dt = cycle_time_s / n_events as f64;
+        let mut out = Vec::with_capacity(n_cycles as usize * n_events);
+        let mut scan: u32 = 1;
+        for c in 0..n_cycles {
+            let cycle_start = start_time_s + c as f64 * cycle_time_s;
+            for (j, ev) in self.cycle.iter().enumerate() {
+                let rt = cycle_start + j as f64 * per_event_dt;
+                match ev {
+                    AcquisitionEvent::Ms1(_) => out.push((scan, rt, 1u8, None, None, None)),
+                    AcquisitionEvent::DiaMs2Frame(f) => {
+                        // SCIEX from_sciex_wiff builds one window per MS2 frame.
+                        if let Some(w) = f.windows.first() {
+                            let center = w.isolation.center_mz;
+                            let ce = w.collision_energy.at(center);
+                            out.push((scan, rt, 2u8, Some(center), Some(w.isolation.width_mz), ce));
+                        }
+                    }
+                }
+                scan += 1;
+            }
+        }
+        out
+    }
+
     /// Build a scheme from an explicit window list (injected / CSV). One MS1
     /// followed by one single-window MS2 frame per window.
     pub fn from_window_table(
@@ -1220,6 +1266,73 @@ pub struct TemplateScan {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn swath_scheme(cycle_time_s: f64, gradient_length_s: f64) -> AcquisitionScheme {
+        let ms1 = Ms1Event {
+            analyzer: Analyzer::Tof,
+            data_mode: DataMode::Centroid,
+            mz_range: None,
+            duration_s: None,
+        };
+        let mk = |center: f64, width: f64| DiaWindow {
+            isolation: IsolationWindow { center_mz: center, width_mz: width },
+            collision_energy: CollisionEnergyPolicy::Linear { intercept: 5.0, slope_per_mz: 0.045 },
+            geometry: DiaGeometry::MzOnly,
+        };
+        AcquisitionScheme::from_window_table(
+            InstrumentKind::SciexZenoTof,
+            ms1,
+            vec![mk(420.0, 40.0), mk(480.0, 20.0)],
+            RepeatPolicy::FixedCycleTime { cycle_time_s, gradient_length_s, start_time_s: 0.0 },
+            (400.0, 500.0),
+        )
+    }
+
+    #[test]
+    fn dia_frame_schedule_expands_cycles() {
+        // 3 cycles of [MS1, MS2(420), MS2(480)] over a 9 s gradient at 3 s cycles.
+        let sched = swath_scheme(3.0, 9.0).dia_frame_schedule();
+        assert_eq!(sched.len(), 9, "3 cycles x 3 events");
+        // Contiguous 1-based scan ids.
+        assert_eq!(
+            sched.iter().map(|r| r.0).collect::<Vec<_>>(),
+            (1u32..=9).collect::<Vec<_>>()
+        );
+        // RT strictly increasing.
+        for w in sched.windows(2) {
+            assert!(w[1].1 > w[0].1, "RT must increase: {:?} !> {:?}", w[1].1, w[0].1);
+        }
+        // Cycle starts: rows 0,3,6 at t = 0,3,6.
+        for (k, &i) in [0usize, 3, 6].iter().enumerate() {
+            assert!((sched[i].1 - (k as f64) * 3.0).abs() < 1e-9);
+            assert_eq!(sched[i].2, 1, "cycle starts with MS1");
+            assert!(sched[i].3.is_none() && sched[i].5.is_none(), "MS1 has no iso/CE");
+        }
+        // First MS2: center 420, width 40, CE resolved by the linear model (>0).
+        assert_eq!(sched[1].2, 2);
+        assert!((sched[1].3.unwrap() - 420.0).abs() < 1e-9);
+        assert!((sched[1].4.unwrap() - 40.0).abs() < 1e-9);
+        assert!(sched[1].5.unwrap() > 0.0, "rolling CE resolved for MS2");
+    }
+
+    #[test]
+    fn dia_frame_schedule_unknown_ce_is_none() {
+        let mut s = swath_scheme(3.0, 6.0);
+        // Force all window CE policies to Unknown.
+        for e in &mut s.cycle {
+            if let AcquisitionEvent::DiaMs2Frame(f) = e {
+                for w in &mut f.windows {
+                    w.collision_energy = CollisionEnergyPolicy::Unknown;
+                }
+            }
+        }
+        let sched = s.dia_frame_schedule();
+        for r in &sched {
+            if r.2 == 2 {
+                assert!(r.5.is_none(), "Unknown CE -> None (caller must supply a model)");
+            }
+        }
+    }
 
     #[test]
     fn activation_condition_carries_typed_unit() {


### PR DESCRIPTION
Extends TimSim from a Bruker-timsTOF simulator to a **four-vendor** open-format simulator, adds a reproducible cross-vendor benchmark, and wires **mzPROV cryptographic provenance** into every output.

## New vendor support

| Vendor | Output | How |
|---|---|---|
| Bruker timsTOF | `.d` | (existing) |
| Thermo Astral / Orbitrap | `.raw` | build-from-template (existing, extended) |
| **SCIEX ZenoTOF SWATH** | mzML | build-from-`.wiff`: SWATH windows read, schedule synthesized, rendered to open mzML |
| **Waters Synapt XS SONAR** | mzML | build-from-parameters: scanning-quad windows synthesized in pure Python, rendered to mzML |

- New Rust mzML writer via `mzdata` + a PyO3 `render_dia_mzml` (`mzml` connector feature); a fast rayon Prosit→DiaNN spectral-library writer.
- Shared `build_frame_tables_from_schedule` / `template_acquisition_common` primitives across the Astral, SCIEX, and Waters builders.
- Fail-fast config validation per vendor (geometry, CE positivity, gradient, capability guards).

## Validation (matched 5K-peptide scale, all 0% FDP vs ground truth)

| Vendor | Engine | Recall | FDP |
|---|---|---|---|
| Bruker `.d` | DiaNN | 45.7% | 0% |
| Thermo `.raw` | alphaDIA | 65.6% | 0% |
| SCIEX mzML | alphaDIA | 81.9% | 0% |
| Waters mzML | DiaNN | 73.7% | 0% |

New `imspy_simulation.timsim.benchmark` package: a consolidator (per-vendor `groundtruth_eval` JSON → side-by-side table) + a test-grid generator (one base config + per-vendor cells → matched configs + manifest).

## mzPROV provenance signing

Every vendor output is Ed25519-signed self-disclosure ("this IS TimSim-simulated data", bound to config + key):
- Bruker `.d` (structural canonicalization) and SCIEX/Waters mzML (mzML content canonicalization) **embed in-band** by default (`provenance_embed=True`).
- Thermo `.raw` gets an opaque whole-file sidecar (the `.raw` attestation added in the mzprov repo).
- Import-guarded + non-fatal; signs with a local key (tamper-evidence + disclosure; not yet identity-anchored).

## Notes

Each behavior-touching commit was codex-reviewed and hardened (visible in the `fix(sim): ...` commits). 20 commits; +20 ahead of main, 2 behind (clean merge).