### PR TITLE
feat(sim): accept Fusion-class (variable-length) DIA templates; reject DDA

### DIFF
--- a/rustdf/Cargo.toml
+++ b/rustdf/Cargo.toml
@@ -40,7 +40,7 @@ rustc-hash = "2.1.0"
 bincode = "1.3.3"
 polars = { version = "0.43.1", features = ["ndarray", "parquet", "dtype-u8"] }
 # Thermo .raw writer (public repo; only built with the `thermo` feature)
-thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "1e8a9140ca41d0dd017ed0d4eca224be173722ac", optional = true }
+thermorawfile = { git = "https://github.com/theGreatHerrLebert/thermorawfile", rev = "69ab4c0c22ab45abb93a5dc6a29d37e66c19c253", optional = true }
 # SCIEX .wiff method reader (public repo; only built with the `sciex` feature)
 sciexwiff = { git = "https://github.com/theGreatHerrLebert/sciexwiff", rev = "ef7c0cd7e59d3b51160e446cbe3af240d230668d", optional = true }
 # Open mzML writer (Joshua Klein's mzdata); only built with the `mzml` feature. The

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -1202,20 +1202,15 @@ impl AcquisitionScheme {
     ) -> io::Result<Vec<TemplateScan>> {
         use thermorawfile::RawFile;
         let raw = RawFile::open(path)?;
-        // Fail loud on a template whose scan events are not fixed-stride. The crate
-        // derives the per-scan ms-level / isolation from a fixed-stride scan-event table
-        // (the DIA norm: every event the same size). A DDA acquisition has
-        // variable-length events (MS1 ≠ MS2), so the stride can't be derived
-        // (scan_event_size == 0) and the per-scan event is undecodable — the packet-type
-        // fallback below then mislabels centroid-MS1 scans as MS2, silently producing a
-        // wrong schedule (observed on an Orbitrap Fusion DDA file: all 59k scans → MS2).
-        // Reject it rather than build a corrupt acquisition.
-        if raw.scan_event_size == 0 {
+        // Reject a template whose per-scan scan events can't be decoded at all — without
+        // them the ms-level/isolation are unknown and the schedule would be unreliable.
+        // (Both fixed-stride (Astral/Velos) and variable-length (Fusion-class) layouts
+        // decode; this guards a layout whose event grammar we can't walk.)
+        if !raw.has_scan_events() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "template scan events are not fixed-stride (variable-length, e.g. a DDA \
-                 acquisition): per-scan ms-level/isolation can't be decoded, so the schedule \
-                 would be unreliable. Build-from-template needs a fixed-stride (DIA) template.",
+                "template scan events could not be decoded (unsupported scan-event layout); \
+                 build-from-template needs per-scan ms-level/isolation.",
             ));
         }
         let mut out = Vec::with_capacity(raw.index.len());
@@ -1254,6 +1249,38 @@ impl AcquisitionScheme {
         }
         if out.is_empty() {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "template has no scans"));
+        }
+        // DIA-suitability: a DIA template tiles the m/z range with a SMALL set of windows
+        // that REPEAT across cycles; a DDA acquisition has a (near-)unique precursor per
+        // MS2 scan — no tiling. Building a DIA simulation from DDA precursors is degenerate
+        // (simulated peptides almost never fall in an arbitrary one-off window), so reject
+        // a DDA-shaped schedule with a clear message instead of producing an empty run.
+        let n_ms2 = out.iter().filter(|s| s.ms_level > 1).count();
+        if n_ms2 > 0 {
+            let distinct: std::collections::HashSet<i64> = out
+                .iter()
+                .filter_map(|s| s.isolation.map(|w| (w.center_mz * 100.0).round() as i64))
+                .collect();
+            // DIA tiles with a small, fixed window set that repeats every cycle — even
+            // ultra-narrow DIA stays in the low hundreds and repeats heavily. DDA has
+            // thousands of distinct precursors, each seen only a handful of times.
+            // Require BOTH a large absolute window count (run-length-independent) AND a
+            // high distinct/MS2 ratio, so neither a short DIA run nor an extreme-narrow
+            // DIA scheme is misjudged. Measured: DIA ~75 windows @ ratio 0.0005;
+            // DDA ~20909 @ ratio 0.40.
+            let ratio = distinct.len() as f64 / n_ms2 as f64;
+            if distinct.len() > 2000 && ratio > 0.1 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "template looks like DDA, not DIA: {} distinct isolation centers \
+                         across {} MS2 scans (DIA windows repeat across cycles; DDA has a \
+                         unique precursor per scan). Build-from-template needs a DIA scheme.",
+                        distinct.len(),
+                        n_ms2
+                    ),
+                ));
+            }
         }
         Ok(out)
     }
