### PR TITLE
docs(sim): Tier 2 plan — re-window a real DIA template

### DIFF
--- a/packages/imspy-simulation/TIER2_REWINDOW.codex-review.md
+++ b/packages/imspy-simulation/TIER2_REWINDOW.codex-review.md
@@ -1,0 +1,76 @@
+The plan is directionally sound, but I would tighten the claims around 3a and be more skeptical about 3b. The highest-risk part is indeed redundant encoding of the isolation window, but the plan should separate “reaction metadata” from “scan acquisition/filter metadata” more explicitly.
+**1. 3a in-place claim**
+Yes, the central 3a claim looks correct if the window count is unchanged: the reaction record is fixed-size, and changing `EV_ISO_CENTER`, `EV_ISO_WIDTH`, and optionally collision energy is an in-place overwrite. No resize is needed for the reaction block itself.
+But I would not phrase this as “only center/width change.” The reaction may be fixed-size, but the *semantic window* may be duplicated outside it. Fields that may co-vary:
+- precursor/isolation center in the reaction record
+- isolation width in the reaction record
+- possibly activation/collision-energy fields if the scheme changes CE by window
+- scan-event mass range block, if it contributes to filter or acquisition range
+- scan-index low/high m/z, depending on whether those are observed peak bounds, acquisition bounds, or filter display bounds
+- cached filter text, if present anywhere as serialized text rather than synthesized by RawFileReader
+So: 3a is no-resize for scan events, but not necessarily “reaction-only.”
+**2. Filter-string risk**
+Yes, this is the right top risk. The validation must require both:
+- `GetReaction(0)` reports the new precursor/isolation values.
+- `GetFilterForScanNumber` reports the new `[lo-hi]`.
+The exact fields to audit/update should be:
+- Reaction record:
+  - isolation center
+  - isolation width
+  - collision energy if intentionally changed
+- Scan-event `nranges` / range block:
+  - Determine whether this is scan acquisition mass range, isolation display range, or something else.
+  - If a DIA MS2 event has a range equal to `[center - width/2, center + width/2]`, update it.
+  - If it instead reflects fragment scan range, e.g. `150-2000`, do not tie it to isolation.
+- Scan-index low/high m/z:
+  - Be careful. In many formats, scan index low/high are observed data bounds, not isolation bounds.
+  - If your existing repack path recomputes them from peaks, then for 3a they probably should remain peak-derived unless RawFileReader demonstrably uses them for filter `[lo-hi]`.
+  - Do not blindly set scan-index low/high to the isolation window unless validation proves that is what Thermo expects.
+- Cached filter string:
+  - Search/parse for any serialized per-scan filter records. If present, update or invalidate them.
+  - If RawFileReader synthesizes filters entirely from binary fields, there may be no cache. But the plan should explicitly verify this by byte-searching old window strings and checking relevant sections.
+Other redundant locations worth checking:
+- trailer extra fields such as isolation width, mono m/z, precursor m/z, or selected ion m/z
+- status log only if it contains method/acquisition text, usually lower priority
+- chromatogram/index structures if they group by precursor/window
+- method/instrument method text, if downstream tools display the nominal DIA method
+- DIA/window-group tables, if present in newer instruments/templates
+The important distinction: `GetReaction` consistency is necessary; `GetFilterForScanNumber` consistency is not enough if chromatogram extraction or downstream indexing still sees old groups.
+**3. 3a vs 3b value**
+The split is technically sound. I would not skip 3a.
+3a is valuable because it proves the redundancy map without introducing scan-count mutations. It gives you a constrained validation surface: same scans, same packets, same cadence, same offsets except patched fields. That is exactly the right place to learn which fields RawFileReader uses for filter synthesis.
+But the plan should be honest that 3a does not unlock “arbitrary DIA window schemes.” It unlocks same-cardinality retargeting: shift, widen, narrow, overlap changes, or map an existing N-window cycle onto another N-window scheme. True 8 Th to 4 Th over the same range is 3b.
+I would keep 3a as a deliberate proving step, then do 3b only after field redundancy is fully characterized.
+**4. 3b hidden hazards**
+`repack_many` helps with data-section relocation, but 3b is more than “resize events and packets.” Hazards I would call out:
+- Scan numbering: Thermo APIs often assume dense scan numbers with consistent offsets across event, index, params, trailer, status, and data.
+- Retention time / cycle structure: duplicated scans need plausible RTs, scan times, injection times, and TIC/base peak metadata.
+- GenericRecord scan-params stream: this may not be a simple fixed array. It may contain per-scan variable records whose offsets/counts are mirrored elsewhere.
+- Trailer extra: precursor fields, isolation width, injection time, charge state, master scan number, dependent scan info may need cloning/patching.
+- Scan-event segment/dependent-scan fields: copied DDA structures can make DIA look like dependent MS/MS unless cleaned.
+- MS1/MS2 cadence: inserting/removing MS2 scans changes cycle time assumptions, scan numbers between MS1s, and possibly controller event numbering.
+- Chromatogram indexes: any precomputed BPC/TIC/SRM/precursor chromatograms may become inconsistent.
+- DIA/window-group tables: if the file has explicit SWATH/DIA grouping metadata, this is likely the hardest hidden dependency.
+- Checksums/section sizes: not just global Adler; any per-section or per-record length tables must be updated.
+- Packet content: a newly inserted MS2 scan needs valid profile/centroid payload, trailer, params, index stats, and timestamps. Zero packets are risky unless already proven readable.
+For 3b, copying a real same-MS-level skeleton is the right instinct, but choose skeletons by cycle position/window group, not just MS level.
+**5. Validation and DIA-vs-DDA suitability**
+The simulator’s heuristic, “distinct centers >2000 and >10% of MS2,” sounds like a DDA rejection rule, not a validation rule for re-windowed DIA. A re-windowed DIA template should still pass if the rewritten MS2 scans have a small repeated set of centers. If validation is looking for “not DDA,” then it should assert something like:
+- number of distinct MS2 centers is much smaller than number of MS2 scans
+- centers repeat across cycles
+- most MS2 scans have isolation width in the DIA-expected range
+- cycle pattern is stable enough for the requested scheme
+The plan’s validation should add:
+- old window strings/values are absent where expected
+- per-cycle window sequence equals the requested scheme
+- every MS2 scan maps to exactly one declared window
+- `GetReaction`, filter `[lo-hi]`, trailer precursor/isolation fields, and any decoded range blocks agree
+- downstream simulator transmission changes as expected for peptides near old/new boundaries
+**6. Sequencing**
+I would revise the sequence:
+1. Build a “window provenance” inspector first: for each MS2 scan, print reaction center/width, filter `[lo-hi]`, event ranges, scan-index low/high, trailer precursor/isolation fields, and any cached strings.
+2. Run it on Fusion and Astral templates before mutation.
+3. Implement 3a with only same-count schemes.
+4. Validate old-vs-new boundary cases in RawFileReader and the simulator.
+5. Only then design 3b, starting with duplicating/removing one MS2 scan in a tiny controlled cycle before full retiling.
+Bottom line: keep 3a. It is not the final payoff, but it is the right diagnostic increment. The plan’s main correction is to downgrade “arbitrary DIA window schemes” to “same-cardinality re-windowing” for 3a, and to broaden the redundancy audit beyond filter strings into trailer, range blocks, scan params, and possible DIA grouping metadata.

