### PR TITLE
fix(rust): clear compile warnings across all feature configs

### DIFF
--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -1,5 +1,7 @@
 use numpy::IntoPyArray;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+#[cfg(feature = "thermo")]
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rustdf::sim::scheme::AcquisitionScheme;

--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -39,9 +39,9 @@ rand = "0.8.5"
 rustc-hash = "2.1.0"
 bincode = "1.3.3"
 polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
-# Thermo .raw writer (private repo; only built with the `thermo` feature)
-thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "9f4c0affe60a639759883fb569d3c9f5f7601856", optional = true }
-# SCIEX .wiff method reader (private repo; only built with the `sciex` feature)
+# Thermo .raw writer (public repo; only built with the `thermo` feature)
+thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "61bf4724bc35cd7bc916b6acebc49319a0f9bbbc", optional = true }
+# SCIEX .wiff method reader (public repo; only built with the `sciex` feature)
 sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "ef7c0cd7e59d3b51160e446cbe3af240d230668d", optional = true }
 # Open mzML writer (Joshua Klein's mzdata); only built with the `mzml` feature. The
 # vendor-neutral output path: render -> mzML (readable by DiaNN/alphaDIA, mzprov-signable).

--- a/rustdf/src/data/dia.rs
+++ b/rustdf/src/data/dia.rs
@@ -9,7 +9,6 @@ use crate::data::meta::{
 use mscore::data::spectrum::MsType;
 use mscore::timstof::frame::{RawTimsFrame, TimsFrame};
 use mscore::timstof::slice::TimsSlice;
-use rand::prelude::IteratorRandom;
 use rayon::iter::IntoParallelRefIterator;
 use crate::cluster::peak::{build_frame_bin_view, build_tof_rt_grid_full, expand_many_im_peaks_along_rt, FrameBinView, ImPeak1D, RtExpandParams, RtFrames, TofRtGrid};
 use crate::cluster::utility::{TofScale};

--- a/rustdf/src/data/raw.rs
+++ b/rustdf/src/data/raw.rs
@@ -1,4 +1,5 @@
 use libloading::{Library, Symbol};
+use std::cell::RefCell;
 use std::os::raw::{c_char, c_double, c_float};
 use std::sync::Mutex;
 
@@ -245,7 +246,7 @@ impl BrukerTimsDataLibrary {
         let _guard = EXTRACT_BUF
             .lock()
             .map_err(|_| "EXTRACT_BUF poisoned")?;
-        unsafe { EXTRACT_BUF_DATA = Some((Vec::new(), Vec::new())); }
+        EXTRACT_BUF_DATA.with(|buf| *buf.borrow_mut() = Some((Vec::new(), Vec::new())));
         unsafe {
             let func: Symbol<
                 unsafe extern "C" fn(
@@ -266,7 +267,7 @@ impl BrukerTimsDataLibrary {
                 return Err("tims_extract_centroided_spectrum_for_frame_v2 returned 0".into());
             }
         }
-        if let Some((mz, intens)) = unsafe { EXTRACT_BUF_DATA.take() } {
+        if let Some((mz, intens)) = EXTRACT_BUF_DATA.with(|buf| buf.borrow_mut().take()) {
             result_mz = mz;
             result_int = intens;
         }
@@ -282,7 +283,7 @@ impl BrukerTimsDataLibrary {
         frame_id: i64,
     ) -> Result<Vec<(i64, Vec<f64>, Vec<f32>)>, Box<dyn std::error::Error>> {
         let _guard = PASEF_BUF.lock().map_err(|_| "PASEF_BUF poisoned")?;
-        unsafe { PASEF_BUF_DATA = Some(Vec::new()); }
+        PASEF_BUF_DATA.with(|buf| *buf.borrow_mut() = Some(Vec::new()));
         unsafe {
             let func: Symbol<
                 unsafe extern "C" fn(
@@ -301,7 +302,7 @@ impl BrukerTimsDataLibrary {
                 return Err("tims_read_pasef_msms_for_frame_v2 returned 0".into());
             }
         }
-        let out = unsafe { PASEF_BUF_DATA.take() }.unwrap_or_default();
+        let out = PASEF_BUF_DATA.with(|buf| buf.borrow_mut().take()).unwrap_or_default();
         Ok(out)
     }
 }
@@ -310,7 +311,9 @@ impl BrukerTimsDataLibrary {
 // only one thread runs the SDK at a time per process — same restriction
 // pyTDFSDK + alphatims live with.
 static EXTRACT_BUF: Mutex<()> = Mutex::new(());
-static mut EXTRACT_BUF_DATA: Option<(Vec<f64>, Vec<f32>)> = None;
+thread_local! {
+    static EXTRACT_BUF_DATA: RefCell<Option<(Vec<f64>, Vec<f32>)>> = const { RefCell::new(None) };
+}
 
 extern "C" fn centroid_trampoline(
     _precursor_id: i64,
@@ -321,16 +324,18 @@ extern "C" fn centroid_trampoline(
     if n_peaks == 0 || mzs.is_null() || intensities.is_null() { return; }
     let mz_slice = unsafe { std::slice::from_raw_parts(mzs, n_peaks as usize) };
     let in_slice = unsafe { std::slice::from_raw_parts(intensities, n_peaks as usize) };
-    unsafe {
-        if let Some((ref mut mz_acc, ref mut in_acc)) = EXTRACT_BUF_DATA {
+    EXTRACT_BUF_DATA.with(|buf| {
+        if let Some((ref mut mz_acc, ref mut in_acc)) = *buf.borrow_mut() {
             mz_acc.extend_from_slice(mz_slice);
             in_acc.extend_from_slice(in_slice);
         }
-    }
+    });
 }
 
 static PASEF_BUF: Mutex<()> = Mutex::new(());
-static mut PASEF_BUF_DATA: Option<Vec<(i64, Vec<f64>, Vec<f32>)>> = None;
+thread_local! {
+    static PASEF_BUF_DATA: RefCell<Option<Vec<(i64, Vec<f64>, Vec<f32>)>>> = const { RefCell::new(None) };
+}
 
 extern "C" fn pasef_trampoline(
     precursor_id: i64,
@@ -342,11 +347,11 @@ extern "C" fn pasef_trampoline(
     if n_peaks == 0 || mzs.is_null() || intensities.is_null() { return; }
     let mz_slice = unsafe { std::slice::from_raw_parts(mzs, n_peaks as usize) };
     let in_slice = unsafe { std::slice::from_raw_parts(intensities, n_peaks as usize) };
-    unsafe {
-        if let Some(ref mut acc) = PASEF_BUF_DATA {
+    PASEF_BUF_DATA.with(|buf| {
+        if let Some(ref mut acc) = *buf.borrow_mut() {
             acc.push((precursor_id, mz_slice.to_vec(), in_slice.to_vec()));
         }
-    }
+    });
 }
 
 // Silence the unused `c_float` warning on platforms where it's only

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -420,12 +420,7 @@ impl AcquisitionScheme {
     pub fn dia_frame_schedule(
         &self,
     ) -> Vec<(u32, f64, u8, Option<f64>, Option<f64>, Option<f64>)> {
-        let (cycle_time_s, start_time_s) = match self.repeat {
-            RepeatPolicy::FixedCycleTime { cycle_time_s, start_time_s, .. } => {
-                (cycle_time_s, start_time_s)
-            }
-            _ => return Vec::new(),
-        };
+        let RepeatPolicy::FixedCycleTime { cycle_time_s, start_time_s, .. } = self.repeat;
         let n_cycles = self.num_cycles().unwrap_or(0);
         let n_events = self.cycle.len();
         if n_cycles == 0 || n_events == 0 {

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -556,7 +556,6 @@ mod tests {
             LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget);
 
         let mut points = 0usize;
-        let mut saw_done = false;
         let mut saw_stats = false;
         loop {
             match handle.rx.recv_timeout(Duration::from_secs(15)) {
@@ -572,10 +571,8 @@ mod tests {
                     assert!(i_min > 0.0 && i_max > i_min);
                     saw_stats = true;
                 }
-                Ok(LoadMsg::Done { .. }) => {
-                    saw_done = true;
-                    break;
-                }
+                // The only non-panic exit: reaching past the loop proves Done arrived.
+                Ok(LoadMsg::Done { .. }) => break,
                 Ok(LoadMsg::PeakChunk { points: p }) => {
                     points += p.len();
                 }
@@ -584,7 +581,6 @@ mod tests {
                 Err(e) => panic!("loader timed out / disconnected: {e}"),
             }
         }
-        assert!(saw_done, "loader never signaled Done");
         assert!(saw_stats, "loader never sent intensity Stats");
         assert!(points > 0, "loader produced no points");
         // ~budget points (stride=2 over 100k); allow generous slack.

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -469,7 +469,7 @@ fn build_compute_stage(
 mod tests {
     use super::*;
     use crate::data::point::GpuPoint;
-    use crate::render::uniforms::{CameraUniform, ParamsUniform};
+    use crate::render::uniforms::ParamsUniform;
 
     /// Build the pipelines (forcing WGSL compilation for both the draw and, when
     /// supported, the compaction compute shader), upload points, run prepare() +


### PR DESCRIPTION
## Summary

Makes the Rust side warning-free in **every** feature configuration — the default `cargo build`, the feature-gated vendor paths (`thermo` / `sciex` / `mzml`), and the `--tests` target. The default build only compiles a subset, so the vendor-path and test-target warnings were previously invisible.

## Changes

**Warnings**
- **`rustdf/src/data/dia.rs`** — remove unused `rand::prelude::IteratorRandom` import (only appeared in comments/method names).
- **`rustdf/src/sim/scheme.rs`** — `RepeatPolicy` has a single variant, so the `_ => …` arm was unreachable; replaced the `match` with an irrefutable `let` destructure.
- **`rustdf/src/data/raw.rs`** — replace the two `static mut` C-callback buffers (`EXTRACT_BUF_DATA`, `PASEF_BUF_DATA`) with `thread_local!` `RefCell`s. The Bruker trampolines fire **synchronously on the calling thread**, so thread-local storage is the correct ownership model — this removes the `static_mut_refs` (Rust 2024) warnings *and* the surrounding `unsafe`, not just silences the lint. The `Mutex<()>` guards that serialize SDK calls are unchanged.
- **`imspy_connector/src/py_acquisition.rs`** — `PyRuntimeError` is only used inside `#[cfg(feature = "thermo")]` blocks; gate the import the same way so it's not unused in the default build.
- **`tims-viewer`** — drop an unused test import (`CameraUniform`) and a dead `saw_done` flag whose only read was a tautological post-loop assert (the loop's sole non-panic exit already proves `Done` arrived).

**Vendor deps (`rustdf/Cargo.toml`)**
- `thermorawfile` / `sciexwiff` are **public repos now** — updated the stale "private repo" comments.
- Bumped the `thermorawfile` pin to current `HEAD` (`61bf4724`). `sciexwiff` was already at its HEAD.

## Verification

| Build configuration | Result |
|---|---|
| `cargo build` (default) | no warnings |
| `cargo build --features "thermo sciex mzml"` (rustdf + connector) | no warnings |
| `cargo build --tests` (workspace) | no warnings |

All three vendor features resolve and build locally (the private repos are now public). Cargo.lock is git-ignored in this repo, so the pin bump lives entirely in `Cargo.toml`.

## Out of scope

Does **not** touch the pre-existing uncommitted edits in `mscore/.../peptide.rs` and `imspy_connector/src/py_peptide.rs` (unrelated work in progress).