### PR TITLE
chore: ignore .venv, .pytest_cache, and training/run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,18 @@ build/
 
 # Jupyter
 .ipynb_checkpoints/
+.pytest_cache/
+
+# Python virtual environments
+.venv/
+**/.venv/
+venv/
+
+# Training/run artifacts
+*.log
+checkpoints/
+results/
+*.tdf
 
 # Test/example data (large files)
 imspy/examples/T*/


### PR DESCRIPTION
## What

Add ignore patterns for local dev noise that was showing up in `git status`:

- Python virtual environments: `.venv/`, `**/.venv/`, `venv/`
- `.pytest_cache/`
- Regenerable training/run artifacts: `*.log`, `checkpoints/`, `results/`, `*.tdf`

## Why

These are all locally-generated and were never meant to be tracked — they cluttered the working tree (e.g. two `.venv` dirs, predictor training logs, `analysis.tdf`). No tracked files are affected.

https://claude.ai/code/session_01TUt4cXkgifJEmTxunk5dWc