### PR TITLE
perf(mscore): cut per-peak allocations in annotated frame building (A + D)

### DIFF
--- a/imspy_connector/src/py_annotation.rs
+++ b/imspy_connector/src/py_annotation.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use mscore::data::spectrum::MsType;
 use pyo3::prelude::*;
 use mscore::simulation::annotation::{SourceType, SignalAttributes, ContributionSource, MzSpectrumAnnotated, PeakAnnotation, TimsFrameAnnotated, TimsSpectrumAnnotated};
+use mscore::data::peptide::FragmentType;
 use numpy::{IntoPyArray, PyArray1, PyArrayMethods};
 
 #[pyclass]
@@ -361,6 +362,18 @@ impl PySourceType {
     pub fn source_type(&self) -> String { self.inner.to_string() }
 }
 
+fn fragment_type_from_str(s: &str) -> Option<FragmentType> {
+    match s.to_ascii_lowercase().as_str() {
+        "a" => Some(FragmentType::A),
+        "b" => Some(FragmentType::B),
+        "c" => Some(FragmentType::C),
+        "x" => Some(FragmentType::X),
+        "y" => Some(FragmentType::Y),
+        "z" => Some(FragmentType::Z),
+        _ => None,
+    }
+}
+
 #[pyclass]
 #[derive(Clone)]
 pub struct PySignalAttributes {
@@ -369,14 +382,15 @@ pub struct PySignalAttributes {
 #[pymethods]
 impl PySignalAttributes {
     #[new]
-    #[pyo3(signature = (charge_state, peptide_id, isotope_peak, description=None))]
-    pub fn new(charge_state: i32, peptide_id: i32, isotope_peak: i32, description: Option<String>) -> PyResult<Self> {
+    #[pyo3(signature = (charge_state, peptide_id, isotope_peak, fragment_kind=None, fragment_ordinal=None))]
+    pub fn new(charge_state: i32, peptide_id: i32, isotope_peak: i32, fragment_kind: Option<String>, fragment_ordinal: Option<i32>) -> PyResult<Self> {
         Ok(PySignalAttributes {
             inner: SignalAttributes {
                 charge_state,
                 peptide_id,
                 isotope_peak,
-                description,
+                fragment_kind: fragment_kind.as_deref().and_then(fragment_type_from_str),
+                fragment_ordinal,
             },
         })
     }
@@ -386,8 +400,16 @@ impl PySignalAttributes {
     pub fn peptide_id(&self) -> i32 { self.inner.peptide_id }
     #[getter]
     pub fn isotope_peak(&self) -> i32 { self.inner.isotope_peak }
+    /// Fragment-ion kind ("a"/"b"/"c"/"x"/"y"/"z") this peak came from, if known.
     #[getter]
-    pub fn description(&self) -> Option<String> { self.inner.description.clone() }
+    pub fn fragment_kind(&self) -> Option<String> { self.inner.fragment_kind.map(|k| k.to_string()) }
+    /// 1-based fragment-ion ordinal (ion number), if known.
+    #[getter]
+    pub fn fragment_ordinal(&self) -> Option<i32> { self.inner.fragment_ordinal }
+    /// Human-readable label "{kind}_{ordinal}_{isotope}" (e.g. "b_5_1"), derived
+    /// on demand from the structured fields; None unless kind+ordinal are known.
+    #[getter]
+    pub fn description(&self) -> Option<String> { self.inner.description() }
 }
 
 #[pyclass]

--- a/mscore/src/data/peptide.rs
+++ b/mscore/src/data/peptide.rs
@@ -447,8 +447,7 @@ impl PeptideProductIonSeries {
         let mut mz_values = Vec::with_capacity(self.n_ions.len() + self.c_ions.len());
         let mut intensity_values = Vec::with_capacity(self.n_ions.len() + self.c_ions.len());
 
-        for (index, n_ion) in self.n_ions.iter().enumerate() {
-            let kind = n_ion.kind;
+        for n_ion in self.n_ions.iter() {
             let charge = n_ion.ion.charge;
             let mz = n_ion.mz();
             let intensity = n_ion.ion.intensity;
@@ -456,7 +455,7 @@ impl PeptideProductIonSeries {
                 charge_state: charge,
                 peptide_id: n_ion.ion.sequence.peptide_id.unwrap_or(-1),
                 isotope_peak: 0,
-                description: Some(format!("{}_{}_{}", kind, index + 1, 0)),
+                description: None, // (perf) per-peak label string dropped; see note in generate_isotopic_spectrum_annotated
             };
             let contribution_source = ContributionSource {
                 intensity_contribution: intensity,
@@ -471,8 +470,7 @@ impl PeptideProductIonSeries {
             intensity_values.push(intensity);
         }
 
-        for (index, c_ion) in self.c_ions.iter().enumerate() {
-            let kind = c_ion.kind;
+        for c_ion in self.c_ions.iter() {
             let charge = c_ion.ion.charge;
             let mz = c_ion.mz();
             let intensity = c_ion.ion.intensity;
@@ -480,7 +478,7 @@ impl PeptideProductIonSeries {
                 charge_state: charge,
                 peptide_id: c_ion.ion.sequence.peptide_id.unwrap_or(-1),
                 isotope_peak: 0,
-                description: Some(format!("{}_{}_{}", kind, index + 1, 0)),
+                description: None, // (perf) per-peak label string dropped; see note in generate_isotopic_spectrum_annotated
             };
             let contribution_source = ContributionSource {
                 intensity_contribution: intensity,
@@ -521,7 +519,7 @@ impl PeptideProductIonSeries {
         let mut mz_values = Vec::new();
         let mut intensity_values = Vec::new();
 
-        for (index, ion) in self.n_ions.iter().enumerate() {
+        for ion in self.n_ions.iter() {
             let n_isotopes = ion.isotope_distribution(mass_tolerance, abundance_threshold, max_result, intensity_min);
             let mut isotope_counter = 0;
             let mut previous_mz = n_isotopes[0].0;
@@ -538,8 +536,13 @@ impl PeptideProductIonSeries {
                     charge_state: ion.ion.charge,
                     peptide_id: ion.ion.sequence.peptide_id.unwrap_or(-1),
                     isotope_peak: isotope_counter,
-                    // use convention of 1-based indexing for fragment ion enumeration
-                    description: Some(format!("{}_{}_{}", ion.kind, index + 1, isotope_counter)),
+                    // (perf) description left unset: building "{kind}_{ordinal}_{isotope}"
+                    // per peak meant a String allocation + format! for every fragment
+                    // peak in the whole simulation, which dominated the annotated
+                    // builder's construction cost and RAM. No consumer reads it
+                    // (charge/peptide_id/isotope_peak carry the labels). The b/y kind +
+                    // ordinal could be promoted to structured fields later if needed.
+                    description: None,
                 };
 
                 let contribution_source = ContributionSource {
@@ -556,7 +559,7 @@ impl PeptideProductIonSeries {
             }
         }
 
-        for (index, ion) in self.c_ions.iter().enumerate() {
+        for ion in self.c_ions.iter() {
             let c_isotopes = ion.isotope_distribution(mass_tolerance, abundance_threshold, max_result, intensity_min);
             let mut isotope_counter = 0;
             let mut previous_mz = c_isotopes[0].0;
@@ -573,7 +576,7 @@ impl PeptideProductIonSeries {
                     charge_state: ion.ion.charge,
                     peptide_id: ion.ion.sequence.peptide_id.unwrap_or(-1),
                     isotope_peak: isotope_counter,
-                    description: Some(format!("{}_{}_{}", ion.kind, index + 1, isotope_counter)),
+                    description: None, // (perf) see note in the n-ion loop above
                 };
 
                 let contribution_source = ContributionSource {
@@ -635,5 +638,62 @@ impl PeptideProductIonSeriesCollection {
         }
 
         MzSpectrumAnnotated::new(mz_values, intensity_values, annotations)
+    }
+}
+
+#[cfg(test)]
+mod annotated_perf_tests {
+    use super::*;
+
+    // Guards optimization "A": the annotated spectrum generators no longer build
+    // a per-peak `description` String, but the structured labels
+    // (peptide_id / charge_state / isotope_peak) and the spectrum itself must be
+    // unchanged. These are exactly the fields the Python `.df` / `*_first_only` /
+    // dense-label consumers read.
+
+    #[test]
+    fn isotopic_annotated_drops_description_but_keeps_labels_and_spectrum() {
+        let seq = PeptideSequence::new("PEPTIDEK".to_string(), Some(7));
+        let series = seq.calculate_product_ion_series(1, FragmentType::B);
+        let spec = series.generate_isotopic_spectrum_annotated(1e-2, 1e-3, 100, 1e-5);
+
+        // vectors stay consistent and non-empty
+        assert!(!spec.mz.is_empty());
+        assert_eq!(spec.mz.len(), spec.intensity.len());
+        assert_eq!(spec.mz.len(), spec.annotations.len());
+
+        // MzSpectrumAnnotated::new invariant: peaks sorted ascending by mz
+        assert!(spec.mz.windows(2).all(|w| w[0] <= w[1]));
+
+        let mut max_isotope = 0;
+        for ann in &spec.annotations {
+            assert_eq!(ann.contributions.len(), 1);
+            let c = &ann.contributions[0];
+            assert_eq!(c.source_type, SourceType::Signal);
+            let sa = c.signal_attributes.as_ref().expect("signal attributes present");
+            assert_eq!(sa.peptide_id, 7);        // label preserved
+            assert!(sa.charge_state >= 1);        // label preserved
+            assert!(sa.isotope_peak >= 0);        // label preserved
+            assert!(sa.description.is_none());    // (A) no longer eagerly built
+            max_isotope = max_isotope.max(sa.isotope_peak);
+        }
+        // sanity: an isotope envelope was actually generated (counter advanced)
+        assert!(max_isotope >= 1);
+    }
+
+    #[test]
+    fn mono_annotated_drops_description_but_keeps_labels() {
+        let seq = PeptideSequence::new("PEPTIDEK".to_string(), Some(3));
+        let series = seq.calculate_product_ion_series(1, FragmentType::B);
+        let spec = series.generate_mono_isotopic_spectrum_annotated();
+
+        assert!(!spec.mz.is_empty());
+        assert_eq!(spec.mz.len(), spec.annotations.len());
+        for ann in &spec.annotations {
+            let sa = ann.contributions[0].signal_attributes.as_ref().unwrap();
+            assert_eq!(sa.peptide_id, 3);
+            assert_eq!(sa.isotope_peak, 0);       // mono-isotopic: always 0
+            assert!(sa.description.is_none());    // (A)
+        }
     }
 }

--- a/mscore/src/data/peptide.rs
+++ b/mscore/src/data/peptide.rs
@@ -91,7 +91,9 @@ impl PeptideIon {
                 charge_state: self.charge,
                 peptide_id: self.sequence.peptide_id.unwrap_or(-1),
                 isotope_peak: isotope_counter,
-                description: None,
+                // precursor ion peaks: no fragment kind/ordinal
+                fragment_kind: None,
+                fragment_ordinal: None,
             };
 
             let contribution_source = ContributionSource {
@@ -447,7 +449,7 @@ impl PeptideProductIonSeries {
         let mut mz_values = Vec::with_capacity(self.n_ions.len() + self.c_ions.len());
         let mut intensity_values = Vec::with_capacity(self.n_ions.len() + self.c_ions.len());
 
-        for n_ion in self.n_ions.iter() {
+        for (index, n_ion) in self.n_ions.iter().enumerate() {
             let charge = n_ion.ion.charge;
             let mz = n_ion.mz();
             let intensity = n_ion.ion.intensity;
@@ -455,7 +457,10 @@ impl PeptideProductIonSeries {
                 charge_state: charge,
                 peptide_id: n_ion.ion.sequence.peptide_id.unwrap_or(-1),
                 isotope_peak: 0,
-                description: None, // (perf) per-peak label string dropped; see note in generate_isotopic_spectrum_annotated
+                // (perf) keep the fragment identity as structured fields instead of
+                // an eagerly-formatted per-peak String; `description` is derived on demand.
+                fragment_kind: Some(n_ion.kind),
+                fragment_ordinal: Some((index + 1) as i32),
             };
             let contribution_source = ContributionSource {
                 intensity_contribution: intensity,
@@ -470,7 +475,7 @@ impl PeptideProductIonSeries {
             intensity_values.push(intensity);
         }
 
-        for c_ion in self.c_ions.iter() {
+        for (index, c_ion) in self.c_ions.iter().enumerate() {
             let charge = c_ion.ion.charge;
             let mz = c_ion.mz();
             let intensity = c_ion.ion.intensity;
@@ -478,7 +483,8 @@ impl PeptideProductIonSeries {
                 charge_state: charge,
                 peptide_id: c_ion.ion.sequence.peptide_id.unwrap_or(-1),
                 isotope_peak: 0,
-                description: None, // (perf) per-peak label string dropped; see note in generate_isotopic_spectrum_annotated
+                fragment_kind: Some(c_ion.kind),
+                fragment_ordinal: Some((index + 1) as i32),
             };
             let contribution_source = ContributionSource {
                 intensity_contribution: intensity,
@@ -519,7 +525,7 @@ impl PeptideProductIonSeries {
         let mut mz_values = Vec::new();
         let mut intensity_values = Vec::new();
 
-        for ion in self.n_ions.iter() {
+        for (index, ion) in self.n_ions.iter().enumerate() {
             let n_isotopes = ion.isotope_distribution(mass_tolerance, abundance_threshold, max_result, intensity_min);
             let mut isotope_counter = 0;
             let mut previous_mz = n_isotopes[0].0;
@@ -536,13 +542,12 @@ impl PeptideProductIonSeries {
                     charge_state: ion.ion.charge,
                     peptide_id: ion.ion.sequence.peptide_id.unwrap_or(-1),
                     isotope_peak: isotope_counter,
-                    // (perf) description left unset: building "{kind}_{ordinal}_{isotope}"
-                    // per peak meant a String allocation + format! for every fragment
-                    // peak in the whole simulation, which dominated the annotated
-                    // builder's construction cost and RAM. No consumer reads it
-                    // (charge/peptide_id/isotope_peak carry the labels). The b/y kind +
-                    // ordinal could be promoted to structured fields later if needed.
-                    description: None,
+                    // (perf) keep the full fragment identity (kind + 1-based ordinal)
+                    // as structured fields instead of allocating + formatting a
+                    // "{kind}_{ordinal}_{isotope}" String for every fragment peak in
+                    // the whole simulation. `description` is derived from these on demand.
+                    fragment_kind: Some(ion.kind),
+                    fragment_ordinal: Some((index + 1) as i32),
                 };
 
                 let contribution_source = ContributionSource {
@@ -559,7 +564,7 @@ impl PeptideProductIonSeries {
             }
         }
 
-        for ion in self.c_ions.iter() {
+        for (index, ion) in self.c_ions.iter().enumerate() {
             let c_isotopes = ion.isotope_distribution(mass_tolerance, abundance_threshold, max_result, intensity_min);
             let mut isotope_counter = 0;
             let mut previous_mz = c_isotopes[0].0;
@@ -576,7 +581,8 @@ impl PeptideProductIonSeries {
                     charge_state: ion.ion.charge,
                     peptide_id: ion.ion.sequence.peptide_id.unwrap_or(-1),
                     isotope_peak: isotope_counter,
-                    description: None, // (perf) see note in the n-ion loop above
+                    fragment_kind: Some(ion.kind), // (perf) see note in the n-ion loop above
+                    fragment_ordinal: Some((index + 1) as i32),
                 };
 
                 let contribution_source = ContributionSource {
@@ -645,14 +651,15 @@ impl PeptideProductIonSeriesCollection {
 mod annotated_perf_tests {
     use super::*;
 
-    // Guards optimization "A": the annotated spectrum generators no longer build
-    // a per-peak `description` String, but the structured labels
-    // (peptide_id / charge_state / isotope_peak) and the spectrum itself must be
-    // unchanged. These are exactly the fields the Python `.df` / `*_first_only` /
-    // dense-label consumers read.
+    // Guards optimization "A2": the annotated spectrum generators no longer build
+    // a per-peak `description` String, but the full fragment identity is preserved
+    // as structured fields (fragment_kind + fragment_ordinal) alongside the existing
+    // labels (peptide_id / charge_state / isotope_peak). The human-readable
+    // description is derived on demand and must match the old
+    // "{kind}_{ordinal}_{isotope}" format exactly.
 
     #[test]
-    fn isotopic_annotated_drops_description_but_keeps_labels_and_spectrum() {
+    fn isotopic_annotated_keeps_full_fragment_identity_and_spectrum() {
         let seq = PeptideSequence::new("PEPTIDEK".to_string(), Some(7));
         let series = seq.calculate_product_ion_series(1, FragmentType::B);
         let spec = series.generate_isotopic_spectrum_annotated(1e-2, 1e-3, 100, 1e-5);
@@ -671,10 +678,18 @@ mod annotated_perf_tests {
             let c = &ann.contributions[0];
             assert_eq!(c.source_type, SourceType::Signal);
             let sa = c.signal_attributes.as_ref().expect("signal attributes present");
-            assert_eq!(sa.peptide_id, 7);        // label preserved
-            assert!(sa.charge_state >= 1);        // label preserved
-            assert!(sa.isotope_peak >= 0);        // label preserved
-            assert!(sa.description.is_none());    // (A) no longer eagerly built
+            assert_eq!(sa.peptide_id, 7);                 // label preserved
+            assert!(sa.charge_state >= 1);                 // label preserved
+            assert!(sa.isotope_peak >= 0);                 // label preserved
+            // fragment identity preserved as structured fields
+            let kind = sa.fragment_kind.expect("fragment kind present");
+            let ordinal = sa.fragment_ordinal.expect("fragment ordinal present");
+            assert!(ordinal >= 1);                         // 1-based
+            // derived description reproduces the old "{kind}_{ordinal}_{isotope}" string
+            assert_eq!(
+                sa.description(),
+                Some(format!("{}_{}_{}", kind, ordinal, sa.isotope_peak)),
+            );
             max_isotope = max_isotope.max(sa.isotope_peak);
         }
         // sanity: an isotope envelope was actually generated (counter advanced)
@@ -682,7 +697,7 @@ mod annotated_perf_tests {
     }
 
     #[test]
-    fn mono_annotated_drops_description_but_keeps_labels() {
+    fn mono_annotated_keeps_full_fragment_identity() {
         let seq = PeptideSequence::new("PEPTIDEK".to_string(), Some(3));
         let series = seq.calculate_product_ion_series(1, FragmentType::B);
         let spec = series.generate_mono_isotopic_spectrum_annotated();
@@ -692,8 +707,11 @@ mod annotated_perf_tests {
         for ann in &spec.annotations {
             let sa = ann.contributions[0].signal_attributes.as_ref().unwrap();
             assert_eq!(sa.peptide_id, 3);
-            assert_eq!(sa.isotope_peak, 0);       // mono-isotopic: always 0
-            assert!(sa.description.is_none());    // (A)
+            assert_eq!(sa.isotope_peak, 0);                // mono-isotopic: always 0
+            assert!(sa.fragment_kind.is_some());
+            assert!(sa.fragment_ordinal.unwrap() >= 1);
+            // mono description always ends in "_0"
+            assert!(sa.description().unwrap().ends_with("_0"));
         }
     }
 }

--- a/mscore/src/simulation/annotation.rs
+++ b/mscore/src/simulation/annotation.rs
@@ -5,6 +5,7 @@ use rand::distributions::{Uniform, Distribution};
 use rand::rngs::ThreadRng;
 use statrs::distribution::Normal;
 use crate::data::spectrum::{MsType, ToResolution, Vectorized};
+use crate::data::peptide::FragmentType;
 
 #[derive(Clone, Debug)]
 pub struct PeakAnnotation {
@@ -69,7 +70,28 @@ pub struct SignalAttributes {
     pub charge_state: i32,
     pub peptide_id: i32,
     pub isotope_peak: i32,
-    pub description: Option<String>,
+    /// Fragment-ion kind (b/y/...) this peak originates from, when known.
+    /// Stored as a small `Copy` enum rather than baked into a per-peak string,
+    /// which is what makes the annotated builder cheap while keeping the peak's
+    /// full fragment identity (see `description`).
+    pub fragment_kind: Option<FragmentType>,
+    /// 1-based fragment-ion ordinal (the ion number, e.g. 5 for b5/y5), when known.
+    pub fragment_ordinal: Option<i32>,
+}
+
+impl SignalAttributes {
+    /// Human-readable fragment label `"{kind}_{ordinal}_{isotope}"` (e.g. `b_5_1`),
+    /// derived on demand from the structured fields. Returns `None` unless both the
+    /// fragment kind and ordinal are known. This reproduces the string that used to
+    /// be eagerly allocated per peak, without paying for it during frame building.
+    pub fn description(&self) -> Option<String> {
+        match (self.fragment_kind, self.fragment_ordinal) {
+            (Some(kind), Some(ordinal)) => {
+                Some(format!("{}_{}_{}", kind, ordinal, self.isotope_peak))
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1035,7 +1057,8 @@ mod new_sort_tests {
                     charge_state: 1,
                     peptide_id,
                     isotope_peak: 0,
-                    description: None,
+                    fragment_kind: None,
+                    fragment_ordinal: None,
                 }),
             }],
         }

--- a/mscore/src/simulation/annotation.rs
+++ b/mscore/src/simulation/annotation.rs
@@ -82,15 +82,24 @@ pub struct MzSpectrumAnnotated {
 impl MzSpectrumAnnotated {
     pub fn new(mz: Vec<f64>, intensity: Vec<f64>, annotations: Vec<PeakAnnotation>) -> Self {
         assert!(mz.len() == intensity.len() && intensity.len() == annotations.len());
-        // zip and sort by mz
-        let mut mz_intensity_annotations: Vec<(f64, f64, PeakAnnotation)> = izip!(mz.iter(), intensity.iter(), annotations.iter()).map(|(mz, intensity, annotation)| (*mz, *intensity, annotation.clone())).collect();
-        mz_intensity_annotations.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        // Zip by value (moving the annotations) and sort by mz. The previous
+        // implementation cloned every PeakAnnotation twice here (once into the
+        // sort buffer, once back out); moving avoids both clones, which matters
+        // for the annotated frame builder that constructs millions of these.
+        // `sort_by` is stable, so the ordering of equal-mz peaks is unchanged.
+        let mut triples: Vec<(f64, f64, PeakAnnotation)> = izip!(mz, intensity, annotations).collect();
+        triples.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
-        MzSpectrumAnnotated {
-            mz: mz_intensity_annotations.iter().map(|(mz, _, _)| *mz).collect(),
-            intensity: mz_intensity_annotations.iter().map(|(_, intensity, _)| *intensity).collect(),
-            annotations: mz_intensity_annotations.iter().map(|(_, _, annotation)| annotation.clone()).collect(),
+        let mut mz = Vec::with_capacity(triples.len());
+        let mut intensity = Vec::with_capacity(triples.len());
+        let mut annotations = Vec::with_capacity(triples.len());
+        for (m, i, a) in triples {
+            mz.push(m);
+            intensity.push(i);
+            annotations.push(a);
         }
+
+        MzSpectrumAnnotated { mz, intensity, annotations }
     }
 
     pub fn filter_ranged(&self, mz_min: f64, mz_max: f64, intensity_min: f64, intensity_max: f64) -> Self {
@@ -1008,5 +1017,64 @@ impl std::ops::Add for TimsFrameAnnotated {
             intensity: intensity_vec,
             annotations: annotations_vec,
         }
+    }
+}
+
+#[cfg(test)]
+mod new_sort_tests {
+    use super::*;
+
+    // Tag a peak's annotation with a distinct peptide_id so we can verify the
+    // sort permutation keeps each annotation attached to its original peak.
+    fn ann(peptide_id: i32) -> PeakAnnotation {
+        PeakAnnotation {
+            contributions: vec![ContributionSource {
+                intensity_contribution: 1.0,
+                source_type: SourceType::Signal,
+                signal_attributes: Some(SignalAttributes {
+                    charge_state: 1,
+                    peptide_id,
+                    isotope_peak: 0,
+                    description: None,
+                }),
+            }],
+        }
+    }
+
+    fn pids(spec: &MzSpectrumAnnotated) -> Vec<i32> {
+        spec.annotations
+            .iter()
+            .map(|a| a.contributions[0].signal_attributes.as_ref().unwrap().peptide_id)
+            .collect()
+    }
+
+    // Guards optimization "D": MzSpectrumAnnotated::new now moves annotations
+    // instead of cloning them twice. Behavior (sort by mz, annotation stays
+    // attached to its peak) must be identical.
+    #[test]
+    fn new_sorts_by_mz_and_keeps_annotation_attached() {
+        // peptide_id == mz * 10 so we can detect any mis-permutation
+        let spec = MzSpectrumAnnotated::new(
+            vec![300.0, 100.0, 200.0],
+            vec![3.0, 1.0, 2.0],
+            vec![ann(3000), ann(1000), ann(2000)],
+        );
+
+        assert_eq!(spec.mz, vec![100.0, 200.0, 300.0]);
+        assert_eq!(spec.intensity, vec![1.0, 2.0, 3.0]);
+        assert_eq!(pids(&spec), vec![1000, 2000, 3000]);
+    }
+
+    // The sort must be stable for equal mz (matters for merge order / which
+    // contribution ends up "first" downstream).
+    #[test]
+    fn new_is_stable_for_equal_mz() {
+        let spec = MzSpectrumAnnotated::new(
+            vec![150.0, 150.0],
+            vec![10.0, 20.0],
+            vec![ann(111), ann(222)],
+        );
+        assert_eq!(spec.intensity, vec![10.0, 20.0]);
+        assert_eq!(pids(&spec), vec![111, 222]);
     }
 }

--- a/packages/imspy-simulation/src/imspy_simulation/annotation.py
+++ b/packages/imspy-simulation/src/imspy_simulation/annotation.py
@@ -36,10 +36,12 @@ class SourceType(RustWrapperObject):
         return self.__py_ptr
 
 
-# charge_state: i32, peptide_id: i32, isotope_peak: i32
+# charge_state: i32, peptide_id: i32, isotope_peak: i32,
+# fragment_kind: Optional[str] ("a"/"b"/"c"/"x"/"y"/"z"), fragment_ordinal: Optional[int]
 class SignalAttributes(RustWrapperObject):
-    def __init__(self, charge_state: int, peptide_id: int, isotope_peak: int, description: Union[None, str] = None):
-        self.__py_ptr = ims.PySignalAttributes(charge_state, peptide_id, isotope_peak, description)
+    def __init__(self, charge_state: int, peptide_id: int, isotope_peak: int,
+                 fragment_kind: Union[None, str] = None, fragment_ordinal: Union[None, int] = None):
+        self.__py_ptr = ims.PySignalAttributes(charge_state, peptide_id, isotope_peak, fragment_kind, fragment_ordinal)
 
     @property
     def charge_state(self):
@@ -54,12 +56,24 @@ class SignalAttributes(RustWrapperObject):
         return self.__py_ptr.isotope_peak
 
     @property
+    def fragment_kind(self) -> Union[None, str]:
+        """Fragment-ion kind ('a'/'b'/'c'/'x'/'y'/'z') this peak came from, if known."""
+        return self.__py_ptr.fragment_kind
+
+    @property
+    def fragment_ordinal(self) -> Union[None, int]:
+        """1-based fragment-ion ordinal (ion number), if known."""
+        return self.__py_ptr.fragment_ordinal
+
+    @property
     def description(self) -> Union[None, str]:
+        """Derived label '{kind}_{ordinal}_{isotope}' (e.g. 'b_5_1'); None unless kind+ordinal known."""
         return self.__py_ptr.description
 
     def __repr__(self):
         return (f"SignalAnnotation(charge_state={self.charge_state}, peptide_id={self.peptide_id}, "
-                f"isotope_peak={self.isotope_peak}, description={self.description})")
+                f"isotope_peak={self.isotope_peak}, fragment_kind={self.fragment_kind}, "
+                f"fragment_ordinal={self.fragment_ordinal})")
 
     @classmethod
     def from_py_ptr(cls, signal_attributes: ims.PySignalAttributes) -> 'SignalAttributes':


### PR DESCRIPTION
## Summary

First, low-risk step of the annotated-frame-builder optimization (the builder is slow + RAM-heavy on large sims). Two changes in `mscore`, no change to the spectrum or to the labels consumers read.

**D — drop the double-clone in `MzSpectrumAnnotated::new`**
Sort by *moving* the annotations instead of cloning every `PeakAnnotation` twice. `sort_by` stays stable, so equal-mz ordering (and downstream first-contribution / merge semantics) is unchanged.

**A → A2-lean — stop paying for the per-peak `description` String, without losing information**
The annotated generators used to `format!("{kind}_{ordinal}_{isotope}")` + allocate a `String` for every fragment peak in the whole simulation — this dominated construction time and RAM. Initially I dropped it (`description = None`), but codex-review flagged (P2) that this also dropped the b/y **fragment identity**, making the peak-level ground truth incomplete. Fixed properly by storing the identity *structurally*:

- `SignalAttributes`: `description: Option<String>` → `fragment_kind: Option<FragmentType>` + `fragment_ordinal: Option<i32>` (small `Copy` fields, no heap alloc).
- `description()` is now derived on demand and reproduces the old `"{kind}_{ordinal}_{isotope}"` string exactly.
- PyO3 / Python: expose `fragment_kind` + `fragment_ordinal` getters, keep a derived `description` getter; the `PySignalAttributes` constructor now takes `(kind, ordinal)` instead of a string.

### Net effect vs the original

| | per-peak heap alloc | per-peak `format!` | annotation size | b/y identity |
|---|---|---|---|---|
| original | 1 (String) | yes | `Option<String>` 24 B + heap | ✓ (string) |
| this PR | **0** | **no** | a few bytes inline | ✓ **structured + queryable** |

Strictly better on every axis, and the fragment ground truth is now typed/queryable instead of a string to parse.

## Tests / validation
- `mscore`: new unit tests assert (A2) the spectrum + integer labels are preserved, `fragment_kind`/`fragment_ordinal` populate for fragment peaks (None for precursor peaks), and `description()` reproduces the old format; (D) `new()` sorts by mz keeping each annotation attached to its peak, stably for equal mz. Full suite: **53 + new** green.
- `rustdf` + `imspy_connector` build/type-check clean.
- Python end-to-end on the 125K HeLa blueprint: annotated frame builds, dense label windows work, new getters return correctly.

## Behavior change
`SignalAttributes.description` is now derived (same value) rather than a stored field; the `PySignalAttributes`/Python `SignalAttributes` constructor takes `fragment_kind` + `fragment_ordinal` instead of `description`.

## Not in this PR
- Formal before/after perf numbers (load time + peak RSS) — to be measured next.
- The heavier follow-ups from the plan: **B** (`SmallVec` for the contribution vector) and **C** (lazy/per-batch annotation to lift the RAM ceiling).