--- a/packages/imspy-simulation/TIER2_REWINDOW.md
+++ b/packages/imspy-simulation/TIER2_REWINDOW.md
@@ -1,0 +1,104 @@
+# TIER2_REWINDOW — re-window a real DIA template (Tier 2, increment 1)
+
+> Status: **design / ready to implement** (next session). Scope chosen 2026-06-24:
+> *re-window an existing template* (vs full-synthetic-layout or insert/remove-scans).
+> Builds on the variable-length scan-event parser (thermorawfile main `69ab4c0`) and the
+> Tier-1 section-graph rebuild (`repack_many`).
+
+## 1. Goal
+
+Take a **real DIA template `.raw`** and rewrite its MS2 **isolation windows** to a *new*
+scheme, keeping everything else real (preamble, calibration, logs, method, data grid).
+Unlocks "any DIA window scheme from one seed template" — e.g. turn the Fusion 8 Th
+narrow-window file into a 4 Th tiling, retile the Astral 20 Th windows, shift centers,
+change widths/overlap — **without** authoring a `.raw` from scratch.
+
+This is the cheapest Tier-2 capability with real payoff: it gives the simulator
+arbitrary DIA window schemes (the thing template-mutation alone can't do), reusing
+machinery we already have.
+
+## 2. Foundation already in place
+
+- **We can read the full scan-event grammar** (`walk_variable_scan_events`, both fixed-
+  and variable-length): `preamble[136] + nprec + nprec·56(reaction) + nranges +
+  nranges·16(range) + calib(44+4·nparam)`. Authoring is the inverse — emit the same blocks.
+- **In-place window patch exists**: `set_isolation(scan, center, width, ce)` writes
+  `EV_ISO_CENTER@+140 / EV_ISO_WIDTH@+148 / EV_COLLISION_ENERGY@+156` within the reaction.
+  It now reads the per-scan offset table, so it **already works on variable-length
+  (Fusion) events** — confirmed: those fields decode/patch at the table offsets.
+- **Section-graph rebuild**: `repack_many` / `splice_packet_and_relocate` already resize
+  the data section + relocate the trailing graph. The same pattern resizes the
+  *scan-event* section when window **count** changes.
+
+## 3. Two sub-cases (different effort)
+
+### 3a. Same window COUNT — in-place reassign (small)
+Reassign each existing MS2 scan's window (center/width) to the new scheme; the scan
+count and cadence are unchanged. **No event resize** — the reaction record is fixed-size,
+so center/width are f64 overwrites. Mostly `set_isolation` per scan, plus consistency:
+- **Mass-range / filter fields**: the preamble (and possibly a per-event mass-range,
+  §scan-event `nranges` block) and the scan-index `low/high m/z` may encode the window
+  redundantly — RawFileReader builds the filter string (`… [lo-hi]`) from them. Update
+  them or the reader shows a *stale* window in the filter even though `GetReaction` is
+  right. **This is the main correctness trap.**
+- Recompute the Adler-32 once at `save` (existing).
+
+Limitation: same count means you can shift/resize windows but not change *how many* —
+so a true finer retiling (8 Th → 4 Th over the same range = 2× windows) needs 3b.
+
+### 3b. Different window COUNT — resize the event section (medium-large)
+Changing windows-per-cycle changes the **MS2 scan count** → must resize the scan-event
+array, scan-params stream, scan-index, and the data section (one packet per new scan),
+then relocate the section graph. This is where the real retiling lives. Reuses the
+Tier-1 relocate machinery, but applied to the **event/index/params** arrays (not just
+data). Author each new scan event from a **real-event skeleton** (copy a same-MS-level
+event, patch center/width/ranges) — never zero-fill (per the Tier-2 §5 caveat: fields
+our reader copies through may be required by RawFileReader).
+
+## 4. API sketch
+
+```
+// thermorawfile
+RawFile::set_scan_window(scan, center, width)         // ≈ set_isolation, case 3a primitive
+RawFile::rewindow_in_place(assign: Fn(scan)->Window)  // 3a: reassign all MS2 windows + fix filter/index stats, validate
+RawFile::rebuild_with_windows(scheme: &WindowScheme)  // 3b: resize event/index/params/data, relocate (later)
+
+// rustdf / sim
+WindowScheme { mz_lo, mz_hi, width, overlap, ms1_every }   // declarative DIA tiling
+// timsim config: [dia] window_scheme = {...}  → re-window the template before authoring
+```
+
+## 5. Risks / open questions
+
+1. **Filter-string consistency (3a)** — the biggest one. RawFileReader's per-scan filter
+   `FTMS + p NSI Full ms2 X@hcd35 [lo-hi]` is built from preamble + index fields, not the
+   reaction alone. Re-windowing must update every field the filter reads, or `scan_filter`
+   / RawFileReader shows the old window. **Verify by reading the filter back, not just the
+   reaction.**
+2. **Per-event mass-range** (the `nranges`/`range` block) — does it track the isolation
+   window, the scan range, or both? Decode it on a real file first (we have the grammar).
+3. **Scan-index `low/high m/z`** — recompute per re-windowed scan (the repack path already
+   recomputes these from peaks; here they may also bound the window).
+4. **Dependent-scan / segment fields** in the preamble — leave as the template's (case 3a
+   keeps the same scan structure) unless retiling (3b) changes cadence.
+
+## 6. Validation (the gate)
+
+- RawFileReader round-trip on the re-windowed file: open OK, all scans read.
+- For each re-windowed MS2 scan: `GetReaction(0).PrecursorMass/IsolationWidth` **and** the
+  **filter string `[lo-hi]`** match the new scheme (catches the §5.1 trap).
+- Run the simulator on the re-windowed template → valid `.raw`, peptides now transmit
+  through the new windows (sanity: non-empty MS2 count tracks the new tiling).
+- Cross-reader (ProteoWizard/Sage) as a stretch.
+
+## 7. First increment (next session)
+
+1. Decode the per-event mass-range block on the Fusion + Astral files; confirm what the
+   filter `[lo-hi]` is built from (resolve §5.1/§5.2).
+2. Implement **3a** (`rewindow_in_place`): reassign MS2 windows to a declarative scheme,
+   fixing filter/index fields; validate with RawFileReader (reaction **and** filter).
+3. Wire a `timsim` `[dia] window_scheme` option that re-windows the template pre-authoring.
+4. Then **3b** (resize) for true finer/coarser retiling, reusing `repack_many`'s relocate.
+
+Estimated: 3a ≈ the size of the `set_isolation`/guard work; 3b ≈ the size of the
+variable-length parser. Each gets its own Codex review (the established loop).

