### PR TITLE
feat(sim): method-aware scan-schedule sanity gate for build-from-template

### DIFF
--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/template_acquisition_common.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/template_acquisition_common.py
@@ -15,10 +15,14 @@ transform (no connector / no DB), so it is unit-testable on its own.
 
 from __future__ import annotations
 
+import logging
+import math
 from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 # A schedule row: (scan, rt_s, ms_level, center_mz|None, width_mz|None, ce|None)
 ScheduleRow = Tuple[int, float, int, Optional[float], Optional[float], Optional[float]]
@@ -49,11 +53,132 @@ def build_synthetic_scan_table(
     return pd.DataFrame({"scan": scans, "mobility": mobilities})
 
 
+def validate_template_schedule(
+    schedule: Sequence[ScheduleRow],
+    *,
+    strict_fixed_dia: bool = False,
+) -> List[str]:
+    """Method-aware sanity gate for a build-from-template scan schedule.
+
+    A build-from-template run reads a vendor ``.raw`` / ``.wiff`` and turns its
+    per-scan schedule into acquisition tables. When the reader mis-decodes a file's
+    scan-event layout it returns plausible-but-wrong scan levels (e.g. a run read as
+    all-MS1), and the error otherwise surfaces cryptically deep in the render. This
+    gate refuses such a schedule at ingestion with an actionable message.
+
+    Hard failures (raise ``ValueError`` — unambiguous corruption / mis-parsed levels):
+      - empty schedule;
+      - any non-finite / negative RT, or non-monotonic (decreasing) RT;
+      - an MS2 row whose isolation center/width is missing, non-finite, or non-positive
+        (the scan level / isolation was mis-parsed);
+      - fewer than 2 MS1 surveys, or zero MS2 scans.
+
+    Soft (returned + logged as warnings; the irregular-cycle one raises only under
+    ``strict_fixed_dia``):
+      - MS1 rows carrying an isolation window — real MS1 events can carry a non-zero
+        center, so this warns rather than failing (hard-failing over-rejects valid files);
+      - irregular windows-per-cycle — legitimate for variable-window / scheduled /
+        GPF / CE-ramp DIA.
+
+    Returns the list of warning strings (empty when clean).
+    """
+    if not schedule:
+        raise ValueError("empty template schedule")
+
+    warnings: List[str] = []
+    n_ms1 = 0
+    n_ms2 = 0
+    prev_rt: Optional[float] = None
+    windows_per_cycle: List[int] = []
+    cur_cycle_ms2 = 0
+    seen_first_ms1 = False
+    n_ms1_with_iso = 0
+
+    for row in schedule:
+        scan, rt, ms_level, center, width, _ce = row
+        if rt is None or not math.isfinite(float(rt)) or rt < 0:
+            raise ValueError(f"scan {scan}: invalid retention time {rt!r}")
+        if prev_rt is not None and rt < prev_rt:
+            raise ValueError(
+                f"scan {scan}: retention time {rt} < previous {prev_rt} — the schedule "
+                f"is not monotonic; scan order or the RT field looks mis-parsed"
+            )
+        prev_rt = rt
+
+        if ms_level <= 1:  # MS1 survey
+            # Real MS1 events can carry a non-zero isolation center; a normalized
+            # schedule usually nulls it. Treat a surviving MS1 window as a WARNING, not
+            # a hard failure — hard-failing here would over-reject legitimate files.
+            if center is not None or width is not None:
+                n_ms1_with_iso += 1
+            n_ms1 += 1
+            if seen_first_ms1:
+                windows_per_cycle.append(cur_cycle_ms2)
+            seen_first_ms1 = True
+            cur_cycle_ms2 = 0
+        else:  # MS2 fragment
+            if center is None or width is None:
+                raise ValueError(
+                    f"scan {scan}: parsed as MS2 (ms_level={ms_level}) but isolation is "
+                    f"missing (center={center}, width={width}) — the scan-event levels "
+                    f"look mis-parsed for this file's layout"
+                )
+            cw, ww = float(center), float(width)
+            if not (math.isfinite(cw) and cw > 0.0 and math.isfinite(ww) and ww > 0.0):
+                raise ValueError(
+                    f"scan {scan}: MS2 isolation center/width is non-finite or non-positive "
+                    f"(center={center}, width={width}) — the scan-event fields look mis-parsed"
+                )
+            n_ms2 += 1
+            cur_cycle_ms2 += 1
+
+    if n_ms1 < 2:
+        raise ValueError(
+            f"template schedule has {n_ms1} MS1 survey(s); a valid DIA acquisition has "
+            f">= 2 — the reader may not support this file's scan-event layout"
+        )
+    if n_ms2 == 0:
+        raise ValueError(
+            "template schedule has no MS2 scans — the reader may not support this "
+            "file's scan-event layout"
+        )
+
+    if n_ms1_with_iso > 0:
+        msg = (
+            f"{n_ms1_with_iso} MS1 survey(s) carry an isolation window — normally a "
+            f"normalized schedule nulls these; non-fatal, but worth checking the extractor"
+        )
+        warnings.append(msg)
+        logger.warning("template schedule: %s", msg)
+
+    # Windows-per-cycle regularity over INTERIOR cycles (the trailing partial cycle in
+    # `cur_cycle_ms2` is excluded). Drop zero-MS2 "cycles" (consecutive MS1 surveys:
+    # lock-mass / system scans / method transitions) — they are not real DIA cycles and
+    # would otherwise spuriously read as irregular. Varies legitimately for non-fixed
+    # methods, so it warns rather than failing unless strict_fixed_dia.
+    interior = [w for w in windows_per_cycle if w > 0]
+    if len(interior) >= 2:
+        lo, hi = min(interior), max(interior)
+        if lo != hi:
+            msg = (
+                f"irregular DIA cycle: windows-per-cycle varies in [{lo}, {hi}] across "
+                f"{len(interior)} interior cycles (legitimate for variable-window / "
+                f"scheduled / GPF methods; unusual for fixed-window DIA)"
+            )
+            if strict_fixed_dia:
+                raise ValueError(msg + " — rejected under strict_fixed_dia")
+            warnings.append(msg)
+            logger.warning("template schedule: %s", msg)
+
+    return warnings
+
+
 def build_frame_tables_from_schedule(
     schedule: Sequence[ScheduleRow],
     *,
     num_scans: int = 1,
     ce_decimals: int = 2,
+    strict_fixed_dia: bool = False,
 ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, List[int]]:
     """Build the DIA acquisition tables from a per-scan template schedule.
 
@@ -69,8 +194,9 @@ def build_frame_tables_from_schedule(
     frame_to_template_scan)`` where the last is a list mapping ``frame_id-1`` ->
     the template scan number (so the writer can author each frame into its slot).
     """
-    if not schedule:
-        raise ValueError("empty template schedule")
+    # Reject a mis-parsed / degenerate schedule at ingestion with an actionable
+    # message, instead of failing cryptically deep in the render.
+    validate_template_schedule(schedule, strict_fixed_dia=strict_fixed_dia)
 
     frames = []
     fragment_rows = []  # (frame_id, window_key)

--- a/packages/imspy-simulation/tests/test_template_acquisition_common.py
+++ b/packages/imspy-simulation/tests/test_template_acquisition_common.py
@@ -38,3 +38,111 @@ def test_stub_handles_carry_the_ranges_jobs_read():
     assert writer.helper_handle is handle
     assert (handle.mz_lower, handle.mz_upper) == (100.0, 1700.0)
     assert (handle.im_lower, handle.im_upper, handle.num_scans) == (0.6, 1.6, 451)
+
+
+# --- validate_template_schedule: method-aware scan-schedule sanity gate ---
+
+import pytest
+
+
+def _regular_dia_schedule(n_cycles=3, n_windows=2):
+    """n_cycles of (1 MS1 + n_windows MS2), monotonic RT, regular cycle."""
+    rows, scan = [], 0
+    for c in range(n_cycles):
+        scan += 1; rows.append((scan, float(scan), 1, None, None, None))
+        for w in range(n_windows):
+            scan += 1; rows.append((scan, float(scan), 2, 500.0 + 20.0 * w, 20.0, 25.0))
+    return rows
+
+
+def test_schedule_gate_accepts_valid_dia():
+    assert C.validate_template_schedule(_regular_dia_schedule()) == []
+
+
+def test_schedule_gate_is_called_by_build():
+    # the gate runs at ingestion: a degenerate schedule fails in build_frame_tables too
+    with pytest.raises(ValueError, match="no MS2"):
+        C.build_frame_tables_from_schedule(
+            [(i + 1, float(i), 1, None, None, None) for i in range(5)], num_scans=10
+        )
+
+
+def test_schedule_gate_rejects_all_ms1():
+    rows = [(i + 1, float(i), 1, None, None, None) for i in range(5)]
+    with pytest.raises(ValueError, match="no MS2"):
+        C.validate_template_schedule(rows)
+
+
+def test_schedule_gate_rejects_ms2_without_isolation():
+    rows = [
+        (1, 0.0, 1, None, None, None),
+        (2, 0.1, 1, None, None, None),
+        (3, 0.2, 2, None, None, 25.0),
+    ]
+    with pytest.raises(ValueError, match="mis-parsed"):
+        C.validate_template_schedule(rows)
+
+
+def test_schedule_gate_rejects_nonfinite_ms2_isolation():
+    base = [(1, 0.0, 1, None, None, None), (2, 0.1, 1, None, None, None)]
+    for bad in ((float("nan"), 20.0), (float("inf"), 20.0), (-500.0, 20.0), (500.0, 0.0), (500.0, float("nan"))):
+        rows = base + [(3, 0.2, 2, bad[0], bad[1], 25.0)]
+        with pytest.raises(ValueError, match="non-finite or non-positive|missing"):
+            C.validate_template_schedule(rows)
+
+
+def test_schedule_gate_rejects_single_ms1():
+    rows = [(1, 0.0, 1, None, None, None), (2, 0.1, 2, 500.0, 20.0, 25.0)]
+    with pytest.raises(ValueError, match="MS1 survey"):
+        C.validate_template_schedule(rows)
+
+
+def test_schedule_gate_rejects_nonmonotonic_rt():
+    rows = [
+        (1, 0.0, 1, None, None, None),
+        (2, 0.1, 2, 500.0, 20.0, 25.0),
+        (3, 0.05, 1, None, None, None),   # RT goes backwards
+        (4, 0.2, 2, 500.0, 20.0, 25.0),
+    ]
+    with pytest.raises(ValueError, match="monotonic"):
+        C.validate_template_schedule(rows)
+
+
+def test_schedule_gate_warns_on_ms1_isolation_not_fails():
+    # real MS1 events can carry an isolation center -> warn, do NOT hard-fail
+    rows = [
+        (1, 0.0, 1, None, None, None),
+        (2, 0.1, 1, 500.0, 20.0, 25.0),   # MS1 carrying isolation
+        (3, 0.2, 2, 500.0, 20.0, 25.0),
+        (4, 0.3, 1, None, None, None),
+        (5, 0.4, 2, 500.0, 20.0, 25.0),
+    ]
+    warns = C.validate_template_schedule(rows)
+    assert any("MS1 survey" in w and "isolation" in w for w in warns)
+
+
+def test_schedule_gate_consecutive_ms1_does_not_false_warn():
+    # a stray extra MS1 survey (lock-mass / system scan) is a zero-MS2 "cycle" that
+    # must be dropped from the regularity check, not read as irregular.
+    rows = [
+        (1, 0.0, 1, None, None, None),
+        (2, 1.0, 2, 500.0, 20.0, 25.0), (3, 2.0, 2, 520.0, 20.0, 25.0),
+        (4, 3.0, 1, None, None, None),
+        (5, 4.0, 1, None, None, None),   # consecutive MS1 -> zero-MS2 "cycle"
+        (6, 5.0, 2, 500.0, 20.0, 25.0), (7, 6.0, 2, 520.0, 20.0, 25.0),
+        (8, 7.0, 1, None, None, None),
+        (9, 8.0, 2, 500.0, 20.0, 25.0), (10, 9.0, 2, 520.0, 20.0, 25.0),
+    ]
+    assert not any("irregular DIA cycle" in w for w in C.validate_template_schedule(rows))
+
+
+def test_schedule_gate_irregular_cycle_warns_then_fails_under_strict():
+    rows, scan = [], 0
+    for n_windows in (2, 3, 2):   # interior windows-per-cycle varies (2 then 3)
+        scan += 1; rows.append((scan, float(scan), 1, None, None, None))
+        for w in range(n_windows):
+            scan += 1; rows.append((scan, float(scan), 2, 500.0 + 20.0 * w, 20.0, 25.0))
+    warns = C.validate_template_schedule(rows)   # default: warn, no raise
+    assert any("irregular DIA cycle" in w for w in warns)
+    with pytest.raises(ValueError, match="strict_fixed_dia"):
+        C.validate_template_schedule(rows, strict_fixed_dia=True)


### PR DESCRIPTION
Build-from-template acquisitions read a vendor `.raw` / `.wiff` and turn its per-scan schedule into the acquisition tables. When a reader **mis-decodes** a file’s scan-event layout it returns plausible-but-wrong scan levels (e.g. an Exploris sub-variant read as **all-MS1**), and the failure otherwise surfaces cryptically deep in the render ("level mismatch at scan N").

This adds `validate_template_schedule()`, run at ingestion by `build_frame_tables_from_schedule`, to **reject such a schedule up front with an actionable message**.

**Hard failures** (unambiguous corruption / mis-parsed levels): empty schedule; non-finite/negative or non-monotonic RT; an MS2 row with missing / non-finite / non-positive isolation; `< 2` MS1 surveys or zero MS2 scans.

**Method-aware soft checks** (warn, returned + logged — no over-rejection):
- MS1 rows carrying an isolation window — real MS1 events can carry a non-zero center, so hard-failing would over-reject valid files (warns instead).
- Irregular windows-per-cycle — legitimate for variable-window / scheduled / GPF / CE-ramp DIA, so it warns unless `strict_fixed_dia`. Zero-MS2 “cycles” (consecutive MS1 / lock-mass / system scans) are excluded from the regularity check.

**Honest limitation:** this catches *gross* mis-decoding; a subtle partial level-swap (some MS2 mislabeled MS1 but still carrying plausible isolation) satisfies these invariants and passes — that needs an external reference, not self-consistency.

10 new tests cover accept, every hard-fail, each warning path, strict mode, and that the gate is enforced through `build_frame_tables_from_schedule`.