### PR TITLE
build(rustdf): bump thermorawfile to merged main rev 3773aa3

### DIFF
--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -40,7 +40,7 @@ rustc-hash = "2.1.0"
 bincode = "1.3.3"
 polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
 # Thermo .raw writer (public repo; only built with the `thermo` feature)
-thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "61bf4724bc35cd7bc916b6acebc49319a0f9bbbc", optional = true }
+thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "3773aa39e72a1fec86e9f90fa6cf8258fd0acbc2", optional = true }
 # SCIEX .wiff method reader (public repo; only built with the `sciex` feature)
 sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "ef7c0cd7e59d3b51160e446cbe3af240d230668d", optional = true }
 # Open mzML writer (Joshua Klein's mzdata); only built with the `mzml` feature. The


### PR DESCRIPTION
Bumps the `thermo`-feature thermorawfile dep from `61bf472` to the merged `main` (`3773aa3` — the feature/format-robustness work: read-side format metadata, clean-room provenance re-base, PyO3 bindings).

Additive and compatible — verified by:
- `cargo build -p rustdf --features thermo` against `3773aa3`;
- a full timsim Astral DIA `.raw` simulation (194k scans), which round-trips clean and re-reads with a valid checksum.

One-line dependency bump only; no source changes.