### PR TITLE
fix(sim): per-cycle rt_cycle_length for non-timsTOF builders (Astral/SCIEX/Waters)

### DIFF
--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
@@ -117,9 +117,26 @@ class AstralAcquisitionBuilder:
         self.frame_to_template_scan = f2scan
         self.num_frames = len(ft)
         self.gradient_length = float(ft["time"].max())
-        diffs = np.diff(ft["time"].values)
-        positive = diffs[diffs > 0]
-        self.rt_cycle_length = float(np.median(positive)) if positive.size else 0.0
+        # rt_cycle_length is the per-CYCLE interval (MS1->MS1 time), NOT the per-scan
+        # interval. These are per-scan frames (~hundreds of MS2 windows per cycle), so the
+        # median diff over ALL frames is the scan spacing; using it under-scales the EMG
+        # frame-abundance per cycle by ~scans-per-cycle. Each cycle's single MS1 (and the
+        # single MS2 window matching a precursor) then carries only ~1/scans-per-cycle of
+        # the elution weight -> rendered peaks come out ~100x too faint and DIA-NN finds
+        # ~nothing. Derive it from the MS1 (precursor, ms_type==0) frames so each cycle's
+        # elution weight is correct, matching the Bruker cycle-frame path.
+        if "ms_type" in ft.columns:
+            cycle_times = ft["time"].values[ft["ms_type"].values == 0]
+        else:
+            cycle_times = ft["time"].values
+        cyc_diffs = np.diff(cycle_times)
+        cyc_pos = cyc_diffs[cyc_diffs > 0]
+        if cyc_pos.size:
+            self.rt_cycle_length = float(np.median(cyc_pos))
+        else:
+            diffs = np.diff(ft["time"].values)
+            positive = diffs[diffs > 0]
+            self.rt_cycle_length = float(np.median(positive)) if positive.size else 0.0
 
         if mz_lower is None:
             mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
@@ -28,6 +28,7 @@ from .template_acquisition_common import (
     TemplateTdfWriterStub,
     build_frame_tables_from_schedule,
     build_synthetic_scan_table,
+    rt_cycle_length_from_ms1,
 )
 
 # Backward-compatible aliases (the function/classes moved to template_acquisition_common).
@@ -117,31 +118,10 @@ class AstralAcquisitionBuilder:
         self.frame_to_template_scan = f2scan
         self.num_frames = len(ft)
         self.gradient_length = float(ft["time"].max())
-        # rt_cycle_length is the per-CYCLE interval (MS1->MS1 time), NOT the per-scan
-        # interval. These are per-scan frames (~hundreds of MS2 windows per cycle), so the
-        # median diff over ALL frames is the scan spacing; using it under-scales the EMG
-        # frame-abundance per cycle by ~scans-per-cycle. Each cycle's single MS1 (and the
-        # single MS2 window matching a precursor) then carries only ~1/scans-per-cycle of
-        # the elution weight -> rendered peaks come out ~100x too faint and DIA-NN finds
-        # ~nothing. Derive it from the MS1 (precursor, ms_type==0) frames so each cycle's
-        # elution weight is correct, matching the Bruker cycle-frame path.
-        # Sort by time before diffing (the schedule is chronological, but don't rely on it).
-        if "ms_type" in ft.columns:
-            cycle_times = np.sort(ft["time"].values[ft["ms_type"].values == 0])
-        else:
-            cycle_times = np.sort(ft["time"].values)
-        cyc_diffs = np.diff(cycle_times)
-        cyc_pos = cyc_diffs[cyc_diffs > 0]
-        if cyc_pos.size:
-            self.rt_cycle_length = float(np.median(cyc_pos))
-        else:
-            # Fail loud rather than silently fall back to the per-scan spacing (which is the
-            # exact bug this derivation fixes): a valid DIA template has multiple MS1 surveys.
-            raise ValueError(
-                "cannot determine rt_cycle_length: template has <2 MS1 (ms_type==0) frames, so "
-                "the per-cycle (MS1->MS1) interval is undefined. A valid DIA acquisition must "
-                "have multiple MS1 survey scans."
-            )
+        # Per-cycle (MS1->MS1) interval, NOT the per-scan frame spacing — see
+        # rt_cycle_length_from_ms1. Using the scan spacing here under-scales the EMG
+        # frame-abundance per cycle by ~scans-per-cycle and collapses rendered peak intensities.
+        self.rt_cycle_length = rt_cycle_length_from_ms1(ft)
 
         if mz_lower is None:
             mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/astral_acquisition.py
@@ -125,18 +125,23 @@ class AstralAcquisitionBuilder:
         # the elution weight -> rendered peaks come out ~100x too faint and DIA-NN finds
         # ~nothing. Derive it from the MS1 (precursor, ms_type==0) frames so each cycle's
         # elution weight is correct, matching the Bruker cycle-frame path.
+        # Sort by time before diffing (the schedule is chronological, but don't rely on it).
         if "ms_type" in ft.columns:
-            cycle_times = ft["time"].values[ft["ms_type"].values == 0]
+            cycle_times = np.sort(ft["time"].values[ft["ms_type"].values == 0])
         else:
-            cycle_times = ft["time"].values
+            cycle_times = np.sort(ft["time"].values)
         cyc_diffs = np.diff(cycle_times)
         cyc_pos = cyc_diffs[cyc_diffs > 0]
         if cyc_pos.size:
             self.rt_cycle_length = float(np.median(cyc_pos))
         else:
-            diffs = np.diff(ft["time"].values)
-            positive = diffs[diffs > 0]
-            self.rt_cycle_length = float(np.median(positive)) if positive.size else 0.0
+            # Fail loud rather than silently fall back to the per-scan spacing (which is the
+            # exact bug this derivation fixes): a valid DIA template has multiple MS1 surveys.
+            raise ValueError(
+                "cannot determine rt_cycle_length: template has <2 MS1 (ms_type==0) frames, so "
+                "the per-cycle (MS1->MS1) interval is undefined. A valid DIA acquisition must "
+                "have multiple MS1 survey scans."
+            )
 
         if mz_lower is None:
             mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/sciex_acquisition.py
@@ -124,9 +124,13 @@ class SciexAcquisitionBuilder:
         self.frame_to_template_scan = f2scan  # synthetic (1..N); no real .wiff slots
         self.num_frames = len(ft)
         self.gradient_length = float(ft["time"].max())
-        diffs = np.diff(ft["time"].values)
-        positive = diffs[diffs > 0]
-        self.rt_cycle_length = float(np.median(positive)) if positive.size else 0.0
+        # rt_cycle_length is the per-CYCLE interval (MS1->MS1), NOT the per-scan frame
+        # spacing. These are per-scan frames (one MS1 + many SWATH windows per cycle), so
+        # median(diff(all frame times)) is the scan spacing — using it under-scales the EMG
+        # frame-abundance per cycle by ~windows-per-cycle and collapses rendered peak
+        # intensities (the elution weight gets spread across every window's frame instead of
+        # carried per cycle). Use the authoritative SWATH cycle time.
+        self.rt_cycle_length = float(cycle_time_s)
 
         if mz_lower is None:
             mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/template_acquisition_common.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/template_acquisition_common.py
@@ -149,3 +149,31 @@ class TemplateTdfWriterStub:
 
     def __init__(self, helper_handle):
         self.helper_handle = helper_handle
+
+
+def rt_cycle_length_from_ms1(frame_table: pd.DataFrame) -> float:
+    """Per-cycle (MS1->MS1) interval from a per-scan-frame table.
+
+    Build-from-template/parameters acquisitions use per-SCAN frames (one MS1 + many
+    MS2/SWATH/SONAR windows per cycle), so ``median(diff(all frame times))`` is the per-scan
+    spacing, NOT the cycle length. Feeding the scan spacing to the EMG frame-abundance
+    integration spreads a peptide's elution weight across every window's frame instead of
+    carrying it per cycle, under-scaling rendered peak intensities by ~windows-per-cycle.
+    Derive the cycle length from the MS1 (``ms_type == 0``) survey spacing instead.
+
+    Raises ``ValueError`` if there are <2 MS1 frames: a valid DIA acquisition has multiple MS1
+    surveys, and silently falling back to the scan spacing would re-introduce the exact bug
+    this fixes.
+    """
+    if "ms_type" in frame_table.columns:
+        times = np.sort(frame_table["time"].values[frame_table["ms_type"].values == 0])
+    else:
+        times = np.sort(frame_table["time"].values)
+    diffs = np.diff(times)
+    positive = diffs[diffs > 0]
+    if positive.size == 0:
+        raise ValueError(
+            "cannot determine rt_cycle_length: <2 MS1 (ms_type==0) frames, so the per-cycle "
+            "(MS1->MS1) interval is undefined; a valid DIA acquisition has multiple MS1 surveys."
+        )
+    return float(np.median(positive))

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/waters_acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/waters_acquisition.py
@@ -200,9 +200,12 @@ class WatersSonarAcquisitionBuilder:
         self.frame_to_template_scan = f2scan  # synthetic (1..N); no real vendor slots
         self.num_frames = len(ft)
         self.gradient_length = float(ft["time"].max())
-        diffs = np.diff(ft["time"].values)
-        positive = diffs[diffs > 0]
-        self.rt_cycle_length = float(np.median(positive)) if positive.size else 0.0
+        # rt_cycle_length is the per-CYCLE interval (one full SONAR quad sweep), NOT the
+        # per-scan frame spacing. These are per-scan frames (many scanning-quad windows per
+        # cycle), so median(diff(all frame times)) is the scan spacing — using it under-scales
+        # the EMG frame-abundance per cycle by ~windows-per-cycle and collapses rendered peak
+        # intensities. Use the authoritative SONAR cycle time.
+        self.rt_cycle_length = float(cycle_time_s)
 
         if mz_lower is None:
             mz_lower = float(win["isolation_mz"].min() - win["isolation_width"].max())