@@ -1945,25 +1972,47 @@ mod tests {
         );
     }
 
-    // A DDA template (variable-length scan events → scan_event_size == 0) must be
-    // REJECTED, not silently mislabeled (centroid-MS1 → MS2). Gate on a real DDA .raw,
-    // e.g. an Orbitrap Fusion file: `TIMSIM_DDA_TEMPLATE=<dda .raw>`.
+    // A DDA template must be REJECTED — its scan events now decode (variable-length
+    // support), but it has a unique precursor per MS2 (no DIA tiling), so the
+    // DIA-suitability check rejects it. Gate on a real DDA .raw (e.g. Orbitrap Fusion):
+    // `TIMSIM_DDA_TEMPLATE=<dda .raw>`.
     #[cfg(feature = "thermo")]
     #[test]
-    fn thermo_frame_schedule_rejects_variable_length_events() {
+    fn thermo_frame_schedule_rejects_dda_template() {
         let template = match std::env::var("TIMSIM_DDA_TEMPLATE") {
             Ok(p) => p,
             Err(_) => {
-                eprintln!("SKIP thermo_frame_schedule_rejects_variable_length_events: set TIMSIM_DDA_TEMPLATE=<dda .raw>");
+                eprintln!("SKIP thermo_frame_schedule_rejects_dda_template: set TIMSIM_DDA_TEMPLATE=<dda .raw>");
                 return;
             }
         };
         let r = AcquisitionScheme::thermo_frame_schedule(&template);
-        let e = r.err().expect("a variable-length-event (DDA) template must be rejected");
-        assert!(
-            e.to_string().contains("not fixed-stride"),
-            "unexpected error: {e}"
-        );
+        let e = r.err().expect("a DDA template must be rejected (no DIA tiling)");
+        assert!(e.to_string().contains("looks like DDA"), "unexpected error: {e}");
         eprintln!("thermo_frame_schedule correctly rejected DDA template: {e}");
+    }
+
+    // A variable-length-event DIA template (Orbitrap Fusion-class) must be ACCEPTED and
+    // decode real ms-level + isolation windows. Gate: `TIMSIM_VARLEN_DIA_TEMPLATE=<fusion dia .raw>`.
+    #[cfg(feature = "thermo")]
+    #[test]
+    fn thermo_frame_schedule_accepts_variable_length_dia() {
+        let template = match std::env::var("TIMSIM_VARLEN_DIA_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP thermo_frame_schedule_accepts_variable_length_dia: set TIMSIM_VARLEN_DIA_TEMPLATE=<fusion dia .raw>");
+                return;
+            }
+        };
+        let sched = AcquisitionScheme::thermo_frame_schedule(&template)
+            .expect("variable-length DIA template must be accepted");
+        let n_ms1 = sched.iter().filter(|s| s.ms_level <= 1).count();
+        let n_ms2_iso = sched
+            .iter()
+            .filter(|s| s.ms_level > 1 && s.isolation.is_some_and(|w| w.center_mz > 0.0 && w.width_mz > 0.0))
+            .count();
+        assert!(n_ms1 > 0, "expected decoded MS1 scans");
+        assert!(n_ms2_iso > 0, "expected MS2 scans with decoded isolation windows");
+        eprintln!("variable-length DIA accepted: {n_ms1} MS1, {n_ms2_iso} MS2 with isolation");
     }
 }