--- a/packages/imspy-simulation/TIER2_REWINDOW.md
+++ b/packages/imspy-simulation/TIER2_REWINDOW.md
@@ -1,9 +1,16 @@
 # TIER2_REWINDOW — re-window a real DIA template (Tier 2, increment 1)
 
-> Status: **design / ready to implement** (next session). Scope chosen 2026-06-24:
-> *re-window an existing template* (vs full-synthetic-layout or insert/remove-scans).
-> Builds on the variable-length scan-event parser (thermorawfile main `69ab4c0`) and the
-> Tier-1 section-graph rebuild (`repack_many`).
+> Status: **design / ready to implement** (next session), **Codex-reviewed** (see
+> `TIER2_REWINDOW.codex-review.md`). Scope chosen 2026-06-24: *re-window an existing
+> template* (vs full-synthetic-layout or insert/remove-scans). Builds on the
+> variable-length scan-event parser (thermorawfile main `69ab4c0`) and the Tier-1
+> section-graph rebuild (`repack_many`).
+>
+> **Review correction:** 3a is **same-cardinality** re-windowing (shift / widen / narrow /
+> change overlap, or remap an N-window cycle onto another N-window scheme) — *not*
+> arbitrary schemes. True finer tiling (8 Th → 4 Th = more windows/cycle) is **3b**. And
+> the window is re-encoded in **several** places, not just the reaction — the redundancy
+> audit (§5) is the crux, so the first step is a **provenance inspector** (§7), not a writer.
 
 ## 1. Goal
 
