### PR TITLE
fix(sim): decode Koina fragment intensities charge-major (was scrambled)

### DIFF
--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_fragment_intensities.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_fragment_intensities.py
@@ -212,7 +212,12 @@ def _koina_result_to_prosit_vectors(
                 charge_idx = int(match.group(3)) - 1  # 0-indexed
                 if 0 <= frag_idx < max_frags and 0 <= charge_idx < 3:
                     tensor[frag_idx, 0 if ion_type == 'y' else 1, charge_idx] = inten
-            vec = tensor.flatten()
+            # Serialize charge-major (Y1..29@z1, B1..29@z1, @z2, @z3) to match the
+            # render-time decode (reshape_prosit_array) and the local-model path's
+            # flatten_prosit_array. numpy's default tensor.flatten() is C-order
+            # (ordinal-major), which maps every intensity onto the WRONG fragment —
+            # scrambling every Koina-predicted spectrum while staying self-consistent.
+            vec = flatten_prosit_array(tensor)
         else:
             vals = np.asarray(group[intensity_col].values, dtype=np.float32)
             vec = np.full(174, fill_value, dtype=np.float32)

--- a/packages/imspy-simulation/tests/test_koina_intensity_decode.py
+++ b/packages/imspy-simulation/tests/test_koina_intensity_decode.py
@@ -1,0 +1,50 @@
+"""Regression guard for the Koina fragment-intensity decode order.
+
+``_koina_result_to_prosit_vectors`` builds a ``(29, 2, 3)`` ``(ordinal, ion-type,
+charge)`` tensor from Koina's annotated output, then serialises it to the 174-dim
+Prosit vector the renderer decodes with ``reshape_prosit_array`` (charge-major).
+
+It must serialise with ``flatten_prosit_array`` (charge-major), NOT numpy's default
+``tensor.flatten()`` (C-order / ordinal-major): the latter maps every intensity onto
+the WRONG fragment, scrambling every Koina-predicted spectrum while staying
+self-consistent (so a self-referential library search still "works", but the data is
+unsearchable by any tool predicting real spectra).
+"""
+
+import numpy as np
+import pandas as pd
+
+from imspy_simulation.timsim.jobs.simulate_fragment_intensities import (
+    _koina_result_to_prosit_vectors,
+)
+
+
+def test_koina_decode_is_charge_major():
+    # one peptide (row index 0), one dominant fragment b8 at charge 1.
+    koina_result = pd.DataFrame(
+        {"annotation": [b"b8+1"], "intensities": [1.0]}, index=[0]
+    )
+    original_data = pd.DataFrame({"sequence": ["PEPTIDEKR"]})
+
+    vec = _koina_result_to_prosit_vectors(koina_result, original_data)
+
+    assert vec.shape == (1, 174)
+    # Charge-major layout: [Y1..29 @z1 = 0..28] [B1..29 @z1 = 29..57] [@z2] [@z3].
+    # So b8 (ordinal 8) at charge 1 -> 29 + (8 - 1) = 36.
+    # (The C-order bug would instead place it at 7*6 + 1*3 + 0 = 45.)
+    assert vec[0].argmax() == 36
+    assert vec[0, 36] == 1.0
+
+
+def test_koina_decode_multiple_fragments_land_on_their_indices():
+    koina_result = pd.DataFrame(
+        {"annotation": [b"y3+2", b"b2+1"], "intensities": [1.0, 0.5]}, index=[0, 0]
+    )
+    original_data = pd.DataFrame({"sequence": ["PEPTIDEKR"]})
+
+    vec = _koina_result_to_prosit_vectors(koina_result, original_data)
+
+    # y3 @z2 -> Y block of charge 2: 58 + (3 - 1) = 60 (base peak, normalised to 1.0)
+    assert vec[0, 60] == 1.0
+    # b2 @z1 -> B block of charge 1: 29 + (2 - 1) = 30
+    assert abs(vec[0, 30] - 0.5) < 1e-6


### PR DESCRIPTION
Anyone using a **Koina** intensity model (e.g. `prosit_hcd`, `prosit`) in the build-from-template / fragment-intensity path gets **scrambled fragment spectra**.

### The bug
`_koina_result_to_prosit_vectors` builds a `(29, 2, 3)` `(ordinal, ion-type, charge)` tensor from Koina’s annotated output, then serialises it to the 174-dim Prosit vector that the renderer decodes with `reshape_prosit_array` — which is **charge-major** (`Y1..29@z1, B1..29@z1, @z2, @z3`).

It serialised with numpy’s default `tensor.flatten()` (**C-order / ordinal-major**), so every intensity landed on the **wrong fragment**. Each simulated spectrum is a scrambled permutation of the real Prosit prediction.

### Why it went unnoticed
- The scramble is **self-consistent** — the library decodes the same way the data was written — so a self-referential / ground-truth-library search still finds peptides.
- The **local PyTorch** path already used `flatten_prosit_array` and is unaffected, and local is the default predictor, so the Koina path was rarely exercised end to end.

But against any tool predicting *real* spectra it fails: **library-free DIA-NN returns ~0 IDs** on Orbitrap/Astral runs simulated via Koina.

### The fix
Serialise with `flatten_prosit_array(tensor)` (the same charge-major convention the renderer and the local path use). One line.

### Validation
Library-free DIA-NN on a fabricated Orbitrap run: **0 → 208 precursors / 116 proteins** after the fix. Adds `test_koina_intensity_decode` locking the charge-major fragment placement (b8@z1 → index 36, not the C-order 45).