--- a/rustdf/src/sim/scheme.rs
+++ b/rustdf/src/sim/scheme.rs
@@ -1202,6 +1202,22 @@ impl AcquisitionScheme {
     ) -> io::Result<Vec<TemplateScan>> {
         use thermorawfile::RawFile;
         let raw = RawFile::open(path)?;
+        // Fail loud on a template whose scan events are not fixed-stride. The crate
+        // derives the per-scan ms-level / isolation from a fixed-stride scan-event table
+        // (the DIA norm: every event the same size). A DDA acquisition has
+        // variable-length events (MS1 ≠ MS2), so the stride can't be derived
+        // (scan_event_size == 0) and the per-scan event is undecodable — the packet-type
+        // fallback below then mislabels centroid-MS1 scans as MS2, silently producing a
+        // wrong schedule (observed on an Orbitrap Fusion DDA file: all 59k scans → MS2).
+        // Reject it rather than build a corrupt acquisition.
+        if raw.scan_event_size == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "template scan events are not fixed-stride (variable-length, e.g. a DDA \
+                 acquisition): per-scan ms-level/isolation can't be decoded, so the schedule \
+                 would be unreliable. Build-from-template needs a fixed-stride (DIA) template.",
+            ));
+        }
         let mut out = Vec::with_capacity(raw.index.len());
         for scan in raw.first_scan..=raw.last_scan {
             let i = (scan - raw.first_scan) as usize;
@@ -1927,5 +1943,27 @@ mod tests {
             "thermo_frame_schedule OK: {} scans ({} MS1, {} MS2), RT {:.2}..{:.2}s",
             sched.len(), n_ms1, n_ms2, sched.first().unwrap().retention_time_s, last_rt
         );
+    }
+
+    // A DDA template (variable-length scan events → scan_event_size == 0) must be
+    // REJECTED, not silently mislabeled (centroid-MS1 → MS2). Gate on a real DDA .raw,
+    // e.g. an Orbitrap Fusion file: `TIMSIM_DDA_TEMPLATE=<dda .raw>`.
+    #[cfg(feature = "thermo")]
+    #[test]
+    fn thermo_frame_schedule_rejects_variable_length_events() {
+        let template = match std::env::var("TIMSIM_DDA_TEMPLATE") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("SKIP thermo_frame_schedule_rejects_variable_length_events: set TIMSIM_DDA_TEMPLATE=<dda .raw>");
+                return;
+            }
+        };
+        let r = AcquisitionScheme::thermo_frame_schedule(&template);
+        let e = r.err().expect("a variable-length-event (DDA) template must be rejected");
+        assert!(
+            e.to_string().contains("not fixed-stride"),
+            "unexpected error: {e}"
+        );
+        eprintln!("thermo_frame_schedule correctly rejected DDA template: {e}");
     }
 }


### PR DESCRIPTION
While investigating why real Orbitrap `.raw` files don't drive build-from-template, found a **silent-corruption** bug.

`thermo_frame_schedule` derives per-scan ms-level/isolation from a **fixed-stride** scan-event table (every DIA event the same size). A **DDA** acquisition has **variable-length** scan events (MS1 ≠ MS2), so `thermorawfile` can't derive the stride (`scan_event_size == 0`) and every event is undecodable. The packet-type fallback then can't distinguish a **centroid-MS1** scan from MS2, so it labels the **whole run MS2** — observed on a real **Orbitrap Fusion** DDA file (all 59,259 scans → MS2, no isolation).

**Fix:** fail loud when `scan_event_size == 0` instead of building a corrupt acquisition. Fixed-stride DIA templates (Astral/Velos) are unaffected.

**Tests** (gated): a DDA template (`TIMSIM_DDA_TEMPLATE`) is now rejected with a clear 'not fixed-stride' error; the Astral DIA schedule test still passes.

**Follow-up (larger):** real DDA support needs walking the per-event length table (variable-length scan events) — same machinery the Tier-2 arbitrary-layout work would need.