### PR TITLE
wip(mscore): peptide fragment-ion chemistry — neutral losses, immonium + internal ions

### DIFF
--- a/imspy_connector/src/py_peptide.rs
+++ b/imspy_connector/src/py_peptide.rs
@@ -1,11 +1,28 @@
 use std::collections::{HashMap};
 use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
 
 use mscore::data::peptide::{FragmentType, PeptideSequence, PeptideProductIon,
-                            PeptideProductIonSeries, PeptideProductIonSeriesCollection, PeptideIon};
+                            PeptideProductIonSeries, PeptideProductIonSeriesCollection, PeptideIon,
+                            NeutralLoss};
 use crate::py_annotation::PyMzSpectrumAnnotated;
 
 use crate::py_mz_spectrum::PyMzSpectrum;
+
+/// Map loss names from Python to mscore NeutralLoss. Recognises the default losses
+/// (with or without a leading "-"); an unknown name raises a Python ValueError rather
+/// than unwinding as a panic across the PyO3 boundary.
+fn parse_neutral_losses(names: &[String]) -> PyResult<Vec<NeutralLoss>> {
+    names.iter().map(|name| {
+        match name.trim_start_matches('-') {
+            "H2O" | "water" => Ok(NeutralLoss::water()),
+            "NH3" | "ammonia" => Ok(NeutralLoss::ammonia()),
+            "H3PO4" | "phospho" => Ok(NeutralLoss::phospho()),
+            other => Err(PyValueError::new_err(format!(
+                "Unknown neutral loss '{}'; expected one of H2O/water, NH3/ammonia, H3PO4/phospho", other))),
+        }
+    }).collect()
+}
 
 #[pyclass]
 pub struct PyPeptideIon {
@@ -215,6 +232,49 @@ impl PyPeptideSequence {
         PyMzSpectrum::from_inner(spectrum)
     }
 
+    /// Monoisotopic product-ion spectrum including neutral-loss peaks. `neutral_losses`
+    /// is a list of loss names; each is applied to every backbone ion. Recognised names:
+    /// "H2O"/"water", "NH3"/"ammonia", "H3PO4"/"phospho" (leading "-" optional).
+    pub fn calculate_mono_isotopic_product_ion_spectrum_with_losses(&self, charge: i32, fragment_type: String, neutral_losses: Vec<String>) -> PyResult<PyMzSpectrum> {
+        let f_type = match fragment_type.as_str() {
+            "a" => FragmentType::A,
+            "b" => FragmentType::B,
+            "c" => FragmentType::C,
+            "x" => FragmentType::X,
+            "y" => FragmentType::Y,
+            "z" => FragmentType::Z,
+            _ => return Err(PyValueError::new_err(format!("Invalid fragment type '{}'", fragment_type))),
+        };
+
+        let losses = parse_neutral_losses(&neutral_losses)?;
+        let spectrum = self.inner.calculate_mono_isotopic_product_ion_spectrum_with_losses(charge, f_type, losses);
+        Ok(PyMzSpectrum::from_inner(spectrum))
+    }
+
+    /// Immonium ions for the distinct residues (including modified residues) in the peptide,
+    /// as (residue_token, m/z) pairs. Charge 1.
+    pub fn calculate_immonium_ions(&self) -> Vec<(String, f64)> {
+        self.inner.calculate_immonium_ions().into_iter().map(|i| (i.residue, i.mz)).collect()
+    }
+
+    /// Monoisotopic immonium spectrum (charge-1 peaks, unit intensity).
+    pub fn calculate_immonium_spectrum(&self) -> PyMzSpectrum {
+        PyMzSpectrum::from_inner(self.inner.calculate_immonium_spectrum())
+    }
+
+    /// Internal fragment ions as (label, m/z) pairs, e.g. ("m2:4", 227.10263). b-type ions
+    /// over interior subsequences; `max_length` optionally caps the subsequence length.
+    #[pyo3(signature = (charge, max_length=None))]
+    pub fn calculate_internal_ions(&self, charge: i32, max_length: Option<usize>) -> Vec<(String, f64)> {
+        self.inner.calculate_internal_ions(charge, max_length).into_iter().map(|i| (i.label(), i.mz())).collect()
+    }
+
+    /// Monoisotopic internal-fragment spectrum (unit intensity).
+    #[pyo3(signature = (charge, max_length=None))]
+    pub fn calculate_internal_ion_spectrum(&self, charge: i32, max_length: Option<usize>) -> PyMzSpectrum {
+        PyMzSpectrum::from_inner(self.inner.calculate_internal_ion_spectrum(charge, max_length))
+    }
+
     pub fn calculate_mono_isotopic_product_ion_spectrum_annotated(&self, charge: i32, fragment_type: String) -> PyMzSpectrumAnnotated {
         let f_type = match fragment_type.as_str() {
             "a" => FragmentType::A,
@@ -326,6 +386,10 @@ impl PyPeptideProductIon {
     #[getter]
     pub fn intensity(&self) -> f64 {
         self.inner.ion.intensity
+    }
+    #[getter]
+    pub fn neutral_loss(&self) -> Option<String> {
+        self.inner.neutral_loss.as_ref().map(|nl| nl.name.clone())
     }
     #[getter]
     pub fn mono_isotopic_mass(&self) -> f64 {

--- a/mscore/src/algorithm/peptide.rs
+++ b/mscore/src/algorithm/peptide.rs
@@ -297,6 +297,7 @@ pub fn atomic_product_ion_composition(product_ion: &PeptideProductIon) -> Vec<(&
 ///         charge: 1,
 ///         intensity: 1.0,
 ///     },
+///     neutral_loss: None,
 /// };
 /// let fragment_comp: Vec<(&str, i32)> = atomic_product_ion_composition(&b3_ion);
 /// let fragment_map: std::collections::HashMap<&str, i32> = fragment_comp.into_iter().collect();

--- a/mscore/src/data/peptide.rs
+++ b/mscore/src/data/peptide.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap};
+use std::collections::{HashMap, HashSet};
 use bincode::{Decode, Encode};
 use itertools::Itertools;
 use regex::Regex;
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::algorithm::peptide::{calculate_peptide_mono_isotopic_mass, calculate_peptide_product_ion_mono_isotopic_mass, peptide_sequence_to_atomic_composition};
 use crate::chemistry::amino_acid::{amino_acid_masses};
 use crate::chemistry::formulas::calculate_mz;
+use crate::chemistry::constants::{MASS_WATER, MASS_NH3, MASS_CO, MASS_PROTON, MASS_ELECTRON};
 use crate::chemistry::utility::{find_unimod_patterns, reshape_prosit_array, unimod_sequence_to_tokens};
 use crate::data::spectrum::MzSpectrum;
 use crate::simulation::annotation::{MzSpectrumAnnotated, ContributionSource, SignalAttributes, SourceType, PeakAnnotation};
@@ -126,10 +127,113 @@ impl std::fmt::Display for FragmentType {
     }
 }
 
+/// A neutral loss from a product ion (e.g. water, ammonia, phospho H3PO4).
+/// Carries the element composition (atoms removed, positive counts) so the loss
+/// ion's isotope envelope stays chemically correct — a mass-only delta would not.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NeutralLoss {
+    pub name: String,
+    pub mono_mass: f64,
+    pub composition: HashMap<String, i32>,
+}
+
+impl NeutralLoss {
+    pub fn new(name: &str, mono_mass: f64, composition: Vec<(&str, i32)>) -> Self {
+        NeutralLoss {
+            name: name.to_string(),
+            mono_mass,
+            composition: composition.into_iter().map(|(e, c)| {
+                intern_element(e); // validate the element symbol at construction (fail-fast)
+                (e.to_string(), c)
+            }).collect(),
+        }
+    }
+    /// Water loss, -H2O (Ser/Thr/Glu/Asp side chains, C-term).
+    pub fn water() -> Self { NeutralLoss::new("H2O", MASS_WATER, vec![("H", 2), ("O", 1)]) }
+    /// Ammonia loss, -NH3 (Lys/Arg/Asn/Gln side chains).
+    pub fn ammonia() -> Self { NeutralLoss::new("NH3", MASS_NH3, vec![("N", 1), ("H", 3)]) }
+    /// Phosphoric acid loss, -H3PO4 (phospho-Ser/Thr diagnostic, -97.9769).
+    pub fn phospho() -> Self { NeutralLoss::new("H3PO4", 97.9768958, vec![("H", 3), ("P", 1), ("O", 4)]) }
+}
+
+/// Intern an element symbol to a 'static reference so a loss composition can be folded
+/// into the 'static-keyed atomic-composition map. Covers every element that appears in a
+/// realistic proteomics neutral loss (organics + common halogens/metals/adduct ions). An
+/// unsupported symbol panics — the same contract as `generate_isotope_distribution`, which
+/// also rejects unknown elements; `NeutralLoss::new` validates against this set so the
+/// failure surfaces at construction rather than deep in a mass calculation.
+fn intern_element(symbol: &str) -> &'static str {
+    match symbol {
+        "H" => "H", "C" => "C", "N" => "N", "O" => "O", "P" => "P", "S" => "S",
+        "Se" => "Se", "Cl" => "Cl", "Br" => "Br", "I" => "I", "F" => "F",
+        "Na" => "Na", "K" => "K", "Fe" => "Fe", "Mg" => "Mg", "Ca" => "Ca", "Zn" => "Zn",
+        other => panic!("Unsupported element symbol '{}' in neutral loss composition", other),
+    }
+}
+
+/// An immonium ion: a single side-chain cation from an internal a/y double cleavage,
+/// `H2N+=CHR`. Charge 1 only. The m/z follows spectrum_utils' convention
+/// `residue_mass - CO + H_atom` (H atom = proton + electron, not the bare proton; note
+/// the backbone ions use the proton — this split mirrors the oracle exactly).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImmoniumIon {
+    /// Residue token the ion derives from, including any modification, e.g. "P" or "S[UNIMOD:21]".
+    pub residue: String,
+    pub mz: f64,
+    /// Atomic composition (residue - CO) for isotope generation.
+    pub composition: HashMap<String, i32>,
+}
+
+impl ImmoniumIon {
+    pub fn isotope_distribution(&self, mass_tolerance: f64, abundance_threshold: f64, max_result: i32, intensity_min: f64) -> IsotopeDistribution {
+        if self.composition.values().any(|&c| c < 0) {
+            return Vec::new();
+        }
+        let composition: HashMap<String, i32> = self.composition.iter().filter(|&(_, &v)| v > 0).map(|(k, v)| (k.clone(), *v)).collect();
+        let raw = crate::algorithm::isotope::generate_isotope_distribution(&composition, mass_tolerance, abundance_threshold, max_result);
+        // Anchor on the true monoisotopic mass (lowest mass) of the UNFILTERED envelope, so
+        // the shift onto the charge-1 immonium m/z is correct even if the mono peak is later
+        // dropped by intensity_min.
+        let mono = match raw.iter().map(|&(m, _)| m).fold(f64::INFINITY, f64::min) {
+            m if m.is_finite() => m,
+            _ => return Vec::new(),
+        };
+        raw.into_iter()
+            .filter(|&(_, abundance)| abundance > intensity_min)
+            .map(|(mass, abundance)| (self.mz + (mass - mono), abundance))
+            .collect()
+    }
+}
+
+/// An internal fragment: a b-type ion over an interior subsequence of the peptide
+/// (both terminal residues excluded), produced by a double backbone cleavage. Chemistry
+/// is identical to a b ion of that subsequence, so it reuses `PeptideProductIon{kind:B}`;
+/// only the label (a residue span) differs. Matches spectrum_utils' "m" ions, whose
+/// `m{start}:{end}` spans 1-based residue positions `start..end-1`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InternalIon {
+    /// 1-based start residue position (inclusive).
+    pub start: usize,
+    /// 1-based end position, exclusive — matching spectrum_utils' `m{start}:{end}` label.
+    pub end: usize,
+    /// The underlying b-type product ion over the interior subsequence (charge baked in).
+    pub ion: PeptideProductIon,
+}
+
+impl InternalIon {
+    pub fn mz(&self) -> f64 { self.ion.mz() }
+    /// spectrum_utils-style label, e.g. "m2:4".
+    pub fn label(&self) -> String { format!("m{}:{}", self.start, self.end) }
+    pub fn isotope_distribution(&self, mass_tolerance: f64, abundance_threshold: f64, max_result: i32, intensity_min: f64) -> IsotopeDistribution {
+        self.ion.isotope_distribution(mass_tolerance, abundance_threshold, max_result, intensity_min)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeptideProductIon {
     pub kind: FragmentType,
     pub ion: PeptideIon,
+    pub neutral_loss: Option<NeutralLoss>,
 }
 
 impl PeptideProductIon {
@@ -141,11 +245,22 @@ impl PeptideProductIon {
                 charge,
                 intensity,
             },
+            neutral_loss: None,
         }
     }
 
+    /// Attach a neutral loss to this product ion (builder; no post-construction mutation).
+    pub fn with_neutral_loss(mut self, loss: NeutralLoss) -> Self {
+        self.neutral_loss = Some(loss);
+        self
+    }
+
     pub fn mono_isotopic_mass(&self) -> f64 {
-        calculate_peptide_product_ion_mono_isotopic_mass(self.ion.sequence.sequence.as_str(), self.kind)
+        let base = calculate_peptide_product_ion_mono_isotopic_mass(self.ion.sequence.sequence.as_str(), self.kind);
+        match &self.neutral_loss {
+            Some(nl) => base - nl.mono_mass,
+            None => base,
+        }
     }
 
     pub fn atomic_composition(&self) -> HashMap<&str, i32> {
@@ -187,6 +302,15 @@ impl PeptideProductIon {
                 *composition.entry("N").or_insert(0) -= 3;
             },
         }
+
+        // Fold in any neutral loss so the composition reflects the actual ion and stays
+        // consistent with mono_isotopic_mass()/mz()/isotope_distribution(). A loss larger
+        // than the fragment leaves negative counts (a chemically impossible ion).
+        if let Some(nl) = &self.neutral_loss {
+            for (element, count) in &nl.composition {
+                *composition.entry(intern_element(element)).or_insert(0) -= count;
+            }
+        }
         composition
     }
 