--- a/packages/imspy-simulation/tests/test_template_acquisition_common.py
+++ b/packages/imspy-simulation/tests/test_template_acquisition_common.py
@@ -38,3 +38,43 @@ def test_stub_handles_carry_the_ranges_jobs_read():
     assert writer.helper_handle is handle
     assert (handle.mz_lower, handle.mz_upper) == (100.0, 1700.0)
     assert (handle.im_lower, handle.im_upper, handle.num_scans) == (0.6, 1.6, 451)
+
+
+# --- rt_cycle_length: per-cycle (MS1->MS1), not per-scan spacing (the fix) ---
+
+def _astral_like_schedule():
+    """3 cycles of MS1 + 2 MS2 windows; MS1 surveys 1.0 s apart, scans ~0.33 s apart."""
+    rows, scan = [], 0
+    for c in range(3):
+        t0 = float(c)
+        scan += 1; rows.append((scan, t0, 1, None, None, None))
+        scan += 1; rows.append((scan, t0 + 0.33, 2, 500.0, 20.0, 25.0))
+        scan += 1; rows.append((scan, t0 + 0.66, 2, 520.0, 20.0, 27.0))
+    return rows
+
+
+def test_rt_cycle_length_uses_ms1_spacing_not_scan_spacing():
+    ft, *_ = C.build_frame_tables_from_schedule(_astral_like_schedule(), num_scans=10)
+    # per-scan spacing is ~0.33 s; the true cycle (MS1->MS1) is 1.0 s
+    assert abs(C.rt_cycle_length_from_ms1(ft) - 1.0) < 1e-9
+
+
+def test_rt_cycle_length_raises_on_single_ms1():
+    import pytest
+    ft, *_ = C.build_frame_tables_from_schedule(
+        [(1, 0.0, 1, None, None, None), (2, 0.33, 2, 500.0, 20.0, 25.0)], num_scans=10
+    )
+    with pytest.raises(ValueError):
+        C.rt_cycle_length_from_ms1(ft)
+
+
+def test_rt_cycle_length_matches_sonar_cycle_time():
+    # Waters/SCIEX builders use the authoritative cycle_time_s; confirm it equals the MS1->MS1
+    # spacing the helper derives (i.e. the per-cycle interval, not the per-scan window spacing).
+    from imspy_simulation.timsim.jobs.waters_acquisition import build_sonar_schedule
+    schedule, _c, _n = build_sonar_schedule(
+        mz_start=400.0, mz_end=900.0, window_width=20.0, window_step=20.0,
+        cycle_time_s=0.5, gradient_length_s=5.0, ce_intercept=5.0, ce_slope_per_mz=0.04,
+    )
+    ft, *_ = C.build_frame_tables_from_schedule(schedule, num_scans=10)
+    assert abs(C.rt_cycle_length_from_ms1(ft) - 0.5) < 1e-6


### PR DESCRIPTION
## Problem
The build-from-template/parameters acquisitions (Astral, SCIEX SWATH, Waters SONAR) set
`rt_cycle_length = median(diff(all frame times))` — the per-**scan** frame spacing, not the
per-**cycle** (MS1→MS1) interval. These builders use **per-scan frames** (one MS1 + many
MS2/SWATH/SONAR windows per cycle), so the EMG `frame_abundance` gets spread across *every*
window's frame instead of being carried per cycle. Each cycle's single MS1 and the single
window matching a precursor then carry only ~`1/windows_per_cycle` of the elution weight, so
rendered peak intensities are under-scaled by ~windows-per-cycle (**~120× for Astral nDIA**).

Downstream effect: fabricated `.raw` peaks land at ~1% of the correct intensity, below
DIA-NN's peak-picking — a COVID `from_findings` Astral cohort searched to **~5 IDs/arm**
vs **~250 proteins/arm** for the equivalent timsTOF `.d` (same seed).

## Fix
- `astral_acquisition.py`: derive `rt_cycle_length` from the MS1 (`ms_type==0`) frame spacing.
- `sciex_acquisition.py` / `waters_acquisition.py`: use the authoritative `cycle_time_s`.

The Bruker timsTOF path was already correct (it uses cycle frames, `acquisition.py`).

## Validation (Astral, one COVID arm)
| | before | after |
|---|---|---|
| MS1 max intensity | 50 | **6077** |
| MS2 max intensity | 20 | **2594** |
| non-empty MS2 windows | 3655 | **6237** |
~120× = scans/cycle, as predicted; peaks now match the working timsTOF scale.

## Note / follow-up (out of scope here)
This corrects a **normalization** error (a peptide's window intensity must not depend on the
*number* of windows). It does **not** model per-instrument **duty cycle**: a fast multiplexing
Astral genuinely captures more ions per cycle than a sequential Orbitrap (Exploris) or SCIEX
SWATH, so a faithful sim would apply a per-instrument duty-cycle down-scale (Astral > SCIEX ≈
Zeno > sequential Orbitrap). That's a realism refinement (a few-× scale factor), separate from
this ~120× under-scaling bug.