@@ -32,28 +39,50 @@ machinery we already have.
 
 ## 3. Two sub-cases (different effort)
 
-### 3a. Same window COUNT — in-place reassign (small)
-Reassign each existing MS2 scan's window (center/width) to the new scheme; the scan
-count and cadence are unchanged. **No event resize** — the reaction record is fixed-size,
-so center/width are f64 overwrites. Mostly `set_isolation` per scan, plus consistency:
-- **Mass-range / filter fields**: the preamble (and possibly a per-event mass-range,
-  §scan-event `nranges` block) and the scan-index `low/high m/z` may encode the window
-  redundantly — RawFileReader builds the filter string (`… [lo-hi]`) from them. Update
-  them or the reader shows a *stale* window in the filter even though `GetReaction` is
-  right. **This is the main correctness trap.**
-- Recompute the Adler-32 once at `save` (existing).
+### 3a. Same window COUNT — in-place reassign (small, but NOT "reaction-only")
+Reassign each existing MS2 scan's window (center/width) to the new scheme; scan count
+and cadence unchanged. **No event resize** — the reaction record is fixed-size, so
+center/width are f64 overwrites. But the window is **re-encoded in several places**; 3a
+must update *every* copy, not just the reaction (this is the whole point of 3a — to map
+that redundancy on a constrained surface). See the audit in §5. At minimum:
+- reaction `EV_ISO_CENTER/WIDTH` (and CE if the scheme changes it) — the `set_isolation`
+  primitive, already works on variable-length events;
+- the scan-event **range block** (`nranges`/range) **iff** it carries the isolation
+  window (vs a fixed fragment scan range — decode first, §5);
+- **trailer-extra** precursor/isolation/selected-ion fields (RawFileReader and downstream
+  tools read these directly);
+- any **cached filter string** (byte-search for the old `[lo-hi]` text);
+- recompute the Adler-32 once at `save` (existing).
 