@@ -202,7 +326,21 @@ impl PeptideProductIon {
         intensity_min: f64,
     ) -> IsotopeDistribution {
 
-        let atomic_composition: HashMap<String, i32> = self.atomic_composition().iter().map(|(k, v)| (k.to_string(), *v)).collect();
+        // atomic_composition() already folds in any neutral loss. Only the loss path needs
+        // the impossible-ion guard; the loss-free path is left byte-identical to before.
+        let composition = self.atomic_composition();
+        let atomic_composition: HashMap<String, i32> = if self.neutral_loss.is_some() {
+            // A loss larger than the fragment (e.g. -H3PO4 on a non-phospho fragment) leaves
+            // a negative atom count -> chemically impossible, no isotope envelope.
+            if composition.values().any(|&c| c < 0) {
+                return Vec::new();
+            }
+            // Drop zero counts: generate_isotope_distribution treats count <= 1 as a single
+            // atom, so a 0 would spuriously add one atom of that element.
+            composition.iter().filter(|&(_, &v)| v > 0).map(|(k, v)| (k.to_string(), *v)).collect()
+        } else {
+            composition.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+        };
 
         let distribution: IsotopeDistribution = crate::algorithm::isotope::generate_isotope_distribution(&atomic_composition, mass_tolerance, abundance_threshold, max_result)
             .into_iter().filter(|&(_, abundance)| abundance > intensity_min).collect();
@@ -340,6 +478,7 @@ impl PeptideSequence {
                     charge: target_charge,
                     intensity: 1.0, // Placeholder intensity
                 },
+                neutral_loss: None,
             });
         }
 