-Limitation: same count means you can shift/resize windows but not change *how many* —
-so a true finer retiling (8 Th → 4 Th over the same range = 2× windows) needs 3b.
+Scope (honest): 3a is **same-cardinality retargeting** — shift, widen, narrow, change
+overlap, or remap one N-window cycle onto another N-window scheme. It does **not** unlock
+arbitrary schemes; true finer tiling (8 Th → 4 Th = 2× windows) is 3b. Its real value is
+**diagnostic**: same scans/packets/offsets except the patched fields, so it's the clean
+place to learn exactly which fields RawFileReader uses to synthesize the filter.
 
 ### 3b. Different window COUNT — resize the event section (medium-large)
 Changing windows-per-cycle changes the **MS2 scan count** → must resize the scan-event
 array, scan-params stream, scan-index, and the data section (one packet per new scan),
 then relocate the section graph. This is where the real retiling lives. Reuses the
 Tier-1 relocate machinery, but applied to the **event/index/params** arrays (not just
-data). Author each new scan event from a **real-event skeleton** (copy a same-MS-level
-event, patch center/width/ranges) — never zero-fill (per the Tier-2 §5 caveat: fields
-our reader copies through may be required by RawFileReader).
+data). Author each new scan event from a **real-event skeleton** — and choose the
+skeleton by **cycle position / window group**, not just MS level (per Codex). Hazards
+beyond what `repack_many` handles:
+- **Dense scan numbering** — Thermo APIs assume contiguous scan numbers with consistent
+  offsets across event / index / params / trailer / status / data; all must stay aligned.
+- **Per-scan metadata for new scans** — plausible RT, scan time, injection time,
+  TIC/base-peak, charge — not zero packets (zero packets unproven-readable).
+- **GenericRecord scan-params stream** — may be variable-length records with counts/offsets
+  mirrored elsewhere, not a simple fixed array.
+- **Trailer-extra** — master-scan-number, dependent-scan info, precursor/isolation fields
+  per scan must be cloned/patched.
+- **Scan-event segment / dependent-scan flags** — a copied DDA-style event can make a DIA
+  MS2 look like a dependent scan; clean these.
+- **MS1/MS2 cadence** — changing windows-per-cycle shifts cycle time, scan-number gaps
+  between MS1s, controller event numbering.
+- **Window-group / SWATH metadata + chromatogram indexes** — likely the hardest hidden
+  dependency on newer instruments; precomputed TIC/BPC/precursor chromatograms go stale.
+- **Per-section / per-record length tables** — update all, not just the global Adler-32.
 
 ## 4. API sketch
 
@@ -68,37 +97,56 @@ WindowScheme { mz_lo, mz_hi, width, overlap, ms1_every }   // declarative DIA ti
 // timsim config: [dia] window_scheme = {...}  → re-window the template before authoring
 ```
 
-## 5. Risks / open questions
+## 5. The redundancy audit (the crux)
 
-1. **Filter-string consistency (3a)** — the biggest one. RawFileReader's per-scan filter
-   `FTMS + p NSI Full ms2 X@hcd35 [lo-hi]` is built from preamble + index fields, not the
-   reaction alone. Re-windowing must update every field the filter reads, or `scan_filter`
-   / RawFileReader shows the old window. **Verify by reading the filter back, not just the
-   reaction.**
-2. **Per-event mass-range** (the `nranges`/`range` block) — does it track the isolation
-   window, the scan range, or both? Decode it on a real file first (we have the grammar).
-3. **Scan-index `low/high m/z`** — recompute per re-windowed scan (the repack path already
-   recomputes these from peaks; here they may also bound the window).
-4. **Dependent-scan / segment fields** in the preamble — leave as the template's (case 3a
-   keeps the same scan structure) unless retiling (3b) changes cadence.
+Separate **reaction metadata** (what `GetReaction` reads) from **scan acquisition / filter
+metadata** (what `GetFilterForScanNumber`, chromatogram extraction, and downstream indexing
+read). `GetReaction` agreement is *necessary*; it is **not sufficient** if a filter, a
+window-group table, or a chromatogram index still points at the old window. Audit every
+place the window is (or might be) encoded:
+
+| Location | Carries the window? | Action |
+|---|---|---|
+| Reaction `EV_ISO_CENTER/WIDTH/CE` | yes | overwrite (`set_isolation`) |
+| Scan-event `nranges`/range block | **decode first** — isolation window `[c±w/2]`, or a fixed fragment scan range (`150–2000`)? | update **only if** it equals the isolation window; else leave |
+| Scan-index `low/high m/z` | maybe — observed-peak bounds vs acquisition vs filter-display | **don't blindly set to the window**; keep peak-derived unless validation proves RawFileReader uses them for the filter `[lo-hi]` |
+| Cached filter string | maybe | byte-search the file for the old `[lo-hi]` text; if present, update/invalidate; if absent, confirm RawFileReader synthesizes filters from binary fields |
+| Trailer-extra (precursor m/z, isolation width, mono/selected-ion m/z) | likely | patch per scan |
+| DIA / SWATH window-group tables (newer instruments) | likely (hardest) | detect + update, or refuse if present and not understood |
+| Status log / instrument-method text | low priority (display only) | note, usually skip |
+| Chromatogram / precursor-grouped indexes | if grouped by window | stale after re-window — validate, regenerate if RawFileReader/PWiz consult them |
+
+The first deliverable (§7.1) is a **provenance inspector** that dumps all of these per scan
+so the table above is filled from *real* Fusion + Astral bytes, not assumed.
 
 ## 6. Validation (the gate)
 
-- RawFileReader round-trip on the re-windowed file: open OK, all scans read.
-- For each re-windowed MS2 scan: `GetReaction(0).PrecursorMass/IsolationWidth` **and** the
-  **filter string `[lo-hi]`** match the new scheme (catches the §5.1 trap).
-- Run the simulator on the re-windowed template → valid `.raw`, peptides now transmit
-  through the new windows (sanity: non-empty MS2 count tracks the new tiling).
-- Cross-reader (ProteoWizard/Sage) as a stretch.
+RawFileReader round-trip (open OK, all scans read), plus **positive** DIA assertions
+(the simulator's `distinct centers > 2000 && > 10% of MS2` is a DDA *rejection* rule — a
+re-windowed DIA must still **pass** it; that's necessary, not the validation):
+- per re-windowed MS2 scan, **all** encodings agree on the new window: `GetReaction`,
+  filter `[lo-hi]`, trailer precursor/isolation, and any decoded range block;
+- the **old** window values/strings are absent where expected (byte-search);
+- the **per-cycle window sequence equals the requested scheme**, and every MS2 scan maps to
+  exactly **one** declared window; centers repeat across cycles; widths in the DIA range;
+- run the simulator on the re-windowed template → valid `.raw`, and **transmission changes
+  as expected at old↔new window boundaries** (peptides near a moved edge switch windows);
+- cross-reader (ProteoWizard `msaccess` / Sage) as a stretch.
 
 ## 7. First increment (next session)
 
-1. Decode the per-event mass-range block on the Fusion + Astral files; confirm what the
-   filter `[lo-hi]` is built from (resolve §5.1/§5.2).
-2. Implement **3a** (`rewindow_in_place`): reassign MS2 windows to a declarative scheme,
-   fixing filter/index fields; validate with RawFileReader (reaction **and** filter).
-3. Wire a `timsim` `[dia] window_scheme` option that re-windows the template pre-authoring.
-4. Then **3b** (resize) for true finer/coarser retiling, reusing `repack_many`'s relocate.
+1. **Build a window-provenance inspector FIRST** (before any mutation): for each MS2 scan,
+   print reaction center/width, filter `[lo-hi]`, scan-event range block, scan-index
+   low/high, trailer precursor/isolation fields, and any cached filter strings. Run it on
+   the **Fusion** and **Astral** templates → fill in the §5 table from real bytes.
+2. Implement **3a** (`rewindow_in_place`, same-cardinality): reassign MS2 windows to a
+   declarative scheme, updating *every* field the inspector showed carries the window.
+3. Validate per §6 — reaction **and** filter **and** trailer agree; old values gone;
+   boundary transmission in the simulator changes as expected.
+4. Wire a `timsim` `[dia] window_scheme` option that re-windows the template pre-authoring.
+5. **Only then** design **3b** (resize): start by duplicating/removing **one** MS2 scan in a
+   tiny controlled cycle (validate that single mutation in RawFileReader) before full
+   retiling, reusing `repack_many`'s relocate.
 
-Estimated: 3a ≈ the size of the `set_isolation`/guard work; 3b ≈ the size of the
-variable-length parser. Each gets its own Codex review (the established loop).
+Estimated: the inspector + 3a ≈ the `set_isolation`/guard work; 3b ≈ the variable-length
+parser. Each gets its own Codex review (the established loop).


### PR DESCRIPTION
Ready-to-implement design for the first Tier-2 increment: **re-windowing an existing DIA template** to a new window scheme (chosen over full-synthetic-layout / insert-scans).

Covers the foundation already in place (variable-length scan-event parser; `set_isolation` already works on variable-length events; `repack_many` relocate machinery), the two sub-cases (3a same-count in-place reassign — small; 3b different-window-count resize — medium-large), an API sketch, the key correctness trap (RawFileReader builds the per-scan filter string from preamble+index fields, not the reaction alone — re-windowing must update both), the validation gate, and the first concrete steps for a fresh session.

Docs-only. Implementation starts next session per the agreed cadence.