@@ -363,10 +502,130 @@ impl PeptideSequence {
                     charge: target_charge,
                     intensity: 1.0, // Placeholder intensity
                 },
+                neutral_loss: None,
             });
         }
 
         PeptideProductIonSeries::new(target_charge, n_terminal_ions, c_terminal_ions)
+    }
+
+    /// Backbone product-ion series augmented with neutral-loss variants. The base
+    /// (loss-free) ions are kept; for every backbone ion and every supplied loss an
+    /// extra ion carrying that loss is appended (spectrum_utils-style: each loss is
+    /// applied to every backbone ion). Residue/mod-conditional pruning is a follow-up.
+    pub fn calculate_product_ion_series_with_losses(
+        &self,
+        target_charge: i32,
+        fragment_type: FragmentType,
+        neutral_losses: Vec<NeutralLoss>,
+    ) -> PeptideProductIonSeries {
+        let base = self.calculate_product_ion_series(target_charge, fragment_type);
+        let mut n_ions = base.n_ions.clone();
+        let mut c_ions = base.c_ions.clone();
+        for ion in &base.n_ions {
+            for loss in &neutral_losses {
+                n_ions.push(ion.clone().with_neutral_loss(loss.clone()));
+            }
+        }
+        for ion in &base.c_ions {
+            for loss in &neutral_losses {
+                c_ions.push(ion.clone().with_neutral_loss(loss.clone()));
+            }
+        }
+        PeptideProductIonSeries::new(target_charge, n_ions, c_ions)
+    }
+
+    /// Monoisotopic product-ion spectrum including neutral-loss peaks.
+    pub fn calculate_mono_isotopic_product_ion_spectrum_with_losses(
+        &self,
+        charge: i32,
+        fragment_type: FragmentType,
+        neutral_losses: Vec<NeutralLoss>,
+    ) -> MzSpectrum {
+        self.calculate_product_ion_series_with_losses(charge, fragment_type, neutral_losses)
+            .generate_mono_isotopic_spectrum()
+    }
+
+    /// Immonium ions for the distinct residues (including modified residues) present in
+    /// the peptide. Charge 1. m/z = residue_mass - CO + H_atom (spectrum_utils convention).
+    /// Modified-residue immonium (e.g. phospho-S) are an extension beyond spectrum_utils,
+    /// which only enumerates the 20 unmodified residues.
+    pub fn calculate_immonium_ions(&self) -> Vec<ImmoniumIon> {
+        let tokens = unimod_sequence_to_tokens(self.sequence.as_str(), true);
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut ions = Vec::new();
+        for token in tokens {
+            // Skip N/C-terminal modification sentinel tokens (they do not begin with a
+            // residue letter, e.g. "\u{0}[UNIMOD:1]"); immonium ions are residue side chains.
+            if !token.chars().next().map_or(false, |c| c.is_ascii_uppercase()) {
+                continue;
+            }
+            if !seen.insert(token.clone()) {
+                continue;
+            }
+            let residue = PeptideSequence::new(token.clone(), self.peptide_id);
+            // single-residue "peptide" mass = residue + water; immonium = residue - CO + H_atom.
+            let residue_mass = calculate_peptide_mono_isotopic_mass(&residue) - MASS_WATER;
+            let mz = residue_mass - MASS_CO + MASS_PROTON + MASS_ELECTRON;
+            // Immonium cation atoms = residue - CO + H  (e.g. proline C4H8N+, glycine CH4N+).
+            // residue.atomic_composition() is (residue + water), so: - water - CO + H, i.e.
+            // net H: -2 (water) -0 (CO) +1 (the immonium H) = -1; O: -1 (water) -1 (CO) = -2; C: -1 (CO).
+            let mut composition: HashMap<String, i32> = residue.atomic_composition().iter().map(|(k, v)| (k.to_string(), *v)).collect();
+            *composition.entry("H".to_string()).or_insert(0) -= 1;
+            *composition.entry("O".to_string()).or_insert(0) -= 2;
+            *composition.entry("C".to_string()).or_insert(0) -= 1;
+            ions.push(ImmoniumIon { residue: token, mz, composition });
+        }
+        ions
+    }
+
+    /// Monoisotopic immonium spectrum (charge-1 peaks, unit intensity).
+    pub fn calculate_immonium_spectrum(&self) -> MzSpectrum {
+        let ions = self.calculate_immonium_ions();
+        let mz: Vec<f64> = ions.iter().map(|i| i.mz).collect();
+        let intensity: Vec<f64> = ions.iter().map(|_| 1.0).collect();
+        MzSpectrum::new(mz, intensity).filter_ranged(0.0, 5_000.0, 1e-6, 1e6)
+    }
+
+    /// Internal fragment ions: b-type ions over interior subsequences (both terminal
+    /// residues excluded), length >= 2. Matches spectrum_utils' "m" ions. Single-residue
+    /// internals are immonium ions, generated separately by `calculate_immonium_ions`.
+    /// `max_length` optionally caps the subsequence length to bound the O(L^2) blow-up;
+    /// `None` enumerates all interior subsequences (spectrum_utils parity).
+    pub fn calculate_internal_ions(&self, charge: i32, max_length: Option<usize>) -> Vec<InternalIon> {
+        // Keep only residue tokens; terminal-modification sentinels (e.g. "\u{0}[UNIMOD:1]")
+        // are not interior residues and would otherwise shift the position indexing.
+        let tokens: Vec<String> = unimod_sequence_to_tokens(self.sequence.as_str(), true)
+            .into_iter()
+            .filter(|t| t.chars().next().map_or(false, |c| c.is_ascii_uppercase()))
+            .collect();
+        let len = tokens.len();
+        let mut ions = Vec::new();
+        if len < 4 {
+            return ions; // need at least two interior residues for a length-2 internal
+        }
+        let cap = max_length.unwrap_or(usize::MAX);
+        // 0-based token indices: start at 1 (exclude N-terminal residue), end exclusive at
+        // most len-1 (exclude C-terminal residue), length (end - start) >= 2.
+        for start_0 in 1..=(len - 3) {
+            for end_excl in (start_0 + 2)..=(len - 1) {
+                if end_excl - start_0 > cap {
+                    break;
+                }
+                let subseq = tokens[start_0..end_excl].join("");
+                let ion = PeptideProductIon::new(FragmentType::B, subseq, charge, 1.0, self.peptide_id);
+                ions.push(InternalIon { start: start_0 + 1, end: end_excl + 1, ion });
+            }
+        }
+        ions
+    }
+
+    /// Monoisotopic internal-fragment spectrum (unit intensity).
+    pub fn calculate_internal_ion_spectrum(&self, charge: i32, max_length: Option<usize>) -> MzSpectrum {
+        let ions = self.calculate_internal_ions(charge, max_length);
+        let mz: Vec<f64> = ions.iter().map(|i| i.mz()).collect();
+        let intensity: Vec<f64> = ions.iter().map(|_| 1.0).collect();
+        MzSpectrum::new(mz, intensity).filter_ranged(0.0, 5_000.0, 1e-6, 1e6)
     }
 
     pub fn associate_with_predicted_intensities(
@@ -635,5 +894,179 @@ impl PeptideProductIonSeriesCollection {
         }
 
         MzSpectrumAnnotated::new(mz_values, intensity_values, annotations)
+    }
+}
+
+#[cfg(test)]
+mod neutral_loss_tests {
+    use super::*;
+    use crate::chemistry::constants::MASS_PROTON;
+
+    // Layer 1 (correctness anchor): hand-computed neutral monoisotopic masses on PEPTIDE.
+    // Base b3 (PEP) neutral mass = residues(P+E+P) + H2O - H2O = sum of residue masses.
+    // P=97.05276384, E=129.04259308 -> b3 neutral = 2*97.05276384 + 129.04259308 = 323.14812076.
+    #[test]
+    fn b3_neutral_mass_matches_hand_computed() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        let series = ps.calculate_product_ion_series(1, FragmentType::B);
+        let b3 = &series.n_ions[2];
+        assert!((b3.mono_isotopic_mass() - 323.14812076).abs() < 1e-5,
+            "b3 neutral mass {} != 323.14812076", b3.mono_isotopic_mass());
+    }
+
+    // Loss subtracts exactly its monoisotopic mass from the neutral fragment mass.
+    #[test]
+    fn neutral_loss_subtracts_mono_mass() {
+        let ps = PeptideSequence::new("PEPTIDESK".to_string(), None);
+        let series = ps.calculate_product_ion_series(1, FragmentType::Y);
+        let y_ion = &series.c_ions[3];
+        let base = y_ion.mono_isotopic_mass();
+        for nl in [NeutralLoss::water(), NeutralLoss::ammonia(), NeutralLoss::phospho()] {
+            let expected = base - nl.mono_mass;
+            let got = y_ion.clone().with_neutral_loss(nl).mono_isotopic_mass();
+            assert!((got - expected).abs() < 1e-9, "loss mass {} != {}", got, expected);
+        }
+    }
+
+    // m/z = (neutral_mass - loss + z*proton)/z : loss applied to the neutral mass before protonation.
+    #[test]
+    fn loss_mz_at_charge_two() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        let series = ps.calculate_product_ion_series(2, FragmentType::B);
+        let b3 = &series.n_ions[2];
+        let loss = NeutralLoss::water();
+        let neutral = b3.mono_isotopic_mass();
+        let expected_mz = (neutral - loss.mono_mass + 2.0 * MASS_PROTON) / 2.0;
+        let got = b3.clone().with_neutral_loss(loss).mz();
+        assert!((got - expected_mz).abs() < 1e-6, "loss mz {} != {}", got, expected_mz);
+    }
+
+    // with-losses generation keeps the base ions and adds one extra peak per (ion, loss).
+    #[test]
+    fn with_losses_appends_variants() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        let base = ps.calculate_product_ion_series(1, FragmentType::B);
+        let augmented = ps.calculate_product_ion_series_with_losses(
+            1, FragmentType::B, vec![NeutralLoss::water(), NeutralLoss::ammonia()]);
+        assert_eq!(augmented.n_ions.len(), base.n_ions.len() * 3);
+        assert_eq!(augmented.c_ions.len(), base.c_ions.len() * 3);
+        assert!(augmented.n_ions[..base.n_ions.len()].iter().all(|i| i.neutral_loss.is_none()));
+        assert!(augmented.n_ions[base.n_ions.len()..].iter().all(|i| i.neutral_loss.is_some()));
+    }
+
+    // atomic_composition() must reflect the loss so it agrees with mass/mz/isotopes.
+    #[test]
+    fn atomic_composition_reflects_loss() {
+        let ps = PeptideSequence::new("PEPTIDESK".to_string(), None);
+        let series = ps.calculate_product_ion_series(1, FragmentType::Y);
+        let y = series.c_ions[3].clone();
+        let y_loss = y.clone().with_neutral_loss(NeutralLoss::water());
+        let base = y.atomic_composition();
+        let lost = y_loss.atomic_composition();
+        assert_eq!(lost["H"], base["H"] - 2, "H not reduced by water loss");
+        assert_eq!(lost["O"], base["O"] - 1, "O not reduced by water loss");
+    }
+
+    // Chemically impossible loss (-H3PO4 on a non-phospho proline b1) -> no isotope envelope.
+    #[test]
+    fn impossible_loss_yields_empty_isotopes() {
+        let ps = PeptideSequence::new("PEPTIDEK".to_string(), None);
+        let series = ps.calculate_product_ion_series(1, FragmentType::B);
+        let b1 = series.n_ions[0].clone().with_neutral_loss(NeutralLoss::phospho());
+        assert!(b1.atomic_composition().values().any(|&c| c < 0), "expected a negative atom count");
+        let iso = b1.isotope_distribution(1e-3, 1e-4, 10, 1e-4);
+        assert!(iso.is_empty(), "impossible loss should yield no isotope peaks, got {}", iso.len());
+    }
+
+    // A valid loss (-H2O) still produces a sane isotope envelope.
+    #[test]
+    fn valid_loss_yields_isotopes() {
+        let ps = PeptideSequence::new("PEPTIDESK".to_string(), None);
+        let series = ps.calculate_product_ion_series(1, FragmentType::Y);
+        let y = series.c_ions[3].clone().with_neutral_loss(NeutralLoss::water());
+        let iso = y.isotope_distribution(1e-3, 1e-4, 10, 1e-6);
+        assert!(!iso.is_empty(), "valid loss ion should have isotope peaks");
+        // monoisotopic peak m/z matches the mono spectrum within tolerance
+        assert!((iso[0].0 - y.mz()).abs() < 1e-3, "first isotope mz {} != mono mz {}", iso[0].0, y.mz());
+    }
+
+    // Layer 1: proline immonium m/z is the well-known 70.0657 (residue - CO + H_atom).
+    #[test]
+    fn immonium_proline_mass() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        let imm = ps.calculate_immonium_ions();
+        let pro = imm.iter().find(|i| i.residue == "P").expect("no proline immonium");
+        assert!((pro.mz - 70.0657).abs() < 1e-3, "proline immonium {} != 70.0657", pro.mz);
+    }
+
+    // Only distinct residues yield immonium ions (PEPTIDE -> P,E,T,I,D = 5).
+    #[test]
+    fn immonium_distinct_residues() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        assert_eq!(ps.calculate_immonium_ions().len(), 5);
+    }
+
+    // Modified-residue immonium: phospho-S immonium = S immonium + phospho mod mass (~79.9663).
+    #[test]
+    fn immonium_modified_residue() {
+        let plain = PeptideSequence::new("SAGE".to_string(), None);
+        let s_plain = plain.calculate_immonium_ions().iter().find(|i| i.residue == "S").unwrap().mz;
+        let phospho = PeptideSequence::new("S[UNIMOD:21]AGE".to_string(), None);
+        let s_phos = phospho.calculate_immonium_ions().iter().find(|i| i.residue == "S[UNIMOD:21]").unwrap().mz;
+        assert!((s_phos - s_plain - 79.966331).abs() < 1e-3, "phospho-S immonium delta {} != 79.9663", s_phos - s_plain);
+    }
+
+    // Immonium cation composition must be residue - CO + H (proline -> C4H8N+), and its
+    // isotope envelope must place the monoisotopic peak exactly on the ion m/z.
+    #[test]
+    fn immonium_composition_and_isotope_anchor() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        let pro = ps.calculate_immonium_ions().into_iter().find(|i| i.residue == "P").unwrap();
+        assert_eq!(pro.composition["C"], 4);
+        assert_eq!(pro.composition["H"], 8);
+        assert_eq!(pro.composition["N"], 1);
+        assert_eq!(pro.composition.get("O").copied().unwrap_or(0), 0);
+        let iso = pro.isotope_distribution(1e-3, 1e-4, 5, 1e-6);
+        assert!(!iso.is_empty(), "immonium should have isotope peaks");
+        assert!(iso.iter().any(|&(m, _)| (m - pro.mz).abs() < 1e-6), "no isotope peak on the immonium m/z");
+    }
+
+    // PEPTIDE has 10 interior subsequences of length >=2 (spectrum_utils gives the same 10).
+    #[test]
+    fn internal_ion_count() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        assert_eq!(ps.calculate_internal_ions(1, None).len(), 10);
+    }
+
+    // First internal of PEPTIDE is m2:4 = "EP", a b-ion: E+P residues + proton = 227.10263.
+    #[test]
+    fn internal_ion_m2_4_mass() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        let ions = ps.calculate_internal_ions(1, None);
+        let m24 = ions.iter().find(|i| i.label() == "m2:4").expect("no m2:4");
+        assert_eq!(m24.ion.ion.sequence.sequence, "EP");
+        assert!((m24.mz() - 227.10263).abs() < 1e-3, "m2:4 mz {} != 227.10263", m24.mz());
+    }
+
+    // Length cap limits subsequence length; termini are always excluded.
+    #[test]
+    fn internal_ion_length_cap() {
+        let ps = PeptideSequence::new("PEPTIDE".to_string(), None);
+        let capped = ps.calculate_internal_ions(1, Some(2));
+        assert!(capped.iter().all(|i| i.end - i.start == 2), "cap=2 should yield only length-2 internals");
+        assert!(capped.iter().all(|i| i.start >= 2 && i.end <= 7), "internals must exclude both termini");
+    }
+
+    // N-terminal modifications tokenize as a sentinel; immonium/internal must skip it
+    // (not panic) and position indexing must stay residue-based.
+    #[test]
+    fn nterm_mod_handled() {
+        let ps = PeptideSequence::new("[UNIMOD:1]EEEDKPK".to_string(), None);
+        let imm = ps.calculate_immonium_ions(); // must not panic
+        assert!(imm.iter().all(|i| i.residue.chars().next().unwrap().is_ascii_uppercase()));
+        let internals = ps.calculate_internal_ions(1, None);
+        // residues are EEEDKPK (7); internals exclude the terminal E(1) and K(7).
+        assert!(internals.iter().all(|i| i.start >= 2 && i.end <= 7),
+            "n-term-mod internals must still exclude both terminal residues");
     }
 }


### PR DESCRIPTION
**Draft / WIP** — opening for visibility + tracking; **not finished or tested yet.**

Adds peptide fragment-ion chemistry (per `TO_IMSPY_FRAGMENT_IONS` plan):
- `NeutralLoss` (H₂O / NH₃ / H₃PO₄) + `calculate_mono_isotopic_product_ion_spectrum_with_losses`
- **immonium ions** (`ImmoniumIon`, `calculate_immonium_ions` / `_spectrum`)
- **internal ions** (`calculate_internal_ions` / `_spectrum`)
- PyO3 bindings in `imspy_connector/src/py_peptide.rs`

~502 lines across `mscore/src/data/peptide.rs`, `mscore/src/algorithm/peptide.rs`,
`imspy_connector/src/py_peptide.rs`.

TODO before ready: finish + unit-test the loss/immonium/internal-ion math, wire into the
fragment predictor path, parity-check against a reference. (Likely to converge with
`feat/peptide-property-ng`.)