### PR TITLE
tims-viewer: browser point-cloud viewer for timsTOF (server, focus-lens, volume, clustering, DIA windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ imspy/docs/build
 packages/imspy-simulation/TIER2_REWINDOW.md
 packages/imspy-simulation/THERMO_RAW_AUTHORING.md
 
+
+# transient codex review reference (originals)
+.codex-ref/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
     "rustms",
     "imspy_connector",
     "imsjl_connector",
-    "tims-viewer"
+    "tims-viewer",
+    "tims-viewer/web"
 ]
 
 resolver = "2"

--- a/packages/imspy-core/src/imspy_core/timstof/data.py
+++ b/packages/imspy-core/src/imspy_core/timstof/data.py
@@ -120,15 +120,21 @@ class TimsDataset(ABC):
                 warnings.warn("Warning: Only x86_64 architecture is supported by bruker SDK, setting use_bruker_sdk to False.")
                 self.use_bruker_sdk = False
 
-        # Try to find SDK path (needed for calibration even when use_bruker_sdk=False)
+        # Try to find SDK path (needed for calibration even when use_bruker_sdk=False).
+        # NOTE: open-tims-bruker-bridge ships the vendor binaries for *all* platforms, so
+        # Path(so_path).exists() is True even for the Windows timsdata.dll on macOS. Loading
+        # a foreign-platform binary makes the Rust dlopen panic ("slice is not valid mach-o
+        # file"). There is no usable Bruker SDK on macOS / non-amd64, so stay on NO_SDK there
+        # (the reader degrades to the boundary m/z model, matching the native viewer).
         sdk_path = "NO_SDK"
-        try:
-            for so_path in obb.get_so_paths():
-                if Path(so_path).exists():
-                    sdk_path = so_path
-                    break
-        except Exception:
-            pass
+        if current_os != "Darwin" and is_amd64():
+            try:
+                for so_path in obb.get_so_paths():
+                    if Path(so_path).exists():
+                        sdk_path = so_path
+                        break
+            except Exception:
+                pass
 
         if not self.use_bruker_sdk:
             # Pass SDK path for calibration derivation, but use_bruker_sdk=False for fast parallel access

--- a/packages/imspy-vis/MIDIA_VIS_PORT_PLAN.md
+++ b/packages/imspy-vis/MIDIA_VIS_PORT_PLAN.md
@@ -28,7 +28,7 @@ Improvements over the original to KEEP:
 
 | Original (7 tabs) | Port (5 tabs) | Status |
 |---|---|---|
-| Data (`MIDIADataLoader`) | Data (`DataPanel`) | merged load+filter; RT FloatText not sliders |
+| Data (`MIDIADataLoader`) | Data (`DataPanel`) | merged load+filter; RT range slider + TIC slice selector |
 | MS-I filter (`MidiaPrecursorScanFilter`) | (folded into Data) | separate-filter tab dropped |
 | MS-I points (`MidiaPrecursorPointCloudVis`) | Precursor cloud (`PointCloudPanel`) | faithful |
 | MS-I HDBSCAN (`HDBSCANVisualizer`) | Precursor HDBSCAN (`PrecursorHDBSCANPanel`) | controls trimmed |
@@ -108,10 +108,34 @@ Decision (David): **rebuild the full filter tab.** Implemented as `MidiaFilterPa
   `..`, unreadable-dir rollback, suppression `finally`). Symlink-following kept (data mounts).
 - Optionally split Data-load from an MS-I scan filter tab (re-filter without reload); the
   slice is already cached so this is mostly UX.
-- RT as scrubbable sliders (0–46 min) instead of FloatText.
+- ~~RT as scrubbable sliders (0–46 min) instead of FloatText.~~ *(DONE — see item 6)*
 - ~~Align defaults: original precursor HDBSCAN `min_samples=1`~~ *(DONE — precursor
   min_cluster_size=13/min_samples=1; MIDIA min_cluster_size=7/min_samples=7/metric=manhattan,
   all matching the originals)*.
+
+### 6. Raw-data-view recovery from proteolizard-vis (timsVIS)  *(DONE)*
+A raw-data-view audit against `proteolizard-vis` (the `DDADataLoader`/`TimsVisualizer` side, not
+just `proteolizard-midia`) found two viewing capabilities the MIDIA tool either never had or the
+port had dropped. Both are now in `DataPanel`/`MidiaVis`:
+- **TIC slice selector** *(restored from `DDADataLoader`)* — `DataPanel` now opens the run on a
+  `.d` pick (a cheap `Frames`-table read) and draws the whole-run TIC from
+  `MidiaExperiment.precursor_tic()` (MS1 `SummedIntensities` vs minutes — zero raw I/O). RT is a
+  `FloatRangeSlider`; a green `add_vrect` span tracks it live so you see which part of the
+  chromatogram you're slicing. Improvements over the original: x-axis in real minutes (no
+  frame-index binning hack) and `continuous_update=False` (no `%3` throttle).
+  NB: this was a `DDADataLoader` feature; `MIDIADataLoader` never had it — so this is a net add.
+- **Intensity surface** *(rebuilt from `surface.py::TimsSurfaceVisualizer`)* — new `SurfacePanel`
+  + "Precursor surface" tab: fold (sum) one of RT/scan/m-z and show the other two as a 2D
+  intensity heatmap, with `exclude_dim` / `identity·sqrt·log` normalization / coarse→fine
+  `resolution`. Rebuilt on `numpy.histogram2d` + `go.Heatmap` — drops the original's TensorFlow
+  dependency and heavy 3D `go.Surface`. MS1-only (the original had no MIDIA surface).
+
+Audit also confirmed the port already matches the rest of the timsVIS raw-data view: point clouds
+(opacity/size/all-colorscales/dynamic m-z ticks, plus a `max_points` cap the original lacked),
+fragment exclude-dim/color-by/quad-scaling, the rich MIDIA filter, and the histogram side-panel.
+Not pursued (low value / never existed in the original): point hover/click-to-inspect, box
+selection, and adding sqrt/identity color-normalization to the point clouds (the surface covers
+the normalization need).
 
 ## Acceptance
 - [x] Save-settings writes a CSV with Name + all filter/cluster params for both panels.
@@ -120,3 +144,5 @@ Decision (David): **rebuild the full filter tab.** Implemented as `MidiaFilterPa
       cluster_selection_method/epsilon, broad metric list).
 - [x] MIDIA filter tab decision recorded (rebuilt for full fidelity).
 - [x] Improvements retained: metadata-derived windows, window-less-fragment drop, max_points.
+- [x] TIC slice selector restored: whole-run TIC + live green RT span on the Data tab.
+- [x] Intensity surface restored: fold-one-axis heatmap with normalization + resolution (no TF).

--- a/packages/imspy-vis/MIDIA_VIS_PORT_PLAN.md
+++ b/packages/imspy-vis/MIDIA_VIS_PORT_PLAN.md
@@ -1,0 +1,122 @@
+# MIDIA Voila visualizer — faithful-port plan
+
+Goal: bring the `imspy_vis.midia` Voila dashboard as close as possible to the original
+`proteolizard-midia` tool, while keeping the improvements the rebuild already gained.
+
+- **Original** (private repos): `theGreatHerrLebert/proteolizard-midia`
+  (`python/proteolizardmidia/vis/*`, clustering, data) + `theGreatHerrLebert/proteolizard-vis`
+  (`proteolizardvis/{cluster,point,filter,data,utility}.py`, the base UI classes).
+  Entry point: `MidiaVis()` in `vis/midia_vis.py`, used from `notebook/MidiaVis.ipynb`.
+- **Port**: `packages/imspy-vis/src/imspy_vis/midia/{data,clustering,transforms,widgets}.py`.
+
+## Where the port already matches (do not regress)
+
+The data layer, clustering math, and the two HDBSCAN panels are faithful:
+- `peak_width_preserving_mz_transform`, cycle/scan `/2**scaling`, MIDIA `mc` recovery.
+- `cluster_midia_hdbscan` 4D `(rt, mc, dt, mz)` / 3D fallback; precursor HDBSCAN.
+- Summary table + 4 nunique histograms (cycle/scan/mz/size); probability-sized colored scatter.
+
+Improvements over the original to KEEP:
+- Extraction windows derived from the run's own `dia_ms_ms_windows` — no external
+  `extraction_windows.h5`.
+- Window-less fragments dropped (`valid = isfinite(mc)`) instead of folded to 0
+  (the noise-sampler bug; see `docs/midia-noise-sampler-bug.md`).
+- `max_points` downsample cap; Voila-robust redraw (go.Figure into an Output, not a 3D
+  FigureWidget).
+
+## Tab parity
+
+| Original (7 tabs) | Port (5 tabs) | Status |
+|---|---|---|
+| Data (`MIDIADataLoader`) | Data (`DataPanel`) | merged load+filter; RT FloatText not sliders |
+| MS-I filter (`MidiaPrecursorScanFilter`) | (folded into Data) | separate-filter tab dropped |
+| MS-I points (`MidiaPrecursorPointCloudVis`) | Precursor cloud (`PointCloudPanel`) | faithful |
+| MS-I HDBSCAN (`HDBSCANVisualizer`) | Precursor HDBSCAN (`PrecursorHDBSCANPanel`) | controls trimmed |
+| MIDIA filter (`MidiaFragmentFilter`) | — | **missing** |
+| MIDIA points (`MidiaFragmentPointCloudVis`) | Fragment cloud (`PointCloudPanel`) | **degraded** (no dim selector) |
+| MIDIA HDBSCAN (`MIDIAHDBSCANVisualizer`) | MIDIA HDBSCAN (`MidiaHDBSCANPanel`) | controls trimmed |
+
+## Gaps to close (ordered)
+
+### 1. Restore "Save settings" + Name field  *(DONE)*
+Original: both cluster panels have a `person` Text field and a **Save settings** button that
+writes a timestamped CSV of every filter + HDBSCAN parameter
+(`PRECURSOR-HDBSCAN-<time>.csv` / `MIDIA-HDBSCAN-<time>.csv`; see
+`proteolizardvis/cluster.py::HDBSCANVisualizer.on_save_clicked` and
+`vis/midia_clustervis.py::on_save_clicked`).
+- Add a `Name` text + `Save settings` button to `_ClusterPanel`.
+- Collect filter settings (from `DataPanel`) + cluster settings into a one-row DataFrame,
+  `to_csv(f"{LEVEL}-HDBSCAN-{timestamp}.csv")`.
+- Each panel supplies its own param dict (`get_save_settings()`); MIDIA adds the extra knobs.
+
+### 2. Rebuild the MIDIA fragment point-cloud view  *(DONE)*
+Original `MidiaFragmentPointCloudVis` exposes:
+- `exclude dim` dropdown: cycle / extraction window / scan / m-z — drop one, plot the other 3.
+- `color by` dropdown: cycle / extraction window / scan / m-z / log-intensity.
+- `quad scaling` (extraction_scaling) and renders the **extraction-window (mc) axis**.
+
+Port's fragment tab currently plots only cycle/scan/mz colored by log-intensity and ignores
+`step`/extraction-window. Plan:
+- Give the fragment `PointCloudPanel` (or a new `FragmentPointCloudPanel`) the `exclude dim`
+  / `color by` / `quad scaling` controls.
+- Compute `mc` per point via `MidiaExperiment.isolation_left_bound(step, scan)` (already
+  exists in `data.py`), scaled by `quad scaling`; use it as the chosen axis/color.
+- Keep the `max_points` cap and Voila-robust redraw.
+
+### 3. Re-expose the dropped HDBSCAN controls  *(DONE)*
+Add the controls the original had but the port hardcodes:
+- Shared: `algorithm` (best/eom/leaf — note: precursor uses `best`, MIDIA uses eom/leaf as
+  `cluster_selection_method`), `alpha`, `leaf_size`, `approx_min_span_tree`,
+  `gen_min_span_tree`, `use_probability` toggle, `mz_scaling`.
+- MIDIA-only: `cluster_selection_method` and `cluster_selection_epsilon` (currently hardcoded
+  eom / 1.0 inside `cluster_midia_hdbscan`).
+- Widen `metric` to the full hdbscan metric set (original used
+  `hdbscan.dist_metrics.METRIC_MAPPING.keys()`).
+- Honor `use_probability` in point sizing: original
+  `size = 2 if noise else bps*p*use_prob + bps*(1-use_prob)` with `bps=3.5`; port currently
+  always does `2 + 3*p`.
+- Wire `algorithm/alpha/leaf_size/approx/gen/mz_scaling` through the clustering functions
+  (signatures already accept most of them).
+
+### 4. MIDIA filter tab  *(DONE — rebuilt, decision: full fidelity)*
+Decision (David): **rebuild the full filter tab.** Implemented as `MidiaFilterPanel` +
+`MidiaExperiment.fragment_scan_ranges()` (ports `get_scan_ranges`) +
+`filter_fragments_by_scan_ranges()`:
+- Controls: `query start`, `query length`, `quad width` (`target_length`), `% overlap`,
+  `scan min/max`, Filter + Reset.
+- For a precursor query it selects, per quadrupole step, the scan range whose isolation window
+  overlaps the query (same `allowed_diff` overlap criterion as the original).
+- Acts as the **fragment source** for the MIDIA cloud + HDBSCAN tabs (proxies
+  `experiment`/`fragment_df`/`filter_settings`), so they consume the filtered set transparently;
+  passes everything through until Filter is pressed (Reset restores).
+- `filter_settings()` now adds `query_start/length`, `quad_width`, `percent_overlap`,
+  `midia_scan_min/max` to the saved CSV when a filter is active (also closes item-1 codex
+  finding #4). Dashboard is now 6 tabs in the original order.
+- Deviation: overlap math uses the run's real window left bounds with the `quad_width` slider as
+  the window width (the original only had the `.h5` left bounds + the same slider). The original's
+  `last_used=450` scan crop is intentionally dropped (a fixed-grid `.h5` artifact; our windows are
+  the real used ranges, and `scan min/max` covers scan limiting).
+- Codex round (originals staged in-repo for the diff): overlap math + proxy wiring confirmed
+  correct. Fixed: stale `_filtered` after a slice reload (source-identity invalidation) and
+  `filter_settings()` now snapshots the params that produced the filter (no save/data desync).
+
+### 5. Smaller structural / default fixes  *(low priority)*
+- *(DONE)* **Run browser** on the Data tab — a dependency-free directory navigator
+  (`DataPanel._refresh_browser`/`_on_browse_select`): click folders to navigate, click a `.d`
+  to select it (sets the path field; load still on "Load slice"). `.d` runs are dirs so it
+  picks them as leaves rather than descending in. Codex-reviewed (re-select-same-`.d`, root
+  `..`, unreadable-dir rollback, suppression `finally`). Symlink-following kept (data mounts).
+- Optionally split Data-load from an MS-I scan filter tab (re-filter without reload); the
+  slice is already cached so this is mostly UX.
+- RT as scrubbable sliders (0–46 min) instead of FloatText.
+- ~~Align defaults: original precursor HDBSCAN `min_samples=1`~~ *(DONE — precursor
+  min_cluster_size=13/min_samples=1; MIDIA min_cluster_size=7/min_samples=7/metric=manhattan,
+  all matching the originals)*.
+
+## Acceptance
+- [x] Save-settings writes a CSV with Name + all filter/cluster params for both panels.
+- [x] Fragment cloud has exclude-dim / color-by / quad-scaling and shows the mc axis.
+- [x] All original HDBSCAN knobs are on the UI and wired through (incl. use_probability,
+      cluster_selection_method/epsilon, broad metric list).
+- [x] MIDIA filter tab decision recorded (rebuilt for full fidelity).
+- [x] Improvements retained: metadata-derived windows, window-less-fragment drop, max_points.

--- a/packages/imspy-vis/notebooks/midia_vis.ipynb
+++ b/packages/imspy-vis/notebooks/midia_vis.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MIDIA / DIA-PASEF interactive clustering\n",
+    "\n",
+    "Load a retention-time slice of a timsTOF run, then tune HDBSCAN parameters live to cluster the precursor (MS1, 3D) or MIDIA fragment (4D) point clouds. Backed by `imspy-core`; served with Voila.\n",
+    "\n",
+    "Set `RUN_PATH` below to a `.d` folder, then use the **Data** tab to load a slice and the cluster tabs to explore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "import os\n",
+    "from imspy_vis.midia import MidiaVis\n",
+    "\n",
+    "RUN_PATH = os.environ.get(\n",
+    "    'MIDIA_RUN_PATH',\n",
+    "    '/Users/davidteschner/Promotion/TIMSIM-HeLa25K-G15-001-NN.d',\n",
+    ")\n",
+    "\n",
+    "app = MidiaVis(default_path=RUN_PATH)\n",
+    "app.display()"
+   ],
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/packages/imspy-vis/notebooks/midia_vis.ipynb
+++ b/packages/imspy-vis/notebooks/midia_vis.ipynb
@@ -15,21 +15,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "source": [
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
-    "\n",
-    "import os\n",
-    "from imspy_vis.midia import MidiaVis\n",
-    "\n",
-    "RUN_PATH = os.environ.get(\n",
-    "    'MIDIA_RUN_PATH',\n",
-    "    '/Users/davidteschner/Promotion/TIMSIM-HeLa25K-G15-001-NN.d',\n",
-    ")\n",
-    "\n",
-    "app = MidiaVis(default_path=RUN_PATH)\n",
-    "app.display()"
-   ],
+   "source": "import warnings\nwarnings.filterwarnings('ignore')\n\nimport os\nfrom imspy_vis.midia import MidiaVis\n\nRUN_PATH = os.environ.get(\n    'MIDIA_RUN_PATH',\n    '/Users/davidteschner/Promotion/midia/timsim/DIA-250K-NOISY-CHRONO/DIA-250K-NOISY-CHRONO.d',\n)\n# Folder the run browser opens in (a directory of runs); override with MIDIA_BROWSE_DIR.\nBROWSE_DIR = os.environ.get('MIDIA_BROWSE_DIR', '/Users/davidteschner/Promotion/midia/timsim/')\n\napp = MidiaVis(default_path=RUN_PATH, browse_dir=BROWSE_DIR)\napp.display()",
    "outputs": []
   }
  ],

--- a/packages/imspy-vis/src/imspy_vis/midia/__init__.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/__init__.py
@@ -1,0 +1,30 @@
+"""MIDIA / DIA-PASEF interactive clustering visualization on the imspy-core backend.
+
+A modern reconstruction of the proteolizard-midia Voila tool: load a retention-time slice of
+a run, then tune HDBSCAN parameters live to cluster precursor (3D) or MIDIA fragment (4D)
+point clouds. No C++/opentims or proteolizard dependencies — everything is derived from the
+run's own metadata via :class:`imspy_core.timstof.dia.TimsDatasetDIA`.
+"""
+
+from .data import MidiaExperiment, MidiaSlice
+from .clustering import (
+    cluster_precursors_dbscan,
+    cluster_precursors_hdbscan,
+    cluster_midia_hdbscan,
+    calculate_statistics,
+)
+from .transforms import peak_width_preserving_mz_transform, calculate_mz_tick_spacing
+from .widgets import (
+    MidiaVis,
+    DataPanel,
+    PrecursorHDBSCANPanel,
+    MidiaHDBSCANPanel,
+)
+
+__all__ = [
+    "MidiaExperiment", "MidiaSlice",
+    "cluster_precursors_dbscan", "cluster_precursors_hdbscan", "cluster_midia_hdbscan",
+    "calculate_statistics",
+    "peak_width_preserving_mz_transform", "calculate_mz_tick_spacing",
+    "MidiaVis", "DataPanel", "PrecursorHDBSCANPanel", "MidiaHDBSCANPanel",
+]

--- a/packages/imspy-vis/src/imspy_vis/midia/clustering.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/clustering.py
@@ -1,0 +1,160 @@
+"""Density clustering of precursor (3D) and MIDIA fragment (4D) point clouds.
+
+Ported from ``proteolizardalgo.clustering`` / ``proteolizardmidia.clustering`` onto the
+imspy-core data layer. Each function takes a plain coordinate DataFrame (as produced by
+:mod:`imspy_vis.midia.data`) and returns the same points with ``label`` (and, for HDBSCAN,
+``probability``) columns appended.
+
+The axes are scaled before clustering so a density clusterer sees comparable distances in
+retention time, ion mobility and m/z: cycle/scan are divided by ``2**scaling`` and m/z is
+mapped through :func:`peak_width_preserving_mz_transform`. The MIDIA variant adds a fourth
+axis, the precursor isolation m/z recovered from the quadrupole step via the extraction
+window (the "MIDIA dimension").
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from sklearn.cluster import DBSCAN
+from hdbscan import HDBSCAN
+
+from .transforms import peak_width_preserving_mz_transform
+
+
+def cluster_precursors_dbscan(points: pd.DataFrame,
+                              epsilon: float = 1.7,
+                              min_samples: int = 7,
+                              metric: str = "euclidean",
+                              cycle_scaling: float = -0.4,
+                              scan_scaling: float = 0.4,
+                              resolution: int = 50_000) -> pd.DataFrame:
+    """DBSCAN over precursor points (``cycle, scan, mz, intensity``)."""
+    rt = points.cycle.to_numpy() / np.power(2, cycle_scaling)
+    dt = points.scan.to_numpy() / np.power(2, scan_scaling)
+    mz = peak_width_preserving_mz_transform(points.mz.to_numpy(), resolution=resolution)
+
+    labels = DBSCAN(eps=epsilon, min_samples=min_samples, n_jobs=-1,
+                    metric=metric).fit(np.vstack([rt, dt, mz]).T).labels_
+
+    out = points[["cycle", "scan", "mz", "intensity"]].copy()
+    out["label"] = labels
+    return out
+
+
+def cluster_precursors_hdbscan(points: pd.DataFrame,
+                               algorithm: str = "best",
+                               alpha: float = 1.0,
+                               approx_min_span_tree: bool = True,
+                               gen_min_span_tree: bool = True,
+                               leaf_size: int = 40,
+                               min_cluster_size: int = 7,
+                               min_samples: int = 7,
+                               p=None,
+                               metric: str = "euclidean",
+                               cycle_scaling: float = -0.4,
+                               scan_scaling: float = 0.4,
+                               resolution: int = 50_000,
+                               mz_scaling: float = 0.0) -> pd.DataFrame:
+    """HDBSCAN over precursor points (``cycle, scan, mz, intensity``)."""
+    rt = points.cycle.to_numpy() / np.power(2, cycle_scaling)
+    dt = points.scan.to_numpy() / np.power(2, scan_scaling)
+    mz = peak_width_preserving_mz_transform(points.mz.to_numpy(), resolution=resolution) / np.power(2, mz_scaling)
+
+    clusters = HDBSCAN(algorithm=algorithm, alpha=alpha,
+                       approx_min_span_tree=approx_min_span_tree,
+                       gen_min_span_tree=gen_min_span_tree,
+                       leaf_size=leaf_size, metric=metric,
+                       min_cluster_size=min_cluster_size,
+                       min_samples=min_samples, p=p).fit(np.vstack([rt, dt, mz]).T)
+
+    out = points[["cycle", "scan", "mz", "intensity"]].copy()
+    out["label"] = clusters.labels_
+    out["probability"] = clusters.probabilities_
+    return out
+
+
+def cluster_midia_hdbscan(points: pd.DataFrame,
+                          experiment,
+                          algorithm: str = "best",
+                          cluster_selection_method: str = "eom",
+                          cluster_selection_epsilon: float = 1.0,
+                          alpha: float = 1.0,
+                          approx_min_span_tree: bool = True,
+                          gen_min_span_tree: bool = True,
+                          leaf_size: int = 40,
+                          min_cluster_size: int = 7,
+                          min_samples: int = 2,
+                          p=None,
+                          metric: str = "manhattan",
+                          cycle_scaling: float = 0.2,
+                          scan_scaling: float = 0.6,
+                          resolution: int = 46_900,
+                          mz_scaling: float = 0.0,
+                          extraction_scaling: float = 36.0,
+                          use_midia_dimension: bool = True) -> pd.DataFrame:
+    """HDBSCAN over MIDIA fragment points (``cycle, step, scan, mz, intensity``).
+
+    The "MIDIA dimension" ``mc`` is the precursor isolation m/z recovered from each point's
+    quadrupole ``step`` and ``scan`` via the run's extraction windows, scaled by
+    ``extraction_scaling``. With ``use_midia_dimension`` the clustering is 4D
+    ``(rt, mc, dt, mz)``; otherwise it falls back to 3D ``(rt, dt, mz)``.
+    """
+    cycle = points.cycle.to_numpy()
+    step = points.step.to_numpy()
+    scan = points.scan.to_numpy()
+    mz_raw = points.mz.to_numpy()
+    intensity = points.intensity.to_numpy()
+
+    rt = cycle / np.power(2, cycle_scaling)
+    mc = _midia_dimension(experiment, step, scan) / extraction_scaling
+    dt = scan / np.power(2, scan_scaling)
+    mz = peak_width_preserving_mz_transform(mz_raw, resolution=resolution) / np.power(2, mz_scaling)
+
+    clusters = HDBSCAN(algorithm=algorithm, alpha=alpha,
+                       cluster_selection_method=cluster_selection_method,
+                       cluster_selection_epsilon=cluster_selection_epsilon,
+                       approx_min_span_tree=approx_min_span_tree,
+                       gen_min_span_tree=gen_min_span_tree,
+                       leaf_size=leaf_size, metric=metric,
+                       min_cluster_size=min_cluster_size,
+                       min_samples=min_samples, p=p)
+
+    feats = np.vstack([rt, mc, dt, mz]).T if use_midia_dimension else np.vstack([rt, dt, mz]).T
+    clusters.fit(feats)
+
+    return pd.DataFrame({
+        "cycle": cycle, "step": step, "mc_dim": mc, "scan": scan,
+        "mz": mz_raw, "intensity": intensity,
+        "label": clusters.labels_, "probability": clusters.probabilities_,
+    })
+
+
+def _midia_dimension(experiment, step: np.ndarray, scan: np.ndarray) -> np.ndarray:
+    """Per-point precursor isolation m/z from (step, scan); 0 where no window applies."""
+    mc = np.zeros(step.shape, dtype=np.float64)
+    for s in np.unique(step):
+        m = step == s
+        mc[m] = experiment.isolation_left_bound(int(s), scan[m])
+    return np.nan_to_num(mc, nan=0.0)
+
+
+def calculate_statistics(clusters: pd.DataFrame, noise: pd.DataFrame):
+    """Summary table (points/intensity/clusters x total/cluster/noise/ratio) + per-label group."""
+    sum_int_clusters = clusters.groupby(["label"])["intensity"].sum().sum()
+    sum_int_noise = noise.groupby(["label"])["intensity"].sum().sum()
+    intensity_ratio = np.round(sum_int_clusters / sum_int_noise, 3) if sum_int_noise else np.inf
+
+    n_clusters_pts = clusters.shape[0]
+    n_noise_pts = noise.shape[0]
+    points_ratio = np.round(n_clusters_pts / n_noise_pts, 3) if n_noise_pts else np.inf
+    num_clusters = int(clusters.label.max()) if n_clusters_pts else 0
+
+    summary_table = pd.DataFrame(
+        {"Total": [n_clusters_pts + n_noise_pts, sum_int_clusters + sum_int_noise, num_clusters],
+         "Cluster": [n_clusters_pts, sum_int_clusters, num_clusters],
+         "Noise": [n_noise_pts, sum_int_noise, 0],
+         "Ratio": [points_ratio, intensity_ratio, 0]},
+        index=["Points", "Intensity", "Clusters"])
+    return summary_table, clusters.groupby("label")

--- a/packages/imspy-vis/src/imspy_vis/midia/clustering.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/clustering.py
@@ -157,11 +157,7 @@ def cluster_midia_hdbscan(points: pd.DataFrame,
 
 def _midia_dimension(experiment: "MidiaExperiment", step: np.ndarray, scan: np.ndarray) -> np.ndarray:
     """Per-point precursor isolation m/z from (step, scan); NaN where no window applies."""
-    mc = np.full(step.shape, np.nan, dtype=np.float64)
-    for s in np.unique(step):
-        m = step == s
-        mc[m] = experiment.isolation_left_bound(int(s), scan[m])
-    return mc
+    return experiment.midia_dimension(step, scan)
 
 
 def calculate_statistics(

--- a/packages/imspy-vis/src/imspy_vis/midia/clustering.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/clustering.py
@@ -125,6 +125,12 @@ def cluster_midia_hdbscan(points: pd.DataFrame,
     else:
         mc = np.nan_to_num(mc, nan=0.0)  # unused in 3D mode; keep the returned column finite
 
+    if len(cycle) == 0:
+        # No fragments survived the window filter; HDBSCAN.fit would raise on 0 samples.
+        return pd.DataFrame(
+            columns=["cycle", "step", "mc_dim", "scan", "mz", "intensity", "label", "probability"]
+        )
+
     rt = cycle / np.power(2, cycle_scaling)
     mc_scaled = mc / extraction_scaling
     dt = scan / np.power(2, scan_scaling)

--- a/packages/imspy-vis/src/imspy_vis/midia/clustering.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/clustering.py
@@ -14,6 +14,8 @@ window (the "MIDIA dimension").
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 
@@ -21,6 +23,10 @@ from sklearn.cluster import DBSCAN
 from hdbscan import HDBSCAN
 
 from .transforms import peak_width_preserving_mz_transform
+
+if TYPE_CHECKING:
+    from pandas.core.groupby import DataFrameGroupBy
+    from .data import MidiaExperiment
 
 
 def cluster_precursors_dbscan(points: pd.DataFrame,
@@ -106,9 +112,21 @@ def cluster_midia_hdbscan(points: pd.DataFrame,
     scan = points.scan.to_numpy()
     mz_raw = points.mz.to_numpy()
     intensity = points.intensity.to_numpy()
+    mc = _midia_dimension(experiment, step, scan)  # NaN where (step, scan) hits no window
+
+    if use_midia_dimension:
+        # Keep only fragments that fall inside an isolation window. Window-less points have
+        # no meaningful MIDIA coordinate; folding them in (as 0) collapses them onto a fake
+        # plane and lets HDBSCAN form a spurious cluster.
+        valid = np.isfinite(mc)
+        cycle, step, scan, mz_raw, intensity, mc = (
+            arr[valid] for arr in (cycle, step, scan, mz_raw, intensity, mc)
+        )
+    else:
+        mc = np.nan_to_num(mc, nan=0.0)  # unused in 3D mode; keep the returned column finite
 
     rt = cycle / np.power(2, cycle_scaling)
-    mc = _midia_dimension(experiment, step, scan) / extraction_scaling
+    mc_scaled = mc / extraction_scaling
     dt = scan / np.power(2, scan_scaling)
     mz = peak_width_preserving_mz_transform(mz_raw, resolution=resolution) / np.power(2, mz_scaling)
 
@@ -121,26 +139,28 @@ def cluster_midia_hdbscan(points: pd.DataFrame,
                        min_cluster_size=min_cluster_size,
                        min_samples=min_samples, p=p)
 
-    feats = np.vstack([rt, mc, dt, mz]).T if use_midia_dimension else np.vstack([rt, dt, mz]).T
+    feats = np.vstack([rt, mc_scaled, dt, mz]).T if use_midia_dimension else np.vstack([rt, dt, mz]).T
     clusters.fit(feats)
 
     return pd.DataFrame({
-        "cycle": cycle, "step": step, "mc_dim": mc, "scan": scan,
+        "cycle": cycle, "step": step, "mc_dim": mc_scaled, "scan": scan,
         "mz": mz_raw, "intensity": intensity,
         "label": clusters.labels_, "probability": clusters.probabilities_,
     })
 
 
-def _midia_dimension(experiment, step: np.ndarray, scan: np.ndarray) -> np.ndarray:
-    """Per-point precursor isolation m/z from (step, scan); 0 where no window applies."""
-    mc = np.zeros(step.shape, dtype=np.float64)
+def _midia_dimension(experiment: "MidiaExperiment", step: np.ndarray, scan: np.ndarray) -> np.ndarray:
+    """Per-point precursor isolation m/z from (step, scan); NaN where no window applies."""
+    mc = np.full(step.shape, np.nan, dtype=np.float64)
     for s in np.unique(step):
         m = step == s
         mc[m] = experiment.isolation_left_bound(int(s), scan[m])
-    return np.nan_to_num(mc, nan=0.0)
+    return mc
 
 
-def calculate_statistics(clusters: pd.DataFrame, noise: pd.DataFrame):
+def calculate_statistics(
+    clusters: pd.DataFrame, noise: pd.DataFrame
+) -> tuple[pd.DataFrame, DataFrameGroupBy]:
     """Summary table (points/intensity/clusters x total/cluster/noise/ratio) + per-label group."""
     sum_int_clusters = clusters.groupby(["label"])["intensity"].sum().sum()
     sum_int_noise = noise.groupby(["label"])["intensity"].sum().sum()
@@ -149,7 +169,8 @@ def calculate_statistics(clusters: pd.DataFrame, noise: pd.DataFrame):
     n_clusters_pts = clusters.shape[0]
     n_noise_pts = noise.shape[0]
     points_ratio = np.round(n_clusters_pts / n_noise_pts, 3) if n_noise_pts else np.inf
-    num_clusters = int(clusters.label.max()) if n_clusters_pts else 0
+    # Labels are 0-based and contiguous, so the count is max(label) + 1.
+    num_clusters = int(clusters.label.max()) + 1 if n_clusters_pts else 0
 
     summary_table = pd.DataFrame(
         {"Total": [n_clusters_pts + n_noise_pts, sum_int_clusters + sum_int_noise, num_clusters],

--- a/packages/imspy-vis/src/imspy_vis/midia/clustering.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/clustering.py
@@ -48,7 +48,7 @@ def cluster_precursors_dbscan(points: pd.DataFrame,
     mz = peak_width_preserving_mz_transform(points.mz.to_numpy(), resolution=resolution)
 
     labels = DBSCAN(eps=epsilon, min_samples=min_samples, n_jobs=-1,
-                    metric=metric).fit(np.vstack([rt, dt, mz]).T).labels_
+                    metric=metric).fit(np.stack([rt, dt, mz], axis=1)).labels_
     out["label"] = labels
     return out
 
@@ -83,10 +83,9 @@ def cluster_precursors_hdbscan(points: pd.DataFrame,
                        gen_min_span_tree=gen_min_span_tree,
                        leaf_size=leaf_size, metric=metric,
                        min_cluster_size=min_cluster_size,
-                       min_samples=min_samples, p=p).fit(np.vstack([rt, dt, mz]).T)
+                       min_samples=min_samples, p=p).fit(np.stack([rt, dt, mz], axis=1))
 
-    out = points[["cycle", "scan", "mz", "intensity"]].copy()
-    out["label"] = clusters.labels_
+    out["label"] = clusters.labels_  # reuse the `out` copy built at the top (no duplicate copy)
     out["probability"] = clusters.probabilities_
     return out
 
@@ -155,7 +154,7 @@ def cluster_midia_hdbscan(points: pd.DataFrame,
                        min_cluster_size=min_cluster_size,
                        min_samples=min_samples, p=p)
 
-    feats = np.vstack([rt, mc_scaled, dt, mz]).T if use_midia_dimension else np.vstack([rt, dt, mz]).T
+    feats = np.stack([rt, mc_scaled, dt, mz], axis=1) if use_midia_dimension else np.stack([rt, dt, mz], axis=1)
     clusters.fit(feats)
 
     return pd.DataFrame({
@@ -174,8 +173,8 @@ def calculate_statistics(
     clusters: pd.DataFrame, noise: pd.DataFrame
 ) -> tuple[pd.DataFrame, DataFrameGroupBy]:
     """Summary table (points/intensity/clusters x total/cluster/noise/ratio) + per-label group."""
-    sum_int_clusters = clusters.groupby(["label"])["intensity"].sum().sum()
-    sum_int_noise = noise.groupby(["label"])["intensity"].sum().sum()
+    sum_int_clusters = clusters["intensity"].sum()  # per-label sums then summed == the column total
+    sum_int_noise = noise["intensity"].sum()
     intensity_ratio = np.round(sum_int_clusters / sum_int_noise, 3) if sum_int_noise else np.inf
 
     n_clusters_pts = clusters.shape[0]

--- a/packages/imspy-vis/src/imspy_vis/midia/clustering.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/clustering.py
@@ -37,14 +37,18 @@ def cluster_precursors_dbscan(points: pd.DataFrame,
                               scan_scaling: float = 0.4,
                               resolution: int = 50_000) -> pd.DataFrame:
     """DBSCAN over precursor points (``cycle, scan, mz, intensity``)."""
+    out = points[["cycle", "scan", "mz", "intensity"]].copy()
+    if len(out) < 2:
+        # .fit raises on 0 samples (and 1 is trivially noise) — return all-noise cleanly instead of
+        # surfacing a raw sklearn ValueError when the RT/mz/scan filter yields (almost) no MS1 points.
+        out["label"] = np.full(len(out), -1, dtype=int)
+        return out
     rt = points.cycle.to_numpy() / np.power(2, cycle_scaling)
     dt = points.scan.to_numpy() / np.power(2, scan_scaling)
     mz = peak_width_preserving_mz_transform(points.mz.to_numpy(), resolution=resolution)
 
     labels = DBSCAN(eps=epsilon, min_samples=min_samples, n_jobs=-1,
                     metric=metric).fit(np.vstack([rt, dt, mz]).T).labels_
-
-    out = points[["cycle", "scan", "mz", "intensity"]].copy()
     out["label"] = labels
     return out
 
@@ -64,6 +68,12 @@ def cluster_precursors_hdbscan(points: pd.DataFrame,
                                resolution: int = 50_000,
                                mz_scaling: float = 0.0) -> pd.DataFrame:
     """HDBSCAN over precursor points (``cycle, scan, mz, intensity``)."""
+    out = points[["cycle", "scan", "mz", "intensity"]].copy()
+    if len(out) < 2:
+        # HDBSCAN.fit raises on 0 samples — return all-noise cleanly (matches the MIDIA path's guard).
+        out["label"] = np.full(len(out), -1, dtype=int)
+        out["probability"] = np.zeros(len(out), dtype=float)
+        return out
     rt = points.cycle.to_numpy() / np.power(2, cycle_scaling)
     dt = points.scan.to_numpy() / np.power(2, scan_scaling)
     mz = peak_width_preserving_mz_transform(points.mz.to_numpy(), resolution=resolution) / np.power(2, mz_scaling)

--- a/packages/imspy-vis/src/imspy_vis/midia/data.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/data.py
@@ -73,6 +73,57 @@ class MidiaExperiment:
         return MidiaSlice(self, frame_ids)
 
     # -- extraction-window lookup -------------------------------------------------------
+    def midia_dimension(self, step: np.ndarray, scan: np.ndarray) -> np.ndarray:
+        """Per-point precursor isolation m/z (window left bound) from ``(step, scan)``.
+
+        This is the "MIDIA dimension": the precursor isolation m/z each fragment point was
+        produced under, recovered from its quadrupole step and scan. ``NaN`` where the
+        ``(step, scan)`` pair falls in no extraction window. Used both by the 4D clustering
+        and the fragment point-cloud view.
+        """
+        step = np.asarray(step)
+        scan = np.asarray(scan)
+        if step.shape != scan.shape:
+            raise ValueError(
+                f"step and scan must have the same shape, got {step.shape} and {scan.shape}")
+        mc = np.full(step.shape, np.nan, dtype=np.float64)
+        for s in np.unique(step):
+            m = step == s
+            mc[m] = self.isolation_left_bound(int(s), scan[m])
+        return mc
+
+    def fragment_scan_ranges(self, query_start: float, query_length: float = 12.0,
+                             target_length: float = 36.0, perc_overlap: float = 50.0) -> dict:
+        """Per-quadrupole-step fragment scan range overlapping a precursor query.
+
+        Ports ``proteolizardmidia.utility.get_scan_ranges`` onto the metadata-derived windows:
+        a precursor *query* (an m/z window of width ``query_length`` starting at ``query_start``)
+        is tested for overlap against each extraction window (treated as ``target_length`` wide,
+        per the original's "quadrupole width" control). ``perc_overlap`` sets how much the two
+        must overlap to count. Returns ``{WindowGroup: (scan_min, scan_max)}`` — for each step,
+        the scan span of the windows whose isolation m/z overlaps the query.
+
+        Note: the original ``get_scan_ranges`` cropped scans to ``< last_used`` (450) before the
+        overlap test — an artifact of its fixed-size ``.h5`` grid, which padded a tail of unused
+        scans. Our windows come straight from ``dia_ms_ms_windows`` (only real, used scan ranges),
+        so there is no padding to crop; the panel's ``scan min/max`` control covers any deliberate
+        scan limiting. The ``last_used`` crop is therefore intentionally dropped.
+        """
+        q_mid = query_start + 0.5 * query_length
+        l = 0.5 * query_length
+        k = 0.5 * target_length
+        factor = perc_overlap / 100.0
+        # Required centre-distance for the demanded overlap (original's allowed_diff).
+        allowed = (l + k * (1 - 2 * factor)) if l > k else (k + l * (1 - 2 * factor))
+
+        ranges: dict[int, tuple[int, int]] = {}
+        for grp, w in self._win_by_group.items():
+            mids = w["left"] + 0.5 * target_length  # window midpoint (left bound + half width)
+            sel = np.abs(mids - q_mid) <= allowed
+            if np.any(sel):
+                ranges[grp] = (int(w["begin"][sel].min()), int(w["end"][sel].max()))
+        return ranges
+
     def isolation_left_bound(self, step: int, scans: np.ndarray) -> np.ndarray:
         """Vectorized ``(step, scan) -> precursor isolation-window left bound``.
 
@@ -149,3 +200,22 @@ class MidiaSlice:
 
 def _empty_points() -> pd.DataFrame:
     return pd.DataFrame({c: [] for c in ["frame", "scan", "mz", "intensity", "cycle", "step"]})
+
+
+def filter_fragments_by_scan_ranges(fragments: pd.DataFrame, scan_ranges: dict,
+                                    scan_min: int = 0, scan_max: int = 1_000_000) -> pd.DataFrame:
+    """Keep fragment points whose ``(step, scan)`` falls in its step's selected scan range.
+
+    ``scan_ranges`` is ``{WindowGroup: (scan_min, scan_max)}`` as returned by
+    :meth:`MidiaExperiment.fragment_scan_ranges`; ``scan_min``/``scan_max`` apply an additional
+    global clamp (the MIDIA scan-range control).
+    """
+    if fragments.empty:
+        return fragments
+    step = fragments.step.to_numpy()
+    scan = fragments.scan.to_numpy()
+    keep = np.zeros(len(fragments), dtype=bool)
+    for grp, (lo, hi) in scan_ranges.items():
+        keep |= (step == grp) & (scan >= lo) & (scan <= hi)
+    keep &= (scan >= scan_min) & (scan <= scan_max)
+    return fragments[keep].reset_index(drop=True)

--- a/packages/imspy-vis/src/imspy_vis/midia/data.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/data.py
@@ -66,6 +66,19 @@ class MidiaExperiment:
         # first MS1 frame fold into cycle 0 instead of getting a spurious -1.
         cycle_of_id = np.maximum(np.cumsum(is_precursor) - 1, 0)
         self._cycle_of_frame = dict(zip(ids, cycle_of_id))
+        # Dense frame-id -> cycle / step lookup arrays, so MidiaSlice._load can gather cycle/step for
+        # its millions of points with a vectorized C index instead of Series.map(pydict) (per-row
+        # Python dict calls). Frame ids are the contiguous Frames.Id (1..N); index by id directly.
+        # Fall back to the dict .map when the ids are NOT contiguous 1..N (dense arrays would misindex).
+        self.cycle_by_frame = None
+        self.step_by_frame = None
+        if len(ids) and ids.min() == 1 and ids.max() == len(ids):
+            self.cycle_by_frame = np.zeros(len(ids) + 1, dtype=np.int64)
+            self.cycle_by_frame[ids] = cycle_of_id
+            self.step_by_frame = np.zeros(len(ids) + 1, dtype=np.int64)  # 0 for MS1 (absent from info)
+            fr, wg = info.Frame.to_numpy(), info.WindowGroup.to_numpy()
+            in_range = (fr >= 1) & (fr <= len(ids))
+            self.step_by_frame[fr[in_range]] = wg[in_range]
         self.precursor_frame_ids = ids[is_precursor]
         self.rt_of_frame = dict(zip(ids, meta.Time.to_numpy()))
         self.n_cycles = int(cycle_of_id.max()) + 1
@@ -189,9 +202,14 @@ class MidiaSlice:
         # Batched, multi-threaded read of the whole slice in one call.
         df = self.exp.dataset.get_tims_slice(self.frame_ids).df
         df = df[["frame", "scan", "mz", "intensity"]].copy()
-        df["cycle"] = df["frame"].map(self.exp._cycle_of_frame).astype("int64")
         # step = quadrupole window group for fragment frames, 0 for precursor (MS1) frames.
-        df["step"] = df["frame"].map(self.exp.frame_to_step).fillna(0).astype("int64")
+        if self.exp.cycle_by_frame is not None:
+            fr = df["frame"].to_numpy()  # frame ids (1..N), used as a direct index into the dense arrays
+            df["cycle"] = self.exp.cycle_by_frame[fr]  # already int64
+            df["step"] = self.exp.step_by_frame[fr]
+        else:  # non-contiguous ids: fall back to the per-row dict map
+            df["cycle"] = df["frame"].map(self.exp._cycle_of_frame).astype("int64")
+            df["step"] = df["frame"].map(self.exp.frame_to_step).fillna(0).astype("int64")
         self._df = df
         return df
 

--- a/packages/imspy-vis/src/imspy_vis/midia/data.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/data.py
@@ -31,7 +31,14 @@ class MidiaExperiment:
         # Per-frame metadata (Id is contiguous 1..N). Time is retention time in seconds;
         # SummedIntensities is Bruker's pre-computed per-frame total ion count — it drives the
         # TIC straight from this metadata read, with no raw-data scan (the old timsVIS source).
-        meta = self.dataset.get_table("Frames")[["Id", "Time", "MsMsType", "SummedIntensities"]].copy()
+        # SummedIntensities is optional: older / converted schemas may lack it, so probe for it and
+        # degrade the TIC gracefully (flat line) instead of KeyError-ing the whole dashboard.
+        frames = self.dataset.get_table("Frames")
+        cols = ["Id", "Time", "MsMsType"]
+        self.has_tic = "SummedIntensities" in frames.columns
+        if self.has_tic:
+            cols.append("SummedIntensities")
+        meta = frames[cols].copy()
         meta = meta.sort_values("Id").reset_index(drop=True)
         self.meta = meta
 
@@ -85,8 +92,9 @@ class MidiaExperiment:
         ``intensity``. The dashboard normalizes for display.
         """
         p = self.meta[self.meta.MsMsType == 0]
-        return pd.DataFrame({"rt_min": p.Time.to_numpy() / 60.0,
-                             "intensity": p.SummedIntensities.to_numpy(dtype=float)})
+        intensity = (p.SummedIntensities.to_numpy(dtype=float) if self.has_tic
+                     else np.zeros(len(p), dtype=float))  # no SummedIntensities column -> flat TIC
+        return pd.DataFrame({"rt_min": p.Time.to_numpy() / 60.0, "intensity": intensity})
 
     # -- extraction-window lookup -------------------------------------------------------
     def midia_dimension(self, step: np.ndarray, scan: np.ndarray) -> np.ndarray:

--- a/packages/imspy-vis/src/imspy_vis/midia/data.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/data.py
@@ -53,7 +53,9 @@ class MidiaExperiment:
         # the next one; the precursor and all its fragment frames share that cycle index.
         is_precursor = meta.MsMsType.to_numpy() == 0
         ids = meta.Id.to_numpy()
-        cycle_of_id = np.cumsum(is_precursor) - 1  # 0-based, aligned to sorted ids
+        # 0-based, aligned to sorted ids. clamp at 0 so any fragment frames that precede the
+        # first MS1 frame fold into cycle 0 instead of getting a spurious -1.
+        cycle_of_id = np.maximum(np.cumsum(is_precursor) - 1, 0)
         self._cycle_of_frame = dict(zip(ids, cycle_of_id))
         self.precursor_frame_ids = ids[is_precursor]
         self.rt_of_frame = dict(zip(ids, meta.Time.to_numpy()))

--- a/packages/imspy-vis/src/imspy_vis/midia/data.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/data.py
@@ -1,0 +1,149 @@
+"""MIDIA data layer reconstructed on top of imspy-core's DIA reader.
+
+This replaces the old C++/opentims ``proteolizard-midia`` stack (``MidiaExperimentCursor``,
+``MidiaSlice``, ``FragmentCoords4D`` ...). The acquisition is read with
+:class:`imspy_core.timstof.dia.TimsDatasetDIA`; everything MIDIA-specific (cycle grouping,
+the 4D fragment coordinate system, and the extraction-window map) is derived here in pure
+Python/NumPy from the run's own metadata tables — no separate ``extraction_windows.h5``.
+
+A MIDIA cycle is one precursor (MS1) frame followed by ``K`` fragment frames, each fragment
+frame being one quadrupole **step** (its ``WindowGroup``). The 4 fragment dimensions are
+therefore ``(cycle, step, scan, mz)`` carrying ``intensity``; precursors are ``(cycle, scan,
+mz)``. The extraction window maps a ``(step, scan)`` pair back to the precursor isolation m/z
+that produced it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from imspy_core.timstof.dia import TimsDatasetDIA
+
+
+class MidiaExperiment:
+    """A MIDIA/DIA-PASEF run, with cycle structure and extraction windows derived once."""
+
+    def __init__(self, data_path: str, use_bruker_sdk: bool = False):
+        self.data_path = data_path
+        self.dataset = TimsDatasetDIA(data_path, in_memory=False, use_bruker_sdk=use_bruker_sdk)
+
+        # Per-frame metadata (Id is contiguous 1..N). Time is retention time in seconds.
+        meta = self.dataset.get_table("Frames")[["Id", "Time", "MsMsType"]].copy()
+        meta = meta.sort_values("Id").reset_index(drop=True)
+        self.meta = meta
+
+        # Fragment frame -> quadrupole step (its WindowGroup). MS1 frames are absent here.
+        info = self.dataset.dia_ms_ms_info
+        self.frame_to_step = dict(zip(info.Frame.to_numpy(), info.WindowGroup.to_numpy()))
+
+        # Extraction windows: (WindowGroup, scan range) -> isolation m/z. Kept as per-group
+        # sorted arrays for a vectorized scan->isolation lookup (see ``isolation_left_bound``).
+        self.windows = self.dataset.dia_ms_ms_windows
+        self._win_by_group: dict[int, dict[str, np.ndarray]] = {}
+        for grp, g in self.windows.groupby("WindowGroup"):
+            g = g.sort_values("ScanNumBegin")
+            self._win_by_group[int(grp)] = {
+                "begin": g.ScanNumBegin.to_numpy(),
+                "end": g.ScanNumEnd.to_numpy(),
+                "left": (g.IsolationMz - g.IsolationWidth / 2.0).to_numpy(),
+            }
+
+        # Cycle index per frame id. A cycle opens on each precursor (MS1) frame and runs until
+        # the next one; the precursor and all its fragment frames share that cycle index.
+        is_precursor = meta.MsMsType.to_numpy() == 0
+        ids = meta.Id.to_numpy()
+        cycle_of_id = np.cumsum(is_precursor) - 1  # 0-based, aligned to sorted ids
+        self._cycle_of_frame = dict(zip(ids, cycle_of_id))
+        self.precursor_frame_ids = ids[is_precursor]
+        self.rt_of_frame = dict(zip(ids, meta.Time.to_numpy()))
+        self.n_cycles = int(cycle_of_id.max()) + 1
+
+    # -- frame selection ----------------------------------------------------------------
+    def frames_in_rt(self, rt_start_s: float, rt_stop_s: float) -> np.ndarray:
+        """All frame ids whose retention time falls in ``[rt_start_s, rt_stop_s]``."""
+        m = self.meta
+        mask = (m.Time >= rt_start_s) & (m.Time <= rt_stop_s)
+        return m.loc[mask, "Id"].to_numpy().astype(np.int32)
+
+    def get_slice_retention_time(self, rt_start_s: float, rt_stop_s: float) -> "MidiaSlice":
+        frame_ids = self.frames_in_rt(rt_start_s, rt_stop_s)
+        return MidiaSlice(self, frame_ids)
+
+    # -- extraction-window lookup -------------------------------------------------------
+    def isolation_left_bound(self, step: int, scans: np.ndarray) -> np.ndarray:
+        """Vectorized ``(step, scan) -> precursor isolation-window left bound``.
+
+        Returns ``NaN`` for scans that fall outside every window of the step.
+        """
+        win = self._win_by_group.get(int(step))
+        out = np.full(scans.shape, np.nan, dtype=np.float64)
+        if win is None:
+            return out
+        # Windows within a group are disjoint scan ranges; assign each scan the window that
+        # contains it. Few windows per group (<=3 here) so a small loop is clearest and fast.
+        for begin, end, left in zip(win["begin"], win["end"], win["left"]):
+            m = (scans >= begin) & (scans <= end)
+            out[m] = left
+        return out
+
+
+class MidiaSlice:
+    """A retention-time slice of a :class:`MidiaExperiment`, loaded lazily.
+
+    Exposes the two coordinate views the clustering needs:
+    :meth:`precursor_coords3D` -> ``cycle, scan, mz, intensity`` and
+    :meth:`fragment_coords4D` -> ``cycle, step, scan, mz, intensity``.
+    """
+
+    def __init__(self, experiment: MidiaExperiment, frame_ids: np.ndarray):
+        self.exp = experiment
+        self.frame_ids = np.asarray(frame_ids, dtype=np.int32)
+        self._df: pd.DataFrame | None = None
+
+    # -- raw point loading --------------------------------------------------------------
+    def _load(self) -> pd.DataFrame:
+        """Load all points for the slice once and tag each with cycle + step."""
+        if self._df is not None:
+            return self._df
+        if len(self.frame_ids) == 0:
+            self._df = _empty_points()
+            return self._df
+        # Batched, multi-threaded read of the whole slice in one call.
+        df = self.exp.dataset.get_tims_slice(self.frame_ids).df
+        df = df[["frame", "scan", "mz", "intensity"]].copy()
+        df["cycle"] = df["frame"].map(self.exp._cycle_of_frame).astype("int64")
+        # step = quadrupole window group for fragment frames, 0 for precursor (MS1) frames.
+        df["step"] = df["frame"].map(self.exp.frame_to_step).fillna(0).astype("int64")
+        self._df = df
+        return df
+
+    # -- coordinate views ---------------------------------------------------------------
+    def precursor_coords3D(self) -> pd.DataFrame:
+        """MS1 points as ``cycle, scan, mz, intensity`` (step == 0)."""
+        df = self._load()
+        out = df[df["step"] == 0][["cycle", "scan", "mz", "intensity"]].reset_index(drop=True)
+        return out
+
+    def fragment_coords4D(self) -> pd.DataFrame:
+        """Fragment points as ``cycle, step, scan, mz, intensity`` (step >= 1)."""
+        df = self._load()
+        out = df[df["step"] >= 1][["cycle", "step", "scan", "mz", "intensity"]].reset_index(drop=True)
+        return out
+
+    # -- filtering ----------------------------------------------------------------------
+    def filtered(self, mz_min: float = 0.0, mz_max: float = 2000.0,
+                 scan_min: int = 0, scan_max: int = 1_000,
+                 intensity_min: float = 1.0) -> "MidiaSlice":
+        """Return a new slice sharing the loaded points but range-filtered."""
+        df = self._load()
+        m = ((df.mz >= mz_min) & (df.mz <= mz_max) &
+             (df.scan >= scan_min) & (df.scan <= scan_max) &
+             (df.intensity >= intensity_min))
+        out = MidiaSlice(self.exp, self.frame_ids)
+        out._df = df[m].reset_index(drop=True)
+        return out
+
+
+def _empty_points() -> pd.DataFrame:
+    return pd.DataFrame({c: [] for c in ["frame", "scan", "mz", "intensity", "cycle", "step"]})

--- a/packages/imspy-vis/src/imspy_vis/midia/data.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/data.py
@@ -28,8 +28,10 @@ class MidiaExperiment:
         self.data_path = data_path
         self.dataset = TimsDatasetDIA(data_path, in_memory=False, use_bruker_sdk=use_bruker_sdk)
 
-        # Per-frame metadata (Id is contiguous 1..N). Time is retention time in seconds.
-        meta = self.dataset.get_table("Frames")[["Id", "Time", "MsMsType"]].copy()
+        # Per-frame metadata (Id is contiguous 1..N). Time is retention time in seconds;
+        # SummedIntensities is Bruker's pre-computed per-frame total ion count — it drives the
+        # TIC straight from this metadata read, with no raw-data scan (the old timsVIS source).
+        meta = self.dataset.get_table("Frames")[["Id", "Time", "MsMsType", "SummedIntensities"]].copy()
         meta = meta.sort_values("Id").reset_index(drop=True)
         self.meta = meta
 
@@ -60,6 +62,8 @@ class MidiaExperiment:
         self.precursor_frame_ids = ids[is_precursor]
         self.rt_of_frame = dict(zip(ids, meta.Time.to_numpy()))
         self.n_cycles = int(cycle_of_id.max()) + 1
+        # Whole-run length in minutes — used to widen the TIC's RT span slider to the real run.
+        self.rt_max_min = float(meta.Time.max()) / 60.0 if len(meta) else 0.0
 
     # -- frame selection ----------------------------------------------------------------
     def frames_in_rt(self, rt_start_s: float, rt_stop_s: float) -> np.ndarray:
@@ -71,6 +75,18 @@ class MidiaExperiment:
     def get_slice_retention_time(self, rt_start_s: float, rt_stop_s: float) -> "MidiaSlice":
         frame_ids = self.frames_in_rt(rt_start_s, rt_stop_s)
         return MidiaSlice(self, frame_ids)
+
+    def precursor_tic(self) -> pd.DataFrame:
+        """Whole-run total ion chromatogram over the precursor (MS1) frames.
+
+        Bruker stores a per-frame ``SummedIntensities`` in the ``Frames`` table, so this is a
+        pure metadata read — the exact quantity the old timsVIS slice selector plotted. Returns
+        one row per MS1 frame: ``rt_min`` (retention time, minutes) and the un-normalized
+        ``intensity``. The dashboard normalizes for display.
+        """
+        p = self.meta[self.meta.MsMsType == 0]
+        return pd.DataFrame({"rt_min": p.Time.to_numpy() / 60.0,
+                             "intensity": p.SummedIntensities.to_numpy(dtype=float)})
 
     # -- extraction-window lookup -------------------------------------------------------
     def midia_dimension(self, step: np.ndarray, scan: np.ndarray) -> np.ndarray:

--- a/packages/imspy-vis/src/imspy_vis/midia/transforms.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/transforms.py
@@ -1,0 +1,31 @@
+"""Coordinate and intensity transforms shared by the MIDIA visualization widgets.
+
+Ported from the (now retired) ``proteolizardalgo`` / ``proteolizardvis`` packages so
+that ``imspy-vis`` has no dependency on the old proteolizard stack.
+"""
+
+import numpy as np
+
+
+def peak_width_preserving_mz_transform(
+        mz: np.ndarray,
+        M0: float = 500.0,
+        resolution: float = 50_000.0) -> np.ndarray:
+    """Transform m/z into an index in which a TOF peak keeps a constant width.
+
+    On a TOF instrument the peak width scales with m/z, so clustering in raw m/z gives
+    distance-distorted neighbourhoods. Mapping ``mz`` through a logarithm normalised by the
+    instrument resolution makes one "peak width" a constant step on the axis, which is what
+    a density clusterer should see.
+
+    Args:
+        mz: Array of mass-to-charge ratios to transform.
+        M0: The m/z at which the TOF resolution is reported.
+        resolution: The resolution of the TOF instrument.
+    """
+    return (np.log(mz) - np.log(M0)) / np.log1p(1.0 / resolution)
+
+
+def calculate_mz_tick_spacing(mz_min: float, mz_max: float, num_ticks: int = 10) -> float:
+    """Round tick spacing for the m/z axis of a 3D scatter."""
+    return float(np.round((mz_max - mz_min) / num_ticks, 1))

--- a/packages/imspy-vis/src/imspy_vis/midia/transforms.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/transforms.py
@@ -27,5 +27,10 @@ def peak_width_preserving_mz_transform(
 
 
 def calculate_mz_tick_spacing(mz_min: float, mz_max: float, num_ticks: int = 10) -> float:
-    """Round tick spacing for the m/z axis of a 3D scatter."""
-    return float(np.round((mz_max - mz_min) / num_ticks, 1))
+    """Round tick spacing for the m/z axis of a 3D scatter. Never 0 — plotly rejects ``dtick=0``,
+    which a very narrow visible m/z span (< ~0.5) would otherwise produce and fail the render."""
+    spacing = float(np.round((mz_max - mz_min) / max(num_ticks, 1), 1))
+    if spacing > 0:
+        return spacing
+    raw = (mz_max - mz_min) / max(num_ticks, 1)  # narrow span rounded to 0 — use the finer raw step
+    return float(raw) if raw > 0 else 1.0

--- a/packages/imspy-vis/src/imspy_vis/midia/widgets.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/widgets.py
@@ -73,7 +73,7 @@ class DataPanel:
             widgets.HBox([self.load_button, self.status]),
         ])
 
-    def _on_load(self, _change):
+    def _on_load(self, _change: object) -> None:
         try:
             self.status.value = "<i>loading…</i>"
             if self.experiment is None or self._loaded_path != self.path.value:
@@ -131,7 +131,7 @@ class PointCloudPanel:
         return (self.data_panel.precursor_df if self.kind == "precursor"
                 else self.data_panel.fragment_df)
 
-    def _on_render(self, _change):
+    def _on_render(self, _change: object) -> None:
         try:
             df = self._source()
             n = len(df)
@@ -172,7 +172,7 @@ class _ClusterPanel:
         self.data_panel = data_panel
         self.title = title
 
-        self.min_cluster_size = widgets.IntSlider(value=13, min=1, max=100, step=1,
+        self.min_cluster_size = widgets.IntSlider(value=13, min=2, max=100, step=1,
                                                   description="min cluster size:", continuous_update=False)
         self.min_samples = widgets.IntSlider(value=5, min=1, max=50, step=1,
                                              description="min samples:", continuous_update=False)
@@ -211,7 +211,7 @@ class _ClusterPanel:
     def _extra_controls(self) -> widgets.Widget:
         return widgets.HBox([])
 
-    def _on_cluster(self, _change):
+    def _on_cluster(self, _change: object) -> None:
         try:
             clustered = self._run_clustering()
         except Exception as e:
@@ -229,7 +229,7 @@ class _ClusterPanel:
         self._update_histograms(signal)
         self._render(clustered)
 
-    def _render(self, clustered: pd.DataFrame):
+    def _render(self, clustered: pd.DataFrame) -> None:
         data = clustered[clustered.label != -1] if self.filter_noise.value else clustered
         fig = self._scatter_figure(data)
         with self.scatter_out:
@@ -261,7 +261,7 @@ class _ClusterPanel:
                                  "zaxis": {"title": "m/z", "dtick": tick}})
         return fig
 
-    def _update_histograms(self, signal: pd.DataFrame):
+    def _update_histograms(self, signal: pd.DataFrame) -> None:
         if signal.empty:
             return
         g = signal.groupby("label")
@@ -271,7 +271,7 @@ class _ClusterPanel:
             self.histograms.data[2].x = g["mz"].nunique().to_numpy()
             self.histograms.data[3].x = g.size().to_numpy()
 
-    def nudge_resize(self):
+    def nudge_resize(self) -> None:
         """Force the 2D histogram FigureWidget to redraw after its tab is revealed."""
         fig = self.histograms
         w = fig.layout.width
@@ -343,12 +343,12 @@ class MidiaVis:
             self.tab.set_title(i, t)
         self.tab.observe(self._on_tab_change, names="selected_index")
 
-    def _on_tab_change(self, change):
+    def _on_tab_change(self, change: object) -> None:
         # Redraw the clustering histogram FigureWidgets when their (hidden) tab is shown.
         panel = {3: self.precursor_panel, 4: self.midia_panel}.get(change["new"])
         if panel is not None:
             panel.nudge_resize()
 
-    def display(self):
+    def display(self) -> None:
         from IPython.display import display
         display(self.tab)

--- a/packages/imspy-vis/src/imspy_vis/midia/widgets.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/widgets.py
@@ -14,6 +14,9 @@ Usage (in a notebook served by Voila)::
 
 from __future__ import annotations
 
+import os
+from datetime import datetime
+
 import numpy as np
 import pandas as pd
 import plotly.express as px
@@ -22,7 +25,7 @@ from plotly.subplots import make_subplots
 from ipywidgets import widgets
 from IPython.display import display
 
-from .data import MidiaExperiment
+from .data import MidiaExperiment, filter_fragments_by_scan_ranges
 from .clustering import (
     cluster_precursors_hdbscan,
     cluster_midia_hdbscan,
@@ -31,6 +34,12 @@ from .clustering import (
 from .transforms import calculate_mz_tick_spacing
 
 _PALETTES = ["Alphabet", "Light24", "Dark24", "Set3", "Bold", "Vivid"]
+
+# The original exposed every key of ``hdbscan.dist_metrics.METRIC_MAPPING``, but most of those
+# (cosine, mahalanobis, haversine, seuclidean, …) need extra parameters or 2D data and raise at
+# fit time. We offer the broad-but-safe subset that fits an n-D point cloud unaided.
+_HDBSCAN_METRICS = ["euclidean", "manhattan", "chebyshev", "l1", "l2", "cityblock",
+                    "canberra", "braycurtis", "infinity"]
 
 
 def _initial_histograms() -> go.FigureWidget:
@@ -54,6 +63,21 @@ class DataPanel:
 
         self.path = widgets.Text(value=default_path, description="run .d:",
                                  layout=widgets.Layout(width="60%"))
+
+        # Browse-to-pick a run instead of typing the whole path. Bruker .d runs are
+        # directories, so this navigates folders and lets you click a .d to select it
+        # (rather than a generic file chooser that would descend *into* the .d).
+        self._suppress_browse = False
+        self.browse_dir = self._initial_browse_dir(default_path)
+        self.browse_label = widgets.HTML()
+        self.browser = widgets.Select(options=[], rows=8, description="",
+                                      layout=widgets.Layout(width="60%"))
+        self.browser.observe(self._on_browse_select, names="value")
+        self.refresh_button = widgets.Button(description="↻", tooltip="refresh listing",
+                                             layout=widgets.Layout(width="40px"))
+        self.refresh_button.on_click(lambda _c: self._refresh_browser())
+        self._refresh_browser()
+
         self.rt_start = widgets.FloatText(value=5.0, description="RT min (min):")
         self.rt_stop = widgets.FloatText(value=7.0, description="RT max (min):")
         self.mz_min = widgets.FloatText(value=700.0, description="m/z min:")
@@ -66,12 +90,74 @@ class DataPanel:
         self.load_button.on_click(self._on_load)
 
         self.controls = widgets.VBox([
+            widgets.HTML("<b>Pick a run</b> — click folders to navigate, click a <code>.d</code> to select:"),
+            widgets.HBox([self.browse_label, self.refresh_button]),
+            self.browser,
             self.path,
             widgets.HBox([self.rt_start, self.rt_stop]),
             widgets.HBox([self.mz_min, self.mz_max]),
             widgets.HBox([self.scan_min, self.scan_max, self.intensity_min]),
             widgets.HBox([self.load_button, self.status]),
         ])
+
+    # -- run browser --------------------------------------------------------------------
+    @staticmethod
+    def _initial_browse_dir(default_path: str) -> str:
+        """Start browsing from the run's parent folder if known, else the home directory."""
+        parent = os.path.dirname(default_path.rstrip("/")) if default_path else ""
+        return parent if os.path.isdir(parent) else os.path.expanduser("~")
+
+    def _clear_browser_selection(self) -> None:
+        """Reset the Select to no-selection (under the guard) so the same item fires again."""
+        self._suppress_browse = True
+        try:
+            self.browser.value = None
+        finally:
+            self._suppress_browse = False
+
+    def _refresh_browser(self) -> None:
+        """List the current directory: an optional '..' entry, sub-folders, and selectable .d runs."""
+        self._suppress_browse = True
+        try:
+            self.browse_label.value = f"📂 <code>{self.browse_dir}</code>"
+            # Only offer '..' when there is a real parent (not at the filesystem root).
+            stripped = self.browse_dir.rstrip(os.sep)
+            parent = os.path.dirname(stripped)
+            entries = [("⬆  ..", "..")] if parent and parent != stripped else []
+            try:
+                for name in sorted(os.listdir(self.browse_dir), key=str.lower):
+                    full = os.path.join(self.browse_dir, name)
+                    if not os.path.isdir(full):
+                        continue
+                    entries.append((f"🎯 {name}" if name.endswith(".d") else f"📁 {name}/", full))
+            except OSError as e:
+                self.browse_label.value = f"<span style='color:red'>cannot read {self.browse_dir}: {e}</span>"
+            self.browser.options = entries
+            self.browser.value = None
+        finally:
+            self._suppress_browse = False
+
+    def _on_browse_select(self, change: object) -> None:
+        val = change["new"]
+        if self._suppress_browse or val is None:
+            return
+        if val == "..":
+            parent = os.path.dirname(self.browse_dir.rstrip(os.sep))
+            self.browse_dir = parent or os.path.sep
+            self._refresh_browser()
+        elif val.endswith(".d"):
+            self.path.value = val  # pick this run; load happens on "Load slice"
+            self.status.value = f"selected <b>{os.path.basename(val)}</b> — press Load slice"
+            self._clear_browser_selection()  # so re-clicking the same .d works
+        else:
+            try:  # validate readability before navigating, so a failed open doesn't strand us
+                os.listdir(val)
+            except OSError as e:
+                self.status.value = f"<span style='color:red'>cannot open {os.path.basename(val)}: {e}</span>"
+                self._clear_browser_selection()
+                return
+            self.browse_dir = val
+            self._refresh_browser()
 
     def _on_load(self, _change: object) -> None:
         try:
@@ -90,6 +176,17 @@ class DataPanel:
                                  f"<b>{len(self.fragment_df):,}</b> fragment pts")
         except Exception as e:  # surface errors in the UI instead of the kernel log
             self.status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
+    def filter_settings(self) -> dict:
+        """Current data-load + range-filter settings, for parameter capture (CSV save)."""
+        parts = [p for p in self.path.value.rstrip("/").split("/") if p]
+        return {
+            "id": parts[-1] if parts else "",
+            "rt_min_min": self.rt_start.value, "rt_max_min": self.rt_stop.value,
+            "mz_min": self.mz_min.value, "mz_max": self.mz_max.value,
+            "scan_min": self.scan_min.value, "scan_max": self.scan_max.value,
+            "intensity_min": self.intensity_min.value,
+        }
 
 
 class PointCloudPanel:
@@ -165,6 +262,131 @@ class PointCloudPanel:
         return fig
 
 
+class FragmentPointCloudPanel:
+    """The 4D MIDIA fragment cloud: pick which dimension to drop and what to colour by.
+
+    Faithful to the original ``MidiaFragmentPointCloudVis``. A fragment point has four
+    dimensions — ``cycle`` (RT), the **extraction window** (the precursor isolation m/z
+    recovered from its quadrupole step+scan, the "MIDIA dimension"), ``scan`` (mobility) and
+    ``m/z``. You exclude one; the remaining three become the x/y/z axes. ``colour by`` chooses
+    the marker colour (any dimension or log-intensity). ``quad scaling`` divides the
+    extraction-window axis so it sits on a comparable scale to the others.
+    """
+
+    _DIMS = ["cycle", "extraction window", "scan", "m/z"]  # dim index 0..3
+    _AXIS_TITLE = {0: "Cycle (RT)", 1: "Extraction window m/z", 2: "Scan (mobility)", 3: "m/z"}
+
+    def __init__(self, data_panel: DataPanel, title: str = "Fragment point cloud"):
+        self.data_panel = data_panel
+
+        self.opacity = widgets.FloatSlider(value=0.3, min=0.1, max=1.0, step=0.1,
+                                            description="opacity:", continuous_update=False)
+        self.point_size = widgets.FloatSlider(value=2.0, min=0.5, max=6.0, step=0.5,
+                                              description="point size:", continuous_update=False)
+        self.colorscale = widgets.Dropdown(options=sorted(px.colors.named_colorscales()),
+                                           value="inferno", description="colors:")
+        self.max_points = widgets.IntSlider(value=60_000, min=5_000, max=200_000, step=5_000,
+                                            description="max points:", continuous_update=False)
+        self.exclude_dim = widgets.Dropdown(options=self._DIMS, value="extraction window",
+                                            description="exclude:")
+        self.color_by = widgets.Dropdown(options=self._DIMS + ["log-intensity"],
+                                         value="log-intensity", description="color by:")
+        self.quad_scaling = widgets.IntSlider(value=36, min=1, max=120, step=1,
+                                              description="quad scaling:", continuous_update=False)
+        self.render_button = widgets.Button(description="Render", button_style="info")
+        self.status = widgets.HTML()
+        self.render_button.on_click(self._on_render)
+        self.out = widgets.Output()
+        with self.out:
+            display(self._figure([np.array([])] * 3, [0, 2, 3]))
+
+        self.box = widgets.VBox([
+            widgets.HTML(f"<b>{title}</b>"),
+            widgets.HBox([self.opacity, self.point_size, self.colorscale, self.max_points]),
+            widgets.HBox([self.exclude_dim, self.color_by, self.quad_scaling]),
+            widgets.HBox([self.render_button, self.status]),
+            self.out,
+        ])
+
+    def _on_render(self, _change: object) -> None:
+        try:
+            df = self.data_panel.fragment_df
+            n = len(df)
+            if n == 0 or self.data_panel.experiment is None:
+                self.status.value = "<i>load a slice first</i>"
+                return
+
+            # Recover the MIDIA (extraction-window) coordinate per point and scale it.
+            mc = self.data_panel.experiment.midia_dimension(
+                df.step.to_numpy(), df.scan.to_numpy()) / self.quad_scaling.value
+
+            exclude = self._DIMS.index(self.exclude_dim.value)
+            remaining = [d for d in range(4) if d != exclude]
+
+            # Always restrict to the in-window fragment population, so the displayed set does
+            # not change with the axis/colour choice (and the extraction-window coordinate is
+            # always defined). Window-less fragments lie outside the MIDIA isolation scheme;
+            # this mirrors the 4D clustering's window filter.
+            view = pd.DataFrame({"cycle": df.cycle.to_numpy(), "mc": mc,
+                                 "scan": df.scan.to_numpy(), "mz": df.mz.to_numpy(),
+                                 "intensity": df.intensity.to_numpy()})
+            view = view[np.isfinite(view.mc)]
+            n_window = len(view)
+            dropped = n - n_window
+            if n_window > self.max_points.value:
+                view = view.sample(self.max_points.value, random_state=0)
+
+            cols = {0: view.cycle.to_numpy(), 1: view.mc.to_numpy(),
+                    2: view.scan.to_numpy(), 3: view.mz.to_numpy()}
+            xyz = [cols[d] for d in remaining]
+            color = self._color_values(view)
+
+            note = f" ({dropped:,} window-less excluded)" if dropped else ""
+            self.status.value = f"showing <b>{len(view):,}</b> / {n_window:,} in-window points{note}"
+            fig = self._figure(xyz, remaining, color)
+            with self.out:
+                self.out.clear_output(wait=True)
+                display(fig)
+        except Exception as e:
+            self.status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
+    def _axis_title(self, dim: int) -> str:
+        # The extraction-window axis plots the window left bound / quad scaling, not raw m/z.
+        if dim == 1:
+            return f"Extraction window m/z /{self.quad_scaling.value}"
+        return self._AXIS_TITLE[dim]
+
+    def _color_values(self, view: pd.DataFrame) -> np.ndarray:
+        by = self.color_by.value
+        if by == "log-intensity":
+            return np.log(view.intensity.to_numpy() + 1e-4)
+        return view[{"cycle": "cycle", "extraction window": "mc",
+                     "scan": "scan", "m/z": "mz"}[by]].to_numpy()
+
+    def _figure(self, xyz: list, remaining: list, color: np.ndarray | None = None) -> go.Figure:
+        fig = go.Figure()
+        if len(xyz[0]):
+            fig.add_trace(go.Scatter3d(
+                x=xyz[0], y=xyz[1], z=xyz[2], mode="markers",
+                marker=dict(size=self.point_size.value, color=color,
+                            colorscale=self.colorscale.value, opacity=self.opacity.value,
+                            line=dict(width=0))))
+        else:
+            fig.add_trace(go.Scatter3d(x=[], y=[], z=[], mode="markers"))
+
+        axis_keys = ["xaxis", "yaxis", "zaxis"]
+        scene = {axis_keys[i]: {"title": self._axis_title(d)} for i, d in enumerate(remaining)}
+        # Put nice m/z ticks on whichever axis carries the m/z dimension.
+        if 3 in remaining:
+            mz_vals = xyz[remaining.index(3)]
+            if len(mz_vals):
+                scene[axis_keys[remaining.index(3)]]["dtick"] = calculate_mz_tick_spacing(
+                    float(np.min(mz_vals)), float(np.max(mz_vals)))
+        fig.update_layout(margin=dict(l=0, r=0, b=0, t=0), width=820, height=600,
+                          template="plotly_white", scene=scene)
+        return fig
+
+
 class _ClusterPanel:
     """Shared UI: HDBSCAN sliders, a Cluster button, a 3D scatter, stats + histograms."""
 
@@ -176,18 +398,39 @@ class _ClusterPanel:
                                                   description="min cluster size:", continuous_update=False)
         self.min_samples = widgets.IntSlider(value=5, min=1, max=50, step=1,
                                              description="min samples:", continuous_update=False)
-        self.metric = widgets.Dropdown(options=["euclidean", "manhattan", "chebyshev"],
+        self.metric = widgets.Dropdown(options=_HDBSCAN_METRICS,
                                        value="euclidean", description="metric:")
         self.cycle_scaling = widgets.FloatSlider(value=-0.2, min=-2, max=2, step=0.1,
                                                  description="cycle scaling:", continuous_update=False)
         self.scan_scaling = widgets.FloatSlider(value=0.4, min=-2, max=2, step=0.1,
                                                 description="scan scaling:", continuous_update=False)
+        self.mz_scaling = widgets.FloatSlider(value=0.0, min=-5, max=5, step=0.1,
+                                              description="mz scaling:", continuous_update=False)
         self.resolution = widgets.IntSlider(value=46_900, min=5_000, max=150_000, step=100,
                                             description="resolution:", continuous_update=False)
+
+        # Advanced HDBSCAN knobs (faithful to the original tool; fixed defaults until now).
+        self.alpha = widgets.FloatSlider(value=1.0, min=0.1, max=5.0, step=0.1,
+                                         description="alpha:", continuous_update=False)
+        self.leaf_size = widgets.IntSlider(value=40, min=1, max=100, step=1,
+                                           description="leaf size:", continuous_update=False)
+        self.approx_min_span_tree = widgets.Checkbox(value=True, description="approx tree", indent=False)
+        self.gen_min_span_tree = widgets.Checkbox(value=True, description="generate tree", indent=False)
+        self.use_probability = widgets.Checkbox(value=True, description="size by probability", indent=False)
+
         self.filter_noise = widgets.Checkbox(value=False, description="remove noise", indent=False)
         self.colors = widgets.Dropdown(options=_PALETTES, value="Alphabet", description="colors:")
         self.cluster_button = widgets.Button(description="Cluster", button_style="success")
         self.cluster_button.on_click(self._on_cluster)
+
+        # Export a tuned strategy: a config name + every filter/cluster parameter, written to a
+        # timestamped CSV (the original tool's core workflow for non-coding scientists).
+        self._save_prefix = "HDBSCAN"
+        self.config_name = widgets.Text(placeholder="e.g. hela-tight", description="config name:",
+                                        layout=widgets.Layout(width="auto"))
+        self.save_button = widgets.Button(description="Export config")
+        self.save_button.on_click(self._on_save)
+        self.save_status = widgets.HTML()
 
         # The 3D cloud is rendered as a fresh go.Figure into an Output widget rather than a
         # live FigureWidget: a Scatter3d FigureWidget does not render under Voila/anywidget
@@ -203,8 +446,11 @@ class _ClusterPanel:
             widgets.HTML(f"<b>{title}</b>"),
             self._extra_controls(),
             widgets.HBox([self.min_cluster_size, self.min_samples, self.metric]),
-            widgets.HBox([self.cycle_scaling, self.scan_scaling, self.resolution]),
+            widgets.HBox([self.cycle_scaling, self.scan_scaling, self.mz_scaling, self.resolution]),
+            widgets.HBox([self.alpha, self.leaf_size,
+                          self.approx_min_span_tree, self.gen_min_span_tree, self.use_probability]),
             widgets.HBox([self.cluster_button, self.filter_noise, self.colors]),
+            widgets.HBox([self.config_name, self.save_button, self.save_status]),
             widgets.HBox([self.scatter_out, widgets.VBox([self.summary, self.histograms])]),
         ])
 
@@ -243,12 +489,15 @@ class _ClusterPanel:
             cmap = dict(enumerate(getattr(px.colors.qualitative, self.colors.value)))
             labels = data.label.to_numpy().astype(int)
             prob = data.probability.to_numpy() if "probability" in data else np.ones(len(data))
+            # Noise stays small; signal points scale with membership probability when the
+            # toggle is on, else use a flat size (original: bps=3.5).
+            bps, up = 3.5, self.use_probability.value
             fig.add_trace(go.Scatter3d(
                 x=data.cycle / np.power(2, self.cycle_scaling.value),
                 y=data.scan / np.power(2, self.scan_scaling.value),
                 z=data.mz, mode="markers",
                 marker=dict(
-                    size=[2 if l == -1 else 2 + 3 * p for l, p in zip(labels, prob)],
+                    size=[2 if l == -1 else (bps * p if up else bps) for l, p in zip(labels, prob)],
                     color=["grey" if l == -1 else cmap[l % len(cmap)] for l in labels],
                     opacity=0.8, line=dict(width=0))))
             tick = calculate_mz_tick_spacing(float(data.mz.min()), float(data.mz.max()))
@@ -280,6 +529,38 @@ class _ClusterPanel:
         with fig.batch_update():
             fig.layout.width = w
 
+    # -- parameter capture --------------------------------------------------------------
+    def _cluster_settings(self) -> dict:
+        """The HDBSCAN parameters the clustering actually runs with (for the saved CSV)."""
+        return {
+            "algorithm": "best",
+            "alpha": self.alpha.value,
+            "approx_min_span_tree": self.approx_min_span_tree.value,
+            "gen_min_span_tree": self.gen_min_span_tree.value,
+            "leaf_size": self.leaf_size.value,
+            "use_probability": self.use_probability.value,
+            "min_cluster_size": self.min_cluster_size.value,
+            "min_samples": self.min_samples.value,
+            "metric": self.metric.value,
+            "cycle_scaling": self.cycle_scaling.value,
+            "scan_scaling": self.scan_scaling.value,
+            "mz_scaling": self.mz_scaling.value,
+            "resolution": self.resolution.value,
+        }
+
+    def _on_save(self, _change: object) -> None:
+        """Write a one-row CSV capturing the config name + filter + cluster settings."""
+        try:
+            row = {"config_name": self.config_name.value,
+                   **self.data_panel.filter_settings(),
+                   **self._cluster_settings()}
+            stamp = datetime.now().strftime("%d-%m-%y-%H-%M-%S")
+            fname = f"{self._save_prefix}-{stamp}.csv"
+            pd.DataFrame(row, index=[0]).to_csv(fname, index=False)
+            self.save_status.value = f"exported <b>{fname}</b>"
+        except Exception as e:
+            self.save_status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
     # subclasses implement the actual clustering call
     def _run_clustering(self) -> pd.DataFrame:  # pragma: no cover
         raise NotImplementedError
@@ -288,40 +569,173 @@ class _ClusterPanel:
 class PrecursorHDBSCANPanel(_ClusterPanel):
     def __init__(self, data_panel: DataPanel):
         super().__init__(data_panel, "Precursor (MS1) HDBSCAN")
+        self._save_prefix = "PRECURSOR-HDBSCAN"
+        self.min_samples.value = 1  # the original precursor-HDBSCAN default
 
     def _run_clustering(self) -> pd.DataFrame:
         return cluster_precursors_hdbscan(
             self.data_panel.precursor_df,
-            min_cluster_size=self.min_cluster_size.value,
-            min_samples=self.min_samples.value,
-            metric=self.metric.value,
-            cycle_scaling=self.cycle_scaling.value,
-            scan_scaling=self.scan_scaling.value,
-            resolution=self.resolution.value)
-
-
-class MidiaHDBSCANPanel(_ClusterPanel):
-    def __init__(self, data_panel: DataPanel):
-        super().__init__(data_panel, "MIDIA fragment HDBSCAN (4D)")
-
-    def _extra_controls(self) -> widgets.Widget:
-        self.use_midia = widgets.Checkbox(value=True, description="include MIDIA dim", indent=False)
-        self.extraction_scaling = widgets.IntSlider(value=36, min=1, max=120, step=1,
-                                                    description="quad scaling:", continuous_update=False)
-        return widgets.HBox([self.use_midia, self.extraction_scaling])
-
-    def _run_clustering(self) -> pd.DataFrame:
-        return cluster_midia_hdbscan(
-            self.data_panel.fragment_df,
-            self.data_panel.experiment,
+            algorithm="best",
+            alpha=self.alpha.value,
+            approx_min_span_tree=self.approx_min_span_tree.value,
+            gen_min_span_tree=self.gen_min_span_tree.value,
+            leaf_size=self.leaf_size.value,
             min_cluster_size=self.min_cluster_size.value,
             min_samples=self.min_samples.value,
             metric=self.metric.value,
             cycle_scaling=self.cycle_scaling.value,
             scan_scaling=self.scan_scaling.value,
             resolution=self.resolution.value,
+            mz_scaling=self.mz_scaling.value)
+
+
+class MidiaHDBSCANPanel(_ClusterPanel):
+    def __init__(self, data_panel: DataPanel):
+        super().__init__(data_panel, "MIDIA fragment HDBSCAN (4D)")
+        self._save_prefix = "MIDIA-HDBSCAN"
+        self.metric.value = "manhattan"  # the original's MIDIA-fragment default
+        self.min_cluster_size.value = 7  # original MIDIA-HDBSCAN defaults
+        self.min_samples.value = 7
+
+    def _extra_controls(self) -> widgets.Widget:
+        self.cluster_selection_method = widgets.Dropdown(options=["eom", "leaf"], value="eom",
+                                                         description="selection:")
+        self.cluster_selection_epsilon = widgets.FloatSlider(value=1.0, min=0.1, max=10.0, step=0.1,
+                                                             description="sel. epsilon:",
+                                                             continuous_update=False)
+        self.use_midia = widgets.Checkbox(value=True, description="include MIDIA dim", indent=False)
+        self.extraction_scaling = widgets.IntSlider(value=36, min=1, max=120, step=1,
+                                                    description="quad scaling:", continuous_update=False)
+        return widgets.HBox([self.cluster_selection_method, self.cluster_selection_epsilon,
+                             self.use_midia, self.extraction_scaling])
+
+    def _cluster_settings(self) -> dict:
+        return {**super()._cluster_settings(),
+                "cluster_selection_method": self.cluster_selection_method.value,
+                "cluster_selection_epsilon": self.cluster_selection_epsilon.value,
+                "use_midia_dimension": self.use_midia.value,
+                "extraction_scaling": self.extraction_scaling.value}
+
+    def _run_clustering(self) -> pd.DataFrame:
+        return cluster_midia_hdbscan(
+            self.data_panel.fragment_df,
+            self.data_panel.experiment,
+            algorithm="best",
+            cluster_selection_method=self.cluster_selection_method.value,
+            cluster_selection_epsilon=self.cluster_selection_epsilon.value,
+            alpha=self.alpha.value,
+            approx_min_span_tree=self.approx_min_span_tree.value,
+            gen_min_span_tree=self.gen_min_span_tree.value,
+            leaf_size=self.leaf_size.value,
+            min_cluster_size=self.min_cluster_size.value,
+            min_samples=self.min_samples.value,
+            metric=self.metric.value,
+            cycle_scaling=self.cycle_scaling.value,
+            scan_scaling=self.scan_scaling.value,
+            resolution=self.resolution.value,
+            mz_scaling=self.mz_scaling.value,
             extraction_scaling=self.extraction_scaling.value,
             use_midia_dimension=self.use_midia.value)
+
+
+class MidiaFilterPanel:
+    """The MIDIA fragment filter: isolate the fragments co-isolated with a precursor query.
+
+    Faithful to the original ``MidiaFragmentFilter``. A precursor *query* (``query start`` +
+    ``query length``), a ``quad width`` and a ``% overlap`` select, per quadrupole step, the
+    scan range whose isolation window overlaps the query
+    (:meth:`MidiaExperiment.fragment_scan_ranges`); an optional ``scan min/max`` clamps further.
+
+    It also acts as the **fragment data source** for the MIDIA cloud and clustering tabs: it
+    exposes the same ``experiment`` / ``fragment_df`` / ``filter_settings`` surface as
+    :class:`DataPanel`, so those panels consume the filtered fragments transparently. Until
+    ``Filter`` is pressed (or after ``Reset``) it passes the full loaded fragment set through.
+    """
+
+    def __init__(self, data_panel: DataPanel):
+        self.data_panel = data_panel
+        self._filtered: pd.DataFrame | None = None  # None => pass the full fragment_df through
+        self._filtered_from = None  # the fragment_df object the filter was computed from
+        self._snapshot: dict | None = None  # query params that produced `_filtered`
+
+        self.query_start = widgets.IntSlider(value=709, min=350, max=1500, step=1,
+                                             description="query start:", continuous_update=False)
+        self.query_length = widgets.IntSlider(value=12, min=6, max=150, step=6,
+                                              description="query length:", continuous_update=False)
+        self.target_length = widgets.IntSlider(value=36, min=12, max=60, step=12,
+                                               description="quad width:", continuous_update=False)
+        self.percent_overlap = widgets.IntSlider(value=50, min=1, max=100, step=1,
+                                                 description="% overlap:", continuous_update=False)
+        self.scan_min = widgets.IntSlider(value=0, min=0, max=1000, step=10,
+                                          description="scan min:", continuous_update=False)
+        self.scan_max = widgets.IntSlider(value=1000, min=0, max=1000, step=10,
+                                          description="scan max:", continuous_update=False)
+        self.filter_button = widgets.Button(description="Filter", button_style="primary")
+        self.reset_button = widgets.Button(description="Reset")
+        self.status = widgets.HTML(value="<i>passing all fragments through</i>")
+        self.filter_button.on_click(self._on_filter)
+        self.reset_button.on_click(self._on_reset)
+
+        self.controls = widgets.VBox([
+            widgets.HTML("<b>MIDIA fragment filter</b>"),
+            widgets.HBox([self.query_start, self.query_length]),
+            widgets.HBox([self.target_length, self.percent_overlap]),
+            widgets.HBox([self.scan_min, self.scan_max]),
+            widgets.HBox([self.filter_button, self.reset_button, self.status]),
+        ])
+
+    # -- fragment-source interface (mirrors DataPanel for the downstream MIDIA panels) ----
+    @property
+    def experiment(self) -> "MidiaExperiment | None":
+        return self.data_panel.experiment
+
+    def _active(self) -> bool:
+        """True only while the cached filter still belongs to the currently-loaded slice.
+
+        A reload in ``DataPanel`` replaces ``fragment_df`` with a fresh object; comparing by
+        identity invalidates the stale filter so downstream tabs never see old fragments.
+        """
+        return self._filtered is not None and self._filtered_from is self.data_panel.fragment_df
+
+    @property
+    def fragment_df(self) -> pd.DataFrame:
+        return self._filtered if self._active() else self.data_panel.fragment_df
+
+    def filter_settings(self) -> dict:
+        """Data filter settings, extended with the MIDIA query params that produced the filter."""
+        settings = dict(self.data_panel.filter_settings())
+        if self._active():
+            settings.update(self._snapshot)  # the params at Filter time, not the live widgets
+        return settings
+
+    def _on_filter(self, _change: object) -> None:
+        try:
+            exp = self.data_panel.experiment
+            source = self.data_panel.fragment_df
+            if exp is None or source.empty:
+                self.status.value = "<i>load a slice first</i>"
+                return
+            ranges = exp.fragment_scan_ranges(self.query_start.value, self.query_length.value,
+                                              self.target_length.value, self.percent_overlap.value)
+            self._filtered = filter_fragments_by_scan_ranges(
+                source, ranges, self.scan_min.value, self.scan_max.value)
+            self._filtered_from = source
+            # Snapshot the params now, so a later slider nudge can't desync data from the saved CSV.
+            self._snapshot = {
+                "query_start": self.query_start.value, "query_length": self.query_length.value,
+                "quad_width": self.target_length.value, "percent_overlap": self.percent_overlap.value,
+                "midia_scan_min": self.scan_min.value, "midia_scan_max": self.scan_max.value,
+            }
+            self.status.value = (f"<b>{len(self._filtered):,}</b> / {len(source):,} fragments in "
+                                 f"{len(ranges)} window group(s)")
+        except Exception as e:
+            self.status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
+    def _on_reset(self, _change: object) -> None:
+        self._filtered = None
+        self._filtered_from = None
+        self._snapshot = None
+        self.status.value = "<i>passing all fragments through</i>"
 
 
 class MidiaVis:
@@ -330,22 +744,25 @@ class MidiaVis:
     def __init__(self, default_path: str = ""):
         self.data_panel = DataPanel(default_path)
         self.precursor_cloud = PointCloudPanel(self.data_panel, "precursor", "Precursor point cloud")
-        self.fragment_cloud = PointCloudPanel(self.data_panel, "fragment", "Fragment point cloud")
         self.precursor_panel = PrecursorHDBSCANPanel(self.data_panel)
-        self.midia_panel = MidiaHDBSCANPanel(self.data_panel)
+        # The MIDIA filter is the fragment source for the MIDIA cloud + clustering tabs.
+        self.midia_filter = MidiaFilterPanel(self.data_panel)
+        self.fragment_cloud = FragmentPointCloudPanel(self.midia_filter, "Fragment point cloud")
+        self.midia_panel = MidiaHDBSCANPanel(self.midia_filter)
         self.tab = widgets.Tab(children=[self.data_panel.controls,
                                          self.precursor_cloud.box,
-                                         self.fragment_cloud.box,
                                          self.precursor_panel.box,
+                                         self.midia_filter.controls,
+                                         self.fragment_cloud.box,
                                          self.midia_panel.box])
-        for i, t in enumerate(["Data", "Precursor cloud", "Fragment cloud",
-                               "Precursor HDBSCAN", "MIDIA HDBSCAN"]):
+        for i, t in enumerate(["Data", "Precursor cloud", "Precursor HDBSCAN",
+                               "MIDIA filter", "Fragment cloud", "MIDIA HDBSCAN"]):
             self.tab.set_title(i, t)
         self.tab.observe(self._on_tab_change, names="selected_index")
 
     def _on_tab_change(self, change: object) -> None:
         # Redraw the clustering histogram FigureWidgets when their (hidden) tab is shown.
-        panel = {3: self.precursor_panel, 4: self.midia_panel}.get(change["new"])
+        panel = {2: self.precursor_panel, 5: self.midia_panel}.get(change["new"])
         if panel is not None:
             panel.nudge_resize()
 

--- a/packages/imspy-vis/src/imspy_vis/midia/widgets.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/widgets.py
@@ -1,0 +1,354 @@
+"""Interactive ipywidgets/Plotly dashboard for MIDIA precursor & fragment clustering.
+
+This is the modern, imspy-backed reconstruction of the proteolizard-midia Voila tool that
+let a non-coding scientist tune clustering parameters and decide a peak-picking strategy by
+eye. A :class:`DataPanel` loads a retention-time slice of a run; the cluster panels expose
+the HDBSCAN parameters as live controls, recompute on a button press, and render the labelled
+3D point cloud together with a summary table and per-axis cluster-size histograms.
+
+Usage (in a notebook served by Voila)::
+
+    from imspy_vis.midia.widgets import MidiaVis
+    MidiaVis(default_path="/path/to/run.d").display()
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+from ipywidgets import widgets
+from IPython.display import display
+
+from .data import MidiaExperiment
+from .clustering import (
+    cluster_precursors_hdbscan,
+    cluster_midia_hdbscan,
+    calculate_statistics,
+)
+from .transforms import calculate_mz_tick_spacing
+
+_PALETTES = ["Alphabet", "Light24", "Dark24", "Set3", "Bold", "Vivid"]
+
+
+def _initial_histograms() -> go.FigureWidget:
+    fig = make_subplots(rows=2, cols=2, subplot_titles=("Cycle", "Scan", "m/z", "Size"))
+    for r, c in [(1, 1), (1, 2), (2, 1), (2, 2)]:
+        fig.add_trace(go.Histogram(x=[]), row=r, col=c)
+    fig.update_layout(title_text="Cluster distributions", showlegend=False,
+                      template="plotly_white", width=480, height=380,
+                      margin=dict(l=10, r=10, b=10, t=60))
+    return go.FigureWidget(fig)
+
+
+class DataPanel:
+    """Loads a retention-time slice of a run and applies a coarse range filter."""
+
+    def __init__(self, default_path: str = ""):
+        self.experiment: MidiaExperiment | None = None
+        self._loaded_path: str | None = None
+        self.precursor_df = pd.DataFrame()
+        self.fragment_df = pd.DataFrame()
+
+        self.path = widgets.Text(value=default_path, description="run .d:",
+                                 layout=widgets.Layout(width="60%"))
+        self.rt_start = widgets.FloatText(value=5.0, description="RT min (min):")
+        self.rt_stop = widgets.FloatText(value=7.0, description="RT max (min):")
+        self.mz_min = widgets.FloatText(value=700.0, description="m/z min:")
+        self.mz_max = widgets.FloatText(value=730.0, description="m/z max:")
+        self.scan_min = widgets.IntText(value=300, description="scan min:")
+        self.scan_max = widgets.IntText(value=800, description="scan max:")
+        self.intensity_min = widgets.FloatText(value=20.0, description="min intensity:")
+        self.load_button = widgets.Button(description="Load slice", button_style="primary")
+        self.status = widgets.HTML(value="<i>no slice loaded</i>")
+        self.load_button.on_click(self._on_load)
+
+        self.controls = widgets.VBox([
+            self.path,
+            widgets.HBox([self.rt_start, self.rt_stop]),
+            widgets.HBox([self.mz_min, self.mz_max]),
+            widgets.HBox([self.scan_min, self.scan_max, self.intensity_min]),
+            widgets.HBox([self.load_button, self.status]),
+        ])
+
+    def _on_load(self, _change):
+        try:
+            self.status.value = "<i>loading…</i>"
+            if self.experiment is None or self._loaded_path != self.path.value:
+                self.experiment = MidiaExperiment(self.path.value)
+                self._loaded_path = self.path.value
+            sl = self.experiment.get_slice_retention_time(
+                self.rt_start.value * 60.0, self.rt_stop.value * 60.0
+            ).filtered(mz_min=self.mz_min.value, mz_max=self.mz_max.value,
+                       scan_min=self.scan_min.value, scan_max=self.scan_max.value,
+                       intensity_min=self.intensity_min.value)
+            self.precursor_df = sl.precursor_coords3D()
+            self.fragment_df = sl.fragment_coords4D()
+            self.status.value = (f"<b>{len(self.precursor_df):,}</b> precursor pts &nbsp; "
+                                 f"<b>{len(self.fragment_df):,}</b> fragment pts")
+        except Exception as e:  # surface errors in the UI instead of the kernel log
+            self.status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
+
+class PointCloudPanel:
+    """A raw inferno 3D point cloud of a coordinate view — no clustering.
+
+    Renders ``cycle x scan x m/z`` coloured by log-intensity. Useful both as a quick look at
+    the loaded slice and as a render sanity check for the 3D pipeline. Drawn as a fresh
+    go.Figure into an Output (the Voila-robust path), with a downsample cap so the browser
+    stays responsive.
+    """
+
+    def __init__(self, data_panel: DataPanel, kind: str, title: str):
+        self.data_panel = data_panel
+        self.kind = kind  # "precursor" or "fragment"
+
+        self.opacity = widgets.FloatSlider(value=0.3, min=0.1, max=1.0, step=0.1,
+                                            description="opacity:", continuous_update=False)
+        self.point_size = widgets.FloatSlider(value=2.0, min=0.5, max=6.0, step=0.5,
+                                              description="point size:", continuous_update=False)
+        self.colorscale = widgets.Dropdown(options=sorted(px.colors.named_colorscales()),
+                                           value="inferno", description="colors:")
+        self.max_points = widgets.IntSlider(value=60_000, min=5_000, max=200_000, step=5_000,
+                                            description="max points:", continuous_update=False)
+        self.render_button = widgets.Button(description="Render", button_style="info")
+        self.status = widgets.HTML()
+        self.render_button.on_click(self._on_render)
+        self.out = widgets.Output()
+        with self.out:
+            display(self._figure(pd.DataFrame()))
+
+        self.box = widgets.VBox([
+            widgets.HTML(f"<b>{title}</b>"),
+            widgets.HBox([self.opacity, self.point_size, self.colorscale, self.max_points]),
+            widgets.HBox([self.render_button, self.status]),
+            self.out,
+        ])
+
+    def _source(self) -> pd.DataFrame:
+        return (self.data_panel.precursor_df if self.kind == "precursor"
+                else self.data_panel.fragment_df)
+
+    def _on_render(self, _change):
+        try:
+            df = self._source()
+            n = len(df)
+            if n > self.max_points.value:
+                df = df.sample(self.max_points.value, random_state=0)
+            self.status.value = f"showing <b>{len(df):,}</b> / {n:,} points"
+            fig = self._figure(df)
+            with self.out:
+                self.out.clear_output(wait=True)
+                display(fig)
+        except Exception as e:
+            self.status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
+    def _figure(self, df: pd.DataFrame) -> go.Figure:
+        fig = go.Figure()
+        if len(df):
+            fig.add_trace(go.Scatter3d(
+                x=df.cycle, y=df.scan, z=df.mz, mode="markers",
+                marker=dict(size=self.point_size.value,
+                            color=np.log(df.intensity.to_numpy() + 1e-4),
+                            colorscale=self.colorscale.value, opacity=self.opacity.value,
+                            line=dict(width=0))))
+            tick = calculate_mz_tick_spacing(float(df.mz.min()), float(df.mz.max()))
+        else:
+            fig.add_trace(go.Scatter3d(x=[], y=[], z=[], mode="markers"))
+            tick = 1
+        fig.update_layout(margin=dict(l=0, r=0, b=0, t=0), width=820, height=600,
+                          template="plotly_white",
+                          scene={"xaxis": {"title": "Cycle (RT)"}, "yaxis": {"title": "Scan (mobility)"},
+                                 "zaxis": {"title": "m/z", "dtick": tick}})
+        return fig
+
+
+class _ClusterPanel:
+    """Shared UI: HDBSCAN sliders, a Cluster button, a 3D scatter, stats + histograms."""
+
+    def __init__(self, data_panel: DataPanel, title: str):
+        self.data_panel = data_panel
+        self.title = title
+
+        self.min_cluster_size = widgets.IntSlider(value=13, min=1, max=100, step=1,
+                                                  description="min cluster size:", continuous_update=False)
+        self.min_samples = widgets.IntSlider(value=5, min=1, max=50, step=1,
+                                             description="min samples:", continuous_update=False)
+        self.metric = widgets.Dropdown(options=["euclidean", "manhattan", "chebyshev"],
+                                       value="euclidean", description="metric:")
+        self.cycle_scaling = widgets.FloatSlider(value=-0.2, min=-2, max=2, step=0.1,
+                                                 description="cycle scaling:", continuous_update=False)
+        self.scan_scaling = widgets.FloatSlider(value=0.4, min=-2, max=2, step=0.1,
+                                                description="scan scaling:", continuous_update=False)
+        self.resolution = widgets.IntSlider(value=46_900, min=5_000, max=150_000, step=100,
+                                            description="resolution:", continuous_update=False)
+        self.filter_noise = widgets.Checkbox(value=False, description="remove noise", indent=False)
+        self.colors = widgets.Dropdown(options=_PALETTES, value="Alphabet", description="colors:")
+        self.cluster_button = widgets.Button(description="Cluster", button_style="success")
+        self.cluster_button.on_click(self._on_cluster)
+
+        # The 3D cloud is rendered as a fresh go.Figure into an Output widget rather than a
+        # live FigureWidget: a Scatter3d FigureWidget does not render under Voila/anywidget
+        # (2D widgets do), so we redraw the whole figure on each Cluster press. This keeps a
+        # fully interactive (rotatable) plot at the cost of resetting the camera per run.
+        self.scatter_out = widgets.Output()
+        with self.scatter_out:
+            display(self._scatter_figure(pd.DataFrame()))
+        self.summary = widgets.Output()
+        self.histograms = _initial_histograms()
+
+        self.box = widgets.VBox([
+            widgets.HTML(f"<b>{title}</b>"),
+            self._extra_controls(),
+            widgets.HBox([self.min_cluster_size, self.min_samples, self.metric]),
+            widgets.HBox([self.cycle_scaling, self.scan_scaling, self.resolution]),
+            widgets.HBox([self.cluster_button, self.filter_noise, self.colors]),
+            widgets.HBox([self.scatter_out, widgets.VBox([self.summary, self.histograms])]),
+        ])
+
+    def _extra_controls(self) -> widgets.Widget:
+        return widgets.HBox([])
+
+    def _on_cluster(self, _change):
+        try:
+            clustered = self._run_clustering()
+        except Exception as e:
+            with self.summary:
+                self.summary.clear_output()
+                print(f"{type(e).__name__}: {e}")
+            return
+        noise = clustered[clustered.label == -1]
+        signal = clustered[clustered.label != -1]
+        table, _ = calculate_statistics(signal, noise)
+        with self.summary:
+            self.summary.clear_output()
+            from IPython.display import display
+            display(table)
+        self._update_histograms(signal)
+        self._render(clustered)
+
+    def _render(self, clustered: pd.DataFrame):
+        data = clustered[clustered.label != -1] if self.filter_noise.value else clustered
+        fig = self._scatter_figure(data)
+        with self.scatter_out:
+            self.scatter_out.clear_output(wait=True)
+            display(fig)
+
+    def _scatter_figure(self, data: pd.DataFrame) -> go.Figure:
+        """Build the labelled 3D cloud as a plain go.Figure (rendered via the Output)."""
+        fig = go.Figure()
+        if len(data):
+            cmap = dict(enumerate(getattr(px.colors.qualitative, self.colors.value)))
+            labels = data.label.to_numpy().astype(int)
+            prob = data.probability.to_numpy() if "probability" in data else np.ones(len(data))
+            fig.add_trace(go.Scatter3d(
+                x=data.cycle / np.power(2, self.cycle_scaling.value),
+                y=data.scan / np.power(2, self.scan_scaling.value),
+                z=data.mz, mode="markers",
+                marker=dict(
+                    size=[2 if l == -1 else 2 + 3 * p for l, p in zip(labels, prob)],
+                    color=["grey" if l == -1 else cmap[l % len(cmap)] for l in labels],
+                    opacity=0.8, line=dict(width=0))))
+            tick = calculate_mz_tick_spacing(float(data.mz.min()), float(data.mz.max()))
+        else:
+            fig.add_trace(go.Scatter3d(x=[], y=[], z=[], mode="markers"))
+            tick = 1
+        fig.update_layout(margin=dict(l=0, r=0, b=0, t=0), width=720, height=560,
+                          template="plotly_white",
+                          scene={"xaxis": {"title": "Cycle"}, "yaxis": {"title": "Scan"},
+                                 "zaxis": {"title": "m/z", "dtick": tick}})
+        return fig
+
+    def _update_histograms(self, signal: pd.DataFrame):
+        if signal.empty:
+            return
+        g = signal.groupby("label")
+        with self.histograms.batch_update():
+            self.histograms.data[0].x = g["cycle"].nunique().to_numpy()
+            self.histograms.data[1].x = g["scan"].nunique().to_numpy()
+            self.histograms.data[2].x = g["mz"].nunique().to_numpy()
+            self.histograms.data[3].x = g.size().to_numpy()
+
+    def nudge_resize(self):
+        """Force the 2D histogram FigureWidget to redraw after its tab is revealed."""
+        fig = self.histograms
+        w = fig.layout.width
+        with fig.batch_update():
+            fig.layout.width = (w or 480) + 1
+        with fig.batch_update():
+            fig.layout.width = w
+
+    # subclasses implement the actual clustering call
+    def _run_clustering(self) -> pd.DataFrame:  # pragma: no cover
+        raise NotImplementedError
+
+
+class PrecursorHDBSCANPanel(_ClusterPanel):
+    def __init__(self, data_panel: DataPanel):
+        super().__init__(data_panel, "Precursor (MS1) HDBSCAN")
+
+    def _run_clustering(self) -> pd.DataFrame:
+        return cluster_precursors_hdbscan(
+            self.data_panel.precursor_df,
+            min_cluster_size=self.min_cluster_size.value,
+            min_samples=self.min_samples.value,
+            metric=self.metric.value,
+            cycle_scaling=self.cycle_scaling.value,
+            scan_scaling=self.scan_scaling.value,
+            resolution=self.resolution.value)
+
+
+class MidiaHDBSCANPanel(_ClusterPanel):
+    def __init__(self, data_panel: DataPanel):
+        super().__init__(data_panel, "MIDIA fragment HDBSCAN (4D)")
+
+    def _extra_controls(self) -> widgets.Widget:
+        self.use_midia = widgets.Checkbox(value=True, description="include MIDIA dim", indent=False)
+        self.extraction_scaling = widgets.IntSlider(value=36, min=1, max=120, step=1,
+                                                    description="quad scaling:", continuous_update=False)
+        return widgets.HBox([self.use_midia, self.extraction_scaling])
+
+    def _run_clustering(self) -> pd.DataFrame:
+        return cluster_midia_hdbscan(
+            self.data_panel.fragment_df,
+            self.data_panel.experiment,
+            min_cluster_size=self.min_cluster_size.value,
+            min_samples=self.min_samples.value,
+            metric=self.metric.value,
+            cycle_scaling=self.cycle_scaling.value,
+            scan_scaling=self.scan_scaling.value,
+            resolution=self.resolution.value,
+            extraction_scaling=self.extraction_scaling.value,
+            use_midia_dimension=self.use_midia.value)
+
+
+class MidiaVis:
+    """Tabbed dashboard: data loading + precursor and MIDIA clustering."""
+
+    def __init__(self, default_path: str = ""):
+        self.data_panel = DataPanel(default_path)
+        self.precursor_cloud = PointCloudPanel(self.data_panel, "precursor", "Precursor point cloud")
+        self.fragment_cloud = PointCloudPanel(self.data_panel, "fragment", "Fragment point cloud")
+        self.precursor_panel = PrecursorHDBSCANPanel(self.data_panel)
+        self.midia_panel = MidiaHDBSCANPanel(self.data_panel)
+        self.tab = widgets.Tab(children=[self.data_panel.controls,
+                                         self.precursor_cloud.box,
+                                         self.fragment_cloud.box,
+                                         self.precursor_panel.box,
+                                         self.midia_panel.box])
+        for i, t in enumerate(["Data", "Precursor cloud", "Fragment cloud",
+                               "Precursor HDBSCAN", "MIDIA HDBSCAN"]):
+            self.tab.set_title(i, t)
+        self.tab.observe(self._on_tab_change, names="selected_index")
+
+    def _on_tab_change(self, change):
+        # Redraw the clustering histogram FigureWidgets when their (hidden) tab is shown.
+        panel = {3: self.precursor_panel, 4: self.midia_panel}.get(change["new"])
+        if panel is not None:
+            panel.nudge_resize()
+
+    def display(self):
+        from IPython.display import display
+        display(self.tab)

--- a/packages/imspy-vis/src/imspy_vis/midia/widgets.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/widgets.py
@@ -752,10 +752,17 @@ class _ClusterPanel:
             return
         g = signal.groupby("label")
         with self.histograms.batch_update():
-            self.histograms.data[0].x = g["cycle"].nunique().to_numpy()
-            self.histograms.data[1].x = g["scan"].nunique().to_numpy()
-            self.histograms.data[2].x = g["mz"].nunique().to_numpy()
-            self.histograms.data[3].x = g.size().to_numpy()
+            # One grouped aggregation pass instead of four separate ones (nunique walks each group).
+            agg = g.agg(
+                cycle=("cycle", "nunique"),
+                scan=("scan", "nunique"),
+                mz=("mz", "nunique"),
+                size=("cycle", "size"),  # group size (matches the old g.size())
+            )
+            self.histograms.data[0].x = agg["cycle"].to_numpy()
+            self.histograms.data[1].x = agg["scan"].to_numpy()
+            self.histograms.data[2].x = agg["mz"].to_numpy()
+            self.histograms.data[3].x = agg["size"].to_numpy()
 
     def nudge_resize(self) -> None:
         """Force the 2D histogram FigureWidget to redraw after its tab is revealed."""

--- a/packages/imspy-vis/src/imspy_vis/midia/widgets.py
+++ b/packages/imspy-vis/src/imspy_vis/midia/widgets.py
@@ -41,6 +41,55 @@ _PALETTES = ["Alphabet", "Light24", "Dark24", "Set3", "Bold", "Vivid"]
 _HDBSCAN_METRICS = ["euclidean", "manhattan", "chebyshev", "l1", "l2", "cityblock",
                     "canberra", "braycurtis", "infinity"]
 
+# Per-knob explanations shown via a hover ⓘ icon next to each clustering control. Phrased for a
+# scientist tuning the result by eye: what the knob does and which way to push it.
+_HELP = {
+    "min_cluster_size": "Smallest group of points HDBSCAN will call a cluster. Higher → fewer, "
+        "bigger clusters and small peaks get dropped as noise; lower → more, smaller clusters.",
+    "min_samples": "How conservative the clustering is. Higher → more points left as noise and "
+        "tighter, denser cluster cores; lower → more points pulled into clusters. Often ≈ min "
+        "cluster size.",
+    "metric": "Distance used to compare points in the scaled (cycle, scan, m/z[, MIDIA]) space. "
+        "euclidean is the default; manhattan / cityblock is more robust to a single odd axis.",
+    "cycle_scaling": "Weights the retention-time (cycle) axis as value → x / 2^scaling. More "
+        "negative compresses RT (points count as closer in time); positive expands it.",
+    "scan_scaling": "Same x / 2^scaling weighting for the scan (ion-mobility) axis. Raise to make "
+        "mobility differences split clusters apart; lower to merge across mobility.",
+    "mz_scaling": "Same x / 2^scaling weighting for the m/z axis. Raise to separate clusters that "
+        "differ in m/z; lower to merge them.",
+    "resolution": "Resolving power used by the peak-width-preserving m/z transform, so m/z spacing "
+        "scales like real peak widths. Higher → finer m/z separation (more clusters).",
+    "alpha": "HDBSCAN robust-linkage distance scaling. Above 1 is more conservative (fewer merges); "
+        "1.0 is standard and rarely needs changing.",
+    "leaf_size": "Internal KD/Ball-tree leaf size — a speed/memory knob for nearest-neighbour "
+        "queries. Does not change the resulting labels.",
+    "approx_min_span_tree": "Use a faster approximate minimum spanning tree. On → quicker on big "
+        "slices, with a tiny chance of a slightly different tree; off → exact but slower.",
+    "gen_min_span_tree": "Also compute and keep the minimum spanning tree (for tree diagnostics). "
+        "No effect on the labels; small extra cost.",
+    "use_probability": "Display only: size points by cluster-membership probability, so core points "
+        "look bigger than fringe points. Does not change which points cluster.",
+    "filter_noise": "Display only: hide the points HDBSCAN labelled as noise (label −1) from the "
+        "3D plot.",
+    "colors": "Display only: qualitative colour palette used to tint the clusters.",
+    # MIDIA-only knobs
+    "cluster_selection_method": "How clusters are cut from the hierarchy. 'eom' (excess of mass) "
+        "favours clusters of varying density; 'leaf' takes the finest leaves → more, smaller clusters.",
+    "cluster_selection_epsilon": "Merge neighbouring clusters closer than this distance. Raise to "
+        "rejoin fragments of one feature that got split; low → keep the raw HDBSCAN split.",
+    "use_midia": "Include the MIDIA extraction-window (precursor isolation m/z) as a 4th clustering "
+        "dimension. On → fragments are also separated by which precursor window isolated them.",
+    "extraction_scaling": "Divides the MIDIA-dimension (mc) axis onto a comparable scale (quad-window "
+        "units). Higher → that axis matters less in the distance.",
+}
+
+
+def _help_html(key: str) -> str:
+    """The formatted explanation block shown when a knob's ⓘ is clicked."""
+    return (f"<div style='background:#eef6fb; border-left:3px solid #2b8cbe;"
+            f" padding:6px 10px; margin:4px 0; border-radius:3px;'>"
+            f"<b>{key.replace('_', ' ')}:</b> {_HELP.get(key, '')}</div>")
+
 
 def _initial_histograms() -> go.FigureWidget:
     fig = make_subplots(rows=2, cols=2, subplot_titles=("Cycle", "Scan", "m/z", "Size"))
@@ -55,7 +104,7 @@ def _initial_histograms() -> go.FigureWidget:
 class DataPanel:
     """Loads a retention-time slice of a run and applies a coarse range filter."""
 
-    def __init__(self, default_path: str = ""):
+    def __init__(self, default_path: str = "", browse_dir: str | None = None):
         self.experiment: MidiaExperiment | None = None
         self._loaded_path: str | None = None
         self.precursor_df = pd.DataFrame()
@@ -66,9 +115,11 @@ class DataPanel:
 
         # Browse-to-pick a run instead of typing the whole path. Bruker .d runs are
         # directories, so this navigates folders and lets you click a .d to select it
-        # (rather than a generic file chooser that would descend *into* the .d).
+        # (rather than a generic file chooser that would descend *into* the .d). The browser
+        # opens at ``browse_dir`` when given (e.g. a folder of runs), else the run's parent.
         self._suppress_browse = False
-        self.browse_dir = self._initial_browse_dir(default_path)
+        self.browse_dir = (browse_dir if browse_dir and os.path.isdir(browse_dir)
+                           else self._initial_browse_dir(default_path))
         self.browse_label = widgets.HTML()
         self.browser = widgets.Select(options=[], rows=8, description="",
                                       layout=widgets.Layout(width="60%"))
@@ -78,8 +129,15 @@ class DataPanel:
         self.refresh_button.on_click(lambda _c: self._refresh_browser())
         self._refresh_browser()
 
-        self.rt_start = widgets.FloatText(value=5.0, description="RT min (min):")
-        self.rt_stop = widgets.FloatText(value=7.0, description="RT max (min):")
+        # RT range as a span over the whole-run TIC, so you can see which part of the
+        # chromatogram you're slicing (faithful to the old timsVIS slice selector). Bounds are
+        # minutes; ``max`` widens to the real run length once a run is opened (_draw_tic).
+        self.rt_range = widgets.FloatRangeSlider(
+            value=[5.0, 7.0], min=0.0, max=46.0, step=0.1, readout_format=".1f",
+            description="RT (min):", continuous_update=False,
+            layout=widgets.Layout(width="60%"))
+        self.rt_range.observe(self._on_rt_range_change, names="value")
+        self.tic = self._make_tic_widget()
         self.mz_min = widgets.FloatText(value=700.0, description="m/z min:")
         self.mz_max = widgets.FloatText(value=730.0, description="m/z max:")
         self.scan_min = widgets.IntText(value=300, description="scan min:")
@@ -94,7 +152,8 @@ class DataPanel:
             widgets.HBox([self.browse_label, self.refresh_button]),
             self.browser,
             self.path,
-            widgets.HBox([self.rt_start, self.rt_stop]),
+            self.rt_range,
+            self.tic,
             widgets.HBox([self.mz_min, self.mz_max]),
             widgets.HBox([self.scan_min, self.scan_max, self.intensity_min]),
             widgets.HBox([self.load_button, self.status]),
@@ -146,9 +205,9 @@ class DataPanel:
             self.browse_dir = parent or os.path.sep
             self._refresh_browser()
         elif val.endswith(".d"):
-            self.path.value = val  # pick this run; load happens on "Load slice"
-            self.status.value = f"selected <b>{os.path.basename(val)}</b> — press Load slice"
+            self.path.value = val  # pick this run; the heavy point load happens on "Load slice"
             self._clear_browser_selection()  # so re-clicking the same .d works
+            self._show_tic()  # open the run (cheap metadata) and draw its TIC to pick against
         else:
             try:  # validate readability before navigating, so a failed open doesn't strand us
                 os.listdir(val)
@@ -159,14 +218,72 @@ class DataPanel:
             self.browse_dir = val
             self._refresh_browser()
 
+    def _ensure_experiment(self) -> None:
+        """Open the run (a cheap metadata read) if not already open for the current path."""
+        if self.experiment is None or self._loaded_path != self.path.value:
+            self.experiment = MidiaExperiment(self.path.value)
+            self._loaded_path = self.path.value
+
+    # -- TIC slice selector (faithful to the old timsVIS DDADataLoader) -------------------
+    @staticmethod
+    def _make_tic_widget() -> go.FigureWidget:
+        """An empty 2D TIC line. 2D FigureWidgets render fine under Voila (unlike Scatter3d)."""
+        fig = go.FigureWidget(data=go.Scatter(x=[], y=[], mode="lines",
+                                              line=dict(color="#444", width=1)))
+        fig.update_layout(title="Total Intensity Count (MS1)", template="plotly_white",
+                          xaxis_title="Time [min]", yaxis_title="Normalized intensity",
+                          yaxis_range=[0, 1], width=620, height=240,
+                          margin=dict(l=10, r=10, b=30, t=40))
+        return fig
+
+    def _show_tic(self) -> None:
+        """Open the run and draw its whole-run TIC, so the RT span is picked against it."""
+        try:
+            self.status.value = "<i>reading frame metadata…</i>"
+            self._ensure_experiment()
+            self._draw_tic()
+            self.status.value = (f"run open — <b>{self.experiment.n_cycles:,}</b> cycles; "
+                                 f"select an RT span, then press Load slice")
+        except Exception as e:
+            self.status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
+    def _draw_tic(self) -> None:
+        """Fill the TIC line from the run's MS1 SummedIntensities and fit the RT slider to it."""
+        tic = self.experiment.precursor_tic().sort_values("rt_min")
+        x = tic.rt_min.to_numpy()
+        y = tic.intensity.to_numpy()
+        ymax = float(y.max()) if len(y) and y.max() > 0 else 1.0
+        with self.tic.batch_update():
+            self.tic.data[0].x = x
+            self.tic.data[0].y = y / ymax
+        # Widen the RT span slider to the real run length and clamp the current span into it.
+        run_max = round(max(self.experiment.rt_max_min, 0.1), 1)
+        lo, hi = self.rt_range.value
+        self.rt_range.max = max(run_max, hi)  # never below the current high (ipywidgets invariant)
+        self.rt_range.value = [min(lo, run_max), min(hi, run_max)]
+        self.rt_range.max = run_max
+        self._draw_span()
+
+    def _draw_span(self) -> None:
+        """Redraw the green selection span on the TIC at the current RT range."""
+        lo, hi = self.rt_range.value
+        self.tic.layout["shapes"] = ()
+        self.tic.add_vrect(x0=lo, x1=hi, line_width=1, fillcolor="green", opacity=0.3)
+
+    def _on_rt_range_change(self, _change: object) -> None:
+        # The span only matters once a TIC is drawn; add_vrect on an empty plot is harmless.
+        self._draw_span()
+
     def _on_load(self, _change: object) -> None:
         try:
             self.status.value = "<i>loading…</i>"
-            if self.experiment is None or self._loaded_path != self.path.value:
-                self.experiment = MidiaExperiment(self.path.value)
-                self._loaded_path = self.path.value
+            newly_opened = self.experiment is None or self._loaded_path != self.path.value
+            self._ensure_experiment()
+            if newly_opened:
+                self._draw_tic()  # a typed-path first load gets its TIC too (not just .d picks)
+            rt0, rt1 = self.rt_range.value
             sl = self.experiment.get_slice_retention_time(
-                self.rt_start.value * 60.0, self.rt_stop.value * 60.0
+                rt0 * 60.0, rt1 * 60.0
             ).filtered(mz_min=self.mz_min.value, mz_max=self.mz_max.value,
                        scan_min=self.scan_min.value, scan_max=self.scan_max.value,
                        intensity_min=self.intensity_min.value)
@@ -182,7 +299,7 @@ class DataPanel:
         parts = [p for p in self.path.value.rstrip("/").split("/") if p]
         return {
             "id": parts[-1] if parts else "",
-            "rt_min_min": self.rt_start.value, "rt_max_min": self.rt_stop.value,
+            "rt_min_min": self.rt_range.value[0], "rt_max_min": self.rt_range.value[1],
             "mz_min": self.mz_min.value, "mz_max": self.mz_max.value,
             "scan_min": self.scan_min.value, "scan_max": self.scan_max.value,
             "intensity_min": self.intensity_min.value,
@@ -204,7 +321,7 @@ class PointCloudPanel:
 
         self.opacity = widgets.FloatSlider(value=0.3, min=0.1, max=1.0, step=0.1,
                                             description="opacity:", continuous_update=False)
-        self.point_size = widgets.FloatSlider(value=2.0, min=0.5, max=6.0, step=0.5,
+        self.point_size = widgets.FloatSlider(value=1.0, min=0.5, max=6.0, step=0.5,
                                               description="point size:", continuous_update=False)
         self.colorscale = widgets.Dropdown(options=sorted(px.colors.named_colorscales()),
                                            value="inferno", description="colors:")
@@ -281,7 +398,7 @@ class FragmentPointCloudPanel:
 
         self.opacity = widgets.FloatSlider(value=0.3, min=0.1, max=1.0, step=0.1,
                                             description="opacity:", continuous_update=False)
-        self.point_size = widgets.FloatSlider(value=2.0, min=0.5, max=6.0, step=0.5,
+        self.point_size = widgets.FloatSlider(value=1.0, min=0.5, max=6.0, step=0.5,
                                               description="point size:", continuous_update=False)
         self.colorscale = widgets.Dropdown(options=sorted(px.colors.named_colorscales()),
                                            value="inferno", description="colors:")
@@ -387,6 +504,94 @@ class FragmentPointCloudPanel:
         return fig
 
 
+class SurfacePanel:
+    """A 2D intensity heatmap over two raw axes — the third is summed (folded) out.
+
+    Recovers the old timsVIS ``TimsSurfaceVisualizer``: voxelize the precursor (MS1) slice and
+    sum one axis to get an intensity surface over the other two (RT×scan, RT×m/z or scan×m/z),
+    with identity/sqrt/log normalization and a coarse→fine resolution control. Rebuilt on
+    ``numpy.histogram2d`` + a 2D ``go.Heatmap`` — no TensorFlow and no heavy 3D ``go.Surface``,
+    so it stays light and renders under Voila. Like the original, this is an MS1-only view (the
+    old tool had no MIDIA surface) and folds the already range-filtered slice.
+    """
+
+    _DIMS = ["retention time", "scan", "m/z"]              # data order: (cycle, scan, mz)
+    _COL = {"retention time": "cycle", "scan": "scan", "m/z": "mz"}
+    _LABEL = {"retention time": "Cycle (RT)", "scan": "Scan (mobility)", "m/z": "m/z"}
+    _NBINS = {0: 60, 1: 120, 2: 240, 3: 480}              # resolution 0..3 -> bins per axis
+
+    def __init__(self, data_panel: DataPanel, title: str = "Intensity surface (MS1)"):
+        self.data_panel = data_panel
+
+        self.exclude_dim = widgets.Dropdown(options=self._DIMS, value="m/z", description="exclude:")
+        self.normalization = widgets.Dropdown(options=["identity", "sqrt", "log"],
+                                              value="identity", description="normalize:")
+        self.resolution = widgets.IntSlider(value=1, min=0, max=3, description="resolution:",
+                                            continuous_update=False)
+        self.colorscale = widgets.Dropdown(options=sorted(px.colors.named_colorscales()),
+                                           value="viridis", description="colors:")
+        self.render_button = widgets.Button(description="Display", button_style="info")
+        self.status = widgets.HTML()
+        self.render_button.on_click(self._on_render)
+        self.out = widgets.Output()
+        with self.out:
+            display(self._figure(None, "retention time", "scan"))
+
+        self.box = widgets.VBox([
+            widgets.HTML(f"<b>{title}</b>"),
+            widgets.HBox([self.exclude_dim, self.normalization, self.resolution, self.colorscale]),
+            widgets.HBox([self.render_button, self.status]),
+            self.out,
+        ])
+
+    def _on_render(self, _change: object) -> None:
+        try:
+            df = self.data_panel.precursor_df
+            if len(df) == 0:
+                self.status.value = "<i>load a slice first</i>"
+                return
+            exclude = self.exclude_dim.value
+            # Remaining dims keep the (cycle, scan, mz) order; first -> rows (y), second -> cols (x).
+            y_dim, x_dim = [d for d in self._DIMS if d != exclude]
+            yv = df[self._COL[y_dim]].to_numpy(dtype=float)
+            xv = df[self._COL[x_dim]].to_numpy(dtype=float)
+            w = df.intensity.to_numpy(dtype=float)
+            nb = self._NBINS[self.resolution.value]
+            # histogram2d(first, second) -> H[i,j] over (first=y, second=x); edges follow that order.
+            H, yedges, xedges = np.histogram2d(yv, xv, bins=nb, weights=w)
+            H = self._normalize(H)
+            xc = 0.5 * (xedges[:-1] + xedges[1:])
+            yc = 0.5 * (yedges[:-1] + yedges[1:])
+            self.status.value = (f"<b>{len(df):,}</b> pts → {H.shape[0]}×{H.shape[1]} grid, "
+                                 f"folded over {exclude}")
+            fig = self._figure((H, xc, yc), y_dim, x_dim)
+            with self.out:
+                self.out.clear_output(wait=True)
+                display(fig)
+        except Exception as e:
+            self.status.value = f"<span style='color:red'>{type(e).__name__}: {e}</span>"
+
+    def _normalize(self, H: np.ndarray) -> np.ndarray:
+        if self.normalization.value == "sqrt":
+            return np.sqrt(H)
+        if self.normalization.value == "log":
+            return np.log(H + 1.0)
+        return H
+
+    def _figure(self, grid: tuple | None, y_dim: str, x_dim: str) -> go.Figure:
+        fig = go.Figure()
+        if grid is not None:
+            H, xc, yc = grid
+            fig.add_trace(go.Heatmap(z=H, x=xc, y=yc, colorscale=self.colorscale.value,
+                                     colorbar=dict(title="Intensity")))
+        else:
+            fig.add_trace(go.Heatmap(z=[[0.0]]))
+        fig.update_layout(margin=dict(l=10, r=10, b=40, t=10), width=720, height=520,
+                          template="plotly_white",
+                          xaxis_title=self._LABEL[x_dim], yaxis_title=self._LABEL[y_dim])
+        return fig
+
+
 class _ClusterPanel:
     """Shared UI: HDBSCAN sliders, a Cluster button, a 3D scatter, stats + histograms."""
 
@@ -442,20 +647,52 @@ class _ClusterPanel:
         self.summary = widgets.Output()
         self.histograms = _initial_histograms()
 
+        # Click an ⓘ to pin its explanation here (hovering shows the same text as a tooltip).
+        self.help_box = widgets.HTML()
+
         self.box = widgets.VBox([
-            widgets.HTML(f"<b>{title}</b>"),
+            widgets.HTML(f"<b>{title}</b> &nbsp;<span style='color:#888'>— hover or click the "
+                         "<span style='color:#2b8cbe'>&#9432;</span> icons to learn what each knob does</span>"),
+            self.help_box,
             self._extra_controls(),
-            widgets.HBox([self.min_cluster_size, self.min_samples, self.metric]),
-            widgets.HBox([self.cycle_scaling, self.scan_scaling, self.mz_scaling, self.resolution]),
-            widgets.HBox([self.alpha, self.leaf_size,
-                          self.approx_min_span_tree, self.gen_min_span_tree, self.use_probability]),
-            widgets.HBox([self.cluster_button, self.filter_noise, self.colors]),
+            widgets.HBox([self._wrap_help(self.min_cluster_size, "min_cluster_size"),
+                          self._wrap_help(self.min_samples, "min_samples"),
+                          self._wrap_help(self.metric, "metric")]),
+            widgets.HBox([self._wrap_help(self.cycle_scaling, "cycle_scaling"),
+                          self._wrap_help(self.scan_scaling, "scan_scaling"),
+                          self._wrap_help(self.mz_scaling, "mz_scaling"),
+                          self._wrap_help(self.resolution, "resolution")]),
+            widgets.HBox([self._wrap_help(self.alpha, "alpha"),
+                          self._wrap_help(self.leaf_size, "leaf_size"),
+                          self._wrap_help(self.approx_min_span_tree, "approx_min_span_tree"),
+                          self._wrap_help(self.gen_min_span_tree, "gen_min_span_tree"),
+                          self._wrap_help(self.use_probability, "use_probability")]),
+            widgets.HBox([self.cluster_button,
+                          self._wrap_help(self.filter_noise, "filter_noise"),
+                          self._wrap_help(self.colors, "colors")]),
             widgets.HBox([self.config_name, self.save_button, self.save_status]),
             widgets.HBox([self.scatter_out, widgets.VBox([self.summary, self.histograms])]),
         ])
 
     def _extra_controls(self) -> widgets.Widget:
         return widgets.HBox([])
+
+    # -- per-knob help (hover tooltip + click-to-pin explanation) ------------------------
+    def _wrap_help(self, widget: widgets.Widget, key: str) -> widgets.HBox:
+        """Pair a control with a small ⓘ button: hover shows the tooltip, click pins the text.
+
+        A Button (not styled HTML) is used because ipywidgets' HTML sanitizes the ``title``
+        attribute away; a Button's ``tooltip`` trait surfaces on hover, and ``on_click`` writes
+        the explanation into the panel's shared ``help_box`` so a click does something visible.
+        """
+        b = widgets.Button(icon="info-circle", tooltip=_HELP.get(key, ""),
+                           layout=widgets.Layout(width="30px", height="28px"))
+        b.style.button_color = "transparent"
+        b.on_click(lambda _b, k=key: self._show_help(k))
+        return widgets.HBox([widget, b], layout=widgets.Layout(align_items="center"))
+
+    def _show_help(self, key: str) -> None:
+        self.help_box.value = _help_html(key)
 
     def _on_cluster(self, _change: object) -> None:
         try:
@@ -606,8 +843,10 @@ class MidiaHDBSCANPanel(_ClusterPanel):
         self.use_midia = widgets.Checkbox(value=True, description="include MIDIA dim", indent=False)
         self.extraction_scaling = widgets.IntSlider(value=36, min=1, max=120, step=1,
                                                     description="quad scaling:", continuous_update=False)
-        return widgets.HBox([self.cluster_selection_method, self.cluster_selection_epsilon,
-                             self.use_midia, self.extraction_scaling])
+        return widgets.HBox([self._wrap_help(self.cluster_selection_method, "cluster_selection_method"),
+                             self._wrap_help(self.cluster_selection_epsilon, "cluster_selection_epsilon"),
+                             self._wrap_help(self.use_midia, "use_midia"),
+                             self._wrap_help(self.extraction_scaling, "extraction_scaling")])
 
     def _cluster_settings(self) -> dict:
         return {**super()._cluster_settings(),
@@ -741,9 +980,11 @@ class MidiaFilterPanel:
 class MidiaVis:
     """Tabbed dashboard: data loading + precursor and MIDIA clustering."""
 
-    def __init__(self, default_path: str = ""):
-        self.data_panel = DataPanel(default_path)
+    def __init__(self, default_path: str = "", browse_dir: str | None = None):
+        self.data_panel = DataPanel(default_path, browse_dir=browse_dir)
         self.precursor_cloud = PointCloudPanel(self.data_panel, "precursor", "Precursor point cloud")
+        # Folded-intensity heatmap of the MS1 slice (recovers the old timsVIS Surface tab).
+        self.precursor_surface = SurfacePanel(self.data_panel)
         self.precursor_panel = PrecursorHDBSCANPanel(self.data_panel)
         # The MIDIA filter is the fragment source for the MIDIA cloud + clustering tabs.
         self.midia_filter = MidiaFilterPanel(self.data_panel)
@@ -751,18 +992,19 @@ class MidiaVis:
         self.midia_panel = MidiaHDBSCANPanel(self.midia_filter)
         self.tab = widgets.Tab(children=[self.data_panel.controls,
                                          self.precursor_cloud.box,
+                                         self.precursor_surface.box,
                                          self.precursor_panel.box,
                                          self.midia_filter.controls,
                                          self.fragment_cloud.box,
                                          self.midia_panel.box])
-        for i, t in enumerate(["Data", "Precursor cloud", "Precursor HDBSCAN",
+        for i, t in enumerate(["Data", "Precursor cloud", "Precursor surface", "Precursor HDBSCAN",
                                "MIDIA filter", "Fragment cloud", "MIDIA HDBSCAN"]):
             self.tab.set_title(i, t)
         self.tab.observe(self._on_tab_change, names="selected_index")
 
     def _on_tab_change(self, change: object) -> None:
         # Redraw the clustering histogram FigureWidgets when their (hidden) tab is shown.
-        panel = {2: self.precursor_panel, 5: self.midia_panel}.get(change["new"])
+        panel = {3: self.precursor_panel, 6: self.midia_panel}.get(change["new"])
         if panel is not None:
             panel.nudge_resize()
 

--- a/packages/imspy-vis/src/imspy_vis/pointcloud.py
+++ b/packages/imspy-vis/src/imspy_vis/pointcloud.py
@@ -11,7 +11,9 @@ def calculate_mz_tick_spacing(mz_min, mz_max, num_ticks=10):
 
 class ImsPointCloudVisualizer(abc.ABC):
     def __init__(self, data):
+        # numpy array of shape (N, 4) where each row is [x, y, z, intensity]
         self.data = data
+        # Create the widgets for the visualizer, including sliders and dropdown
         self.__create_widgets()
 
     def __create_widgets(self):

--- a/tims-viewer/CLUSTERING_WEB_PLAN.md
+++ b/tims-viewer/CLUSTERING_WEB_PLAN.md
@@ -1,0 +1,142 @@
+# Plan — clustering on the web (DBSCAN + MIDIA-style stats)
+
+Status: DESIGN (for codex review). The capstone: cluster the (focused) cloud, color it by cluster,
+and show a MIDIA-style stats panel. Builds on the focus-lens (FOCUS_LENS_PLAN.md) and reuses the
+native clustering + cluster-color path.
+
+## What already exists (recon)
+
+- **DBSCAN, render-safe.** `tims-viewer/src/cluster.rs` — hand-rolled, grid-accelerated DBSCAN in
+  pure `std` (no rayon/native deps), `dbscan(&[[f32;3]], eps, min_pts) -> (Vec<i32>, k)`,
+  noise = `-1`. Scales to ~2M points. **Compiles for wasm** — IF the `cluster` module is `pub` and
+  not behind `#[cfg(feature="native")]` (must verify/ungate so the web crate can call it).
+- **Cluster-color path, wired.** `GpuPoint._pad[0]` is the cluster id (sentinel `NO_CLUSTER =
+  u32::MAX`); `ParamsUniform.color_mode == 1` makes `point_cloud.wgsl` color by cluster
+  (`hsv2rgb(fract(id*0.618…), 0.65, 1.0)`, grey for noise) and **forces opaque** blending.
+- **Native reference.** `app.rs::run_clustering` clusters the *filtered* resident subset (window +
+  intensity + MS), capped at `CLUSTER_CAP = 2_000_000`; defaults `eps = 0.012` (normalized cube
+  units), `min_pts = 8`; writes labels into `_pad[0]`, re-uploads, records `cluster_count` /
+  `cluster_noise` / `cluster_input_count`.
+- **MIDIA stats (Python, to reproduce):** a summary table (Points / Intensity / Clusters × Total /
+  Cluster / Noise / Ratio) + four histograms across clusters (RT-extent, mobility-extent, m/z-extent,
+  and cluster size). HDBSCAN adds per-point membership probability — **no Rust HDBSCAN exists**, so
+  the web is **DBSCAN-only** for now.
+
+## Architecture: client-side, reuse everything
+
+Clustering runs **in wasm** on the retained `cpu_points`. No server. The lens makes it tractable:
+**Focus a region → cluster that** (fewer points). The flow:
+
+1. **Select the input:** ALL resident points passing the current filter (spatial crop + intensity
+   floor + MS mask) — *not* the Display draw-count prefix (Display is a render perf knob; native
+   clusters the full filtered resident). Build `idx: Vec<usize>` of those `cpu_points` indices for an
+   exact writeback. **V1: require `idx.len() <= CLUSTER_CAP` (2M)** — if more, prompt "Focus a region
+   first" (matches native, which refuses oversize input). Lowering the web cap further is fine since
+   it blocks the main thread.
+2. **Run** `tims_viewer::cluster::dbscan(&positions, eps, min_pts)` (positions = normalized cube
+   coords of the survivors). Status "clustering…" (it blocks the main thread for seconds — like the
+   volume build; worker later).
+3. **Write back + recolor:** set `cpu_points[idx[j]]._pad[0] = label as u32` (or `NO_CLUSTER` for
+   noise; non-survivors stay `NO_CLUSTER`), re-upload via `renderer.reset()` + `append(&cpu_points)`
+   (full re-upload for V1 — no partial `_pad[0]`-only API exists), set `params.color_mode = 1`, and
+   **switch the view to Points + force `PointMode::StructuralOpaque`** while clustered. ⚠ The web
+   `frame()` always renders with `self.point_mode`, so additive mode would mush the cluster hues —
+   render opaque when `color_mode == 1` (native does exactly this).
+4. **Stats:** compute the MIDIA metrics from the labels + survivor points (below), render into the
+   right-hand panel.
+
+## Cluster lifecycle (state)
+
+A clustering result is tied to the current loaded set + filter. Add `invalidate_clusters()`:
+`color_mode = 0`, reset all `_pad[0]` to `NO_CLUSTER`, clear the stats/right-panel, restore the
+user's point_mode. Call it on **Load / Focus / Back** (apply_load) and on **filter changes**
+(crop/floor/MS — `filter_dirty`): either invalidate, or mark the result **stale** and disable
+"Color by cluster" until re-run (so stale labels never colour a changed cloud). Track `clustered:
+bool` + the result (`k`, noise count, per-cluster aggregates) on `Gfx`.
+
+**Volume mode:** cluster coloring is a point-render concept and is invisible in Volume mode. On Run,
+switch to Points (and grey the Cluster tab while in Volume), matching native.
+
+## Stats to compute (web, from labels + survivors)
+
+- **Summary:** `k` clusters; signal vs noise point counts; signal vs noise intensity sums; the two
+  ratios (signal/noise points, signal/noise intensity) — exactly the MIDIA table.
+- **Per-cluster aggregates** (one pass over survivors, bucket by label): count, intensity sum, and
+  the bounding extent on each axis (mz/im/rt, in real units via `axis_bounds`). The MIDIA "unique
+  cycle/scan/mz per cluster" → web equivalent = per-cluster **extent** (or distinct-bin count) on
+  RT / 1/K₀ / m/z.
+- **Four histograms across clusters:** distributions of {RT-extent, 1/K₀-extent, m/z-extent, size},
+  drawn as SVG bars (same technique as the crop strips / projection maps).
+
+## UI
+
+- **Left rail — a new "Cluster" tab** (alongside View / Focus): ε slider, min-pts slider, a **Run**
+  button, a **Color by cluster** toggle (sets `color_mode`), and a readout (`k` clusters, noise %).
+- **Right panel — results** (a second `.rail` on `right: 16px`), shown only when the Cluster tab is
+  active *and* a result exists: the summary table + the four histograms. Hidden otherwise so the
+  canvas keeps the full width. Responsive: collapse/overlay on narrow viewports.
+
+## Phasing
+
+- **C1 — cluster + color.** Verify/ungate the `cluster` module for wasm; Cluster tab (ε / min-pts /
+  Run / Color-by-cluster); run DBSCAN on the filtered survivors (capped), write `_pad[0]`, re-upload,
+  `color_mode = 1`; HUD/readout `k` + noise %. Invalidate on reload.
+- **C2 — stats panel.** Right-hand panel with the summary table + four cluster histograms.
+- **C3 — interactions.** Click a cluster (in a list or on the cloud) → isolate/highlight it; optional
+  per-cluster intensity/RT profile; export labels.
+
+## Open questions / risks (for codex)
+
+- **Module reachability.** Is `tims-viewer/src/cluster.rs` `pub` and free of `#[cfg(feature=
+  "native")]` so `tims-viewer-web` (built `--no-default-features`) can call `dbscan`? If gated,
+  ungate it (it's pure std).
+- **Input selection + cap.** Cluster the filtered survivors capped at 2M — for a full-run resident
+  set (>2M) we cluster a prefix; is that acceptable, or require a Focus first? Keep the survivor↔
+  `cpu_points` index map straight so writeback targets the right points.
+- **eps units / scaling.** ε is in normalized cube units (uniform across m/z·1/K₀·RT), so the metric
+  is isotropic in normalized space but anisotropic in real units. MIDIA had an `mz_scaling`; do we
+  need per-axis weights for the web (defer to C3)? After a Focus, the cube is re-normalized to the
+  region, so the same ε clusters finer in real units — intended, but document it.
+- **Re-upload cost.** Writeback re-uploads the resident `cpu_points` (`reset` + `append`) — up to
+  N_cap × 32 B. Acceptable one-time per Run? Or update only the cluster-id attribute (partial
+  `write_buffer`) to avoid re-sending positions.
+- **color_mode + blend.** Cluster mode forces opaque in the shader — confirm it composes with the
+  Density/Solid `point_mode` and the Display draw-count; the recount HUD is intensity/MS based, not
+  cluster.
+- **Main-thread block.** 2M-point DBSCAN in wasm is seconds and freezes the tab — status + (later)
+  a worker; the grid-accelerated O(n) helps but verify.
+- **Lifecycle correctness.** Clearing ids/color on reload/Focus; not leaving a stale colored cloud or
+  a stale stats panel; what Volume mode shows (clusters are a point-render concept — disable or grey
+  the Cluster tab in Volume mode, or build a per-cluster density?).
+- **Right panel layout.** A second fixed rail — z-index, the canvas width, axis-label overlay, and
+  small/again-narrow viewports.
+- **HDBSCAN.** Deferred (no Rust impl); if needed it's a server-side (Python imspy) path — out of
+  scope for the wasm-only V1.
+
+## Codex review (incorporated)
+
+**Feasibility gate: PASS** — `cluster` is `pub mod cluster;` with no native cfg, so
+`tims_viewer::cluster::dbscan` is callable from the wasm web crate as-is (no ungate needed).
+
+- **[blocker] opaque blend** — the web `frame()` always renders `self.point_mode`, so cluster colour
+  in additive mode mushes. Render `StructuralOpaque` when `color_mode == 1` (folded into step 3).
+- **[risk] input set** — cluster the *filtered resident* set, not the drawn prefix; build the index
+  map from exactly that set for writeback (folded into step 1).
+- **[risk] cap** — V1 requires `idx.len() <= CLUSTER_CAP` (Focus first if larger); a lower web cap is
+  fine.
+- **[risk] re-upload** — only `reset()+append()` exists; V1 does a full re-upload (a partial
+  `_pad[0]` update would need a new renderer API + is awkward at the 32-byte stride).
+- **[risk] invalidation** — `apply_load` + filter changes must clear cluster state / mark stale
+  (folded into Lifecycle).
+- **[risk] Volume** — switch to Points on Run / grey the tab in Volume (folded in).
+- **[risk] main-thread block** — 2M DBSCAN is seconds–tens of seconds in wasm; status + a lower V1
+  cap, worker later.
+- **[nit] stats** — `GpuPoint` has no cycle/scan/original-m/z metadata, so the web histograms are
+  per-cluster **extents** (from `axis_bounds`), not exact unique counts; intensity sums use
+  `intensity * weight`.
+- **[nit] layout** — the right stats rail competes with the colorbar; hide the colorbar in cluster
+  mode / reserve the right-rail layout.
+
+**Codex's simpler first cut (= our C1):** Cluster tab (eps / min_pts / Run), require filtered
+resident ≤ CLUSTER_CAP, full `reset()+append()` re-upload, force opaque, basic `k / noise / input`
+stats. Defer partial GPU updates, the worker, and the full MIDIA histograms to C2/C3.

--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -11,44 +11,59 @@ rust-version = "1.84"
 [[bin]]
 name = "tims-viewer"
 path = "src/main.rs"
+# The binary is the native app (window + CLI + Bruker loader). The render library
+# (`src/lib.rs`) builds without these — see `native` below and NATIVE_WEB.md.
+required-features = ["native"]
 
 [dependencies]
-# Local data layer (zero-copy access to raw timsTOF frames)
-rustdf = { path = "../rustdf", version = "0.4.1" }
-mscore = { path = "../mscore", version = "0.4.1" }
-
-# GPU + windowing + UI. Pin the triple exactly: this is a known-compatible set
-# (egui-wgpu 0.29 -> wgpu 22, egui-winit 0.29 -> winit 0.30). Broad ranges risk a
-# resolution that mixes incompatible majors.
+# --- Render-safe core (compiles for wasm32 too): GPU, math, UI ---
+# Pin the GPU/UI versions exactly: a known-compatible set (egui-wgpu 0.29 -> wgpu 22).
 wgpu = "=22.1.0"
-winit = "=0.30.5"
 egui = "=0.29.1"
 egui-wgpu = "=0.29.1"
-egui-winit = { version = "=0.29.1", default-features = false, features = ["links", "wayland", "x11"] }
-
-# Math / GPU data
 bytemuck = { version = "1.21", features = ["derive"] }
 glam = { version = "0.29", features = ["bytemuck"] }
-
-# Async bridge for wgpu adapter/device requests
-pollster = "0.3"
-
-# Misc
-anyhow = "1"
 log = "0.4"
-env_logger = "0.11"
-clap = { version = "4.5", features = ["derive"] }
-rayon = "1.10"
-crossbeam-channel = "0.5"
-# f32 -> f16 conversion for the R16Float volume texture
+# f32 -> f16 conversion for the R16Float volume texture.
 half = { version = "2", features = ["bytemuck"] }
-# PNG screenshot export
-png = "0.17"
+
+# --- Native-only (gated behind `native`): Bruker .d loader, windowing, CLI, PNG export ---
+# These pull SQLite/filesystem/threads and can't run in a browser; excluded from the wasm
+# render lib. egui-winit 0.29 -> winit 0.30 (keep paired with the egui/wgpu triple above).
+# `pollster` (blocking adapter/device init) and `anyhow` are only used by native code; the
+# wasm shell will init async. (`pollster` is also a dev-dependency for the GPU smoke tests.)
+pollster = { version = "0.3", optional = true }
+anyhow = { version = "1", optional = true }
+rustdf = { path = "../rustdf", version = "0.4.1", optional = true }
+mscore = { path = "../mscore", version = "0.4.1", optional = true }
+winit = { version = "=0.30.5", optional = true }
+egui-winit = { version = "=0.29.1", default-features = false, features = ["links", "wayland", "x11"], optional = true }
+env_logger = { version = "0.11", optional = true }
+clap = { version = "4.5", features = ["derive"], optional = true }
+rayon = { version = "1.10", optional = true }
+crossbeam-channel = { version = "0.5", optional = true }
+png = { version = "0.17", optional = true }
+# Tiny synchronous HTTP server for the Phase-2 point-streaming endpoint (`--serve`).
+tiny_http = { version = "0.12", optional = true }
+serde_json = { version = "1", optional = true }
 
 [features]
-default = []
-# Pack positions/intensity as f16 to roughly double on-GPU point capacity.
+default = ["native"]
+# Everything that needs the OS / filesystem / threads. Off => the render-only library
+# (the wasm target builds with `--no-default-features`).
+native = [
+    "dep:pollster", "dep:anyhow", "dep:rustdf", "dep:mscore", "dep:winit", "dep:egui-winit",
+    "dep:env_logger", "dep:clap", "dep:rayon", "dep:crossbeam-channel", "dep:png",
+    "dep:tiny_http", "dep:serde_json",
+]
+# (reserved) Pack positions/intensity as f16 to roughly halve on-GPU/wire size. Not yet
+# implemented — see NATIVE_WEB.md Phase 3.
 compact = []
+
+[dev-dependencies]
+# The GPU smoke tests in render/{point_cloud,volume}.rs block on async adapter/device init,
+# so they need pollster even when building the render lib with --no-default-features.
+pollster = "0.3"
 
 # This crate is a leaf binary; keep its own release profile knobs consistent with the
 # workspace (panic=abort etc. are inherited from the workspace [profile.release]).

--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -26,6 +26,9 @@ glam = { version = "0.29", features = ["bytemuck"] }
 log = "0.4"
 # f32 -> f16 conversion for the R16Float volume texture.
 half = { version = "2", features = ["bytemuck"] }
+# Fast (non-DoS-resistant) hasher for the DBSCAN spatial-hash grid; pure Rust, wasm-safe, already in
+# the tree via wgpu/naga.
+rustc-hash = "2"
 
 # --- Native-only (gated behind `native`): Bruker .d loader, windowing, CLI, PNG export ---
 # These pull SQLite/filesystem/threads and can't run in a browser; excluded from the wasm

--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -49,6 +49,9 @@ png = { version = "0.17", optional = true }
 # Tiny synchronous HTTP server for the Phase-2 point-streaming endpoint (`--serve`).
 tiny_http = { version = "0.12", optional = true }
 serde_json = { version = "1", optional = true }
+# Optional over-the-wire compression of the (large) /points payload, negotiated via Accept-Encoding
+# (`--compress`). Native-only; the browser decompresses `Content-Encoding: zstd` transparently.
+zstd = { version = "0.13", optional = true }
 
 [features]
 default = ["native"]
@@ -57,7 +60,7 @@ default = ["native"]
 native = [
     "dep:pollster", "dep:anyhow", "dep:rustdf", "dep:mscore", "dep:winit", "dep:egui-winit",
     "dep:env_logger", "dep:clap", "dep:rayon", "dep:crossbeam-channel", "dep:png",
-    "dep:tiny_http", "dep:serde_json",
+    "dep:tiny_http", "dep:serde_json", "dep:zstd",
 ]
 # (reserved) Pack positions/intensity as f16 to roughly halve on-GPU/wire size. Not yet
 # implemented — see NATIVE_WEB.md Phase 3.

--- a/tims-viewer/DIA_WINDOWS_WEB_PLAN.md
+++ b/tims-viewer/DIA_WINDOWS_WEB_PLAN.md
@@ -1,0 +1,83 @@
+# Plan — DIA isolation-window overlay on the web (precursor selection in the scan×m/z plane)
+
+Status: DESIGN (for codex review). Port the native viewer's DIA/MIDIA window overlay to the WASM
+viewer's 3D scene: group-colored wireframe rectangles showing where the quadrupole selects precursors,
+in the m/z × 1/K₀ (scan) plane. Reuses the native window-read logic + the render-safe
+`AnnotationRenderer` + `group_color`.
+
+## What exists (recon)
+
+- **Native** (`src/data/loader.rs::build_annotations`, DIA branch): reads `read_dia_ms_ms_windows` +
+  `read_dia_ms_ms_info`, maps each window's `scan_num_begin/end → 1/K₀` (per-group representative
+  frame, `scan_to_inverse_mobility`), and draws the `(m/z × 1/K₀)` footprint
+  `[isolation_mz ± isolation_width/2] × [im0,im1]` as a rectangle at `N_SLICES=6` RT slices, colored
+  by `group_color(window_group, n_groups)`. Subsamples a fine MIDIA diagonal to `TARGET_WINDOWS≈800`.
+- **Renderer**: `AnnotationRenderer` (render-safe, wasm-reachable) draws `LineVertex` line-lists with
+  a depth-Always overlay pass + a per-vertex filter cull (`update_filter`). The web already uses ONE
+  instance for the axes cube.
+- **`group_color`** is in render-safe `render/colormap.rs` — callable from the web.
+- **Server** (`serve.rs`): `MetaIndex.mode = LoaderMode::Real { path }` carries the run path, so the
+  server can read windows at init; the dataset opens via `TimsDataset::new("NO_SDK", path, …)`.
+- **Web** has NO window data today (`/meta` doesn't send it; the web never parses it).
+
+## Architecture: run-level `/windows`, re-normalized client-side
+
+Windows are a property of the **run**, not the region — so fetch them **once**, re-normalize locally
+on each focus (no re-fetch). Cleaner than embedding per-region in `/meta`.
+
+### Server
+1. **Helper** (`loader.rs`): `dia_window_rects(mode: &LoaderMode) -> (Vec<WindowRect>, u32)` where
+   `WindowRect { group: u32, mz0,mz1,im0,im1: f64 }` in **real units**. DIA only (open the dataset,
+   read windows+info, scan→im per group, subsample to `TARGET_WINDOWS`); Demo/DDA → empty. Factor the
+   real-unit math out of `build_annotations`' DIA branch so both share it (the native then normalizes
+   the same rects to `LineVertex`).
+2. **State**: compute once in `serve()` init from `plan.meta.mode`; store `windows: Vec<WindowRect>`,
+   `n_window_groups: u32`.
+3. **Endpoint** `GET /windows` → JSON `{ "n_window_groups": N, "windows": [[g,mz0,mz1,im0,im1], …] }`.
+   Run-level, tiny, served from State (no per-region build).
+
+### Web
+1. **Fetch `/windows` once** at startup → `Vec<WindowRect>` (real units) + `n_window_groups` on `Gfx`.
+2. **Build the overlay** (`rebuild_window_overlay`): for each window × `N_SLICES` RT slices, normalize
+   the 4 `(m/z,1/K₀)` corners via `axis_bounds`, push the 4 edges as `LineVertex` colored by
+   `group_color(g, n_window_groups)`. Port `push_rect_mz_im`. Upload to a **second
+   `AnnotationRenderer`** (`windows`).
+3. **Cull off-region** windows with `update_filter([-1,1]³)` so windows outside the focused cube clip
+   (mirrors the native per-vertex cull) — windows normalize outside `[-1,1]` when off-region.
+4. **frame()**: `windows.update_camera` each frame; when `show_windows`, `windows.render(rpass)` after
+   the axes (depth Always). Re-`update_filter` from the crop sliders if we want them to honor crops
+   (decide: cull to cube only, or to the crop box too).
+5. **Rebuild triggers**: on `apply_load` (new `axis_bounds` → re-normalize) and on the toggle.
+6. **UI**: a **"Show DIA windows"** toggle (Focus tab), disabled when `n_window_groups == 0` (demo/
+   DDA). Per-group visibility bitmask is a follow-up (native has it; V1 shows all groups).
+
+## Phasing
+
+- **W1** — server `/windows` (helper + State + endpoint) and the web overlay (fetch, build, second
+  renderer, toggle, rebuild on load). DIA only, all groups.
+- **W2** — per-group visibility (checklist / legend, like the native bitmask), DDA precursor crosses,
+  honor crop sliders.
+
+## Open questions / risks (for codex)
+
+- **Helper refactor / reuse.** Factor `dia_window_rects` out of `build_annotations` cleanly (the scan→
+  im per-group + subsample + symmetric scan-widening for MIDIA) so the native overlay and the server
+  endpoint don't drift. Keep the native rendering identical.
+- **Server init cost / availability.** Reading windows + opening the dataset once at `serve()` init —
+  acceptable? Demo/DDA must no-op (empty). Confirm `read_dia_ms_ms_windows`/`scan_to_inverse_mobility`
+  are reachable from `serve.rs` (they're rustdf/native; the server is native).
+- **Normalization consistency.** Web normalizes windows to `axis_bounds` (= region bounds from
+  `/meta`), exactly like the cloud, so they align; on refocus, re-normalize the same real-unit list to
+  the new bounds (no re-fetch). Off-region windows map outside `[-1,1]` → `update_filter` clips them.
+- **RT slicing.** The native draws the footprint at `N_SLICES` RT slices so the recurring selection
+  sits on the data through the run. Port the same; confirm it reads well in the web (a focused RT
+  region still gets slices within `[rt0,rt1]`).
+- **Payload / subsample.** `TARGET_WINDOWS≈800` real-unit rects = a few KB JSON. A fine MIDIA scheme
+  (~15k windows) must subsample; surface the stride so we don't silently drop.
+- **Second AnnotationRenderer.** Confirm a second instance composes (its own buffer/camera/filter) and
+  the extra depth-Always overlay pass after axes is correct; per-frame `update_camera` for both.
+- **Toggle/UI + lifecycle.** Disabled when no windows; rebuild on load; does it interact with cluster
+  coloring / volume mode (windows are a 3D-scene overlay — show in Points and Volume? native shows
+  over the scene; decide for Volume).
+- **Crop interaction.** Should windows honor the crop sliders (cull to the crop box) or only the cube?
+  The native culls to the cube; the crop box is a separate decision.

--- a/tims-viewer/FLOW_PLAN.md
+++ b/tims-viewer/FLOW_PLAN.md
@@ -1,6 +1,6 @@
 # tims-viewer web — Flow restructure PLAN
 
-Status: **proposed, codex-reviewed (revisions incorporated)**
+Status: **codex-reviewed ×2 — buildable as written**
 Scope: `tims-viewer/web/index.html` + `tims-viewer/web/src/lib.rs`. One small server addition
 (frame count in `/meta`) is **optional** — see §4.
 
@@ -64,7 +64,9 @@ histograms, projections, `cycle_duration` — but **not** `n_points`, dataset na
 ([lib.rs:1121]). `/meta` exposes `n_points` + `cycle_duration` but **not** name/frame count
 ([serve.rs:609]); the name lives only in `/datasets`. So the summary will show **only what we can
 source cheaply**:
-- **name** — from the selected `/datasets` entry (stash it in `populate_datasets`),
+- **name** — from the selected `/datasets` entry. **[must-fix]** stash it **before**
+  `populate_datasets`' `arr.length() <= 1` early return ([lib.rs:1215]), or single-dataset runs
+  never get a name. (Move the name-stash above the "reveal picker only if >1" guard.)
 - **points** — add `n_points` to `MetaInfo` parsing (already in the `/meta` JSON),
 - **m/z · 1/K₀ · RT ranges** — from `MetaInfo.bounds`,
 - **cycle duration** — from `MetaInfo.cycle_duration`.
@@ -89,14 +91,19 @@ Two distinct artifacts, two buttons, distinct enable rules:
 So the post-run `cluster_params.json` stays tied to results; the new live `config.json` is the
 anytime recipe. (`cluster_params_json` gains a `dataset` field so both agree.)
 
+**[risk] `ClusterRunParams` is `Copy`** ([lib.rs] snapshot struct). Add the dataset **id** (`usize`,
+Copy-safe) there — **not** the name (a `String` would break `Copy`). Resolve the name at serialize
+time (it's already in client state from the picker), keeping the snapshot `Copy`.
+
 ## 6. Implementation steps (revised)
 
 1. **Tabs bar** (`index.html`): 5 buttons, `data-tab` = `data|region|cluster|save|display`; gear
    right-aligned (`margin-left:auto`), four numbered `①…④`.
 2. **`switch_tab` is NOT generic today** — it hard-codes `["view","focus","cluster"]`
    ([lib.rs:2800]). **Must** update that list to `["data","region","cluster","save","display"]`
-   (or derive it from `document.querySelectorAll(".tab[data-tab]")`). Update the **default active
-   tab** in both HTML (`.active`) and this list.
+   (or derive it from `document.querySelectorAll(".tab[data-tab]")`). The **default active tab** is
+   set purely by the HTML `.active` class on the tab button + pane (`switch_tab`'s list only needs to
+   *contain* the names) — set `.active` on the **② Region** button+pane in markup.
 3. **① Data pane** (`#tab-data`): move `#dspick` here; add summary nodes
    (`#data-name`, `#data-points`, `#data-mz`, `#data-im`, `#data-rt`, `#data-cycle`).
 4. **② Region**: rename `#tab-focus` → `#tab-region`, `data-tab="region"`. Content as-is (maps stay
@@ -139,6 +146,12 @@ anytime recipe. (`cluster_params_json` gains a `dataset` field so both agree.)
 - Carry these **companion ids** with their controls so markup moves don't orphan them:
   `#load-cap`+`#load-n`; `#cl-algo-status`/`#opt-sklearn`/`#opt-hdbscan`+`#cl-algo`;
   `#floor-src`+Floor; `#railtgl-r`/`.railbtn-r` stay with the (unchanged) cluster panel.
+- **[risk] Rail toggles are CSS sibling-structure dependent**, not listener-dependent: `#railtgl` /
+  `#railtgl-r` must keep their position **relative to their rails/buttons** (the `:checked ~` sibling
+  selectors). Don't relocate them — they sit outside the tab panes already, so the tab work won't
+  touch them, but note it.
+- Map drag is id-bound to `#mw-*` (+ window move/up) and dual crop sliders are id-bound, so moving
+  the maps **within** Region is a no-op for their handlers. *(codex pass 2 confirmed.)*
 
 ## 8. Out of scope (future)
 

--- a/tims-viewer/FLOW_PLAN.md
+++ b/tims-viewer/FLOW_PLAN.md
@@ -1,0 +1,154 @@
+# tims-viewer web — Flow restructure PLAN
+
+Status: **proposed, codex-reviewed (revisions incorporated)**
+Scope: `tims-viewer/web/index.html` + `tims-viewer/web/src/lib.rs`. One small server addition
+(frame count in `/meta`) is **optional** — see §4.
+
+## 1. Goal
+
+Make the GUI embody the natural working flow so it reads as a guided sequence, not a
+pile of controls:
+
+> **① select a dataset → ② select a subsection → ③ iterate on clustering → ④ save a config + results**
+
+…without losing free-form **interactive exploration** (orbit/zoom, colormap, transfer,
+volume, etc.).
+
+## 2. Core design decision: layers, not modes
+
+Exploration is **not a mode you switch into — it is always on** (the canvas is live the
+whole time, and display tuning is one click away). The flow is a **task spine laid over**
+that ambient exploration. Therefore **no hard "Flow/Explore mode" toggle** (it would split a
+shared control set, add a hidden "which mode" variable, and double the layout). Combine via
+**relocation + progressive disclosure**:
+
+- the numbered tabs carry the **flow** (lean, only flow-essential controls),
+- a separate **⚙ Display** tab is the **exploration toolbox** (all render/display knobs),
+- a per-tab **`Advanced ▾`** disclosure reveals the few genuinely-deep knobs in context.
+
+A global `Simple/Advanced` toggle is **out of scope for v1** (add later only if missed).
+*(Codex concurred this is sound; a hard mode would only be warranted if two canvas drag-gestures
+ever conflicted — e.g. box-select vs lasso vs measure. Not the case today.)*
+
+## 3. Target structure
+
+```
+tims·view                              ⚙
+┌─────────────────────────────────────────┐
+│ ① Data   ② Region   ③ Cluster   ④ Save  │   ⚙ = Display (right-aligned, un-numbered)
+├─────────────────────────────────────────┤
+│ ② REGION                                 │
+│ Drag on the cloud to box-select          │
+│ [⊕ Focus]   [← Back]                      │
+│ m/z 612–680 · 1/K₀ 0.94–1.10 · RT 31–44s │
+│ Floor ▁▂▃▅▇  1.2k                         │
+└─────────────────────────────────────────┘
+   numbers signal order; tabs are NOT gated (re-focus / re-cluster freely)
+```
+
+## 4. What goes in each tab (mapping from today)
+
+| Tab | New content | Comes from |
+|-----|-------------|-----------|
+| **① Data** | Dataset dropdown + a read-only **meta summary** (see scope below) | dataset picker **moves out of `.head`**; summary is **new** |
+| **② Region** | Focus/Back, MS show, DIA-windows toggle + legend (`#show-windows`, `#win-groups`), the 3 axis crop sliders, the 3 box-select **maps** (must stay visible — they are layout-measured, never behind a collapsed `<details>`), intensity **Floor** (`#floor`, `#floor-n`, `#floor-src`) | current **`tab-focus`** |
+| **③ Cluster** | Algorithm (`#cl-algo` + `#cl-algo-status`, `#opt-sklearn`, `#opt-hdbscan`) + its params, Run/Stop (`#cl-run`), progress, `#cl-color` / `#hide-noise`, result readout. **`Advanced ▾`** holds RT-cycles (`#cl-rtc`), m/z-peak-widths (`#cl-mzw`), HDBSCAN selection-ε (`#cl-cse`) | current **`tab-cluster`**, levers moved under `<details>` |
+| **④ Save** | **Export results** + **Export config** (two buttons — see §5) | results button relocates from the right rail (`#cl-export`); config button (`#cfg-export`) is **new** |
+| **⚙ Display** | view/reset/roll, Points/Volume + vol style/steps, display fraction (`#disp`), **load** (`#load-n` + `#load-cap`), density/solid, colormap, point size, opacity, transfer, exposure | current **`tab-view`** (renamed) |
+
+The **right rail** (cluster stats: summary table, per-cluster histograms, cluster list, and its
+own `#railtgl-r` / `.railbtn-r` toggle) is **unchanged** except the Export button leaves it.
+
+**Data-summary scope (revised — codex [must-fix]).** `MetaInfo` today parses bounds, intensity,
+histograms, projections, `cycle_duration` — but **not** `n_points`, dataset name, or frame count
+([lib.rs:1121]). `/meta` exposes `n_points` + `cycle_duration` but **not** name/frame count
+([serve.rs:609]); the name lives only in `/datasets`. So the summary will show **only what we can
+source cheaply**:
+- **name** — from the selected `/datasets` entry (stash it in `populate_datasets`),
+- **points** — add `n_points` to `MetaInfo` parsing (already in the `/meta` JSON),
+- **m/z · 1/K₀ · RT ranges** — from `MetaInfo.bounds`,
+- **cycle duration** — from `MetaInfo.cycle_duration`.
+- **frame count** — **dropped** in v1 (not in `/meta`). *Optional:* add `frames` to the `/meta`
+  JSON in `serve.rs` if we want it. Plan assumes dropped.
+
+## 5. Save: export + config (revised — codex [must-fix])
+
+Two distinct artifacts, two buttons, distinct enable rules:
+
+- **Export config** (`#cfg-export`, **always enabled**): a **live** serializer (new) — the
+  reproducible *recipe*, available before any run: `dataset` (id + name), `region`
+  (`axis_bounds`), `ms_mask`, `intensity_floor`, `algorithm` + its params + the metric levers.
+  **Does not reuse `cluster_params_json`** (that only exists post-run and carries result stats and
+  no dataset id — [lib.rs:2876]). Writes `config.json`.
+- **Export results** (`#cl-export`, **disabled until a result exists**): the existing dual
+  download — `clusters.csv` + the post-run `cluster_params.json` (params + counts that produced
+  *these* results). Today `export_clusters` silently no-ops with no result ([lib.rs:2927]); in Save
+  it must instead be **disabled** (greyed) until `cluster_stats` is set, toggled where the result
+  is finished/invalidated.
+
+So the post-run `cluster_params.json` stays tied to results; the new live `config.json` is the
+anytime recipe. (`cluster_params_json` gains a `dataset` field so both agree.)
+
+## 6. Implementation steps (revised)
+
+1. **Tabs bar** (`index.html`): 5 buttons, `data-tab` = `data|region|cluster|save|display`; gear
+   right-aligned (`margin-left:auto`), four numbered `①…④`.
+2. **`switch_tab` is NOT generic today** — it hard-codes `["view","focus","cluster"]`
+   ([lib.rs:2800]). **Must** update that list to `["data","region","cluster","save","display"]`
+   (or derive it from `document.querySelectorAll(".tab[data-tab]")`). Update the **default active
+   tab** in both HTML (`.active`) and this list.
+3. **① Data pane** (`#tab-data`): move `#dspick` here; add summary nodes
+   (`#data-name`, `#data-points`, `#data-mz`, `#data-im`, `#data-rt`, `#data-cycle`).
+4. **② Region**: rename `#tab-focus` → `#tab-region`, `data-tab="region"`. Content as-is (maps stay
+   visible, not behind `<details>`).
+5. **③ Cluster**: wrap `#cl-rtc`/`#cl-mzw`/`#cl-cse` rows in `<details class="adv"><summary>` …
+   keep their ids (collapsed bound inputs still sync — codex confirmed). Do **not** put any
+   button inside an `.ey` header (the section-collapse delegate keys on `.ey`+parent).
+6. **④ Save pane** (`#tab-save`): two `.btn` buttons (`#cl-export` relocated → restyle from
+   `.cs-export` to `.btn`; `#cfg-export` new). Neither inside an `.ey` header.
+7. **⚙ Display**: rename `#tab-view` → `#tab-display`, `data-tab="display"`.
+8. **CSS**: 5-tab row, numbered spacing, gear right-aligned, `.adv` disclosure, Data summary list,
+   the relocated export buttons.
+9. **Rust (`lib.rs`) — the bulk of the work:**
+   - `switch_tab` tab-key list + default tab (step 2).
+   - Parse `n_points` into `MetaInfo`; stash dataset **name** from `/datasets`; **populate the Data
+     summary** (new fn, called after `/meta` + after dataset name is known).
+   - **Split export:** `#cl-export` → results (csv + post-run params json), **disabled** until
+     `cluster_stats` exists (toggle on finish/invalidate). `#cfg-export` → new **live config
+     serializer** (dataset id+name, region, ms, floor, algorithm+params+levers).
+   - Add a `dataset` field to `cluster_params_json` so results-json and config agree.
+   - `on_cluster_tab` keys on `#tabbtn-cluster` ([lib.rs:2833]) — unchanged (Cluster keeps that id).
+   - `populate_datasets` already targets `#dataset-sel`/`#dspick` (now in `#tab-data`) — no change.
+
+## 7. Safety / non-breaking notes (revised — codex [risk])
+
+- **Most** bindings are by id (`by_id`, `set_checked`, id pairs), so moving `#disp`, `#floor`,
+  `#cl-eps`, `#dataset-sel`, `#cl-export`, etc. between panes is safe.
+- **Structure-delegated listeners are the exception** — keep these intact:
+  - `.tab` click via `closest(".tab")` ([lib.rs:2813]) — the new tabs must keep `class="tab"` +
+    `data-tab`.
+  - **Section collapse** keys on `.ey` + `parent_element()` ([lib.rs:2674]) → **never place a
+    button inside an `.ey`**. (The old `#cl-export` lived in an `.ey` and stopped propagation; in
+    Save it becomes a normal row, so the issue disappears.)
+  - cluster-list `.cs-row` and window-legend `.wg` delegates ([lib.rs:2714]) — both stay in the
+    right rail / Region, untouched.
+- `.points-only` / `.vol-only` are keyed on `body.volmode`, **not** tab names — they survive the
+  `view→display` rename.
+- The right stats rail shows iff `#tabbtn-cluster` is active; **Save export reads `gfx`
+  state, not the rail DOM**, so it works even though the rail is hidden on the Save tab.
+- Carry these **companion ids** with their controls so markup moves don't orphan them:
+  `#load-cap`+`#load-n`; `#cl-algo-status`/`#opt-sklearn`/`#opt-hdbscan`+`#cl-algo`;
+  `#floor-src`+Floor; `#railtgl-r`/`.railbtn-r` stay with the (unchanged) cluster panel.
+
+## 8. Out of scope (future)
+
+- Global `Simple/Advanced` toggle. — **Loading** a config to restore a flow (v1 only *exports*).
+- Per-step "done" cues (② shows the active region, ③ the cluster count). — Frame count in `/meta`.
+
+## 9. Decisions (open questions resolved)
+
+1. **Default landing tab → ② Region.** The page already loads a dataset; the first *action* is
+   selecting a subsection. (① Data is one click away to orient/switch.)
+2. **Export lives solely in ④ Save** (removed from the right rail) — no duplication.
+3. **Floor stays in ② Region** — it's part of selecting *what* to cluster (prior decision).
+4. **`#cl-color` / `#hide-noise` stay primary** in ③ Cluster (not Advanced).

--- a/tims-viewer/FOCUS_LENS_PLAN.md
+++ b/tims-viewer/FOCUS_LENS_PLAN.md
@@ -1,0 +1,213 @@
+# Focus-Lens LOD — plan (tims-viewer web)
+
+Status: DESIGN, codex-reviewed (findings folded in — see "Codex review" at end).
+Builds on NATIVE_WEB.md Phase 2 (point server + WASM shell).
+
+## Problem
+
+A real run is ~1.1 billion points (~33 GB at 32 B/point). The GPU can hold only
+**N_cap = max_buffer_size / 32** points (already the hard cap in the web shell). We need both an
+overview of the whole run and the ability to drill into a region at high detail, never exceeding
+N_cap. The current 12M `--budget` is an arbitrary pre-cap; the real ceiling is N_cap.
+
+## Mental model: a fixed-capacity 4D lens
+
+The GPU is a lens of fixed point-capacity (N_cap) that we move and resize over the run. Resizing the
+lens **smaller** concentrates the same point budget into a smaller volume → higher local resolution
+at constant GPU cost. The lens is **4D**: m/z × 1/K₀ × RT × **intensity**. Narrowing *any* axis
+(including intensity) shrinks the region, so the same budget resolves it more finely; once the
+survivors in the source fall below N_cap, we load **all** of them (stride 1, full detail) and the
+displayed count simply drops.
+
+## The single primitive — and its contract
+
+```
+load(region: Region4D, budget: u32) -> LoadResult     // budget ≤ N_cap, enforced
+```
+
+`load()` must return ONE coherent object (codex: the contract was too thin):
+
+```
+LoadResult {
+  points:        Vec<GpuPoint>,   // shuffled, normalized to display_bounds
+  returned:      u32,             // == points.len()
+  survivors_est: u64,             // est. total points matching region in the source (pre-sample)
+  sampling:      { stride|reservoir, seed },   // how `points` was drawn from survivors
+  source_region: Region4D,        // the committed filter (for cache key + intensity semantics)
+  display_bounds:[(f64,f64);3],   // the [-1,1] re-normalization basis (mz,im,rt)
+  meta:          { hist[mz,im,rt], i_hist, percentiles, sample_based: true },
+}
+```
+
+`Region4D = { mz:(f64,f64), im:(f64,f64), rt:(f64,f64), intensity_min:f32 }`. Server returns
+`min(survivors_est, budget)` points. Client rebuilds the GPU buffer, re-normalizes to
+`display_bounds`, and rebinds axes / crop ranges / strips from `meta` — **atomically**.
+
+| Operation     | call                                  |
+|---------------|---------------------------------------|
+| coarse view   | `load(full_bounds, N_cap)`            |
+| pre-load      | the first `load(full, N_cap)` at start|
+| focus / drill | `load(crop_region_4d, N_cap)`         |
+| re-load       | any subsequent `load(...)`            |
+| reset / back  | replay a cached `LoadResult` (stack)  |
+| display       | runtime `draw_count` (no reload)      |
+
+## ⚠ Budget must be region-relative (codex blocker 1)
+
+The loader computes `stride_for(total_estimate, budget)` from the **full-run** estimate *before*
+filtering ([loader.rs:203], filter applied later at [loader.rs:388]). So a naive region query keeps
+the coarse full-run stride and **focus would not densify** — the core premise. Fix, required in
+Phase A:
+
+- Estimate **survivors in the region** first: frames in `[rt0,rt1]` give the frame set; scale the
+  per-frame point estimate by the m/z·1/K₀·intensity selectivity (cheap heuristic) OR do a real
+  **count pass** over the filtered stream.
+- Drive the sampler from `survivors_est`, not the full-run total: stride = `survivors_est / budget`
+  (≥1), or switch to a **bounded reservoir** over the filtered stream (size = budget) so we don't
+  need an exact pre-count. Reservoir is the robust default; it self-limits to `budget` and yields
+  stride 1 automatically when survivors ≤ budget.
+- Return `survivors_est` separately from `returned` so the client/HUD can say "showing all" vs
+  "sampled X of ~Y".
+
+## Two-tier filtering (the crux) + intensity's dual role
+
+The crop sliders and the intensity floor do double duty:
+
+1. **Preview (instant, in-GPU cull):** the existing window + intensity-floor cull runs in the
+   vertex/compute shader on the *currently loaded* sample. Free and live; the displayed count drops
+   as you filter (see Displayed count).
+2. **Commit (Focus → re-load):** the *same* 4D crop+intensity box becomes the `Region4D`; the
+   re-load spends the full budget on survivors and re-normalizes the cube to fill the view.
+
+**Intensity has two distinct roles (codex risk).** The floor is BOTH a live display cull (on the
+resident set) AND, when committed via Focus, a *source* filter. After a focus with `intensity_min`,
+low-intensity points are no longer resident — lowering the live floor below the **committed source
+floor** cannot reveal them. So state splits explicitly:
+
+- `display_floor` — live cull on resident points (instant, reversible).
+- `committed_floor` — part of `source_region` of the current load.
+- If the user drags `display_floor` **below** `committed_floor`, the UI marks it "needs reload"
+  (greys the region beyond what's loaded) and offers Re-load; it never silently shows nothing.
+
+## Displayed count (must reflect the 4D filter)
+
+"Displayed" = points surviving the active cull, not resident / `draw_count`. Use **CPU recount on
+both backends** (simpler and correct; avoids the compaction pitfalls below):
+
+- Keep the resident `Vec<GpuPoint>` in scene state (codex risk: `Gfx` doesn't retain it today — add
+  it; update on every reload). Recount survivors **on filter change** (not per frame) over the same
+  `draw_count` prefix Display uses. O(resident) occasionally — fine at ≤ N_cap.
+- HUD shows `displayed / resident` (+ "of ~survivors_est in source" when sampled).
+
+Why not the WebGPU indirect count (codex blocker 2): the compaction shader culls window+MS+frustum
+but **not intensity** ([compact.wgsl:67] vs [point_cloud.wgsl:86]), so `instance_count` overcounts;
+and `draw_args` lacks `COPY_SRC` for readback ([point_cloud.rs:377]). CPU recount sidesteps both. (If
+we later want GPU truth, add intensity to compaction + `COPY_SRC` + a staging readback, and define
+whether the count includes frustum culling.)
+
+## Server: query-capable with a job + cache layer (codex risk)
+
+`serve()` today precomputes one `Arc<[u8]>`, ignores query strings, and handles requests serially in
+the `tiny_http` loop ([serve.rs:36], [serve.rs:85]). A blocking region load would stall everything.
+Redesign:
+
+- **Job layer:** region loads run off the accept loop (worker thread/pool); the HTTP handler returns
+  job status / the finished `LoadResult` bytes. Support cancellation (a newer focus supersedes an
+  in-flight one).
+- **Shared result:** `/meta` and `/points` for a region serve from ONE computed `LoadResult` keyed
+  by `(Region4D, budget, display_bounds)` — never recompute independently.
+- **Cache:** an LRU of `LoadResult`s keyed as above. Each entry is an inseparable bundle
+  (points + meta + display_bounds + source_region); cached bytes are normalized to *their* bounds,
+  so they cannot be mixed. **Only cached stack entries are instant** — nested Back is instant only if
+  each focused `LoadResult` is still cached; otherwise it re-queries.
+- Bind localhost-only; keep CORS. Query: `GET /points?n=&mz0=&mz1=&im0=&im1=&rt0=&rt1=&imin=` and
+  matching `/meta?…`.
+
+### RegionFilter extension (loader)
+
+`RegionFilter` is `{ mz, im }` today (RT via frame selection). Extend with `intensity_min: f32` so
+intensity is a source-side cull. RT stays frame-selection-based; the web query maps `rt0/rt1` →
+frame_ids, `mz/im/imin` → `RegionFilter`. **Note (codex):** apply `intensity_min` *before* peak
+selection so peaks are chosen from survivors; and label region `meta` as **sample-based** (hists /
+percentiles are over the kept systematic sample + peak tail, not the true region distribution) —
+optionally add a true stats pass later.
+
+## Re-normalization must be atomic (codex risk)
+
+Points are normalized before upload, and the shader also has a `params.focus` re-fit path
+([point_cloud.wgsl:109]). A focused reload that normalizes the region to `[-1,1]` while leaving old
+crop slider values or shader focus active → double-crop/remap. On every load, **atomically**:
+reset spatial crop uniforms + sliders to full `[-1,1]`, turn shader `focus` off, and set
+`axis_bounds`, tick labels, distribution strips, and crop readouts from `LoadResult.display_bounds`.
+
+## Client: reload path
+
+- **N_cap detect:** `device.limits().max_buffer_size / size_of::<GpuPoint>()` (clamp by
+  storage-bind limit on the compaction path). Already computed for the capacity cap; surface it.
+- **`load(region, budget)`** (async): fetch `/meta?…` + `/points?…&n=budget`, rebuild the
+  `PointCloudRenderer` at the new capacity, upload, retain CPU points, re-normalize + rebind
+  atomically, reset Display to 100%, show a loading state during the query.
+- **Focus stack:** `Vec<Region4D + LoadResult-ref>`; Focus pushes the current crop+intensity box,
+  Back pops (replays cache or re-queries). Full-run region is the base.
+- **UI:** Focus button, Back/Reset, Load field (budget within `[0, N_cap]`), the existing Display
+  slider (runtime draw_count). Loading spinner during queries; "needs reload" hint when the live
+  floor drops below the committed floor.
+
+## Decisions (confirmed with user)
+
+1. Focus **re-normalizes** the region to `[-1,1]`; full bounds cached for Back. ✔
+2. **Nested drill-down via a focus stack**. ✔
+3. Default pre-load budget = **N_cap**. ✔
+4. Focus region source = **crop box + intensity floor + a Focus button**; 2D box-select feeds the
+   same primitive later. ✔
+5. **Drop the server "pool" concept** — every (uncached) load re-queries the source; `--budget` is
+   only a fallback default for N_cap when the GPU can't be probed. ✔
+6. **Caveat:** the lens is 4D — intensity shrinks the region and lowers the displayed count, both as
+   a live cull and as part of the Focus re-load. ✔
+
+## Phasing (reordered per codex — de-risk the hard parts first)
+
+- **A1 — server job/cache/query model.** Query parser, off-loop job runner, `LoadResult` cache,
+  shared `/meta`+`/points`. No new sampling yet.
+- **A2 — region + intensity sampling on DEMO (known counts).** Extend `RegionFilter` with
+  `intensity_min`; make sampling **region-relative** (reservoir or count-then-stride); validate that
+  a focused region actually spends the budget and `survivors_est` is right, using the demo source
+  where counts are known. *(This is the blocker-1 proof.)*
+- **A3 — client reload/rebind.** `load()` end to end on full bounds: rebuild renderer, retain CPU
+  points, atomic re-normalize + rebind, Load field, N_cap surfaced.
+- **B — displayed-count parity.** CPU recount on both backends; HUD `displayed / resident`
+  (+survivors). Split `display_floor` vs `committed_floor`.
+- **C — Focus / Back.** Crop+intensity box → Focus re-load → focus stack + cache replay + "needs
+  reload" affordance.
+- **D — 2D projection tab + (optional) progressive streaming.** Heatmaps of
+  `proj_mz_im/proj_mz_rt/proj_im_rt`; box-select writes a `Region4D` and calls the same `load()`.
+
+## Risks / open questions
+
+- **Region-relative sampling is the crux** — without it, focus doesn't densify (blocker 1). Reservoir
+  sampling over the filtered stream is the recommended default (no exact pre-count needed).
+- **Region query latency:** re-reading frames per Focus takes seconds → non-blocking job + loading
+  state; progressive first paint is a later option.
+- **Sample-based meta:** region hists/percentiles approximate the region (kept sample + peak tail);
+  label as such, add a true stats pass only if needed.
+- **Empty regions:** a focus yielding 0 survivors must no-op (keep prior view + warn).
+- **Cache memory:** each cached stack entry is ~N_cap × 32 B; bound the LRU.
+
+## Codex review (incorporated)
+
+- [blocker] region budget was driven by the full-run estimate → focus wouldn't densify → added the
+  "Budget must be region-relative" section (reservoir / count-then-sample) and `survivors_est`.
+- [blocker] WebGPU displayed-count via indirect `instance_count` overcounts (no intensity cull in
+  compaction) and `draw_args` isn't `COPY_SRC` → switched Displayed count to **CPU recount on both
+  backends** + retain CPU points in scene state.
+- [risk] intensity's dual role (live cull vs committed source floor) → split `display_floor` /
+  `committed_floor` + "needs reload" affordance.
+- [risk] server can't be lightly extended → job/cache layer, off-loop loads, shared `LoadResult`.
+- [risk] cache correctness → keyed by `Region4D+budget+display_bounds`, inseparable bundle, only
+  cached stack entries instant.
+- [risk] intensity-at-source vs peak preservation / histograms → apply floor before peak selection;
+  label meta sample-based.
+- [risk] re-normalization double-apply → atomic reset of crops + shader focus + bounds rebind.
+- [risk] CPU recount needs retained CPU points → add resident `Vec<GpuPoint>` to scene state.
+- [nit] phase order → reordered to A1/A2/A3 → B → C → D so sampling + displayed-count land before
+  Focus UX.

--- a/tims-viewer/NATIVE_WEB.md
+++ b/tims-viewer/NATIVE_WEB.md
@@ -1,0 +1,235 @@
+# tims-viewer on the web — embedding the native GPU renderer in a browser
+
+Goal: run the `tims-viewer` GPU renderer **inside a web application** (a `<canvas>`), so the
+web tool gets the native viewer's look and large-data efficiency instead of Plotly. The Bruker
+`.d` loader stays server-side; the browser renders points on the **client GPU** via WebGPU
+(WebGL2 fallback).
+
+## Why this is feasible (verified against the code + codex review)
+
+- **It's `wgpu` + WGSL.** `wgpu` targets Vulkan/Metal/DX12 natively **and WebGPU/WebGL2 in the
+  browser via wasm32**; shaders are `src/shaders/*.wgsl` and WGSL *is* the WebGPU shading
+  language — so on **WebGPU** there's no shader translation. On the **WebGL2** fallback, `wgpu`'s
+  `naga` translates WGSL→GLSL and must validate against GL limits (an acceptance item, not free).
+  (`Cargo.toml`: `wgpu=22.1`, `egui=0.29.1`, `egui-wgpu`, `winit=0.30.5`, all wasm-capable.)
+- **The point renderer is window-independent (but the canvas path is new work).**
+  `PointCloudRenderer::new(device, queue, color_format, depth_format, capacity,
+  supports_compaction)` (`render/point_cloud.rs`) needs only a wgpu device/queue, and
+  `offscreen.rs::render_png` builds `Instance → adapter → device` and renders to a texture with
+  no winit window — so the **renderer** detaches cleanly. But `offscreen.rs` still uses
+  `pollster`, the native loader, `Plan`, file output, and **no surface**, so it does *not* prove
+  the browser canvas/surface/event-loop path is trivial — that shell is net-new (see Phase 1).
+- **Points are a flat POD buffer — necessary but not a complete wire contract.** `GpuPoint`
+  (`data/point.rs`) is **always 32 bytes** (`pos[3] f32`, `intensity`, `weight`, `flags`,
+  `_pad[2]` where `_pad[0]` = mutable cluster id), uploaded via `bytemuck::cast_slice`. Good as a
+  payload body, but it's native-endian raw floats normalized to **server-selected bounds**, so
+  the protocol needs a framed header (magic/version/endian/stride/layout-id/bounds/chunk-kind).
+  Note: the `compact` Cargo feature is currently an **empty stub** — `GpuPoint` is f32 only;
+  any f16/16-byte path must be *implemented* (struct + vertex layout + shader + negotiation + tests).
+- **The compute/indirect fallback exists but is NOT yet WebGL2-safe.** The renderer branches on
+  `supports_compaction` and can cull in the vertex shader instead — but `PointCloudRenderer::new`
+  *unconditionally* allocates buffers with `STORAGE` and `INDIRECT` usages
+  (`point_cloud.rs:69/77/83`), which WebGL2 can't provide. The fallback needs **capability-split
+  buffer creation** (vertex/copy only when compute is off) before it runs on WebGL2.
+
+## The one real blocker: the loader is native-only
+
+`data/loader.rs` cannot run in a browser:
+- reads Bruker `.d` via `rustdf` → `rusqlite` (SQLite) + file I/O + zstd/lzf — no FS/SQLite in wasm;
+- runs on `std::thread` + `crossbeam_channel` + `rayon` — browser threads need
+  SharedArrayBuffer/cross-origin isolation;
+- init uses `pollster::block_on` — the web main thread can't block (must be async).
+
+`data/meta.rs` is also native/server-side: it reads `.d` metadata via `rustdf`, and `Plan`
+carries a `MetaIndex` into app init (`app.rs:29`). The browser can't build that — so the server
+must also emit a **metadata DTO** (axis bounds, frame/window info, point-count estimate, sensible
+default ranges) that seeds the client before any points arrive.
+
+⇒ **Renderer → browser; loader + metadata → server.** The server runs the existing `rustdf` read
++ downsample + `GpuPoint` packing (what `loader.rs` already does) and streams a **message
+protocol** to the browser (not just a point buffer — see Phase 2), which uploads point chunks
+into the instance buffer and renders. `loader.rs`'s packing becomes the server encoder.
+
+## Chosen approach
+
+**A. Renderer-in-browser (WASM + WebGPU).** Compile the render half to `wasm32`, host in a
+`<canvas>`, stream `GpuPoint` chunks from the server. Local rotate/zoom on the client GPU,
+millions of points, native look. This is the target.
+
+**B. Server-side render + stream pixels (documented fallback).** Run the native renderer on a
+server GPU (the `offscreen.rs` path nearly does this already) and stream frames/WebRTC. Almost
+no renderer changes, client needs no GPU — but every interaction is a server round-trip and you
+ship pixels. Use only for weak clients / data too large to ship, or as a stopgap.
+
+## Work breakdown
+
+### Phase 0 — crate split (render lib vs native binary)  *(DONE — feature-gate approach)*
+**Implemented** via a `native` feature + `src/lib.rs` (rather than a separate crate dir, which
+stays an optional later refactor): native deps (`rustdf`, `mscore`, `winit`, `egui-winit`,
+`clap`, `env_logger`, `rayon`, `crossbeam-channel`, `png`) are now `optional = true` under
+`native` (default on); `[[bin]]` has `required-features = ["native"]`; `app`/`offscreen` and
+`data::{loader,meta}` are `#[cfg(feature = "native")]`; `main.rs` consumes the lib. The one real
+code coupling — `group_color` in the native loader, used by `ui.rs` — was moved to the
+render-safe `render::colormap`. **Verified:** `cargo check` (native) green + 20 unit tests pass;
+`cargo check --no-default-features --lib` compiles the render half with **no** rustdf/winit/
+rayon/etc.; and `cargo check --no-default-features --lib --target wasm32-unknown-unknown`
+**already compiles** (wgpu 22 pulls wasm-bindgen/web-sys automatically). The remaining notes
+below are the original rationale / the separate-crate option.
+
+Module moves alone are insufficient: `Cargo.toml` pulls `rustdf`, `mscore`, `pollster`, `rayon`,
+`crossbeam-channel`, `winit`, and desktop `egui-winit` features **unconditionally** (`Cargo.toml:17`).
+- Create a **separate render crate with its own manifest** (e.g. `tims-viewer-render`) whose deps
+  are render-safe only (`wgpu`, `glam`, `bytemuck`, `egui`, `egui-wgpu`, `half`, `log`). It holds
+  the render-only modules: `render/*`, `data/point`, **`data/demo`** (portable — no loader/thread
+  deps), `camera`, `state`, `ticks`, `colormap`, `uniforms`, the egui UI, and the WGSL shaders.
+  Must compile for host **and** `wasm32-unknown-unknown`.
+- **Split `app.rs`** (currently imports desktop `winit`, `pollster`, loader types, `crossbeam`
+  errors, `rayon` — `app.rs:8/17/357/908`) into three parts: (a) renderer state (portable),
+  (b) the loader/message-drain logic (shared, transport-agnostic), (c) the **native platform
+  shell** (winit window + event loop + pollster init). A parallel **wasm shell** replaces (c).
+- Keep the native binary crate (`tims-viewer`) for `data/loader`, `data/meta`, `offscreen`,
+  `main`, the `clap` CLI, and the native deps.
+- Acceptance: `cargo build` (native) unchanged & tests green; `cargo build --target
+  wasm32-unknown-unknown -p tims-viewer-render` compiles (verified free of
+  rustdf/thread/crossbeam/rayon/pollster, including via transitive deps).
+
+### Phase 1 — WASM shell (render a buffer in-browser)  *(BUILT — pending in-browser check)*
+**Implemented** as a Trunk crate `tims-viewer/web/` (`tims-viewer-web`, a wasm-only cdylib;
+empty on native so the workspace build is unaffected). `src/lib.rs`: gets the `<canvas>`, async
+wgpu init (`request_adapter/_device().await`, no `pollster`), WebGPU with `webgl` fallback +
+WebGL2 downlevel limits, builds `PointCloudRenderer` with a seeded synthetic `demo_cloud()`
+(helix + 2 blobs, 250k pts) and runs a `requestAnimationFrame` loop with an auto-orbiting camera.
+**Verified here:** `cargo build -p tims-viewer-web --target wasm32-unknown-unknown` is clean;
+native workspace build unaffected. **Codex-reviewed + hardened:** proper `SurfaceError` match
+(skip on Timeout, reconfigure on Lost/Outdated, stop on OOM); DPR-correct sizing + a `resize`
+listener (shared `Gfx` in `Rc<RefCell>`, depth texture tracks resize); `run() -> Result` that
+surfaces fatal errors into a `#status` DOM element instead of a blank page; capacity sized to the
+demo cloud (not a fixed 1M). **Not yet verified:** actual in-browser render (needs a display) —
+run `cargo install trunk` then `cd tims-viewer/web && trunk serve` and open the URL.
+**Mouse controls (DONE):** left-drag orbit, wheel zoom, shift/right-drag pan (wired to the
+camera's `orbit`/`zoom`/`pan`); auto-orbit until first interaction; `mousemove`/`mouseup` on the
+window so drags survive leaving the canvas; context menu suppressed for right-drag.
+Deferred (Phase 4, app-embedding): cancellable RAF loop / teardown for unmount.
+
+**Web UI console (DONE — DOM, not egui):** the web's payoff is real DOM/CSS, so instead of
+porting egui we built an *instrument console* over the canvas (`index.html` + `wire_controls`):
+a glass control rail (View / Render / Intensity / Filters), a monospace telemetry HUD (backend,
+device, points, live FPS), and a colormap colorbar. Controls drive live `ParamsUniform` fields —
+mode, colormap, point size/opacity, transfer (lin/sqrt/log) + exposure + intensity floor, MS1/MS2,
+and per-axis cube crop (m/z · 1/K₀ · RT) — plus auto-orbit/reset/roll. Palette derived from the
+data's viridis/inferno colormaps (teal `#35E0C4` + amber `#FFB23E`) on instrument-blue-black;
+Space Grotesk / Inter / JetBrains Mono. All Rust-attached listeners (no hand-written JS). Compiles
+for wasm; **in-browser visual check pending** (headless dev box). egui-on-web is no longer planned.
+**Codex-reviewed + hardened:** wiring confirmed correct (radio handlers, crop/floor semantics, no
+double-borrow); fixed the Auto-orbit switch desync (mouse drag + wheel now uncheck it) and made the
+colormap read its option value (not DOM order); a11y pass (real `<label for>` / `role=radiogroup` /
+`aria-label`s, `:focus-visible` proxies on the hidden inputs, reduced-motion); CSS hardening (HUD
+ellipsis for long device names, `backdrop-filter` opaque fallback, mobile toggle placement).
+
+- Web entry: create the canvas surface, **async** wgpu init (replace `pollster::block_on` with
+  `request_adapter().await` / `request_device().await`), request WebGPU with a WebGL2 fallback.
+- Port the egui panel to web (egui-wgpu/egui-winit support wasm) — or start headless (no UI) to
+  de-risk, UI in Phase 3.
+- **Capability-split the renderer** *(DONE)*: `compacted`/`draw_args` moved into `ComputeStage`
+  (created only when `supports_compaction`), and `master` drops `STORAGE` on the fallback — so the
+  WebGL2 path allocates no storage/indirect buffers. Verified by a forced-fallback GPU smoke test
+  (`offscreen_render_smoke_webgl2_fallback`, `run_smoke(Some(false))`) — renders clean on Metal.
+- Feed a **hardcoded/demo** `Vec<GpuPoint>` (reuse the portable `data/demo`) into
+  `PointCloudRenderer` and render + orbit-camera in the canvas.
+- Acceptance: a demo cloud renders and rotates in Chrome (WebGPU) **and** in a WebGL2-only
+  context (compaction off, vertex-shader cull path, no storage/indirect resources created),
+  with the WGSL→GLSL translation validating against GL limits.
+
+### Phase 2 — server → browser streaming  *(increment 1 DONE: raw points over HTTP)*
+**Built + verified here:** a native-gated `serve.rs` (the `--serve <port>` flag) drains the loader
+into a `Vec<GpuPoint>` (no GPU — loader is pure CPU, points already normalized to the cube) and
+serves them over HTTP via `tiny_http`: `GET /points` → raw little-endian `GpuPoint` bytes
+(`application/octet-stream`, CORS `*`), `GET /meta` → JSON (stride, count, cube bounds). Works with
+a `.d` path or `DEMO`. Curl-verified: `tims-viewer DEMO --serve 8090 --budget 300000` → `/points`
+returns exactly `n*32` bytes, `/meta` valid. Client (`tims-viewer-web`): `fetch_points()` GETs the
+bytes (URL `http://localhost:<?port=N | 8090>/points`), reinterprets them, and renders — falling
+back to the synthetic `demo_cloud()` if no server. **Run:** `tims-viewer DEMO --serve 8090` +
+`trunk serve` (the page fetches port 8090). **Not yet (increment 2+):** the framed message protocol
+below (stats/histograms/annotations), websocket-progressive streaming, axis-label bounds wired from
+`/meta`, and per-request slice params.
+
+**Codex-reviewed + hardened:** binds `127.0.0.1` (not `0.0.0.0`); serves the byte body from an
+`Arc<[u8]>` via a `Cursor` (no per-request copy); `collect_points` bounds the buffer at `capacity`
+while still draining to `Done`; `/meta` numbers finite-guarded; `--serve` hard-fails on big-endian
+targets; respond errors logged. Client rejects a body that isn't a multiple of the 32-byte stride,
+and supports `?points=<url>` override (proxied/same-origin deploys). Re-verified by curl.
+
+**Increment 2 (DONE — real-unit context + validation):** `/meta` is now a `serde_json` DTO
+(version, point_stride, n_points, cube bounds, intensity p99). The client fetches `/meta` *first*,
+**validates** `version == 1` and `point_stride == 32` before trusting `/points` (falls back to the
+demo on mismatch/absence), and uses the bounds so the per-axis crop filters read in **real units**
+(m/z · 1/K₀ with decimals · RT) instead of percentages, and the intensity **Floor** control scales
+to the data's p99. Curl-verified (`/meta` DTO, `/points` n*32). **Codex-reviewed + hardened:**
+exact stride validation (no `as usize` truncation); robust bounds parse (best-effort → % labels on
+malformed); `intensity_p99` filters non-finite + uses `select_nth`; server routes by path (handles
+`/meta?query`); query-aware `meta_url`. Still deferred to increment 3:
+multi-threaded serving, websocket-progressive streaming (one HTTP blob today, no progress bar), the
+full framed `LoadMsg` protocol (stats/histograms/annotations), and per-request slice params.
+
+Parity needs the **whole `LoadMsg` set**, not only point bytes: `app.rs` also consumes `Stats`
+(transfer-fn percentiles), `Histograms` + 2D projections (the filter UI / minimaps), annotations,
+`Progress`, and `PeakChunk` enrichment (`loader.rs:34`, `app.rs:589`). Plus the metadata DTO.
+- **Define a framed message protocol** mirroring `LoadMsg`: a header per frame
+  (magic, version, endian, message kind, generation) then the body. Point bodies carry the
+  `GpuPoint` stride/layout-id and the axis bounds they were normalized to; cluster-id semantics
+  in `_pad[0]` stay explicit (it's mutable client state).
+- Server endpoint (reuse `loader.rs` packing): given run ref + RT/m-z/scan window + budget, read
+  via `rustdf`, downsample (stratified, as today), emit the metadata DTO then stream the frames
+  over a websocket.
+- Client receiver mirrors `app.rs`'s loader-drain for every message kind (points → instance
+  buffer; stats/histograms → UI; annotations → overlay; progress → status).
+- **Version + validate** the protocol on both ends (length/stride/layout/endian checks); the f16
+  layout (if/when implemented) is a distinct layout-id negotiated up front.
+- Acceptance: a real slice from a server-resident `.d` streams to the browser and renders with
+  point counts, filters, histograms, and look matching the native tool.
+
+### Phase 3 — feature parity + web polish
+- Volume raycaster (`render/volume`): it creates an **`R16Float` 3D texture** with filterable
+  float sampling and uploads f16 voxels (`volume.rs:185/234/369`). Gate it behind **explicit
+  capability checks**: 3D textures, `R16Float` renderable/filterable support, float-texture
+  filtering, max-3D-texture-size, and upload row/alignment — not just "off on WebGL2."
+- Annotations (DIA windows / DDA crosses), axis frame + tick labels, colorbar, the control panel.
+- **Implement a real `compact` f16 `GpuPoint`** (struct + vertex layout + shader + protocol
+  layout-id + tests — today the feature is an empty stub) to roughly halve client buffer memory
+  (12M pts × 32 B ≈ 384 MB → ~192 MB). Treat the memory win as *conditional on this work*.
+- Verify the WebGL2 fallback end-to-end (no compute/indirect, capability-split buffers, volume
+  disabled or degraded per the checks above).
+
+### Phase 4 — packaging & integration
+- Build with `trunk`/`wasm-pack`; host the wasm + canvas; wire into the web app shell.
+- Co-locate the streaming endpoint with the data (matches the "compute near data" decision).
+
+## Gotchas / risks
+- **WebGL2 fallback isn't free** — `PointCloudRenderer::new` must be split so the no-compute path
+  allocates **no STORAGE/INDIRECT buffers**; otherwise WebGL2 device creation fails. Plus
+  WGSL→GLSL (`naga`) translation must validate against GL limits.
+- **`compact` f16 is a stub today** — the memory-halving claim is *conditional* on implementing a
+  real f16 point struct + vertex layout + shader + protocol layout-id.
+- **Volume needs capability gating** — `R16Float` 3D texture + float filtering + 3D-texture-size
+  + upload alignment; not a simple on/off.
+- **WebGPU availability**: stable in Chrome/Edge and recent Safari/Firefox; older browsers hit the
+  WebGL2 fallback (lower throughput; no compute/indirect; volume likely disabled).
+- **No client threads/rayon** — fine, all parallelism is server-side in the loader.
+- **Async init** — drop `pollster` on web; keep it native.
+- **Surface format / sRGB** differences between native and web canvas configuration.
+- **egui-winit on wasm** — event/resize/DPI handling differs from native; budget time for it.
+- **Wire-format drift** — the framed protocol (`GpuPoint` body + metadata DTO + `LoadMsg` kinds)
+  is a network contract: header with magic/version/endian/stride/layout-id/bounds/chunk-kind,
+  validated on both ends; cluster-id (`_pad[0]`) semantics kept explicit.
+
+## Acceptance (project)
+- [x] Render library compiles for `wasm32` (no rustdf/thread/crossbeam/rayon, transitively);
+      native binary + 20 unit tests unchanged. *(Phase 0 — via the `native` feature + `lib.rs`.)*
+- [ ] `PointCloudRenderer` is capability-split; demo cloud renders + orbits in-browser on **WebGPU**
+      and on a **WebGL2** context (no storage/indirect buffers created).
+- [ ] Server emits a metadata DTO + a versioned, framed message protocol (points + stats +
+      histograms/projections + annotations + progress + peak chunks), reusing `loader.rs` packing.
+- [ ] A server-resident `.d` slice streams to the browser and renders at parity (points, filters,
+      histograms) with the native point cloud.
+- [ ] Documented WebGPU/WebGL2 capability matrix (compute, indirect, 3D/`R16Float` volume); f16
+      compact path either implemented + negotiated or explicitly deferred.

--- a/tims-viewer/NEXT_GUI_STEPS.md
+++ b/tims-viewer/NEXT_GUI_STEPS.md
@@ -1,0 +1,68 @@
+# tims-viewer GUI upgrade — Plan A+C
+
+Goal: turn the prototype from "a glowing cloud in an unlabeled box with every control
+thrown at you" into a readable scientific instrument that looks right the moment data lands.
+Two tracks: **A — make it a real plot** (readable axes + legends), **C — smart defaults**
+(it just works). Plus the chosen panel reorg (collapsible, filters unified).
+
+## A — Instrument the cube
+
+### A1. Axis ticks + numeric labels  *(highest clarity-per-effort)*
+- For each axis (x=m/z, y=1/K0, z=RT) place ~5 ticks at **"nice" round steps** spanning the
+  visible range (full bounds, or the window range when focus is on — mirror `draw_axis_labels`).
+- Nice-step algorithm: pick step ∈ {1,2,5}·10^k so 4–6 ticks cover the span; first tick at
+  `ceil(lo/step)*step`.
+- Per tick: a short 3D tick segment just outside the cube edge (reuse the line renderer) + a
+  numeric label projected to screen (reuse `draw_axis_labels`'s world→screen projection).
+- Formatting per axis: m/z integer, 1/K0 2 decimals, RT integer seconds (or min if range large).
+- Must re-fit under focus/zoom (use window range when `state.focus`).
+
+### A2. Faint back-face gridlines  *(optional, lower priority)*
+- Light lines connecting opposite ticks across the two far cube faces for depth reference.
+  Subtle (low alpha / dim color); skip on the near faces to avoid clutter over the cloud.
+
+### A3. Intensity colorbar
+- Vertical colorbar showing the active colormap gradient with `i_min`/`i_max` end labels and
+  the transfer mode (lin/sqrt/log). egui-drawn, in the panel or a screen corner.
+
+### A4. Group-color legend
+- When selection windows are on, a compact legend: group number → swatch (same `group_color`
+  as the boxes and the checkboxes). Lets the colored diagonals be read.
+
+## C — Smart defaults (it just works)
+
+### C1. Auto-exposure / transfer on load
+- On load-complete (and on MS toggle), set `i_min`/`i_max`/`exposure` from the data so the
+  cloud is **never blown out** on first paint (kills the white-out on noiseless data).
+  - Points: robust p1/p99 of retained intensity (already computed) + choose exposure so the
+    median maps to mid-range under the active transfer.
+  - Volume: density percentiles (already computed).
+- Acceptance: opening MIDIA-250K-NOISELESS-FRAG renders a legible viridis/inferno cloud with
+  no manual slider tweaking.
+
+### C2. Good default camera + point size
+- Verify the default orbit angle frames the cube nicely; keep the existing "Reset".
+- Default point size scaled to resident count (denser → smaller) so it reads at any budget.
+
+### C3. Default render mode
+- Decide: keep Points as default, or open in Volume/MIP as the "hero" view. (Lean: Points for
+  responsiveness, but auto-exposed so it's not white.)
+
+## Panel reorg (chosen: collapsible, filters unified)
+egui `CollapsingHeader` sections; readouts always visible at top:
+- **Filters** (default open): MS1/MS2 · RT/m-z/1-K0 range sliders · Focus to window · Reset.
+- **Selection windows**: show toggle · per-group colored checkboxes · all/none.
+- **Rendering**: Points/Volume · Additive/Opaque · Composite/MIP · transfer · colormap ·
+  point size/opacity.
+- **View / Camera**: axis frame · ortho · m/z|mob|RT snaps.
+
+## Out of scope here (later: Plan B — explorable)
+Hover/click readout (m/z,1/K0,RT,intensity), linked 2D projections, crosshair probe.
+
+## Acceptance checklist
+- [ ] Ticks with values on all 3 axes, correct under focus/zoom.
+- [ ] Intensity colorbar with end values + transfer mode.
+- [ ] Group legend when windows on.
+- [ ] Default load is legible (not white) with zero slider tweaks.
+- [ ] Panel is collapsible with all data filters under one "Filters" section.
+- [ ] `cargo build --release` clean, `cargo test` green, headless render still works.

--- a/tims-viewer/PERF_PLAN.md
+++ b/tims-viewer/PERF_PLAN.md
@@ -13,47 +13,75 @@ feature branch. Tier-2/3 are follow-ups.
 
 ---
 
-## Tier 1 — this pass (surgical, low-risk, test-covered)
+## Tier 1 — this pass (behavior-preserving, low-risk)
+
+> **Claudex (codex second-opinion) corrections folded in.** Every item verified against the code;
+> `[risk]`/`[gap]` annotations are codex's. Two items (C3, D1) were found **not** behavior-preserving
+> and moved to their own "behavior-changing" note below. Two Tier-2 items (zstd cache, idle render)
+> were promoted — they outrank the micro-cleanups.
 
 ### Group A — `serve.rs`
-- **A1** body build: replace `bytemuck::cast_slice(&points).to_vec()` with an in-place
-  `bytemuck::allocation::cast_vec::<GpuPoint,u8>(points)` → **−356 MB transient + one ~50–100 ms
-  memcpy** per build. (Also flagged by the loader agent.)
+- **A1** body build (`serve.rs:645`): replace `bytemuck::cast_slice(&points).to_vec().into_boxed_slice()`
+  → `Arc::<[u8]>::from(bytemuck::cast_slice::<GpuPoint,u8>(&points))` (then `drop(points)`).
+  `[risk]` **Do NOT use `cast_vec`** — `bytemuck::allocation` isn't enabled and `cast_vec` needs equal
+  alignment (GpuPoint is align-4, not 1). This is **one copy instead of two** (not "in-place"):
+  **−356 MB transient + one ~50–100 ms memcpy** per build.
 
 ### Group B — `data/loader.rs`
-- **B1** fold hot loop: replace `global_i % stride_u64` with a countdown counter (preserve the
-  "index 0 kept" phase the tests assert) → removes an integer division over **100 M+ points**.
-- **B2** peak-tail: `select_nth_unstable_by(peak_room, …)` instead of a full `sort_by` of ~1 M peaks
-  (order irrelevant — shuffled downstream).
-- **B3** reserve capacity where survivor Vecs grow in a loop (if any remain after B1/B2).
+- **B1** fold hot loop: replace the per-point gate `if global_i % stride_u64 == 0` with a countdown
+  (init 0 → keep survivor index 0, reset to `stride-1`; `stride==1` keeps all) → removes a division
+  over **100 M+ points**. `[risk]` **`global_i` must still increment** — the peak-tail dedup at
+  `loader.rs:441` reads `gi % stride`, so that modulo stays (it runs ~1 M×, not per point). Regression
+  test `region_estimate_concentrates_budget` (`loader.rs:861`) asserts exact `ceil(survivors/stride)`.
+  Gain plausible but decode may dominate.
+- **B2** peak-tail (`loader.rs:437`): `select_nth_unstable_by(peak_room, …)` + `truncate` instead of a
+  full sort. `[risk]` **guard `if peak_room < peak_pts.len()`** — `select_nth` at `index == len` is OOB.
+- ~~**B3** reserve capacity~~ — *demoted*: `collect` and loader chunks already reserve; only `peak_pts`
+  and the web `idx/positions` gathers are candidates (fold the latter into C1).
 
-### Group C — `web/src/lib.rs` + `render/volume.rs` + `shaders/volume.wgsl`
+### Group C — `web/src/lib.rs` + `render/volume.rs`
 - **C1** clustering boundary: drop the `flat`↔`[f32;3]` rebuilds — `Float32Array::from(cast_slice::
-  <[f32;3],f32>(&positions))` on send and `cast_slice(flat)` in the worker → **−144 MB memcpy per
-  Run** (6 M pts). Reserve `idx`/`positions` gather Vecs (`with_capacity`).
-- **C2** `VolumeGrid::density_percentiles`: `select_nth_unstable_by` (quickselect) instead of a full
-  sort of up to 6.3 M voxels on every re-voxel.
-- **C3** raymarch default `vol_steps` 256 → 128 (+ add the composite early-out to the MIP branch) →
-  ~2× volume fragment throughput on the fill-bound WebGL2 path.
+  <[f32;3],f32>(&positions))` on send (`lib.rs:2882,2935`) and `cast_slice(flat)` in the worker
+  (`lib.rs:277`) + `with_capacity` on the `idx/positions` gathers. `[risk]` **add `flat.len() % 3 == 0`
+  guard** before `cast_slice(flat)` in the exported `cluster_dbscan_flat` — today `chunks_exact`
+  truncates malformed input, `cast_slice` would panic. Gain **smaller than −144 MB**: only one backend
+  path runs per Run and `Float32Array::from` still copies wasm→JS. Saves the two intermediate rebuilds.
+- **C2** `VolumeGrid::density_percentiles` (`volume.rs:125`): `select_nth_unstable_by` instead of a full
+  sort of ≤6.3 M voxels. `[risk]` **handle empty first**; use `lo=(len-1)*0.50`, `hi=(len-1)*0.999` to
+  reproduce the exact percentile indices; keep the `hi>lo` enforcement.
 
 ### Group D — Python (`cluster_service.py`, `midia/*.py`)
-- **D1** `cluster_service.py`: keep **float32** (drop `.astype(float64)` — sklearn preserves f32 and
-  eps≈0.012 has huge headroom) → working set 144 → 72 MB; add `n_jobs=-1` to the `HDBSCAN(...)` call.
-- **D2** `midia/data.py`: build dense numpy lookup arrays for `cycle_by_frame`/`step_by_frame` once in
-  `MidiaExperiment.__init__`, gather with `frame-1` indexing instead of `Series.map(pydict)` over
-  millions of rows → **~0.3 s → ~10 ms** per slice-load.
-- **D3** midia cleanups: `groupby(...).sum().sum()` → `.sum()`; four `nunique` groupbys → one `.agg`;
-  `np.vstack([...]).T` → `np.stack(..., axis=1)`; drop the duplicate `.copy()` in
-  `cluster_precursors_hdbscan` (introduced by the earlier empty-guard fix).
+- **D2** `midia/data.py`: dense numpy `cycle_by_frame`/`step_by_frame` lookup arrays built once in
+  `__init__`, gathered via `frame-1` instead of `Series.map(pydict)` over millions of rows →
+  **~0.3 s → ~10 ms** per slice-load. `[risk]` **assert Id contiguity (1..N) before `frame-1`** (Python
+  doesn't prove it like `meta.rs:79` does); keep the `int64` dtypes and `fillna(0)` step semantics.
+- **D3** midia cleanups (safe, small): `groupby(...).sum().sum()` → `.sum()` (`clustering.py:177`);
+  `np.vstack([...]).T` → `np.stack(..., axis=1)` (`clustering.py:51,86,158`); four `nunique` groupbys →
+  one `.agg` (`widgets.py:753`); drop the duplicate `.copy()` in `cluster_precursors_hdbscan`
+  (`clustering.py:71` vs `:88`, from the earlier empty-guard fix).
+
+### Promoted from Tier 2 by claudex (do alongside Tier 1)
+- **P1 — cache the zstd body** per (region,budget) in `LoadResult` → the compressed `/points` is
+  re-encoded (0.3–0.9 s) on **every** request today; the raw path is already cached. Medium; biggest
+  remote-latency win. **[gap] outranks the micro-cleanups.**
+- **P2 — idle render dirty flag** (`web/lib.rs frame()`): a `needs_redraw` so a static cloud isn't
+  re-splat at 60 fps → idle GPU/CPU → ~0 (subsumes per-frame uniform + DOM-label churn). Medium; must
+  wake on every state change. **[gap] likely a larger user-visible win than B/D micro-items.**
+
+### Behavior-CHANGING (not silent low-risk — decide explicitly, not folded into "preserving")
+- **C3** raymarch default `vol_steps` 256 → 128 (`lib.rs:883`, `uniforms.rs:85`): a **quality/perf
+  trade**, not test-covered-safe. ~2× volume fragment throughput but visibly coarser. MIP has no clean
+  early-out (transfer clamps at `volume.wgsl:51`; only valid when `maxt>=1.0`). Ship only if we accept
+  the visual change (or make it a UI default we can bump).
+- **D1** `cluster_service.py` **float32** (drop `.astype(float64)`): 144 → 72 MB + faster kNN, **but f32
+  distance math can flip labels for points near `eps`** — "numerically acceptable, not exact." Also
+  `DBSCAN` already has `n_jobs=-1`; only `HDBSCAN` would gain it — **verify the installed `HDBSCAN`
+  accepts `n_jobs`** first. `[gap]` separately, the handler does `bytearray` + `bytes(buf)` before
+  numpy (`:74,:87`) — using the mutable buffer directly avoids one full body copy regardless of dtype.
 
 ---
 
-## Tier 2 — fast-follow (bigger UX / latency wins)
-- **Idle render loop** (`web/lib.rs frame()`): a `needs_redraw` dirty flag so a static cloud isn't
-  re-splat at 60 fps → idle GPU/CPU → ~0 (subsumes per-frame uniform + DOM-label churn). Medium —
-  must wake on every state change.
-- **Cache the zstd body** per (region,budget) in `LoadResult` → saves 0.3–0.9 s re-encode per repeat
-  `/points`. Medium.
+## Tier 2 — fast-follow (remaining, after Tier 1 + P1/P2)
 - **Two persistent volume grids + the (dead, already-tested) `VolumeGrid::combine`** for MS-mask
   toggles → O(8N pts) scatter becomes O(voxels). Medium.
 - **Peak-grid SoA** in `loader.rs` (48 MB RMW → 4 MB read) + double-buffer decode/fold → fold

--- a/tims-viewer/PERF_PLAN.md
+++ b/tims-viewer/PERF_PLAN.md
@@ -1,0 +1,73 @@
+# tims-viewer performance plan (pre-merge)
+
+Source: a 5-agent efficiency deep-dive (data pipeline, server transport/memory, GPU/render,
+clustering, Python) over the `feature/tims-viewer-web` branch. The core algorithms are already
+well-tuned; the wins are three themes — **stop copying full buffers, stop working when idle, cache
+recomputes.**
+
+## Execution model
+Tier-1 is landed via a multi-agent workflow: one agent per **subsystem group** (disjoint file sets)
+implements its items in an isolated git worktree, builds + tests + commits; a second adversarial
+agent verifies behavior-preservation per group; only verified commits are cherry-picked onto the
+feature branch. Tier-2/3 are follow-ups.
+
+---
+
+## Tier 1 — this pass (surgical, low-risk, test-covered)
+
+### Group A — `serve.rs`
+- **A1** body build: replace `bytemuck::cast_slice(&points).to_vec()` with an in-place
+  `bytemuck::allocation::cast_vec::<GpuPoint,u8>(points)` → **−356 MB transient + one ~50–100 ms
+  memcpy** per build. (Also flagged by the loader agent.)
+
+### Group B — `data/loader.rs`
+- **B1** fold hot loop: replace `global_i % stride_u64` with a countdown counter (preserve the
+  "index 0 kept" phase the tests assert) → removes an integer division over **100 M+ points**.
+- **B2** peak-tail: `select_nth_unstable_by(peak_room, …)` instead of a full `sort_by` of ~1 M peaks
+  (order irrelevant — shuffled downstream).
+- **B3** reserve capacity where survivor Vecs grow in a loop (if any remain after B1/B2).
+
+### Group C — `web/src/lib.rs` + `render/volume.rs` + `shaders/volume.wgsl`
+- **C1** clustering boundary: drop the `flat`↔`[f32;3]` rebuilds — `Float32Array::from(cast_slice::
+  <[f32;3],f32>(&positions))` on send and `cast_slice(flat)` in the worker → **−144 MB memcpy per
+  Run** (6 M pts). Reserve `idx`/`positions` gather Vecs (`with_capacity`).
+- **C2** `VolumeGrid::density_percentiles`: `select_nth_unstable_by` (quickselect) instead of a full
+  sort of up to 6.3 M voxels on every re-voxel.
+- **C3** raymarch default `vol_steps` 256 → 128 (+ add the composite early-out to the MIP branch) →
+  ~2× volume fragment throughput on the fill-bound WebGL2 path.
+
+### Group D — Python (`cluster_service.py`, `midia/*.py`)
+- **D1** `cluster_service.py`: keep **float32** (drop `.astype(float64)` — sklearn preserves f32 and
+  eps≈0.012 has huge headroom) → working set 144 → 72 MB; add `n_jobs=-1` to the `HDBSCAN(...)` call.
+- **D2** `midia/data.py`: build dense numpy lookup arrays for `cycle_by_frame`/`step_by_frame` once in
+  `MidiaExperiment.__init__`, gather with `frame-1` indexing instead of `Series.map(pydict)` over
+  millions of rows → **~0.3 s → ~10 ms** per slice-load.
+- **D3** midia cleanups: `groupby(...).sum().sum()` → `.sum()`; four `nunique` groupbys → one `.agg`;
+  `np.vstack([...]).T` → `np.stack(..., axis=1)`; drop the duplicate `.copy()` in
+  `cluster_precursors_hdbscan` (introduced by the earlier empty-guard fix).
+
+---
+
+## Tier 2 — fast-follow (bigger UX / latency wins)
+- **Idle render loop** (`web/lib.rs frame()`): a `needs_redraw` dirty flag so a static cloud isn't
+  re-splat at 60 fps → idle GPU/CPU → ~0 (subsumes per-frame uniform + DOM-label churn). Medium —
+  must wake on every state change.
+- **Cache the zstd body** per (region,budget) in `LoadResult` → saves 0.3–0.9 s re-encode per repeat
+  `/points`. Medium.
+- **Two persistent volume grids + the (dead, already-tested) `VolumeGrid::combine`** for MS-mask
+  toggles → O(8N pts) scatter becomes O(voxels). Medium.
+- **Peak-grid SoA** in `loader.rs` (48 MB RMW → 4 MB read) + double-buffer decode/fold → fold
+  ~1.3–1.8×, load ~1.3×. Low-med / med.
+
+## Tier 3 — post-merge / blocked
+- Lighter `rustdf` `get_frame` decode (skip unused `tof_i32`/`scan as i32`, narrow intensity) →
+  −~1.2 GB alloc for a 100 M-pt run. Touches shared API.
+- `mmap` the `.tdf_bin` (remove per-frame `File::open` + scratch allocs). `unsafe`, shared crate.
+- `Arc<Vec<u8>>` to eliminate the *second* 356 MB copy. Broad ripple.
+- WebGPU compute-compaction (draw visible, not loaded) — **blocked on the deferred wgpu 23+ upgrade.**
+
+## Confirmed already-optimal (do not touch)
+Per-request `/points` serving (zero-copy Arc), the Fisher–Yates shuffle (required for the
+prefix-is-uniform contract), the DBSCAN core (squared distances, no re-scans, BFS dedup, hoisted
+scales), `fetch_points` bulk cast, incremental `append`, gated `recount_displayed`, FPS-HUD throttle,
+Rayon batch endpoint, histogram `batch_update`.

--- a/tims-viewer/QUAD_FILTER_IDEA.md
+++ b/tims-viewer/QUAD_FILTER_IDEA.md
@@ -1,0 +1,173 @@
+# Feature idea — correlated quad filter (4-point select on the maps)
+
+Status: IDEA (pre-design, for codex feasibility review). Extends the focus-lens (FOCUS_LENS_PLAN.md)
+and the 2D box-select maps (focus-lens D).
+
+## Motivation
+
+Today's filter is **separable**: independent per-axis windows (the crop sliders) + an intensity
+floor. The box-select on a projection map drags an *axis-aligned rectangle* — two independent
+ranges. But real features in timsTOF data follow **correlated, diagonal bands**: a charge state is a
+slanted streak in m/z × 1/K₀; an eluting species is a diagonal in m/z × RT. An axis-aligned box
+can't isolate a diagonal band without dragging in a lot of neighbouring junk.
+
+A **convex quadrilateral** select expresses the filter as **4 linear functions** (half-planes),
+coupling the two projected axes — a *correlated* filter, which we don't have yet. Drag 4 corners
+around a diagonal streak and keep only that streak.
+
+## Core idea: 4 half-planes
+
+A convex quad with corners `P0..P3` (consistent winding, say CCW) defines, per edge
+`(Pᵢ → Pᵢ₊₁)`, an inside half-plane. A point `(u, v)` is inside iff for all 4 edges
+`aᵢ·u + bᵢ·v + cᵢ ≥ 0`, where for edge `(dx, dy) = Pᵢ₊₁ − Pᵢ`:
+
+```
+a = −dy,  b = dx,  c = dy·Pᵢ.x − dx·Pᵢ.y
+```
+
+So the whole selection is just `[vec3(a,b,c); 4]` evaluated against a point's two projected
+coordinates. This is the same lens, made correlated — it slots into the existing filter, it does not
+add a new subsystem.
+
+The quad constrains **2 of the 4 axes** (the projection's pair); the third spatial axis and the
+intensity floor keep their existing separable filters. The three projections map to axis pairs:
+`mz_im → (mz, im)`, `mz_rt → (mz, rt)`, `im_rt → (im, rt)`.
+
+## Where it plugs in (two layers, same as the lens)
+
+### 1. Live preview — shader cull (instant, on the loaded cloud)
+
+Add a polygon to `ParamsUniform`:
+
+```
+poly_edges : [vec4; 4]   // (a, b, c, _) per edge, in NORMALIZED cube coords of the two axes
+poly_axes  : u32         // which pair: 0=(mz,im)=axes 0,1 · 1=(mz,rt)=0,2 · 2=(im,rt)=1,2
+poly_active: u32         // 0/1
+```
+
+The point shader (`point_cloud.wgsl`) and the compaction shader (`compact.wgsl`) both pick the two
+`pos` components from `poly_axes` and cull the point if any of the 4 half-planes is negative —
+alongside the existing window / MS / intensity culls. The CPU displayed-count recount (focus-lens B)
+evaluates the same 4 lines so the HUD stays correct.
+
+*(Alignment, confirmed by codex: `ParamsUniform` is currently 80 B (three `vec4` at 0/16/32 + 8
+scalar slots at 48..76) with **no spare pad**. Appending `poly_edges:[vec4;4]` + the two `u32`s
+lands at a clean **160 B** with an explicit `_poly_pad:[u32;2]`. This must be changed in lockstep
+across the Rust struct (`uniforms.rs`), **both** WGSL `Params` structs (`point_cloud.wgsl`,
+`compact.wgsl`), and **every** struct literal — `state.rs` and `web/src/lib.rs` — or the buffer
+silently desyncs.)*
+
+### 2. Commit — source cull on Focus (densify the band)
+
+`RegionFilter` gains an optional polygon in **real units** of the two axes:
+
+```
+poly: Option<{ axes: (u8, u8), edges: [[f64; 3]; 4] }>
+```
+
+`handle_point!` already has `mz`, `im` (per point) and `rt` (per frame), so all three projection
+pairs are checkable per point at the source. Focus then spends the budget only on points inside the
+quad → the diagonal band is rendered densely.
+
+On Focus the cube **re-normalizes to the quad's axis-aligned bounding box** (we always render an
+axis-aligned cube); the source cull has already removed the points outside the quad, so the focused
+view shows the band filling the bbox with empty corners. The live `poly_active` resets to off (the
+loaded set is already inside the quad).
+
+**Stride estimate must use the quad area, not the bbox** (codex blocker): the loader strides *before*
+`collect`'s reservoir sees points, so an over-estimate skips points the reservoir can never recover →
+budget under-spent. The bbox over-estimates a quad by ~2×, so multiply the bbox-fraction estimate by
+`quad_area / bbox_area` (shoelace) to size the stride to the actual poly survivors.
+
+**The committed quad must live in `Region`** (codex blocker): otherwise a later Load-budget reload of
+a focused quad re-queries from the stack and silently degrades to the quad's bbox. So the poly must
+be part of `Region`, the focus-stack entry, the `/points` + `/meta` query, the server `source_region`,
+and the `LoadKey`.
+
+## UI: 4-corner drag on a map
+
+- A per-map mode: **box** (today, 2-corner drag) and **quad** (4 draggable corner handles). A box is
+  a special quad, so quad mode can initialize from the current box.
+- Render the quad as an SVG `<polygon>` overlay on the map-wrap + 4 round handles; dragging a handle
+  updates the live poly (preview) immediately.
+- **Focus** commits the current quad (source cull + re-normalize). **Back** pops as usual.
+- Keep the quad **convex**: order the 4 handles by angle around the centroid, then *validate* —
+  angle-sort alone is not a convexity guarantee (a point inside the others' triangle yields a concave
+  ordered polygon). Require consistent non-zero edge cross-product signs + a minimum area + minimum
+  edge length + no near-collinear adjacent triple (like the degenerate-box guard in D). Be explicit
+  about the map y-flip (heatmaps render low-bin-at-bottom; the box mapping already flips it back).
+
+## Recommended shape: rotated rectangle first (codex nit, elevated)
+
+A **free quad has 8 DOF**; a **rotated rectangle has 5** (center, width, height, angle) and is still
+exactly 4 half-planes — but with far less query/cache entropy, trivial convexity (always convex), and
+a simpler UI (drag/resize/rotate one rect vs. juggle 4 independent corners). It already captures the
+common case: a *straight slanted band*. So:
+
+- **Start with a rotated rectangle.** Free quad (tapered/non-parallel bands) becomes P3 if needed.
+
+## Phasing
+
+- **P1 — live preview, explicitly preview-only.** `ParamsUniform` poly (rotated-rect → 4 half-planes)
+  + the cull in the **point shader** and the **CPU recount** (compaction too, for count/perf parity)
+  + a **distinct map UI** (rotate/resize handles) that updates the shader params + recount live.
+  Crucially this is a *separate path* from the current "drag→commit-focus-on-mouseup": Focus is
+  disabled or clearly labelled until P2, so users never think a band was densified when it was only
+  previewed on the resident sample.
+- **P2 — Focus commit.** Add the poly to `Region` (+ stack/query/`source_region`/`LoadKey`), the
+  `RegionFilter` source cull in `handle_point!`, the **quad-area** stride estimate, demo RT policy
+  for testing, and re-normalize to the bbox. Densifies the band.
+- **P3 — polish (optional).** Free quad (8 DOF), >4-point convex polygons, per-map quads composing
+  across projections, named/persisted selections.
+
+## Open questions / risks (for codex)
+
+- **Uniform layout.** Exact placement/alignment of `poly_edges`/`poly_axes`/`poly_active` in
+  `ParamsUniform` so the Rust struct and both WGSL shaders agree (std140). Does the current struct
+  have room, or does it need a version bump / careful repacking?
+- **Normalized vs real units.** Preview keeps the quad in normalized cube coords (cheap shader eval);
+  commit needs it in real units for the loader. Two representations of the same quad — derive both
+  from the corner positions to avoid drift.
+- **Server query encoding.** How to pass a quad (8 floats + axis pair) in the `/points?…` query, and
+  how it factors into the `LoadKey` cache key + snapping.
+- **Composition.** Poly AND the existing per-axis crops AND the intensity floor all compose; confirm
+  the shader/loader apply them together and the displayed-count recount mirrors all of them.
+- **Convexity + degeneracy.** Enforce convex ordering; reject zero-area / collinear quads (like the
+  degenerate-box guard in D).
+- **Focus bbox vs quad.** The focused view re-normalizes to the quad's *bbox* (empty corners are
+  expected); is that the desired UX, or should the band be re-fit some other way?
+- **Scope.** P1 alone is a meaningful, self-contained increment (shader + UI + recount). P2 is the
+  loader/server half. Worth doing P1, verifying in-browser, then P2.
+
+## Codex feasibility review (incorporated)
+
+Verdict: feasible; the half-plane math and `handle_point!` data are confirmed. Three blockers, all
+addressable, folded into the design above:
+
+- **[blocker] uniform layout** — no spare pad; grow `ParamsUniform` to a clean 160 B with an explicit
+  `_poly_pad`, in lockstep across `uniforms.rs` + both WGSL `Params` + every literal (`state.rs`,
+  `web/src/lib.rs`). → folded into "Live preview".
+- **[blocker] committed quad must persist in `Region`** — else a Load-budget reload silently degrades
+  a focused quad to its bbox. → folded into "Commit".
+- **[blocker] stride estimate** — "reservoir makes over-estimate safe" was **wrong**: the loader
+  strides before the reservoir, so a bbox over-estimate under-spends the budget. Size the stride to
+  the quad area (`quad_area/bbox_area`). → folded into "Commit".
+
+Confirmed/refined risks:
+- `handle_point!` has per-point m/z·1/K₀·intensity and per-frame RT, and runs before peak/hist/
+  `global_i` — the right place. But the demo forces RT to full in `parse_query`, so testing m/z×RT /
+  1/K₀×RT *source* poly on the demo needs a demo-RT policy change.
+- Convexity: angle-sort is **not** sufficient — validate cross-product signs + min area/edge.
+- Derive normalized (preview) and real-unit f64 (commit) edges both from the same UI corner
+  *fractions*, never one from the other (avoids f32 drift across m/z vs 1/K₀ vs RT scales).
+- Composition is currently **uneven**: point shader culls spatial+intensity+MS, compaction only
+  spatial+MS, CPU recount spatial+floor+MS. P1 must add the poly to the point shader **and** the CPU
+  recount at minimum (compaction for parity); decide the intensity-max story.
+- Today's box-select **resets** the unselected axes to full and carries only the floor; if the poly
+  is meant to compose with the crop sliders, intersect with the active crops + carry the third axis.
+- Server cache: canonicalize (snap) the poly before keying or 8 floats of entropy blow up the cache;
+  reject non-finite/degenerate; include the committed poly in `/meta`.
+
+**Recommendation:** ship **P1 with a rotated rectangle** (preview-only, Focus gated) as the
+self-contained, satisfying core; then P2 for the source-cull densify. Reassess the free quad (P3)
+only if straight slanted bands prove insufficient.

--- a/tims-viewer/RUN.txt
+++ b/tims-viewer/RUN.txt
@@ -1,0 +1,34 @@
+tims-viewer — start commands (3 terminals)
+==========================================
+
+Open http://localhost:8080/?port=8090  → go to the ① Data tab to pick a dataset.
+Point the server at a FOLDER of .d datasets to get the picker (a single .d works
+too, the picker just stays hidden). Example folder below holds 3 datasets.
+
+
+1) POINT SERVER  (multi-dataset; the folder is the confinement root)
+-------------------------------------------------------------------
+cd /Users/davidteschner/Promotion/rustims
+# (rebuild only if Rust changed since last time)
+cargo build -p tims-viewer --release
+./target/release/tims-viewer /Users/davidteschner/Promotion/midia/timsim --serve 8090 --budget 12000000
+
+
+2) WEB APP  (release = the fast wasm)
+-------------------------------------
+cd /Users/davidteschner/Promotion/rustims/tims-viewer/web
+trunk serve --release
+
+
+3) CLUSTER SERVICE  (optional — sklearn DBSCAN + HDBSCAN; auto-detected by the UI)
+---------------------------------------------------------------------------------
+cd /Users/davidteschner/Promotion/rustims
+python tims-viewer/cluster_service.py --port 8091
+
+
+Notes
+-----
+- Swap the /midia/timsim path for any directory of .d folders (scanned recursively).
+- ?port=8090 tells the web where the point server is. ?cluster=<url> / ?clusterport=N
+  override the cluster service (default http://localhost:8091/cluster).
+- Switching datasets reloads the page with ?dataset=N — a clean re-init.

--- a/tims-viewer/RUN.txt
+++ b/tims-viewer/RUN.txt
@@ -33,6 +33,9 @@ python tims-viewer/cluster_service.py --port 8091
 # Point it at a prepared synthetic-sim DB (synthetic_data.db), NOT a .d.
 /Users/davidteschner/Promotion/thesis/.venv/bin/python tims-viewer/acquisition_service.py \
     --db /Users/davidteschner/Promotion/timsim/TIMSIM-DIA/synthetic_data.db --port 8092
+# Big sims (e.g. the 2GB 250K MIDIA blueprints) take minutes to init the eager builder. Use
+# --max-peptides N for a ~seconds startup over a slice (full frame schedule kept; ~2s per 2k peptides):
+#   ... --db .../MIDIA-250K-NOISY-CHRONO-FRAG/synthetic_data.db --port 8092 --max-peptides 5000
 # Status today: the viewer DETECTS it (logs the run meta to the browser console). The
 # play/pause/timeline UI is the next slice — no visible playback yet. Override URL: ?acq=<base>.
 

--- a/tims-viewer/RUN.txt
+++ b/tims-viewer/RUN.txt
@@ -42,6 +42,19 @@ python tims-viewer/cluster_service.py --port 8091
 # play/pause/timeline UI is the next slice — no visible playback yet. Override URL: ?acq=<base>.
 
 
+5) MIDIA VOILA NOTEBOOK  (separate tool — the imspy-vis dashboard, NOT the web viewer)
+-------------------------------------------------------------------------------------
+# An independent Voila app (ipywidgets + plotly) for loading a run, slicing by RT off the
+# TIC, and tuning HDBSCAN on the precursor/MIDIA point clouds. Unrelated to the WebGPU
+# viewer above — listed here only so the launch command lives in one place.
+cd /Users/davidteschner/Promotion/rustims
+voila packages/imspy-vis/notebooks/midia_vis.ipynb
+# Point it at a different run / browse folder (defaults are baked into the notebook):
+#   MIDIA_RUN_PATH=/path/to/run.d MIDIA_BROWSE_DIR=/path/to/folder-of-runs \
+#     voila packages/imspy-vis/notebooks/midia_vis.ipynb
+# First-time setup (same env): pip install voila && pip install -e packages/imspy-vis
+
+
 Notes
 -----
 - Swap the /midia/timsim path for any directory of .d folders (scanned recursively).

--- a/tims-viewer/RUN.txt
+++ b/tims-viewer/RUN.txt
@@ -14,6 +14,10 @@ cargo build -p tims-viewer --release
 ./target/release/tims-viewer /Users/davidteschner/Promotion/midia/timsim --serve 8090 --budget 12000000
 # Over a network, add --compress: zstd-compresses /points when the browser supports it (~2.6x,
 # 356MB -> 138MB; transparent client-side decode). Leave it off for localhost (raw is faster).
+# PROD deploy: add --telemetry-dir <dir> to enable optional in-app error telemetry + a user
+# feedback widget, appended as JSONL to <dir>/telemetry.jsonl and <dir>/feedback.jsonl (kept
+# in-house, no external SaaS). Omit it for local dev — endpoints stay off, the frontend hides the
+# feedback button and sends nothing. Tail the logs:  tail -f <dir>/feedback.jsonl
 
 
 2) WEB APP  (release = the fast wasm)

--- a/tims-viewer/RUN.txt
+++ b/tims-viewer/RUN.txt
@@ -12,6 +12,8 @@ cd /Users/davidteschner/Promotion/rustims
 # (rebuild only if Rust changed since last time)
 cargo build -p tims-viewer --release
 ./target/release/tims-viewer /Users/davidteschner/Promotion/midia/timsim --serve 8090 --budget 12000000
+# Over a network, add --compress: zstd-compresses /points when the browser supports it (~2.6x,
+# 356MB -> 138MB; transparent client-side decode). Leave it off for localhost (raw is faster).
 
 
 2) WEB APP  (release = the fast wasm)

--- a/tims-viewer/RUN.txt
+++ b/tims-viewer/RUN.txt
@@ -26,6 +26,17 @@ cd /Users/davidteschner/Promotion/rustims
 python tims-viewer/cluster_service.py --port 8091
 
 
+4) ACQUISITION SIDECAR  (optional, WIP — live annotated playback; auto-detected)
+--------------------------------------------------------------------------------
+# Needs imspy_simulation IN SYNC with the compiled imspy_connector. The base envs are
+# stale; use thesis/.venv (or rebuild: cd imspy_connector && maturin develop).
+# Point it at a prepared synthetic-sim DB (synthetic_data.db), NOT a .d.
+/Users/davidteschner/Promotion/thesis/.venv/bin/python tims-viewer/acquisition_service.py \
+    --db /Users/davidteschner/Promotion/timsim/TIMSIM-DIA/synthetic_data.db --port 8092
+# Status today: the viewer DETECTS it (logs the run meta to the browser console). The
+# play/pause/timeline UI is the next slice — no visible playback yet. Override URL: ?acq=<base>.
+
+
 Notes
 -----
 - Swap the /midia/timsim path for any directory of .d folders (scanned recursively).

--- a/tims-viewer/VOLUME_WEB_IDEA.md
+++ b/tims-viewer/VOLUME_WEB_IDEA.md
@@ -1,0 +1,125 @@
+# Feature idea — volume rendering on the web
+
+Status: IDEA (pre-design, for codex feasibility review). Brings the native viewer's volume mode to
+the WASM shell, and exploits the focus-lens for high-resolution local volumes.
+
+## What the native volume is (recon)
+
+A self-contained **fragment-shader raymarcher** (`src/render/volume.rs`, `src/shaders/volume.wgsl`):
+
+- A **3D density grid** `VOLUME_DIMS = [256, 128, 192]` (m/z · 1/K₀ · RT), `R16Float`.
+- Built **CPU-side**: each point is trilinearly deposited (cloud-in-cell, mass-conserving) into one of
+  two grids by MS level (`grid_ms1`, `grid_ms2`); a toggle folds them into the display grid. Peak
+  chunks are not deposited. Normalized by `density_scale` (max voxel → ~60000 in f16).
+- Uploaded via `write_texture` (3D extent); a fullscreen triangle raymarches it in the fragment
+  shader (ray↔box intersect, per-sample transfer lookup, front-to-back **composite** or **MIP**).
+- `VolumeUniform` (128 B): `inv_view_proj`, `box_min/max`, `transfer[mode,i_min,i_max,exposure]`,
+  `steps`, `style` (composite/MIP), `colormap_id`, `density_scale`, `focus`.
+- **Compiles for wasm already** (no native deps: wgpu/bytemuck/half), not feature-gated.
+
+## Why it fits the web — and the lens synergy
+
+- The renderer + grid math are wasm-ready; the web client **already retains the points**
+  (`cpu_points`), so the CPU trilinear deposit ports directly (build MS1/MS2 grids from the resident
+  set, optionally skipping points below the intensity floor during deposit).
+- **Focus → high-res volume.** The grid is fixed-resolution; over a *focused region* (a small box)
+  the same 256×128×192 voxels resolve far finer detail than over the whole run. So "Focus, then
+  Volume" is the fine-grain mode, and a re-focus rebuilds the local volume — the lens and the volume
+  reinforce each other.
+
+## The backend decision (headline — corrected by codex)
+
+**Earlier premise ("WebGL2 has no 3D textures") was WRONG.** WebGL2 (the API) supports 3D textures
+(`texImage3D`), and wgpu-22's WebGL2 backend maps `TextureDimension::D3` → `TEXTURE_3D` and uploads
+via `tex_sub_image_3d`, with a default **max 3D dimension of 256** — which exactly fits the native
+`VOLUME_DIMS = [256, 128, 192]`. `R16Float` is reported sampleable + **filterable** on that path. So
+the **native 3D-texture raymarcher may run directly on WebGL2** — the current backend — with no atlas.
+
+That collapses the design: V1 is a near-direct reuse of `volume.rs` + `VolumeGrid`, not a rewrite.
+
+1. **Native 3D-texture path (recommended).** Reuse `VolumeRenderer` + `VolumeGrid` as-is. First add a
+   **forced-WebGL2 capability smoke probe** (`R16Float` 3D texture + linear filtering + `write_texture`)
+   so we *confirm* it on the target browser; gate volume off (or fall back) if it ever fails.
+2. **2D-atlas emulation (fallback only).** Flatten the 192 slices into a tiled 2D R16F atlas with
+   manual trilinear — *only* if the 3D path fails a probe. More shader work, edge-bleed care, bounded
+   by `max_texture_dimension_2d` (WebGL2 guarantees only 2048; pick the layout from the real limit).
+
+**Recommendation:** smoke-test the native 3D path on forced WebGL2 first; if green (expected), ship
+that. Keep the atlas as a documented fallback, not the default.
+
+## Sketch of the web implementation (native 3D path)
+
+- **Reuse, don't reimplement.** `VolumeRenderer`, `VolumeGrid` (`deposit`, `combine`, `density_scale`,
+  `to_f16_scaled`) and `volume.wgsl` are public + render-safe (wasm-reachable). The web shell builds
+  the grid and drives the renderer; it does NOT mirror the deposit math.
+- **Grid build** (`web/src/lib.rs`, from the retained `cpu_points`): `VolumeGrid::deposit` each point
+  into `grid_ms1` / `grid_ms2`, `combine` by the current MS mask. Track `max_density`. Built **once
+  per load/focus** (and on MS-toggle), with a "building volume…" status; for big loads, chunk across
+  RAF / yield (or a worker) later — millions × 8 deposits + f16 pack blocks the main thread otherwise.
+- **Upload + draw**: `VolumeRenderer::upload(to_f16_scaled())` (3D `write_texture`) + a fullscreen
+  raymarch pass. Reuse the existing camera `inv_view_proj`, depth attachment, and colormap LUT.
+- **View mode**: add an explicit `ViewMode { Points, Volume }`; in `frame()`, Volume mode draws the
+  **volume + axes** (not the points). Don't make it "just a second pass" — branch deliberately.
+- **What the volume reflects (product decision, per codex):** *all resident points* + *current MS
+  mask* + the *current crop box* (passed as `box_min/max` into the volume shader, which already has a
+  window box). Do **not** tie it to the Display % (that's a point draw-count, not a density). The
+  intensity floor: either ignore it in the grid, or bake it during deposit and accept a rebuild when
+  the floor changes — decide explicitly.
+- **UI**: a **View** segment "Points / Volume" + volume-only controls (composite/MIP style, steps,
+  density transfer mode/exposure), reusing the colormap select.
+
+## Phasing
+
+- **V0 — capability probe.** Forced-WebGL2 smoke test: create an `R16Float` 3D texture, `write_texture`
+  a tiny grid, sample with linear filtering in an offscreen pass. Decides 3D-path vs atlas fallback.
+- **V1 — native 3D volume.** Wire `VolumeRenderer` + `VolumeGrid` into the web `Gfx`/`frame()`, build
+  the grid from `cpu_points` on load/focus, Points/Volume toggle, density transfer/steps/MIP controls.
+  Whole-run and focused volumes (the lens gives the fine grain). Capability-gate: disable with a
+  message if the probe fails.
+- **V2 — atlas fallback (only if V0 fails on a target).** 2D R16F atlas + manual trilinear.
+- **V3 — polish.** Gradient/lighting shading, isosurface, per-MS coloring, density auto-range on
+  enter (mirror native), coarser-while-moving, off-main-thread grid build.
+
+## Open questions / risks (for codex)
+
+- **WebGL2 R16F atlas support.** Confirm `R16F` sample + `OES_texture_half_float_linear` filtering on
+  the target (Apple M-series via ANGLE/Metal). Fallback to `RGBA8` packing of f16 if linear R16F is
+  unavailable. Max 2D texture size vs the atlas (4096×1536 fits 8192). Upload row alignment.
+- **Grid build cost.** Trilinear deposit of up to ~N_cap points (millions) CPU-side per load — tens to
+  hundreds of ms, blocking the frame. Acceptable one-time on load? Or chunk / web-worker (later).
+- **Manual trilinear correctness.** Slice bracketing + tile UV math (clamp at slice/tile edges; avoid
+  bleeding across tile borders — pad tiles or clamp UVs). Compare visually to native 3D trilinear.
+- **Memory.** `grid f32` (256·128·192·4 ≈ 25 MB ×2 for MS) + atlas (~12 MB f16). Bounded, fine.
+- **Filter composition.** Should the volume reflect the window crops + intensity floor + MS like the
+  points do? Native builds raw MS grids + folds by toggle (no window/intensity in the grid). For the
+  web, the resident points are already the focused set; applying the floor during deposit is a cheap
+  win, but window crops would need either re-deposit or a box test in the shader (`box_min/max`).
+- **Reuse vs reimplement.** Is the native `VolumeGrid::deposit` / `to_f16_scaled` reachable from the
+  web crate (render-safe), so V1 reuses the deposit math instead of mirroring it?
+- **Scope.** With the 3D path, V1 is mostly *wiring* (reuse the renderer + grid; new code = grid build
+  from `cpu_points`, the view-mode branch, the controls, the probe). Much smaller than the atlas.
+
+## Codex feasibility review (incorporated)
+
+Verdict: feasible, and **simpler than first written** — the atlas premise was wrong.
+
+- **[blocker→fixed] "WebGL2 has no 3D textures" is false.** wgpu-22's WebGL2 maps `D3` →
+  `TEXTURE_3D` (max dim 256, fits `256×128×192`) and `R16Float` is filterable. → Recommendation
+  flipped to the **native 3D path**, smoke-probed on forced WebGL2 first; atlas demoted to fallback.
+- **[risk] grid build blocks the main thread** (millions × 8 deposits + f16). → build once per
+  load/focus with status; chunk/worker later.
+- **[risk] `VolumeGrid` reuse is viable** — `deposit`/`combine`/`density_scale`/`to_f16_scaled` are
+  public + render-safe; only raw `data` is private (we don't need it). → reuse, don't mirror.
+- **[risk] filter semantics need a decision** — volume = all resident points + current MS mask +
+  current crop box (in-shader `box_min/max`); not tied to Display %; bake the floor only if accepting
+  rebuild-on-floor-change.
+- **[risk] frame integration** — add an explicit `ViewMode`; Volume draws volume + axes, not points.
+- **[risk] atlas (fallback only)** — `R16F` 2D sample/filter looks supported; `4096×1536` is not
+  WebGL2-guaranteed (only 2048) — size from `max_texture_dimension_2d`; clamp tile UVs / add gutters
+  to avoid bilinear bleed; cell-centered sampling must match `dim*norm - 0.5`.
+- **[nit]** the native `volume.rs` header comment is stale (says MIP/nearest MVP; code is trilinear
+  additive) — update before treating it as authority.
+
+**Bottom line (codex):** start with **V0 — a forced-WebGL2 capability probe** of the existing 3D
+`R16Float` renderer. If green (expected), V1 is a direct reuse; the atlas is only needed if a target
+browser fails the probe.

--- a/tims-viewer/acquisition_service.py
+++ b/tims-viewer/acquisition_service.py
@@ -60,47 +60,73 @@ class Acquisition:
         self.builder = DIAFrameBuilder(db_path, num_threads=num_threads, with_annotations=True)
         print(f"builder ready in {time.perf_counter() - t:.1f}s", flush=True)
 
-        # Frame metadata from the synthetic DB's `frames` table (frame_id, time, ms_type).
+        # Frame metadata from the synthetic DB's `frames` table — detect columns FIRST (some DBs use
+        # `id`/`rt`), then order by the detected id column.
         con = sqlite3.connect(db_path)
         con.row_factory = sqlite3.Row
         try:
-            rows = con.execute("SELECT * FROM frames ORDER BY frame_id").fetchall()
+            fcols = {r[1] for r in con.execute("PRAGMA table_info(frames)").fetchall()}
+            if not fcols:
+                raise SystemExit("no `frames` table — is this a prepared TimSim synthetic DB?")
+            id_col = next((c for c in ("frame_id", "id") if c in fcols), None)
+            time_col = next((c for c in ("time", "rt", "retention_time") if c in fcols), None)
+            ms_col = next((c for c in ("ms_type", "ms_ms_type", "scan_mode") if c in fcols), None)
+            if not id_col or not time_col:
+                raise SystemExit(f"`frames` missing id/time column (have: {sorted(fcols)})")
+            rows = con.execute(f"SELECT * FROM frames ORDER BY {id_col}").fetchall()
+            # Authoritative full 1/K0 range from the `scans` table (mobility per scan), if present —
+            # far more reliable than sampling a few frames.
+            im_range = None
+            scols = {r[1] for r in con.execute("PRAGMA table_info(scans)").fetchall()}
+            if "mobility" in scols:
+                lo, hi = con.execute("SELECT MIN(mobility), MAX(mobility) FROM scans").fetchone()
+                if lo is not None and hi is not None:
+                    im_range = (float(lo), float(hi))
         finally:
             con.close()
         if not rows:
-            raise SystemExit("no rows in the `frames` table — is this a prepared TimSim synthetic DB?")
-        cols = set(rows[0].keys())
-        id_col = "frame_id" if "frame_id" in cols else "id"
-        time_col = "time" if "time" in cols else ("rt" if "rt" in cols else "retention_time")
-        ms_col = next((c for c in ("ms_type", "ms_ms_type", "scan_mode") if c in cols), None)
+            raise SystemExit("the `frames` table is empty")
         self.frame_ids = [int(r[id_col]) for r in rows]
+        self._frame_id_set = set(self.frame_ids)
         times = [float(r[time_col]) for r in rows]
         self.ms_types = [int(r[ms_col]) for r in rows] if ms_col else [0] * len(rows)
         self.n_frames = len(self.frame_ids)
+        # Per-FRAME interval = the playback cadence (reveal one frame every rt_cycle_length seconds).
         self.rt_cycle_length = float(np.mean(np.diff(times))) if len(times) > 1 else 0.0
         self.rt_min, self.rt_max = (min(times), max(times)) if times else (0.0, 1.0)
 
-        # Sample a few frames for axis bounds + an intensity p99 (the eager builder is already loaded).
-        self._compute_bounds()
+        # m/z + intensity p99 from a spread of sampled frames; 1/K0 from the scans table when available.
+        self._compute_bounds(im_range)
 
     def _build(self, frame_id: int):
         return self.builder.build_frame_annotated(frame_id, fragment=self.fragmentation)
 
-    def _compute_bounds(self):
-        mz_lo = im_lo = float("inf")
-        mz_hi = im_hi = float("-inf")
+    def _compute_bounds(self, im_range):
+        mz_lo, mz_hi = float("inf"), float("-inf")
+        im_lo, im_hi = float("inf"), float("-inf")
         ints = []
-        step = max(1, self.n_frames // 8)
-        for fid in self.frame_ids[::step][:8]:
+        step = max(1, self.n_frames // 24)
+        for fid in self.frame_ids[::step][:24]:
             f = self._build(fid)
             mz = np.asarray(f.mz, dtype=np.float64)
-            im = np.asarray(f.inv_mobility, dtype=np.float64)
             if mz.size:
                 mz_lo, mz_hi = min(mz_lo, mz.min()), max(mz_hi, mz.max())
+                im = np.asarray(f.inv_mobility, dtype=np.float64)
                 im_lo, im_hi = min(im_lo, im.min()), max(im_hi, im.max())
                 ints.append(np.asarray(f.intensity, dtype=np.float64))
-        self.mz_min, self.mz_max = (mz_lo, mz_hi) if np.isfinite(mz_lo) else (100.0, 1700.0)
-        self.im_min, self.im_max = (im_lo, im_hi) if np.isfinite(im_lo) else (0.6, 1.6)
+        # m/z: sampled, padded ~1% (sampling can miss the extremes; padding avoids edge-clipping).
+        if np.isfinite(mz_lo):
+            pad = 0.01 * (mz_hi - mz_lo) + 0.5
+            self.mz_min, self.mz_max = mz_lo - pad, mz_hi + pad
+        else:
+            self.mz_min, self.mz_max = 100.0, 1700.0
+        # 1/K0: prefer the authoritative full range from the scans table; else fall back to samples.
+        if im_range:
+            self.im_min, self.im_max = min(im_range), max(im_range)
+        elif np.isfinite(im_lo):
+            self.im_min, self.im_max = im_lo, im_hi
+        else:
+            self.im_min, self.im_max = 0.6, 1.6
         allint = np.concatenate(ints) if ints else np.array([1.0])
         self.i_p99 = float(np.percentile(allint, 99)) if allint.size else 1.0
 
@@ -124,7 +150,9 @@ class Acquisition:
         im = np.asarray(f.inv_mobility, dtype="<f4")
         intensity = np.asarray(f.intensity, dtype="<f4")
         rt = np.full(n, float(f.retention_time), dtype="<f4")
-        # peptide_ids_first_only: the (Rust-side, fast) dominant-or-first contributor per peak.
+        # peptide_ids_first_only: the FIRST contributor per peak (fast Rust ndarray). For convolved
+        # peaks the dominant max-intensity contributor would be truer, but that needs a per-peak Python
+        # walk over `contributions` — too slow at frame cadence; first-only is the v1 choice.
         # Negative ids (unassigned/noise) → the grey sentinel.
         pid = np.asarray(f.peptide_ids_first_only, dtype=np.int64)
         pid = np.where(pid < 0, NO_PEPTIDE, pid).astype("<u4")
@@ -170,12 +198,15 @@ class Handler(BaseHTTPRequestHandler):
             except ValueError:
                 self._send(400, b"bad frame id", "text/plain")
                 return
+            if fid not in self.acq._frame_id_set:  # 404 reserved for genuinely out-of-range ids
+                self._send(404, f"frame {fid} out of range".encode(), "text/plain")
+                return
             t = time.perf_counter()
             try:
                 body = self.acq.frame_bytes(fid)
-            except Exception as exc:  # out-of-range id / build failure — don't drop the connection
-                print(f"frame {fid} failed: {exc}", flush=True)
-                self._send(404, f"frame {fid}: {exc}".encode(), "text/plain")
+            except Exception as exc:  # a real build/packing failure — surface it, don't drop the conn
+                print(f"frame {fid} build failed: {exc}", flush=True)
+                self._send(500, f"frame {fid}: {exc}".encode(), "text/plain")
                 return
             dt = time.perf_counter() - t
             print(f"frame {fid}: {len(body)//24} peaks in {dt*1000:.0f} ms", flush=True)

--- a/tims-viewer/acquisition_service.py
+++ b/tims-viewer/acquisition_service.py
@@ -13,7 +13,9 @@ a GET health probe and only enables the "live acquisition" mode when it's up.
 Wire format (``/acq/frame``): little-endian records, 24 bytes/peak —
     [ mz f32, im f32, rt f32, intensity f32, peptide_id u32, flags u32 ]
 ``flags`` bit0 = fragment (MS2); ``peptide_id`` = 0xFFFFFFFF for unassigned/noise peaks (the viewer
-renders those grey). Positions are real units; the viewer normalizes them to its cube.
+renders those grey). Positions are real units; the viewer normalizes them to its cube. The ``id`` query
+param is a 0-based frame INDEX (``0..n_frames-1``), not a DB frame id — the client plays the run in
+order without needing to know the actual frame ids.
 
 Run (needs the imspy_simulation env: DIAFrameBuilder + its Rust bindings):
 
@@ -87,7 +89,6 @@ class Acquisition:
         if not rows:
             raise SystemExit("the `frames` table is empty")
         self.frame_ids = [int(r[id_col]) for r in rows]
-        self._frame_id_set = set(self.frame_ids)
         times = [float(r[time_col]) for r in rows]
         self.ms_types = [int(r[ms_col]) for r in rows] if ms_col else [0] * len(rows)
         self.n_frames = len(self.frame_ids)
@@ -141,8 +142,10 @@ class Acquisition:
             "ms_types": self.ms_types,
         }).encode()
 
-    def frame_bytes(self, frame_id: int) -> bytes:
-        f = self._build(frame_id)
+    def frame_bytes(self, index: int) -> bytes:
+        # `index` is a 0-based position into the (frame_id-ordered) frame list — the client plays
+        # 0..n_frames-1 and never needs to know the actual DB frame ids (which may not be 0-based).
+        f = self._build(self.frame_ids[index])
         mz = np.asarray(f.mz, dtype="<f4")
         n = mz.size
         if n == 0:
@@ -198,8 +201,8 @@ class Handler(BaseHTTPRequestHandler):
             except ValueError:
                 self._send(400, b"bad frame id", "text/plain")
                 return
-            if fid not in self.acq._frame_id_set:  # 404 reserved for genuinely out-of-range ids
-                self._send(404, f"frame {fid} out of range".encode(), "text/plain")
+            if not (0 <= fid < self.acq.n_frames):  # `id` is a 0-based frame index
+                self._send(404, f"frame index {fid} out of range [0,{self.acq.n_frames})".encode(), "text/plain")
                 return
             t = time.perf_counter()
             try:

--- a/tims-viewer/acquisition_service.py
+++ b/tims-viewer/acquisition_service.py
@@ -17,6 +17,11 @@ renders those grey). Positions are real units; the viewer normalizes them to its
 param is a 0-based frame INDEX (``0..n_frames-1``), not a DB frame id — the client plays the run in
 order without needing to know the actual frame ids.
 
+``GET /acq/frames?start=N&count=K`` builds a contiguous batch of K frames IN PARALLEL (Rayon) in one
+call and returns ``u32 count``, then ``count × [u32 frame_index, u32 n_peaks]``, then the concatenated
+records — so the viewer can prefetch ahead of the cursor cheaply instead of paying a round-trip +
+per-call build per frame.
+
 Run (needs the imspy_simulation env: DIAFrameBuilder + its Rust bindings):
 
     python tims-viewer/acquisition_service.py --db <synthetic_sim.db> --port 8092
@@ -86,6 +91,10 @@ def build_subset_db(src_path: str, max_peptides: int) -> str:
 # u32::MAX — matches the viewer's NO_CLUSTER sentinel, so unassigned peaks render in the neutral grey.
 NO_PEPTIDE = 0xFFFFFFFF
 
+# Largest batch a single /acq/frames request may build (bounds per-request work/memory; the client
+# prefetches in batches well under this).
+MAX_BATCH = 128
+
 # Per-peak record dtype sent over the wire (little-endian; 24 bytes).
 _REC = np.dtype([
     ("mz", "<f4"), ("im", "<f4"), ("rt", "<f4"),
@@ -98,6 +107,8 @@ class Acquisition:
 
     def __init__(self, db_path: str, num_threads: int, fragmentation: bool, max_peptides: int = 0):
         self.fragmentation = fragmentation
+        # Threads for the (Rayon-parallel) batch build — resolve -1 to the core count.
+        self.num_threads = num_threads if num_threads and num_threads > 0 else (os.cpu_count() or 4)
         # Optional "semi-lazy" startup: build over a peptide subset so the eager builder inits in
         # seconds (the frame schedule stays whole, so playback covers the full run).
         builder_db = db_path
@@ -108,7 +119,7 @@ class Acquisition:
         # all (subset) peptides + annotated fragment spectra up front.
         print(f"loading annotated builder from {builder_db}…", flush=True)
         t = time.perf_counter()
-        self.builder = DIAFrameBuilder(builder_db, num_threads=num_threads, with_annotations=True)
+        self.builder = DIAFrameBuilder(builder_db, num_threads=self.num_threads, with_annotations=True)
         print(f"builder ready in {time.perf_counter() - t:.1f}s", flush=True)
         # Frame metadata comes from the (subset or full) builder DB — both carry the full frames table.
         db_path = builder_db
@@ -153,6 +164,26 @@ class Acquisition:
     def _build(self, frame_id: int):
         return self.builder.build_frame_annotated(frame_id, fragment=self.fragmentation)
 
+    @staticmethod
+    def _records(f) -> np.ndarray:
+        """Pack one built annotated frame into the 24-byte/peak wire records."""
+        mz = np.asarray(f.mz, dtype="<f4")
+        n = mz.size
+        if n == 0:
+            return np.empty(0, dtype=_REC)
+        rec = np.empty(n, dtype=_REC)
+        rec["mz"] = mz
+        rec["im"] = np.asarray(f.inv_mobility, dtype="<f4")
+        rec["rt"] = np.full(n, float(f.retention_time), dtype="<f4")
+        rec["intensity"] = np.asarray(f.intensity, dtype="<f4")
+        # peptide_ids_first_only: the FIRST contributor per peak (fast Rust ndarray). The dominant
+        # max-intensity contributor would be truer for convolved peaks but needs a per-peak Python walk
+        # over `contributions` — too slow at frame cadence. Negative ids (noise) → the grey sentinel.
+        pid = np.asarray(f.peptide_ids_first_only, dtype=np.int64)
+        rec["peptide_id"] = np.where(pid < 0, NO_PEPTIDE, pid).astype("<u4")
+        rec["flags"] = np.uint32(1 if int(f.ms_type_numeric) == 9 else 0)  # frame-level: MS2 ⇒ fragments
+        return rec
+
     def _compute_bounds(self, im_range):
         mz_lo, mz_hi = float("inf"), float("-inf")
         im_lo, im_hi = float("inf"), float("-inf")
@@ -196,26 +227,33 @@ class Acquisition:
     def frame_bytes(self, index: int) -> bytes:
         # `index` is a 0-based position into the (frame_id-ordered) frame list — the client plays
         # 0..n_frames-1 and never needs to know the actual DB frame ids (which may not be 0-based).
-        f = self._build(self.frame_ids[index])
-        mz = np.asarray(f.mz, dtype="<f4")
-        n = mz.size
-        if n == 0:
-            return b""
-        im = np.asarray(f.inv_mobility, dtype="<f4")
-        intensity = np.asarray(f.intensity, dtype="<f4")
-        rt = np.full(n, float(f.retention_time), dtype="<f4")
-        # peptide_ids_first_only: the FIRST contributor per peak (fast Rust ndarray). For convolved
-        # peaks the dominant max-intensity contributor would be truer, but that needs a per-peak Python
-        # walk over `contributions` — too slow at frame cadence; first-only is the v1 choice.
-        # Negative ids (unassigned/noise) → the grey sentinel.
-        pid = np.asarray(f.peptide_ids_first_only, dtype=np.int64)
-        pid = np.where(pid < 0, NO_PEPTIDE, pid).astype("<u4")
-        is_fragment = 1 if int(f.ms_type_numeric) == 9 else 0  # frame-level: MS2 ⇒ all peaks fragments
-        flags = np.full(n, is_fragment, dtype="<u4")
-        rec = np.empty(n, dtype=_REC)
-        rec["mz"], rec["im"], rec["rt"] = mz, im, rt
-        rec["intensity"], rec["peptide_id"], rec["flags"] = intensity, pid, flags
-        return rec.tobytes()
+        return self._records(self._build(self.frame_ids[index])).tobytes()
+
+    def frames_bytes(self, start: int, count: int) -> bytes:
+        """Build a CONTIGUOUS batch of frames in parallel (Rayon, `num_threads`) and pack them into one
+        response so the client can prefetch ahead of the cursor without per-frame round-trips.
+
+        Wire layout (little-endian):
+            u32 count
+            count × [u32 frame_index, u32 n_peaks]    -- the per-frame table, in order
+            then the concatenated 24-byte records for frame[0], frame[1], … (n_peaks each)
+
+        NOTE: the annotated build is STOCHASTIC per call (the simulator's shot-noise model), so
+        re-fetching a frame yields slightly different peaks. That's realistic, but it means the client
+        must CACHE streamed frames for scrub/replay rather than re-fetching them.
+        """
+        indices = list(range(start, start + count))
+        frame_ids = [self.frame_ids[i] for i in indices]
+        frames = self.builder.build_frames_annotated(
+            frame_ids, fragment=self.fragmentation, num_threads=self.num_threads
+        )
+        recs = [self._records(f) for f in frames]
+        table = np.empty(count, dtype=[("idx", "<u4"), ("n", "<u4")])
+        table["idx"] = np.asarray(indices, dtype="<u4")
+        table["n"] = np.asarray([r.size for r in recs], dtype="<u4")
+        head = np.array([count], dtype="<u4").tobytes() + table.tobytes()
+        body = b"".join(r.tobytes() for r in recs)
+        return head + body
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -264,6 +302,34 @@ class Handler(BaseHTTPRequestHandler):
                 return
             dt = time.perf_counter() - t
             print(f"frame {fid}: {len(body)//24} peaks in {dt*1000:.0f} ms", flush=True)
+            self._send(200, body, "application/octet-stream")
+            return
+        if path == "/acq/frames":  # parallel batch — the client prefetches ahead with this
+            q = parse_qs(urlparse(self.path).query)
+            try:
+                start = int(q.get("start", ["?"])[0])
+                count = int(q.get("count", ["?"])[0])
+            except ValueError:
+                self._send(400, b"bad start/count", "text/plain")
+                return
+            if count <= 0:
+                self._send(400, b"count must be > 0", "text/plain")
+                return
+            if start < 0 or start >= self.acq.n_frames:
+                self._send(404, f"start {start} out of range [0,{self.acq.n_frames})".encode(), "text/plain")
+                return
+            # Clamp to the run end AND a sane max so one request can't build the whole run into memory.
+            count = min(count, self.acq.n_frames - start, MAX_BATCH)
+            t = time.perf_counter()
+            try:
+                body = self.acq.frames_bytes(start, count)
+            except Exception as exc:
+                print(f"batch [{start},{start+count}) build failed: {exc}", flush=True)
+                self._send(500, f"batch [{start},{start+count}): {exc}".encode(), "text/plain")
+                return
+            dt = time.perf_counter() - t
+            print(f"batch [{start},{start+count}): {len(body)} B in {dt*1000:.0f} ms "
+                  f"({dt*1000/count:.1f} ms/frame, {self.acq.num_threads} threads)", flush=True)
             self._send(200, body, "application/octet-stream")
             return
         # health probe (the viewer auto-detects the sidecar via this)

--- a/tims-viewer/acquisition_service.py
+++ b/tims-viewer/acquisition_service.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Acquisition sidecar — stream annotated DIA frames for live playback in tims-viewer.
+"""Acquisition sidecar (EXPERIMENTAL) — stream annotated SIMULATED DIA frames for live playback.
+
+STATUS: experimental. This streams a *simulated* acquisition (TimSim synthetic data), not real
+instrument output; the wire format and endpoints may still change, and it's an optional, off-by-
+default sidecar. The viewer flags the "Live acquisition" mode as experimental to match.
 
 Wraps TimSim's ``DIAFrameBuilder(with_annotations=True)`` over a prepared synthetic-simulation DB and
 serves, per frame, the annotated points (m/z, 1/K0, RT, intensity + peptide_id + precursor/fragment

--- a/tims-viewer/acquisition_service.py
+++ b/tims-viewer/acquisition_service.py
@@ -26,14 +26,57 @@ Then load the viewer with ``?acq=http://localhost:8092`` (or it auto-detects the
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
+import os
 import sqlite3
+import tempfile
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 from imspy_simulation.builders.dia import DIAFrameBuilder
+
+
+def build_subset_db(src_path: str, max_peptides: int) -> str:
+    """Write a temp DB with only the first `max_peptides` peptides (+ their ions/fragment_ions),
+    keeping every other table whole (frames/scans/dia windows are the acquisition schedule, not
+    peptide data). Lets the eager annotated builder init in seconds over a slice of a huge sim instead
+    of minutes over all of it — a no-Rust "semi-lazy" startup. Returns the temp DB path (auto-removed
+    at exit)."""
+    fd, tmp = tempfile.mkstemp(suffix=".db", prefix="acq_subset_")
+    os.close(fd)
+    os.remove(tmp)  # let sqlite create it fresh
+    t = time.perf_counter()
+    con = sqlite3.connect(tmp)
+    try:
+        con.execute("ATTACH DATABASE ? AS src", (src_path,))
+        tables = [
+            r[0] for r in con.execute(
+                "SELECT name FROM src.sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        ]
+        # peptides first (ions/fragment_ions reference it); CREATE AS SELECT copies data, no indexes —
+        # fine for the small subset the builder reads.
+        con.execute(
+            f"CREATE TABLE peptides AS SELECT * FROM src.peptides ORDER BY peptide_id LIMIT {int(max_peptides)}"
+        )
+        for t_name in ("ions", "fragment_ions"):
+            if t_name in tables:
+                con.execute(
+                    f"CREATE TABLE {t_name} AS SELECT * FROM src.{t_name} "
+                    "WHERE peptide_id IN (SELECT peptide_id FROM peptides)"
+                )
+        for t_name in tables:
+            if t_name not in ("peptides", "ions", "fragment_ions"):
+                con.execute(f"CREATE TABLE {t_name} AS SELECT * FROM src.{t_name}")
+        con.commit()
+    finally:
+        con.close()
+    atexit.register(lambda: os.path.exists(tmp) and os.remove(tmp))
+    print(f"subset DB ({max_peptides} peptides) built in {time.perf_counter() - t:.1f}s", flush=True)
+    return tmp
 
 # NOTE: the Rust builder (PyTimsTofSyntheticsFrameBuilderDIA) is *unsendable* — it must stay on the
 # thread that created it — so this server is single-threaded (plain HTTPServer). That's fine: the DIA
@@ -53,14 +96,22 @@ _REC = np.dtype([
 class Acquisition:
     """Holds the eager annotated builder + precomputed run metadata."""
 
-    def __init__(self, db_path: str, num_threads: int, fragmentation: bool):
+    def __init__(self, db_path: str, num_threads: int, fragmentation: bool, max_peptides: int = 0):
         self.fragmentation = fragmentation
+        # Optional "semi-lazy" startup: build over a peptide subset so the eager builder inits in
+        # seconds (the frame schedule stays whole, so playback covers the full run).
+        builder_db = db_path
+        if max_peptides > 0:
+            print(f"subsetting to the first {max_peptides} peptides for a fast startup…", flush=True)
+            builder_db = build_subset_db(db_path, max_peptides)
         # Eager builder WITH annotations (lazy + annotations is not supported yet). This reads/builds
-        # all peptides + annotated fragment spectra up front — fine for small/medium sims.
-        print(f"loading annotated builder from {db_path} (this reads all peptides up front)…", flush=True)
+        # all (subset) peptides + annotated fragment spectra up front.
+        print(f"loading annotated builder from {builder_db}…", flush=True)
         t = time.perf_counter()
-        self.builder = DIAFrameBuilder(db_path, num_threads=num_threads, with_annotations=True)
+        self.builder = DIAFrameBuilder(builder_db, num_threads=num_threads, with_annotations=True)
         print(f"builder ready in {time.perf_counter() - t:.1f}s", flush=True)
+        # Frame metadata comes from the (subset or full) builder DB — both carry the full frames table.
+        db_path = builder_db
 
         # Frame metadata from the synthetic DB's `frames` table — detect columns FIRST (some DBs use
         # `id`/`rt`), then order by the detected id column.
@@ -228,9 +279,11 @@ def main():
     ap.add_argument("--port", type=int, default=8092)
     ap.add_argument("--threads", type=int, default=-1, help="builder threads (-1 = auto)")
     ap.add_argument("--no-fragmentation", action="store_true", help="precursor-only (skip MS2 fragments)")
+    ap.add_argument("--max-peptides", type=int, default=0,
+                    help="semi-lazy: build over only the first N peptides for a fast startup (0 = all)")
     args = ap.parse_args()
 
-    Handler.acq = Acquisition(args.db, args.threads, not args.no_fragmentation)
+    Handler.acq = Acquisition(args.db, args.threads, not args.no_fragmentation, args.max_peptides)
     a = Handler.acq
     print(
         f"acquisition service on http://localhost:{args.port}  "

--- a/tims-viewer/acquisition_service.py
+++ b/tims-viewer/acquisition_service.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Acquisition sidecar — stream annotated DIA frames for live playback in tims-viewer.
+
+Wraps TimSim's ``DIAFrameBuilder(with_annotations=True)`` over a prepared synthetic-simulation DB and
+serves, per frame, the annotated points (m/z, 1/K0, RT, intensity + peptide_id + precursor/fragment
+flag). The viewer plays the acquisition over time at the device's real frame rate and colors each
+peak by its precursor — a precursor's MS1 signal and all its MS2 fragments share one ``peptide_id``,
+so you can watch DIA fragment convolution build up.
+
+A decoupled, optional sidecar (same shape as ``cluster_service.py``): the viewer auto-detects it via
+a GET health probe and only enables the "live acquisition" mode when it's up.
+
+Wire format (``/acq/frame``): little-endian records, 24 bytes/peak —
+    [ mz f32, im f32, rt f32, intensity f32, peptide_id u32, flags u32 ]
+``flags`` bit0 = fragment (MS2); ``peptide_id`` = 0xFFFFFFFF for unassigned/noise peaks (the viewer
+renders those grey). Positions are real units; the viewer normalizes them to its cube.
+
+Run (needs the imspy_simulation env: DIAFrameBuilder + its Rust bindings):
+
+    python tims-viewer/acquisition_service.py --db <synthetic_sim.db> --port 8092
+
+Then load the viewer with ``?acq=http://localhost:8092`` (or it auto-detects the default port).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import numpy as np
+from imspy_simulation.builders.dia import DIAFrameBuilder
+
+# NOTE: the Rust builder (PyTimsTofSyntheticsFrameBuilderDIA) is *unsendable* — it must stay on the
+# thread that created it — so this server is single-threaded (plain HTTPServer). That's fine: the DIA
+# build is internally Rayon-parallel and is the bottleneck, and the viewer pulls frames sequentially
+# (with its own prefetch), so request-level concurrency would add nothing.
+
+# u32::MAX — matches the viewer's NO_CLUSTER sentinel, so unassigned peaks render in the neutral grey.
+NO_PEPTIDE = 0xFFFFFFFF
+
+# Per-peak record dtype sent over the wire (little-endian; 24 bytes).
+_REC = np.dtype([
+    ("mz", "<f4"), ("im", "<f4"), ("rt", "<f4"),
+    ("intensity", "<f4"), ("peptide_id", "<u4"), ("flags", "<u4"),
+])
+
+
+class Acquisition:
+    """Holds the eager annotated builder + precomputed run metadata."""
+
+    def __init__(self, db_path: str, num_threads: int, fragmentation: bool):
+        self.fragmentation = fragmentation
+        # Eager builder WITH annotations (lazy + annotations is not supported yet). This reads/builds
+        # all peptides + annotated fragment spectra up front — fine for small/medium sims.
+        print(f"loading annotated builder from {db_path} (this reads all peptides up front)…", flush=True)
+        t = time.perf_counter()
+        self.builder = DIAFrameBuilder(db_path, num_threads=num_threads, with_annotations=True)
+        print(f"builder ready in {time.perf_counter() - t:.1f}s", flush=True)
+
+        # Frame metadata from the synthetic DB's `frames` table (frame_id, time, ms_type).
+        con = sqlite3.connect(db_path)
+        con.row_factory = sqlite3.Row
+        try:
+            rows = con.execute("SELECT * FROM frames ORDER BY frame_id").fetchall()
+        finally:
+            con.close()
+        if not rows:
+            raise SystemExit("no rows in the `frames` table — is this a prepared TimSim synthetic DB?")
+        cols = set(rows[0].keys())
+        id_col = "frame_id" if "frame_id" in cols else "id"
+        time_col = "time" if "time" in cols else ("rt" if "rt" in cols else "retention_time")
+        ms_col = next((c for c in ("ms_type", "ms_ms_type", "scan_mode") if c in cols), None)
+        self.frame_ids = [int(r[id_col]) for r in rows]
+        times = [float(r[time_col]) for r in rows]
+        self.ms_types = [int(r[ms_col]) for r in rows] if ms_col else [0] * len(rows)
+        self.n_frames = len(self.frame_ids)
+        self.rt_cycle_length = float(np.mean(np.diff(times))) if len(times) > 1 else 0.0
+        self.rt_min, self.rt_max = (min(times), max(times)) if times else (0.0, 1.0)
+
+        # Sample a few frames for axis bounds + an intensity p99 (the eager builder is already loaded).
+        self._compute_bounds()
+
+    def _build(self, frame_id: int):
+        return self.builder.build_frame_annotated(frame_id, fragment=self.fragmentation)
+
+    def _compute_bounds(self):
+        mz_lo = im_lo = float("inf")
+        mz_hi = im_hi = float("-inf")
+        ints = []
+        step = max(1, self.n_frames // 8)
+        for fid in self.frame_ids[::step][:8]:
+            f = self._build(fid)
+            mz = np.asarray(f.mz, dtype=np.float64)
+            im = np.asarray(f.inv_mobility, dtype=np.float64)
+            if mz.size:
+                mz_lo, mz_hi = min(mz_lo, mz.min()), max(mz_hi, mz.max())
+                im_lo, im_hi = min(im_lo, im.min()), max(im_hi, im.max())
+                ints.append(np.asarray(f.intensity, dtype=np.float64))
+        self.mz_min, self.mz_max = (mz_lo, mz_hi) if np.isfinite(mz_lo) else (100.0, 1700.0)
+        self.im_min, self.im_max = (im_lo, im_hi) if np.isfinite(im_lo) else (0.6, 1.6)
+        allint = np.concatenate(ints) if ints else np.array([1.0])
+        self.i_p99 = float(np.percentile(allint, 99)) if allint.size else 1.0
+
+    def meta_json(self) -> bytes:
+        return json.dumps({
+            "n_frames": self.n_frames,
+            "rt_cycle_length": self.rt_cycle_length,
+            "mz_min": self.mz_min, "mz_max": self.mz_max,
+            "im_min": self.im_min, "im_max": self.im_max,
+            "rt_min": self.rt_min, "rt_max": self.rt_max,
+            "i_p99": self.i_p99,
+            "ms_types": self.ms_types,
+        }).encode()
+
+    def frame_bytes(self, frame_id: int) -> bytes:
+        f = self._build(frame_id)
+        mz = np.asarray(f.mz, dtype="<f4")
+        n = mz.size
+        if n == 0:
+            return b""
+        im = np.asarray(f.inv_mobility, dtype="<f4")
+        intensity = np.asarray(f.intensity, dtype="<f4")
+        rt = np.full(n, float(f.retention_time), dtype="<f4")
+        # peptide_ids_first_only: the (Rust-side, fast) dominant-or-first contributor per peak.
+        # Negative ids (unassigned/noise) → the grey sentinel.
+        pid = np.asarray(f.peptide_ids_first_only, dtype=np.int64)
+        pid = np.where(pid < 0, NO_PEPTIDE, pid).astype("<u4")
+        is_fragment = 1 if int(f.ms_type_numeric) == 9 else 0  # frame-level: MS2 ⇒ all peaks fragments
+        flags = np.full(n, is_fragment, dtype="<u4")
+        rec = np.empty(n, dtype=_REC)
+        rec["mz"], rec["im"], rec["rt"] = mz, im, rt
+        rec["intensity"], rec["peptide_id"], rec["flags"] = intensity, pid, flags
+        return rec.tobytes()
+
+
+class Handler(BaseHTTPRequestHandler):
+    acq: Acquisition = None  # set in main()
+
+    def _cors(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+
+    def _send(self, code, body: bytes, ctype):
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self._cors()
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self._cors()
+        self.end_headers()
+
+    def do_GET(self):
+        path = urlparse(self.path).path
+        if path == "/acq/meta":
+            self._send(200, self.acq.meta_json(), "application/json")
+            return
+        if path == "/acq/frame":
+            q = parse_qs(urlparse(self.path).query)
+            try:
+                fid = int(q.get("id", ["?"])[0])
+            except ValueError:
+                self._send(400, b"bad frame id", "text/plain")
+                return
+            t = time.perf_counter()
+            try:
+                body = self.acq.frame_bytes(fid)
+            except Exception as exc:  # out-of-range id / build failure — don't drop the connection
+                print(f"frame {fid} failed: {exc}", flush=True)
+                self._send(404, f"frame {fid}: {exc}".encode(), "text/plain")
+                return
+            dt = time.perf_counter() - t
+            print(f"frame {fid}: {len(body)//24} peaks in {dt*1000:.0f} ms", flush=True)
+            self._send(200, body, "application/octet-stream")
+            return
+        # health probe (the viewer auto-detects the sidecar via this)
+        self._send(200, b"tims-viewer acquisition service: ok\n", "text/plain")
+
+    def log_message(self, *_args):
+        pass
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Annotated-frame acquisition sidecar for tims-viewer")
+    ap.add_argument("--db", required=True, help="prepared TimSim synthetic simulation DB")
+    ap.add_argument("--port", type=int, default=8092)
+    ap.add_argument("--threads", type=int, default=-1, help="builder threads (-1 = auto)")
+    ap.add_argument("--no-fragmentation", action="store_true", help="precursor-only (skip MS2 fragments)")
+    args = ap.parse_args()
+
+    Handler.acq = Acquisition(args.db, args.threads, not args.no_fragmentation)
+    a = Handler.acq
+    print(
+        f"acquisition service on http://localhost:{args.port}  "
+        f"({a.n_frames} frames, rt_cycle_length={a.rt_cycle_length:.4f}s, "
+        f"mz [{a.mz_min:.0f},{a.mz_max:.0f}] 1/K0 [{a.im_min:.3f},{a.im_max:.3f}])",
+        flush=True,
+    )
+    HTTPServer(("127.0.0.1", args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tims-viewer/cluster_service.py
+++ b/tims-viewer/cluster_service.py
@@ -79,24 +79,36 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         pts = np.frombuffer(bytes(buf), dtype="<f4").reshape(-1, 3).astype(np.float64)
+        n_pts = pts.shape[0]
         t = time.perf_counter()
+        # Never drop the connection on a bad/degenerate input: clamp params to the point count and,
+        # on any sklearn error, fall back to all-noise so the client always gets valid labels.
         with _DBSCAN_LOCK:  # serialize the heavy compute across overlapping requests
-            if method == "hdbscan":
-                mcs = int(q.get("mcs", ["7"])[0])
-                ms = int(q.get("ms", ["0"])[0])
-                cse = float(q.get("cse", ["0"])[0])
-                labels = HDBSCAN(
-                    min_cluster_size=max(2, mcs),
-                    min_samples=(ms if ms > 0 else None),
-                    cluster_selection_epsilon=cse,
-                    copy=True,  # don't mutate our buffer (and silence the 1.10 FutureWarning)
-                ).fit(pts).labels_
-                desc = f"HDBSCAN mcs={mcs} ms={ms or 'auto'} cse={cse}"
-            else:
-                eps = float(q.get("eps", ["0.012"])[0])
-                min_samples = int(q.get("min", ["8"])[0])
-                labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
-                desc = f"DBSCAN eps={eps} min={min_samples}"
+            try:
+                if method == "hdbscan":
+                    mcs = max(2, min(int(q.get("mcs", ["7"])[0]), n_pts))
+                    ms_raw = int(q.get("ms", ["0"])[0])
+                    ms = min(ms_raw, n_pts) if ms_raw > 0 else None
+                    cse = float(q.get("cse", ["0"])[0])
+                    if n_pts < 2:
+                        labels = np.full(n_pts, -1, dtype="<i4")
+                    else:
+                        labels = HDBSCAN(
+                            min_cluster_size=mcs,
+                            min_samples=ms,
+                            cluster_selection_epsilon=cse,
+                            copy=True,  # don't mutate our buffer (+ silence the 1.10 FutureWarning)
+                        ).fit(pts).labels_
+                    desc = f"HDBSCAN mcs={mcs} ms={ms or 'auto'} cse={cse}"
+                else:
+                    eps = float(q.get("eps", ["0.012"])[0])
+                    min_samples = int(q.get("min", ["8"])[0])
+                    labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
+                    desc = f"DBSCAN eps={eps} min={min_samples}"
+            except Exception as exc:  # degenerate input, etc. — return all-noise, don't 500
+                print(f"clustering failed ({method}, {n_pts} pts): {exc}", flush=True)
+                labels = np.full(n_pts, -1, dtype="<i4")
+                desc = f"{method} (fallback all-noise)"
         k = int(labels.max()) + 1 if labels.size else 0
         dt = time.perf_counter() - t
         print(f"{desc}: {pts.shape[0]} pts -> {k} clusters in {dt:.2f}s", flush=True)

--- a/tims-viewer/cluster_service.py
+++ b/tims-viewer/cluster_service.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Minimal sklearn-DBSCAN clustering service for the tims-viewer web client.
+
+A feasibility step toward running clustering through Python (sklearn today; HDBSCAN /
+the MIDIA 4D pipeline later) instead of the in-wasm DBSCAN. The web client POSTs the
+exact (already axis-scaled) points it would have clustered locally, so the result is
+directly comparable to the wasm path.
+
+Wire format (matches the wasm worker's): the body is the little-endian float32 point
+buffer ``[x,y,z, x,y,z, ...]``; the reply is little-endian int32 labels (one per point,
+``-1`` = noise). eps / min_samples ride the query string.
+
+    POST /cluster?eps=<f>&min=<n>        body: float32 xyz triples
+      -> int32 labels
+
+Run (needs numpy + scikit-learn, both in the imspy env):
+
+    python tims-viewer/cluster_service.py --port 8091
+
+Then load the viewer with ``?cluster=http://localhost:8091/cluster`` to route Run
+through this service; without that query param the viewer uses its built-in wasm DBSCAN.
+"""
+from __future__ import annotations
+
+import argparse
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _cors(self) -> None:
+        # The trunk page is served from a different origin than this service.
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "*")
+
+    def do_OPTIONS(self) -> None:  # CORS preflight
+        self.send_response(204)
+        self._cors()
+        self.end_headers()
+
+    def do_POST(self) -> None:
+        if urlparse(self.path).path != "/cluster":
+            self.send_response(404)
+            self._cors()
+            self.end_headers()
+            return
+        q = parse_qs(urlparse(self.path).query)
+        eps = float(q.get("eps", ["0.012"])[0])
+        min_samples = int(q.get("min", ["8"])[0])
+        n = int(self.headers.get("Content-Length", 0))
+        buf = self.rfile.read(n) if n else b""
+        pts = np.frombuffer(buf, dtype="<f4")
+        if pts.size == 0 or pts.size % 3 != 0:
+            self.send_response(400)
+            self._cors()
+            self.end_headers()
+            return
+        pts = pts.reshape(-1, 3).astype(np.float64)
+        t = time.perf_counter()
+        labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
+        k = int(labels.max()) + 1 if labels.size else 0
+        dt = time.perf_counter() - t
+        print(f"DBSCAN: {pts.shape[0]} pts, eps={eps} min={min_samples} -> {k} clusters in {dt:.2f}s")
+        out = labels.astype("<i4").tobytes()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(out)))
+        self._cors()
+        self.end_headers()
+        self.wfile.write(out)
+
+    def log_message(self, *_args) -> None:  # quiet the default per-request logging
+        pass
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="sklearn-DBSCAN clustering service for tims-viewer web")
+    ap.add_argument("--port", type=int, default=8091)
+    args = ap.parse_args()
+    print(f"sklearn-DBSCAN cluster service on http://localhost:{args.port}/cluster")
+    ThreadingHTTPServer(("127.0.0.1", args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tims-viewer/cluster_service.py
+++ b/tims-viewer/cluster_service.py
@@ -48,7 +48,15 @@ class Handler(BaseHTTPRequestHandler):
         self._cors()
         self.end_headers()
 
+    def do_GET(self) -> None:  # health probe — the web auto-enables the Python backend if this is 200
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self._cors()
+        self.end_headers()
+        self.wfile.write(b"tims-viewer sklearn cluster service: ok\n")
+
     def do_POST(self) -> None:
+        print(f"POST {self.path}  ({self.headers.get('Content-Length', '?')} bytes)", flush=True)
         if urlparse(self.path).path != "/cluster":
             self.send_response(404)
             self._cors()
@@ -76,7 +84,10 @@ class Handler(BaseHTTPRequestHandler):
             labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
         k = int(labels.max()) + 1 if labels.size else 0
         dt = time.perf_counter() - t
-        print(f"DBSCAN: {pts.shape[0]} pts, eps={eps} min={min_samples} -> {k} clusters in {dt:.2f}s")
+        print(
+            f"DBSCAN: {pts.shape[0]} pts, eps={eps} min={min_samples} -> {k} clusters in {dt:.2f}s",
+            flush=True,
+        )
         out = labels.astype("<i4").tobytes()
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")

--- a/tims-viewer/cluster_service.py
+++ b/tims-viewer/cluster_service.py
@@ -29,7 +29,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
-from sklearn.cluster import DBSCAN
+from sklearn.cluster import DBSCAN, HDBSCAN
 
 # Single-flight: DBSCAN(n_jobs=-1) already uses every core, so serialize requests (the browser does
 # not abort superseded fetches) to avoid oversubscribing the CPU with overlapping runs.
@@ -63,8 +63,7 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         q = parse_qs(urlparse(self.path).query)
-        eps = float(q.get("eps", ["0.012"])[0])
-        min_samples = int(q.get("min", ["8"])[0])
+        method = q.get("method", ["dbscan"])[0]
         n = int(self.headers.get("Content-Length", 0))
         buf = bytearray()
         while len(buf) < n:  # the socket can hand back the body in chunks
@@ -81,13 +80,25 @@ class Handler(BaseHTTPRequestHandler):
         pts = pts.reshape(-1, 3).astype(np.float64)
         t = time.perf_counter()
         with _DBSCAN_LOCK:  # serialize the heavy compute across overlapping requests
-            labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
+            if method == "hdbscan":
+                mcs = int(q.get("mcs", ["7"])[0])
+                ms = int(q.get("ms", ["0"])[0])
+                cse = float(q.get("cse", ["0"])[0])
+                labels = HDBSCAN(
+                    min_cluster_size=max(2, mcs),
+                    min_samples=(ms if ms > 0 else None),
+                    cluster_selection_epsilon=cse,
+                    copy=True,  # don't mutate our buffer (and silence the 1.10 FutureWarning)
+                ).fit(pts).labels_
+                desc = f"HDBSCAN mcs={mcs} ms={ms or 'auto'} cse={cse}"
+            else:
+                eps = float(q.get("eps", ["0.012"])[0])
+                min_samples = int(q.get("min", ["8"])[0])
+                labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
+                desc = f"DBSCAN eps={eps} min={min_samples}"
         k = int(labels.max()) + 1 if labels.size else 0
         dt = time.perf_counter() - t
-        print(
-            f"DBSCAN: {pts.shape[0]} pts, eps={eps} min={min_samples} -> {k} clusters in {dt:.2f}s",
-            flush=True,
-        )
+        print(f"{desc}: {pts.shape[0]} pts -> {k} clusters in {dt:.2f}s", flush=True)
         out = labels.astype("<i4").tobytes()
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")

--- a/tims-viewer/cluster_service.py
+++ b/tims-viewer/cluster_service.py
@@ -64,7 +64,13 @@ class Handler(BaseHTTPRequestHandler):
             return
         q = parse_qs(urlparse(self.path).query)
         method = q.get("method", ["dbscan"])[0]
-        n = int(self.headers.get("Content-Length", 0))
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+        except (ValueError, TypeError):  # malformed header -> clean 400, don't drop the connection
+            self.send_response(400)
+            self._cors()
+            self.end_headers()
+            return
         buf = bytearray()
         while len(buf) < n:  # the socket can hand back the body in chunks
             chunk = self.rfile.read(n - len(buf))

--- a/tims-viewer/cluster_service.py
+++ b/tims-viewer/cluster_service.py
@@ -23,12 +23,17 @@ through this service; without that query param the viewer uses its built-in wasm
 from __future__ import annotations
 
 import argparse
+import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 from sklearn.cluster import DBSCAN
+
+# Single-flight: DBSCAN(n_jobs=-1) already uses every core, so serialize requests (the browser does
+# not abort superseded fetches) to avoid oversubscribing the CPU with overlapping runs.
+_DBSCAN_LOCK = threading.Lock()
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -53,16 +58,22 @@ class Handler(BaseHTTPRequestHandler):
         eps = float(q.get("eps", ["0.012"])[0])
         min_samples = int(q.get("min", ["8"])[0])
         n = int(self.headers.get("Content-Length", 0))
-        buf = self.rfile.read(n) if n else b""
-        pts = np.frombuffer(buf, dtype="<f4")
-        if pts.size == 0 or pts.size % 3 != 0:
+        buf = bytearray()
+        while len(buf) < n:  # the socket can hand back the body in chunks
+            chunk = self.rfile.read(n - len(buf))
+            if not chunk:
+                break
+            buf.extend(chunk)
+        pts = np.frombuffer(bytes(buf), dtype="<f4")
+        if len(buf) != n or pts.size == 0 or pts.size % 3 != 0:
             self.send_response(400)
             self._cors()
             self.end_headers()
             return
         pts = pts.reshape(-1, 3).astype(np.float64)
         t = time.perf_counter()
-        labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
+        with _DBSCAN_LOCK:  # serialize the heavy compute across overlapping requests
+            labels = DBSCAN(eps=eps, min_samples=min_samples, n_jobs=-1).fit(pts).labels_
         k = int(labels.max()) + 1 if labels.size else 0
         dt = time.perf_counter() - t
         print(f"DBSCAN: {pts.shape[0]} pts, eps={eps} min={min_samples} -> {k} clusters in {dt:.2f}s")

--- a/tims-viewer/cluster_service.py
+++ b/tims-viewer/cluster_service.py
@@ -71,13 +71,14 @@ class Handler(BaseHTTPRequestHandler):
             if not chunk:
                 break
             buf.extend(chunk)
-        pts = np.frombuffer(bytes(buf), dtype="<f4")
-        if len(buf) != n or pts.size == 0 or pts.size % 3 != 0:
+        # Guard the length BEFORE np.frombuffer (which raises on non-4-byte-aligned input): xyz f4
+        # triples = 12 bytes/point, so a valid body is a non-empty multiple of 12.
+        if len(buf) != n or len(buf) == 0 or len(buf) % 12 != 0:
             self.send_response(400)
             self._cors()
             self.end_headers()
             return
-        pts = pts.reshape(-1, 3).astype(np.float64)
+        pts = np.frombuffer(bytes(buf), dtype="<f4").reshape(-1, 3).astype(np.float64)
         t = time.perf_counter()
         with _DBSCAN_LOCK:  # serialize the heavy compute across overlapping requests
             if method == "hdbscan":

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -287,6 +287,33 @@ fn proj_to_color_image(data: &[u32]) -> egui::ColorImage {
     egui::ColorImage { size: [n, n], pixels }
 }
 
+/// Whether a point passes the active filter (normalized window + intensity range + MS mask).
+/// Mirrors the point-cloud shader cull so the DBSCAN input matches what is displayed.
+#[inline]
+fn point_passes(
+    p: &crate::data::point::GpuPoint,
+    fmin: [f32; 3],
+    fmax: [f32; 3],
+    irange: (f32, f32),
+    ms_mask: u32,
+) -> bool {
+    let pos = p.pos;
+    if pos[0] < fmin[0] || pos[0] > fmax[0] || pos[1] < fmin[1] || pos[1] > fmax[1]
+        || pos[2] < fmin[2] || pos[2] > fmax[2]
+    {
+        return false;
+    }
+    if p.intensity < irange.0 || p.intensity > irange.1 {
+        return false;
+    }
+    let is_ms2 = p.flags & crate::data::point::GpuPoint::MS2_FLAG != 0;
+    if is_ms2 {
+        ms_mask & 2 != 0
+    } else {
+        ms_mask & 1 != 0
+    }
+}
+
 fn create_depth(device: &wgpu::Device, config: &wgpu::SurfaceConfiguration) -> wgpu::TextureView {
     let tex = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("depth"),
@@ -528,10 +555,10 @@ impl Gfx {
                         g.deposit(p.pos, p.intensity * p.weight);
                     }
                     self.points.append(&self.queue, &points);
-                    // Retain a CPU copy for DBSCAN, bounded by the cluster cap AND the GPU
-                    // residency so cpu_points never exceeds the displayed set (keeps the
-                    // run_clustering equality guard reachable on small-capacity GPUs too).
-                    let cap = crate::state::CLUSTER_CAP.min(self.state.capacity) as usize;
+                    // Retain a CPU copy of every resident point (bounded by GPU capacity) so
+                    // DBSCAN can run on any FILTERED subset — you filter the region down to a
+                    // clusterable count instead of shrinking the spatial window.
+                    let cap = self.state.capacity as usize;
                     if self.cpu_points.len() < cap {
                         let room = cap - self.cpu_points.len();
                         self.cpu_points.extend(points.iter().take(room).copied());
@@ -541,10 +568,10 @@ impl Gfx {
                     // Peaks are display-only enrichment; append to the cloud but do NOT
                     // add to the volume density (would double-count dense cells).
                     self.points.append(&self.queue, &points);
-                    // Retain a CPU copy for DBSCAN, bounded by the cluster cap AND the GPU
-                    // residency so cpu_points never exceeds the displayed set (keeps the
-                    // run_clustering equality guard reachable on small-capacity GPUs too).
-                    let cap = crate::state::CLUSTER_CAP.min(self.state.capacity) as usize;
+                    // Retain a CPU copy of every resident point (bounded by GPU capacity) so
+                    // DBSCAN can run on any FILTERED subset — you filter the region down to a
+                    // clusterable count instead of shrinking the spatial window.
+                    let cap = self.state.capacity as usize;
                     if self.cpu_points.len() < cap {
                         let room = cap - self.cpu_points.len();
                         self.cpu_points.extend(points.iter().take(room).copied());
@@ -830,29 +857,74 @@ impl Gfx {
         self.state.refined = true;
     }
 
-    /// Run DBSCAN on the resident points (only when the full resident set is retained on the
-    /// CPU, i.e. within CLUSTER_CAP), write per-point cluster ids back into the GPU buffer, and
-    /// switch to cluster coloring. No-op while still streaming or if too many points are resident.
+    /// The active point filter, mirroring the shader cull: normalized window min/max, the
+    /// intensity range (real units), and the MS bit mask.
+    fn active_filter(&self) -> ([f32; 3], [f32; 3], (f32, f32), u32) {
+        let s = &self.state;
+        let fmin = s
+            .bounds
+            .normalize(s.mz_window.min, s.im_window.min, s.rt_window.min);
+        let fmax = s
+            .bounds
+            .normalize(s.mz_window.max, s.im_window.max, s.rt_window.max);
+        let ms_mask = (s.show_ms1 as u32) | ((s.show_ms2 as u32) << 1);
+        (
+            fmin,
+            fmax,
+            (s.intensity_window.min as f32, s.intensity_window.max as f32),
+            ms_mask,
+        )
+    }
+
+    /// Count the resident points that pass the active filter (the DBSCAN input size). Parallel
+    /// so it can run every frame for a live readout even on a large resident set.
+    fn count_filtered(&self) -> usize {
+        use rayon::prelude::*;
+        let (fmin, fmax, irange, ms) = self.active_filter();
+        self.cpu_points
+            .par_iter()
+            .filter(|p| point_passes(p, fmin, fmax, irange, ms))
+            .count()
+    }
+
+    /// Run DBSCAN on the FILTERED resident points (intensity + window + MS filters), write per-
+    /// point cluster ids into the GPU buffer, and switch to cluster coloring. Filtered-out points
+    /// are cleared to NO_CLUSTER (the shader culls them anyway). No-op while streaming, with no
+    /// filtered points, or with more than CLUSTER_CAP in the filter (tighten the filters).
     fn run_clustering(&mut self) {
         if self.state.load_progress < 1.0
             || self.cpu_points.is_empty()
             || self.cpu_points.len() as u32 != self.state.resident_points
         {
-            return; // still streaming, or partial retention (too many points) — refine first
+            return; // still streaming or partial retention
         }
-        let positions: Vec<[f32; 3]> = self.cpu_points.iter().map(|p| p.pos).collect();
+        let (fmin, fmax, irange, ms) = self.active_filter();
+        let mut idx: Vec<usize> = Vec::new();
+        let mut positions: Vec<[f32; 3]> = Vec::new();
+        for (i, p) in self.cpu_points.iter().enumerate() {
+            if point_passes(p, fmin, fmax, irange, ms) {
+                idx.push(i);
+                positions.push(p.pos);
+            }
+        }
+        if positions.is_empty() || positions.len() > crate::state::CLUSTER_CAP as usize {
+            return; // nothing in the filter, or still too many — tighten the filters
+        }
         let (labels, k) = crate::cluster::dbscan(
             &positions,
             self.state.cluster_eps,
             self.state.cluster_min_pts as usize,
         );
+        for p in self.cpu_points.iter_mut() {
+            p._pad[0] = crate::data::point::GpuPoint::NO_CLUSTER;
+        }
         let mut noise = 0usize;
-        for (p, &lab) in self.cpu_points.iter_mut().zip(labels.iter()) {
-            p._pad[0] = if lab < 0 {
+        for (j, &pi) in idx.iter().enumerate() {
+            self.cpu_points[pi]._pad[0] = if labels[j] < 0 {
                 noise += 1;
                 crate::data::point::GpuPoint::NO_CLUSTER
             } else {
-                lab as u32
+                labels[j] as u32
             };
         }
         self.points.reset();
@@ -860,6 +932,7 @@ impl Gfx {
         self.state.resident_points = self.points.resident();
         self.state.cluster_count = k;
         self.state.cluster_noise = noise;
+        self.state.cluster_input_count = positions.len();
         self.state.color_mode = crate::state::ColorMode::Cluster;
         self.state.view_mode = ViewMode::Points;
         // Cluster coloring renders opaque in the shader regardless of point_mode, so the
@@ -884,7 +957,12 @@ impl Gfx {
                 crate::state::RefineAction::FullRun => self.load_full_run(),
             }
         }
-        // Clustering: run DBSCAN on the resident points and color by cluster id.
+        // Live DBSCAN input size = points passing the active filter (so the Cluster gate +
+        // readout react as you drag the intensity / window sliders).
+        if self.state.load_progress >= 1.0 {
+            self.state.cluster_input_count = self.count_filtered();
+        }
+        // Clustering: run DBSCAN on the filtered resident points and color by cluster id.
         if self.state.cluster_request {
             self.state.cluster_request = false;
             self.run_clustering();

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -84,6 +84,9 @@ struct Gfx {
     loader: LoaderHandle,
     /// The full run's metadata, retained so a refined region can revert to the whole run.
     full_meta: MetaIndex,
+    /// CPU copy of the resident points (bounded by CLUSTER_CAP) so DBSCAN can run on them
+    /// and write per-point cluster ids back into the GPU buffer.
+    cpu_points: Vec<crate::data::point::GpuPoint>,
 
     // interaction
     modifiers: ModifiersState,
@@ -463,6 +466,7 @@ impl App {
             state,
             loader,
             full_meta,
+            cpu_points: Vec::new(),
             modifiers: ModifiersState::empty(),
             left_down: false,
             right_down: false,
@@ -506,11 +510,21 @@ impl Gfx {
                         g.deposit(p.pos, p.intensity * p.weight);
                     }
                     self.points.append(&self.queue, &points);
+                    // Retain a CPU copy (bounded) for DBSCAN clustering.
+                    if (self.cpu_points.len() as u32) < crate::state::CLUSTER_CAP {
+                        let room = crate::state::CLUSTER_CAP as usize - self.cpu_points.len();
+                        self.cpu_points.extend(points.iter().take(room).copied());
+                    }
                 }
                 Ok(LoadMsg::PeakChunk { points }) => {
                     // Peaks are display-only enrichment; append to the cloud but do NOT
                     // add to the volume density (would double-count dense cells).
                     self.points.append(&self.queue, &points);
+                    // Retain a CPU copy (bounded) for DBSCAN clustering.
+                    if (self.cpu_points.len() as u32) < crate::state::CLUSTER_CAP {
+                        let room = crate::state::CLUSTER_CAP as usize - self.cpu_points.len();
+                        self.cpu_points.extend(points.iter().take(room).copied());
+                    }
                 }
                 Ok(LoadMsg::Progress(p)) => self.state.load_progress = p,
                 Ok(LoadMsg::Stats { i_min, i_max, i_med }) => {
@@ -666,6 +680,10 @@ impl Gfx {
         );
         // Reset GPU/CPU buffers for a fresh stream.
         self.points.reset();
+        self.cpu_points.clear();
+        self.state.color_mode = crate::state::ColorMode::Intensity;
+        self.state.cluster_count = 0;
+        self.state.cluster_noise = 0;
         self.grid_ms1.clear();
         self.grid_ms2.clear();
         self.grid.clear();
@@ -722,6 +740,39 @@ impl Gfx {
         self.state.refined = true;
     }
 
+    /// Run DBSCAN on the resident points (only when the full resident set is retained on the
+    /// CPU, i.e. within CLUSTER_CAP), write per-point cluster ids back into the GPU buffer, and
+    /// switch to cluster coloring (opaque points for clarity). No-op if too many points.
+    fn run_clustering(&mut self) {
+        if self.cpu_points.is_empty()
+            || self.cpu_points.len() as u32 != self.state.resident_points
+        {
+            return; // partial retention (too many points) — refine first
+        }
+        let positions: Vec<[f32; 3]> = self.cpu_points.iter().map(|p| p.pos).collect();
+        let (labels, k) = crate::cluster::dbscan(
+            &positions,
+            self.state.cluster_eps,
+            self.state.cluster_min_pts as usize,
+        );
+        let mut noise = 0usize;
+        for (p, &lab) in self.cpu_points.iter_mut().zip(labels.iter()) {
+            p._pad[0] = if lab < 0 {
+                noise += 1;
+                crate::data::point::GpuPoint::NO_CLUSTER
+            } else {
+                lab as u32
+            };
+        }
+        self.points.reset();
+        self.points.append(&self.queue, &self.cpu_points);
+        self.state.cluster_count = k;
+        self.state.cluster_noise = noise;
+        self.state.color_mode = crate::state::ColorMode::Cluster;
+        self.state.point_mode = crate::render::point_cloud::PointMode::StructuralOpaque;
+        self.state.view_mode = ViewMode::Points;
+    }
+
     /// Revert a refinement: re-stream the whole run at the global downsample.
     fn load_full_run(&mut self) {
         let frame_ids: Vec<u32> = self.full_meta.frames.iter().map(|f| f.id).collect();
@@ -747,6 +798,11 @@ impl Gfx {
                     }
                 }
             }
+        }
+        // Clustering: run DBSCAN on the resident points and color by cluster id.
+        if self.state.cluster_request {
+            self.state.cluster_request = false;
+            self.run_clustering();
         }
         // Re-range when switching Volume->Points. The two modes live in completely different
         // value ranges (per-point intensity vs summed density), so a transfer range pinned in

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -484,10 +484,9 @@ impl App {
             LoaderMode::Real {
                 path: plan.meta.data_path.clone(),
                 frame_ids,
-                filter: None,
             }
         };
-        let loader = LoaderHandle::spawn(mode, plan.meta.bounds, total, capacity as usize);
+        let loader = LoaderHandle::spawn(mode, plan.meta.bounds, total, capacity as usize, None);
 
         Ok(Gfx {
             window,
@@ -774,10 +773,9 @@ impl Gfx {
             LoaderMode::Real {
                 path: self.full_meta.data_path.clone(),
                 frame_ids,
-                filter,
             }
         };
-        self.loader = LoaderHandle::spawn(mode, bounds, total, capacity);
+        self.loader = LoaderHandle::spawn(mode, bounds, total, capacity, filter);
         // Reset GPU/CPU buffers for a fresh stream.
         self.points.reset();
         self.cpu_points.clear();
@@ -859,6 +857,7 @@ impl Gfx {
         let filter = Some(crate::data::loader::RegionFilter {
             mz: (mz0, mz1),
             im: (im0, im1),
+            intensity_min: 0.0, // native region refinement does not cull intensity at the source
         });
         self.respawn_loader(frame_ids, bounds, total, filter);
         self.state.refined = true;

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -267,6 +267,26 @@ fn axis_geometry(
     (verts, labels)
 }
 
+/// Render a 2D projection (row-major `x + PROJ_BINS*y` counts) into an egui image: log-scaled
+/// through inferno, with the vertical axis flipped so its low end sits at the image bottom.
+fn proj_to_color_image(data: &[u32]) -> egui::ColorImage {
+    let n = crate::data::loader::PROJ_BINS;
+    let maxc = data.iter().copied().max().unwrap_or(1).max(1) as f32;
+    let lmax = (maxc + 1.0).ln();
+    let mut pixels = vec![egui::Color32::from_gray(16); n * n];
+    for y in 0..n {
+        for x in 0..n {
+            let c = data[x + n * y];
+            if c > 0 {
+                let t = ((c as f32 + 1.0).ln() / lmax).clamp(0.0, 1.0);
+                let rgb = crate::render::colormap::sample(1, t); // inferno
+                pixels[x + n * (n - 1 - y)] = egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]);
+            }
+        }
+    }
+    egui::ColorImage { size: [n, n], pixels }
+}
+
 fn create_depth(device: &wgpu::Device, config: &wgpu::SurfaceConfiguration) -> wgpu::TextureView {
     let tex = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("depth"),
@@ -544,7 +564,17 @@ impl Gfx {
                         self.state.auto_transfer_points();
                     }
                 }
-                Ok(LoadMsg::Histograms { mz, im, rt, intensity, i_lo, i_hi }) => {
+                Ok(LoadMsg::Histograms {
+                    mz,
+                    im,
+                    rt,
+                    intensity,
+                    i_lo,
+                    i_hi,
+                    proj_mz_im,
+                    proj_mz_rt,
+                    proj_im_rt,
+                }) => {
                     // Distribution strips for the levels-style filters; the intensity slider
                     // spans the data range, default filter = full (no cull).
                     self.state.hist_mz = mz;
@@ -557,6 +587,23 @@ impl Gfx {
                         min: i_lo as f64,
                         max: i_hi as f64,
                     };
+                    // Upload the 2D projection minimaps as egui textures.
+                    let opt = egui::TextureOptions::LINEAR;
+                    self.state.proj_mz_im = Some(self.egui_ctx.load_texture(
+                        "proj_mz_im",
+                        proj_to_color_image(&proj_mz_im),
+                        opt,
+                    ));
+                    self.state.proj_mz_rt = Some(self.egui_ctx.load_texture(
+                        "proj_mz_rt",
+                        proj_to_color_image(&proj_mz_rt),
+                        opt,
+                    ));
+                    self.state.proj_im_rt = Some(self.egui_ctx.load_texture(
+                        "proj_im_rt",
+                        proj_to_color_image(&proj_im_rt),
+                        opt,
+                    ));
                 }
                 Ok(LoadMsg::Annotations { lines, groups, n_groups }) => {
                     // Suppress the selection overlay in a refined region: it is normalized to
@@ -705,6 +752,9 @@ impl Gfx {
         self.state.hist_im.clear();
         self.state.hist_rt.clear();
         self.state.hist_intensity.clear();
+        self.state.proj_mz_im = None;
+        self.state.proj_mz_rt = None;
+        self.state.proj_im_rt = None;
         self.state.intensity_window = crate::state::Window {
             min: 0.0,
             max: f64::INFINITY,

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -761,14 +761,19 @@ impl Gfx {
         &mut self,
         frame_ids: Vec<u32>,
         bounds: crate::data::point::AxisBounds,
+        // Stride estimate: the region-relative survivor estimate (== `demo_source_total` for a full
+        // load, or scaled by the m/z·1/K0 window for a refinement).
         total: u64,
+        // Actual points the DEMO source should generate (the RT-region size, BEFORE the m/z·1/K0
+        // cull) — the loader's region filter then culls it once. For real data this is unused.
+        demo_source_total: u64,
         filter: Option<crate::data::loader::RegionFilter>,
     ) {
         let capacity = self.state.capacity as usize;
         // Stay in the source's mode: a DEMO session must respawn a synthetic source, not try
         // to open a real `.d` at the placeholder path.
         let mode = if self.is_demo {
-            LoaderMode::Demo(DemoSource::new(frame_ids.len(), total))
+            LoaderMode::Demo(DemoSource::new(frame_ids.len(), demo_source_total))
         } else {
             LoaderMode::Real {
                 path: self.full_meta.data_path.clone(),
@@ -848,7 +853,8 @@ impl Gfx {
         let b = &self.full_meta.bounds;
         let mz_frac = ((mz1 - mz0) / (b.mz.max - b.mz.min).max(1e-9)).clamp(0.0, 1.0);
         let im_frac = ((im1 - im0) / (b.im.max - b.im.min).max(1e-9)).clamp(0.0, 1.0);
-        let total = (((total as f64) * mz_frac * im_frac).ceil() as u64).max(1);
+        // `total` is the RT-region size (all m/z·1/K0); the stride estimate scales it by the window.
+        let estimate = (((total as f64) * mz_frac * im_frac).ceil() as u64).max(1);
         let bounds = AxisBounds {
             mz: AxisTransform::new(mz0, mz1),
             im: AxisTransform::new(im0, im1),
@@ -859,7 +865,7 @@ impl Gfx {
             im: (im0, im1),
             intensity_min: 0.0, // native region refinement does not cull intensity at the source
         });
-        self.respawn_loader(frame_ids, bounds, total, filter);
+        self.respawn_loader(frame_ids, bounds, estimate, total, filter);
         self.state.refined = true;
     }
 
@@ -969,7 +975,7 @@ impl Gfx {
         let frame_ids: Vec<u32> = self.full_meta.frames.iter().map(|f| f.id).collect();
         let bounds = self.full_meta.bounds;
         let total = self.full_meta.total_points_estimate;
-        self.respawn_loader(frame_ids, bounds, total, None);
+        self.respawn_loader(frame_ids, bounds, total, total, None);
         self.state.refined = false;
     }
 

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -65,6 +65,11 @@ struct Gfx {
     /// Last MS toggle the display grid was folded for (to detect changes).
     last_ms: (bool, bool),
     annotations: AnnotationRenderer,
+    /// Full annotation geometry + parallel per-vertex group ids, retained so the overlay
+    /// can be re-uploaded filtered by the per-group visibility mask without a reload.
+    anno_lines: Vec<LineVertex>,
+    anno_groups: Vec<u32>,
+    last_group_mask: u32,
     /// Wireframe of the full data cube, drawn for spatial orientation.
     axes: AnnotationRenderer,
     camera: OrbitCamera,
@@ -300,6 +305,9 @@ impl App {
             grid_ms2,
             last_ms: (true, true),
             annotations,
+            anno_lines: Vec::new(),
+            anno_groups: Vec::new(),
+            last_group_mask: u32::MAX,
             axes,
             camera: OrbitCamera::default(),
             state,
@@ -362,8 +370,11 @@ impl Gfx {
                         self.state.i_max = i_max;
                     }
                 }
-                Ok(LoadMsg::Annotations { lines }) => {
-                    self.annotations.upload(&self.device, &lines);
+                Ok(LoadMsg::Annotations { lines, groups, n_groups }) => {
+                    self.anno_lines = lines;
+                    self.anno_groups = groups;
+                    self.state.n_window_groups = n_groups;
+                    self.reupload_annotations();
                 }
                 Ok(LoadMsg::Done { .. }) => {
                     self.state.load_progress = 1.0;
@@ -417,8 +428,28 @@ impl Gfx {
         ms_changed
     }
 
+    /// Re-upload the selection overlay, keeping only vertices whose window group is enabled
+    /// in `state.group_mask` (ungrouped vertices, u32::MAX, are always kept).
+    fn reupload_annotations(&mut self) {
+        let mask = self.state.group_mask;
+        let visible = |g: u32| g == u32::MAX || g > 32 || (mask & (1u32 << g.saturating_sub(1))) != 0;
+        let filtered: Vec<LineVertex> = self
+            .anno_lines
+            .iter()
+            .zip(self.anno_groups.iter())
+            .filter(|(_, &g)| visible(g))
+            .map(|(v, _)| *v)
+            .collect();
+        self.annotations.upload(&self.device, &filtered);
+        self.last_group_mask = mask;
+    }
+
     fn render(&mut self) {
         self.pump_loader();
+        // Re-filter the selection overlay if the per-group visibility changed.
+        if self.state.group_mask != self.last_group_mask {
+            self.reupload_annotations();
+        }
 
         // FPS (exponential smoothing).
         let now = Instant::now();
@@ -500,7 +531,7 @@ impl Gfx {
             vu.density_scale = self.grid.density_scale();
             self.volume.update_uniform(&self.queue, &vu);
             if self.grid.dirty() {
-                self.volume.upload(&self.queue, &self.grid.to_f16_scaled());
+                self.volume.upload(&self.queue, self.grid.to_f16_scaled());
                 self.grid.clear_dirty();
             }
         }

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -641,14 +641,13 @@ impl Gfx {
                     ));
                 }
                 Ok(LoadMsg::Annotations { lines, groups, n_groups }) => {
-                    // Suppress the selection overlay in a refined region: it is normalized to
-                    // the window, so off-region windows would clutter the cube edges.
-                    if !self.state.refined {
-                        self.anno_lines = lines;
-                        self.anno_groups = groups;
-                        self.state.n_window_groups = n_groups;
-                        self.reupload_annotations();
-                    }
+                    // Show the selection overlay in refined regions too: it is normalized to the
+                    // current bounds, and the per-vertex window cull clips off-region boxes to
+                    // the cube, so only the windows overlapping the region remain.
+                    self.anno_lines = lines;
+                    self.anno_groups = groups;
+                    self.state.n_window_groups = n_groups;
+                    self.reupload_annotations();
                 }
                 Ok(LoadMsg::Done { .. }) => {
                     self.state.load_progress = 1.0;

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -585,12 +585,12 @@ impl Gfx {
                     }
                 }
                 Ok(LoadMsg::Progress(p)) => self.state.load_progress = p,
-                Ok(LoadMsg::Stats { i_min, i_max, i_med }) => {
+                Ok(LoadMsg::Stats { i_p1, i_p99, i_p50 }) => {
                     // Stash the raw, mode-independent percentiles so any later mode switch
                     // or Auto button can re-run the heuristic from scratch.
-                    self.state.i_p1 = i_min;
-                    self.state.i_med = i_med;
-                    self.state.i_p99 = i_max;
+                    self.state.i_p1 = i_p1;
+                    self.state.i_med = i_p50;
+                    self.state.i_p99 = i_p99;
                     // Auto-expose the point cloud the moment the range is known (the cloud
                     // snaps legible without slider tweaks). Volume re-ranges on Done.
                     if self.state.view_mode == ViewMode::Points && self.state.may_auto_transfer()

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -510,9 +510,12 @@ impl Gfx {
                         g.deposit(p.pos, p.intensity * p.weight);
                     }
                     self.points.append(&self.queue, &points);
-                    // Retain a CPU copy (bounded) for DBSCAN clustering.
-                    if (self.cpu_points.len() as u32) < crate::state::CLUSTER_CAP {
-                        let room = crate::state::CLUSTER_CAP as usize - self.cpu_points.len();
+                    // Retain a CPU copy for DBSCAN, bounded by the cluster cap AND the GPU
+                    // residency so cpu_points never exceeds the displayed set (keeps the
+                    // run_clustering equality guard reachable on small-capacity GPUs too).
+                    let cap = crate::state::CLUSTER_CAP.min(self.state.capacity) as usize;
+                    if self.cpu_points.len() < cap {
+                        let room = cap - self.cpu_points.len();
                         self.cpu_points.extend(points.iter().take(room).copied());
                     }
                 }
@@ -520,9 +523,12 @@ impl Gfx {
                     // Peaks are display-only enrichment; append to the cloud but do NOT
                     // add to the volume density (would double-count dense cells).
                     self.points.append(&self.queue, &points);
-                    // Retain a CPU copy (bounded) for DBSCAN clustering.
-                    if (self.cpu_points.len() as u32) < crate::state::CLUSTER_CAP {
-                        let room = crate::state::CLUSTER_CAP as usize - self.cpu_points.len();
+                    // Retain a CPU copy for DBSCAN, bounded by the cluster cap AND the GPU
+                    // residency so cpu_points never exceeds the displayed set (keeps the
+                    // run_clustering equality guard reachable on small-capacity GPUs too).
+                    let cap = crate::state::CLUSTER_CAP.min(self.state.capacity) as usize;
+                    if self.cpu_points.len() < cap {
+                        let room = cap - self.cpu_points.len();
                         self.cpu_points.extend(points.iter().take(room).copied());
                     }
                 }
@@ -716,6 +722,10 @@ impl Gfx {
         let (rt0, rt1) = (self.state.rt_window.min, self.state.rt_window.max);
         let (mz0, mz1) = (self.state.mz_window.min, self.state.mz_window.max);
         let (im0, im1) = (self.state.im_window.min, self.state.im_window.max);
+        // A zero-width axis would make the new AxisTransform divide by zero (NaN positions).
+        if rt1 <= rt0 || mz1 <= mz0 || im1 <= im0 {
+            return;
+        }
         let mut frame_ids = Vec::new();
         let mut total: u64 = 0;
         for f in &self.full_meta.frames {
@@ -727,6 +737,14 @@ impl Gfx {
         if frame_ids.is_empty() {
             return;
         }
+        // num_peaks counts every m/z·1/K0 in each in-RT frame, but the loader culls to the
+        // m/z·1/K0 window. Scale the estimate by the window's fraction of the full run so the
+        // stride is sized to the surviving points — otherwise it is far too coarse and the
+        // region streams sparse instead of the intended (often stride-1) detail.
+        let b = &self.full_meta.bounds;
+        let mz_frac = ((mz1 - mz0) / (b.mz.max - b.mz.min).max(1e-9)).clamp(0.0, 1.0);
+        let im_frac = ((im1 - im0) / (b.im.max - b.im.min).max(1e-9)).clamp(0.0, 1.0);
+        let total = (((total as f64) * mz_frac * im_frac).ceil() as u64).max(1);
         let bounds = AxisBounds {
             mz: AxisTransform::new(mz0, mz1),
             im: AxisTransform::new(im0, im1),
@@ -742,12 +760,13 @@ impl Gfx {
 
     /// Run DBSCAN on the resident points (only when the full resident set is retained on the
     /// CPU, i.e. within CLUSTER_CAP), write per-point cluster ids back into the GPU buffer, and
-    /// switch to cluster coloring (opaque points for clarity). No-op if too many points.
+    /// switch to cluster coloring. No-op while still streaming or if too many points are resident.
     fn run_clustering(&mut self) {
-        if self.cpu_points.is_empty()
+        if self.state.load_progress < 1.0
+            || self.cpu_points.is_empty()
             || self.cpu_points.len() as u32 != self.state.resident_points
         {
-            return; // partial retention (too many points) — refine first
+            return; // still streaming, or partial retention (too many points) — refine first
         }
         let positions: Vec<[f32; 3]> = self.cpu_points.iter().map(|p| p.pos).collect();
         let (labels, k) = crate::cluster::dbscan(
@@ -766,11 +785,13 @@ impl Gfx {
         }
         self.points.reset();
         self.points.append(&self.queue, &self.cpu_points);
+        self.state.resident_points = self.points.resident();
         self.state.cluster_count = k;
         self.state.cluster_noise = noise;
         self.state.color_mode = crate::state::ColorMode::Cluster;
-        self.state.point_mode = crate::render::point_cloud::PointMode::StructuralOpaque;
         self.state.view_mode = ViewMode::Points;
+        // Cluster coloring renders opaque in the shader regardless of point_mode, so the
+        // user's additive/opaque choice is left untouched.
     }
 
     /// Revert a refinement: re-stream the whole run at the global downsample.
@@ -794,7 +815,19 @@ impl Gfx {
                     if self.state.refined {
                         self.refine_to_window();
                     } else {
+                        // In-place re-stream of the full run: preserve the user's window
+                        // narrowing and focus (load_full_run otherwise resets them).
+                        let (rt, mz, im, focus) = (
+                            self.state.rt_window,
+                            self.state.mz_window,
+                            self.state.im_window,
+                            self.state.focus,
+                        );
                         self.load_full_run();
+                        self.state.rt_window = rt;
+                        self.state.mz_window = mz;
+                        self.state.im_window = im;
+                        self.state.focus = focus;
                     }
                 }
             }

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -42,6 +42,10 @@ impl Plan {
     }
 }
 
+/// Filter signature for caching the DBSCAN-input count: the three window ranges, the intensity
+/// range, the two MS toggles, and the resident point count.
+type CountSig = (f64, f64, f64, f64, f64, f64, f64, f64, bool, bool, usize);
+
 /// Everything that exists only once the window/GPU are live.
 struct Gfx {
     window: Arc<Window>,
@@ -87,9 +91,12 @@ struct Gfx {
     /// True for the built-in synthetic DEMO source: respawns must stay in demo mode rather
     /// than trying to open a real `.d` at the placeholder data path.
     is_demo: bool,
-    /// CPU copy of the resident points (bounded by CLUSTER_CAP) so DBSCAN can run on them
-    /// and write per-point cluster ids back into the GPU buffer.
+    /// CPU copy of the resident points (bounded by GPU capacity) so DBSCAN can run on a
+    /// filtered subset and write per-point cluster ids back into the GPU buffer.
     cpu_points: Vec<crate::data::point::GpuPoint>,
+    /// Cached filter signature; the filtered DBSCAN-input count is recomputed only when this
+    /// changes (avoids rescanning millions of points every frame).
+    last_count_sig: Option<CountSig>,
 
     // interaction
     modifiers: ModifiersState,
@@ -512,6 +519,7 @@ impl App {
             full_meta,
             is_demo: plan.is_demo,
             cpu_points: Vec::new(),
+            last_count_sig: None,
             modifiers: ModifiersState::empty(),
             left_down: false,
             right_down: false,
@@ -876,8 +884,27 @@ impl Gfx {
         )
     }
 
+    /// Signature of everything the filtered count depends on; used to skip the rescan when
+    /// nothing changed.
+    fn count_sig(&self) -> CountSig {
+        let s = &self.state;
+        (
+            s.mz_window.min,
+            s.mz_window.max,
+            s.im_window.min,
+            s.im_window.max,
+            s.rt_window.min,
+            s.rt_window.max,
+            s.intensity_window.min,
+            s.intensity_window.max,
+            s.show_ms1,
+            s.show_ms2,
+            self.cpu_points.len(),
+        )
+    }
+
     /// Count the resident points that pass the active filter (the DBSCAN input size). Parallel
-    /// so it can run every frame for a live readout even on a large resident set.
+    /// for speed; called only when the filter signature changes (see `count_sig`).
     fn count_filtered(&self) -> usize {
         use rayon::prelude::*;
         let (fmin, fmax, irange, ms) = self.active_filter();
@@ -958,9 +985,14 @@ impl Gfx {
             }
         }
         // Live DBSCAN input size = points passing the active filter (so the Cluster gate +
-        // readout react as you drag the intensity / window sliders).
+        // readout react as you drag the sliders). Recompute only when the filter or point set
+        // changes — rescanning millions of points every frame would stall the render loop.
         if self.state.load_progress >= 1.0 {
-            self.state.cluster_input_count = self.count_filtered();
+            let sig = self.count_sig();
+            if self.last_count_sig != Some(sig) {
+                self.state.cluster_input_count = self.count_filtered();
+                self.last_count_sig = Some(sig);
+            }
         }
         // Clustering: run DBSCAN on the filtered resident points and color by cluster id.
         if self.state.cluster_request {

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -70,8 +70,15 @@ struct Gfx {
     anno_lines: Vec<LineVertex>,
     anno_groups: Vec<u32>,
     last_group_mask: u32,
-    /// Wireframe of the full data cube, drawn for spatial orientation.
+    /// Wireframe of the full data cube + axis ticks (+ optional back-face grid), drawn for
+    /// spatial orientation.
     axes: AnnotationRenderer,
+    /// Numeric tick labels for the overlay text pass, rebuilt only when the shown ranges,
+    /// focus, or the back-face-grid toggle change (avoids per-frame string allocs).
+    tick_labels: Vec<ui::TickLabel>,
+    /// Cached (mz, im, rt) real ranges + grid-toggle the `axes` geometry was built for.
+    shown_ranges: ((f64, f64), (f64, f64), (f64, f64)),
+    shown_grid: bool,
     camera: OrbitCamera,
     state: AppState,
     loader: LoaderHandle,
@@ -107,10 +114,18 @@ impl App {
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 
+/// Neutral steel for the cube wireframe, distinct from the window overlay colors.
+const FRAME_COLOR: [f32; 3] = [0.45, 0.55, 0.7];
+/// Dimmed frame color for the short tick segments.
+const TICK_COLOR: [f32; 3] = [0.6, 0.7, 0.85];
+/// Very dim back-face gridlines (faintness via low RGB, the pipeline has no alpha blend).
+const GRID_COLOR: [f32; 3] = [0.18, 0.21, 0.27];
+/// Tick length in cube units (the segments sit just outside the near edges).
+const TICK_LEN: f32 = 0.04;
+
 /// The 12 edges of the normalized data cube `[-1, 1]^3` as a line list (pairs = segments),
 /// for the orientation wireframe.
 fn cube_edges() -> Vec<LineVertex> {
-    const FRAME_COLOR: [f32; 3] = [0.45, 0.55, 0.7]; // neutral steel, distinct from windows
     let c = [-1.0f32, 1.0f32];
     let corner = |i: usize, j: usize, k: usize| LineVertex::new([c[i], c[j], c[k]], FRAME_COLOR);
     let mut v = Vec::with_capacity(24);
@@ -133,6 +148,115 @@ fn cube_edges() -> Vec<LineVertex> {
         }
     }
     v
+}
+
+/// Build the cube wireframe + short 3D tick segments (+ optional back-face gridlines) and
+/// the matching numeric tick labels. `mz/im/rt` are the (lo,hi) real ranges currently shown
+/// (window if focus, else bounds). All geometry rides the always-on-top `axes` renderer.
+fn axis_geometry(
+    mz: (f64, f64),
+    im: (f64, f64),
+    rt: (f64, f64),
+    show_grid: bool,
+) -> (Vec<LineVertex>, Vec<ui::TickLabel>) {
+    use crate::data::point::AxisTransform;
+    use crate::ticks::{fmt_tick, ticks_for, Axis};
+
+    // Axis label colors mirror ui::draw_axis_labels (m/z orange, 1/K0 cyan, RT green).
+    const MZ_COL: egui::Color32 = egui::Color32::from_rgb(255, 150, 90);
+    const IM_COL: egui::Color32 = egui::Color32::from_rgb(120, 220, 255);
+    const RT_COL: egui::Color32 = egui::Color32::from_rgb(150, 235, 150);
+
+    let mut verts = cube_edges();
+    let mut labels = Vec::new();
+
+    let tx_mz = AxisTransform::new(mz.0, mz.1);
+    let tx_im = AxisTransform::new(im.0, im.1);
+    let tx_rt = AxisTransform::new(rt.0, rt.1);
+    let mz_ticks = ticks_for(mz.0, mz.1, 5, |v| tx_mz.normalize(v));
+    let im_ticks = ticks_for(im.0, im.1, 5, |v| tx_im.normalize(v));
+    let rt_ticks = ticks_for(rt.0, rt.1, 5, |v| tx_rt.normalize(v));
+    let mz_span = (mz.1 - mz.0).abs();
+    let im_span = (im.1 - im.0).abs();
+    let rt_span = (rt.1 - rt.0).abs();
+
+    let mut seg = |a: [f32; 3], b: [f32; 3], color: [f32; 3]| {
+        verts.push(LineVertex::new(a, color));
+        verts.push(LineVertex::new(b, color));
+    };
+
+    // m/z (x) axis: edge at y=-1, z=-1; tick + label extend in -y (just outside).
+    for t in &mz_ticks {
+        let n = t.norm;
+        seg([n, -1.0, -1.0], [n, -1.0 - TICK_LEN, -1.0], TICK_COLOR);
+        labels.push(ui::TickLabel {
+            world: glam::vec3(n, -1.0 - 2.2 * TICK_LEN, -1.0),
+            text: fmt_tick(Axis::Mz, t.value, mz_span),
+            axis_color: MZ_COL,
+        });
+    }
+    // 1/K0 (y) axis: edge at x=-1, z=-1; tick + label extend in -x.
+    for t in &im_ticks {
+        let n = t.norm;
+        seg([-1.0, n, -1.0], [-1.0 - TICK_LEN, n, -1.0], TICK_COLOR);
+        labels.push(ui::TickLabel {
+            world: glam::vec3(-1.0 - 2.2 * TICK_LEN, n, -1.0),
+            text: fmt_tick(Axis::Im, t.value, im_span),
+            axis_color: IM_COL,
+        });
+    }
+    // RT (z) axis: edge at x=-1, y=-1; tick + label extend in -y (reads against the floor).
+    for t in &rt_ticks {
+        let n = t.norm;
+        seg([-1.0, -1.0, n], [-1.0, -1.0 - TICK_LEN, n], TICK_COLOR);
+        labels.push(ui::TickLabel {
+            world: glam::vec3(-1.0, -1.0 - 2.2 * TICK_LEN, n),
+            text: fmt_tick(Axis::Rt, t.value, rt_span),
+            axis_color: RT_COL,
+        });
+    }
+
+    // Optional faint gridlines on the three faces meeting at the max-corner (+1,+1,+1),
+    // which sit "behind" the cloud for the default orbit. Skip near-edge ticks so the
+    // gridlines don't double the cube wireframe.
+    if show_grid {
+        let interior = |n: f32| n > -0.999 && n < 0.999;
+        // Face z=+1 (m/z × 1/K0 plane).
+        for t in &mz_ticks {
+            if interior(t.norm) {
+                seg([t.norm, -1.0, 1.0], [t.norm, 1.0, 1.0], GRID_COLOR);
+            }
+        }
+        for t in &im_ticks {
+            if interior(t.norm) {
+                seg([-1.0, t.norm, 1.0], [1.0, t.norm, 1.0], GRID_COLOR);
+            }
+        }
+        // Face y=+1 (m/z × RT plane).
+        for t in &mz_ticks {
+            if interior(t.norm) {
+                seg([t.norm, 1.0, -1.0], [t.norm, 1.0, 1.0], GRID_COLOR);
+            }
+        }
+        for t in &rt_ticks {
+            if interior(t.norm) {
+                seg([-1.0, 1.0, t.norm], [1.0, 1.0, t.norm], GRID_COLOR);
+            }
+        }
+        // Face x=+1 (1/K0 × RT plane).
+        for t in &im_ticks {
+            if interior(t.norm) {
+                seg([1.0, t.norm, -1.0], [1.0, t.norm, 1.0], GRID_COLOR);
+            }
+        }
+        for t in &rt_ticks {
+            if interior(t.norm) {
+                seg([1.0, -1.0, t.norm], [1.0, 1.0, t.norm], GRID_COLOR);
+            }
+        }
+    }
+
+    (verts, labels)
 }
 
 fn create_depth(device: &wgpu::Device, config: &wgpu::SurfaceConfiguration) -> wgpu::TextureView {
@@ -251,18 +375,29 @@ impl App {
         let grid_ms2 = VolumeGrid::new(VOLUME_DIMS);
         let annotations = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
 
-        // Data-cube wireframe for orientation: the 12 edges of the normalized cube, with
-        // the clip window opened past the cube so the frame is never culled.
-        let mut axes = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
-        axes.upload(&device, &cube_edges());
-        // The axis frame outlines the cube itself, so it never re-fits (focus = 0).
-        axes.update_filter(&queue, [-2.0, -2.0, -2.0, 0.0], [2.0, 2.0, 2.0, 0.0], 0.0);
-
         let n_colormaps = COLORMAP_NAMES.len() as u32;
         let mut state = AppState::new(plan.meta.bounds, total, n_colormaps);
         state.capacity = capacity;
         state.downsample_stride =
             crate::data::loader::stride_for(total, capacity as usize) as u32;
+
+        // Data-cube wireframe + axis ticks for orientation, with the clip window opened past
+        // the cube so the frame and the slightly-out-of-cube ticks are never culled.
+        let init_ranges = (
+            (plan.meta.bounds.mz.min, plan.meta.bounds.mz.max),
+            (plan.meta.bounds.im.min, plan.meta.bounds.im.max),
+            (plan.meta.bounds.rt.min, plan.meta.bounds.rt.max),
+        );
+        let mut axes = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
+        let (init_verts, init_labels) = axis_geometry(
+            init_ranges.0,
+            init_ranges.1,
+            init_ranges.2,
+            state.show_grid_backfaces,
+        );
+        axes.upload(&device, &init_verts);
+        // The axis frame outlines the cube itself, so it never re-fits (focus = 0).
+        axes.update_filter(&queue, [-2.0, -2.0, -2.0, 0.0], [2.0, 2.0, 2.0, 0.0], 0.0);
 
         // egui plumbing.
         let egui_ctx = egui::Context::default();
@@ -309,6 +444,9 @@ impl App {
             anno_groups: Vec::new(),
             last_group_mask: u32::MAX,
             axes,
+            tick_labels: init_labels,
+            shown_ranges: init_ranges,
+            shown_grid: state.show_grid_backfaces,
             camera: OrbitCamera::default(),
             state,
             loader,
@@ -362,12 +500,17 @@ impl Gfx {
                     self.points.append(&self.queue, &points);
                 }
                 Ok(LoadMsg::Progress(p)) => self.state.load_progress = p,
-                Ok(LoadMsg::Stats { i_min, i_max }) => {
-                    // Point-intensity range; only relevant to point mode (volume uses a
-                    // density range derived from the grid).
-                    if self.state.view_mode == ViewMode::Points {
-                        self.state.i_min = i_min;
-                        self.state.i_max = i_max;
+                Ok(LoadMsg::Stats { i_min, i_max, i_med }) => {
+                    // Stash the raw, mode-independent percentiles so any later mode switch
+                    // or Auto button can re-run the heuristic from scratch.
+                    self.state.i_p1 = i_min;
+                    self.state.i_med = i_med;
+                    self.state.i_p99 = i_max;
+                    // Auto-expose the point cloud the moment the range is known (the cloud
+                    // snaps legible without slider tweaks). Volume re-ranges on Done.
+                    if self.state.view_mode == ViewMode::Points && self.state.may_auto_transfer()
+                    {
+                        self.state.auto_transfer_points();
                     }
                 }
                 Ok(LoadMsg::Annotations { lines, groups, n_groups }) => {
@@ -379,11 +522,11 @@ impl Gfx {
                 Ok(LoadMsg::Done { .. }) => {
                     self.state.load_progress = 1.0;
                     // Recompute the volume range against the now-complete grid.
-                    if self.state.view_mode == ViewMode::Volume {
+                    if self.state.view_mode == ViewMode::Volume && self.state.may_auto_transfer()
+                    {
                         self.refresh_volume_grid();
                         let (lo, hi) = self.grid.density_percentiles();
-                        self.state.i_min = lo;
-                        self.state.i_max = hi;
+                        self.state.auto_transfer_volume(lo, hi);
                     }
                 }
                 Ok(LoadMsg::Error(e)) => {
@@ -446,8 +589,51 @@ impl Gfx {
         self.last_group_mask = mask;
     }
 
+    /// Rebuild the axis tick geometry + numeric labels when the shown ranges (focus toggle
+    /// or a window slider moved while focused) or the back-face-grid toggle change. Mirrors
+    /// the focus branch of `ui::draw_axis_labels`.
+    fn refresh_axis_geometry(&mut self) {
+        let ranges = if self.state.focus {
+            (
+                (self.state.mz_window.min, self.state.mz_window.max),
+                (self.state.im_window.min, self.state.im_window.max),
+                (self.state.rt_window.min, self.state.rt_window.max),
+            )
+        } else {
+            (
+                (self.state.bounds.mz.min, self.state.bounds.mz.max),
+                (self.state.bounds.im.min, self.state.bounds.im.max),
+                (self.state.bounds.rt.min, self.state.bounds.rt.max),
+            )
+        };
+        let grid = self.state.show_grid_backfaces;
+        // Epsilon compare so float jitter on the sliders doesn't rebuild every frame.
+        let close = |a: (f64, f64), b: (f64, f64)| {
+            (a.0 - b.0).abs() < 1e-6 && (a.1 - b.1).abs() < 1e-6
+        };
+        let unchanged = grid == self.shown_grid
+            && close(ranges.0, self.shown_ranges.0)
+            && close(ranges.1, self.shown_ranges.1)
+            && close(ranges.2, self.shown_ranges.2);
+        if unchanged {
+            return;
+        }
+        let (verts, labels) = axis_geometry(ranges.0, ranges.1, ranges.2, grid);
+        self.axes.upload(&self.device, &verts);
+        self.tick_labels = labels;
+        self.shown_ranges = ranges;
+        self.shown_grid = grid;
+    }
+
     fn render(&mut self) {
         self.pump_loader();
+        // Re-range when switching Volume->Points. The two modes live in completely different
+        // value ranges (per-point intensity vs summed density), so a transfer range pinned in
+        // one mode is meaningless in the other: always re-range on the switch and clear the
+        // manual-edit latch so the new mode starts from a sensible auto view.
+        if self.last_view_mode == ViewMode::Volume && self.state.view_mode == ViewMode::Points {
+            self.state.reset_transfer_auto((0.0, 0.0));
+        }
         // Re-filter the selection overlay if the per-group visibility changed.
         if self.state.group_mask != self.last_group_mask {
             self.reupload_annotations();
@@ -485,10 +671,16 @@ impl Gfx {
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
 
-        // egui frame.
+        // egui frame. The "Auto" transfer button needs the volume density percentiles, but
+        // computing them scans + sorts every non-zero voxel (~6M), so pass a CLOSURE that
+        // ui::build invokes only on click — never on the per-frame render path.
         let raw_input = self.egui_state.take_egui_input(self.window.as_ref());
+        let tick_labels = &self.tick_labels;
+        let grid = &self.grid;
         let full_output = self.egui_ctx.run(raw_input, |ctx| {
-            ui::build(ctx, &mut self.state, &mut self.camera);
+            ui::build(ctx, &mut self.state, &mut self.camera, tick_labels, || {
+                grid.density_percentiles()
+            });
         });
         self.egui_state
             .handle_platform_output(self.window.as_ref(), full_output.platform_output);
@@ -499,6 +691,12 @@ impl Gfx {
             self.egui_renderer
                 .update_texture(&self.device, &self.queue, *id, delta);
         }
+
+        // Rebuild axis ticks/labels (and back-face grid) AFTER ui::build, so a same-frame
+        // toggle of "Focus to window", a window slider, or the back-face grid is reflected
+        // by the tick geometry in the SAME frame the point cloud / volume box snaps to it
+        // (params() below also reads the post-build state). Mirrors ui::draw_axis_labels.
+        self.refresh_axis_geometry();
 
         // Uniforms — computed AFTER egui so they reflect this frame's UI/camera changes
         // (otherwise a Points->Volume switch renders one frame with a stale matrix and
@@ -521,12 +719,17 @@ impl Gfx {
         if self.state.view_mode == ViewMode::Volume {
             // Fold MS1/MS2 density per the toggle (rebuilds the display grid if changed).
             let ms_changed = self.refresh_volume_grid();
-            // Auto-range the transfer fn on entering volume mode or when the MS toggle
-            // changed the density (sums differ in range from per-point intensity).
-            if self.last_view_mode != ViewMode::Volume || ms_changed {
+            // Entering Volume always re-ranges to the density scale and clears the manual-edit
+            // latch (a range pinned in Points mode is meaningless for density — this is what
+            // made the volume render flat after a Points-mode transfer tweak). An MS toggle
+            // within Volume re-ranges too, but respects a manual pin set in Volume mode.
+            let entering_volume = self.last_view_mode != ViewMode::Volume;
+            if entering_volume {
                 let (lo, hi) = self.grid.density_percentiles();
-                self.state.i_min = lo;
-                self.state.i_max = hi;
+                self.state.reset_transfer_auto((lo, hi));
+            } else if ms_changed && self.state.may_auto_transfer() {
+                let (lo, hi) = self.grid.density_percentiles();
+                self.state.auto_transfer_volume(lo, hi);
             }
             let inv_vp = self.camera.inv_view_proj(aspect);
             let mut vu = self.state.volume_uniform(inv_vp);

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -17,7 +17,7 @@ use crate::data::demo::DemoSource;
 use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
 use crate::data::meta::MetaIndex;
 use crate::render::colormap::COLORMAP_NAMES;
-use crate::render::annotation::AnnotationRenderer;
+use crate::render::annotation::{AnnotationRenderer, LineVertex};
 use crate::render::point_cloud::PointCloudRenderer;
 use crate::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
 use crate::state::{AppState, ViewMode};
@@ -57,8 +57,16 @@ struct Gfx {
 
     points: PointCloudRenderer,
     volume: VolumeRenderer,
+    /// Display density grid (folded from the MS1/MS2 grids per the MS toggle).
     grid: VolumeGrid,
+    /// Per-MS-level density grids, deposited separately so the volume can filter MS1/MS2.
+    grid_ms1: VolumeGrid,
+    grid_ms2: VolumeGrid,
+    /// Last MS toggle the display grid was folded for (to detect changes).
+    last_ms: (bool, bool),
     annotations: AnnotationRenderer,
+    /// Wireframe of the full data cube, drawn for spatial orientation.
+    axes: AnnotationRenderer,
     camera: OrbitCamera,
     state: AppState,
     loader: LoaderHandle,
@@ -93,6 +101,34 @@ impl App {
 }
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+
+/// The 12 edges of the normalized data cube `[-1, 1]^3` as a line list (pairs = segments),
+/// for the orientation wireframe.
+fn cube_edges() -> Vec<LineVertex> {
+    const FRAME_COLOR: [f32; 3] = [0.45, 0.55, 0.7]; // neutral steel, distinct from windows
+    let c = [-1.0f32, 1.0f32];
+    let corner = |i: usize, j: usize, k: usize| LineVertex::new([c[i], c[j], c[k]], FRAME_COLOR);
+    let mut v = Vec::with_capacity(24);
+    for &j in &[0usize, 1] {
+        for &k in &[0usize, 1] {
+            v.push(corner(0, j, k));
+            v.push(corner(1, j, k)); // edges along x (m/z)
+        }
+    }
+    for &i in &[0usize, 1] {
+        for &k in &[0usize, 1] {
+            v.push(corner(i, 0, k));
+            v.push(corner(i, 1, k)); // edges along y (1/K0)
+        }
+    }
+    for &i in &[0usize, 1] {
+        for &j in &[0usize, 1] {
+            v.push(corner(i, j, 0));
+            v.push(corner(i, j, 1)); // edges along z (RT)
+        }
+    }
+    v
+}
 
 fn create_depth(device: &wgpu::Device, config: &wgpu::SurfaceConfiguration) -> wgpu::TextureView {
     let tex = device.create_texture(&wgpu::TextureDescriptor {
@@ -206,7 +242,16 @@ impl App {
         );
         let volume = VolumeRenderer::new(&device, &queue, format, DEPTH_FORMAT, VOLUME_DIMS);
         let grid = VolumeGrid::new(VOLUME_DIMS);
+        let grid_ms1 = VolumeGrid::new(VOLUME_DIMS);
+        let grid_ms2 = VolumeGrid::new(VOLUME_DIMS);
         let annotations = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
+
+        // Data-cube wireframe for orientation: the 12 edges of the normalized cube, with
+        // the clip window opened past the cube so the frame is never culled.
+        let mut axes = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
+        axes.upload(&device, &cube_edges());
+        // The axis frame outlines the cube itself, so it never re-fits (focus = 0).
+        axes.update_filter(&queue, [-2.0, -2.0, -2.0, 0.0], [2.0, 2.0, 2.0, 0.0], 0.0);
 
         let n_colormaps = COLORMAP_NAMES.len() as u32;
         let mut state = AppState::new(plan.meta.bounds, total, n_colormaps);
@@ -251,7 +296,11 @@ impl App {
             points,
             volume,
             grid,
+            grid_ms1,
+            grid_ms2,
+            last_ms: (true, true),
             annotations,
+            axes,
             camera: OrbitCamera::default(),
             state,
             loader,
@@ -287,9 +336,15 @@ impl Gfx {
             match self.loader.rx.try_recv() {
                 Ok(LoadMsg::Chunk { points, .. }) => {
                     // Volume density: deposit intensity*weight so the density is
-                    // independent of the downsample ratio (weight = 1/p = stride).
+                    // independent of the downsample ratio (weight = 1/p = stride). Deposit
+                    // into the per-MS-level grid so the volume can filter MS1/MS2 like points.
                     for p in &points {
-                        self.grid.deposit(p.pos, p.intensity * p.weight);
+                        let g = if p.flags & crate::data::point::GpuPoint::MS2_FLAG != 0 {
+                            &mut self.grid_ms2
+                        } else {
+                            &mut self.grid_ms1
+                        };
+                        g.deposit(p.pos, p.intensity * p.weight);
                     }
                     self.points.append(&self.queue, &points);
                 }
@@ -314,6 +369,7 @@ impl Gfx {
                     self.state.load_progress = 1.0;
                     // Recompute the volume range against the now-complete grid.
                     if self.state.view_mode == ViewMode::Volume {
+                        self.refresh_volume_grid();
                         let (lo, hi) = self.grid.density_percentiles();
                         self.state.i_min = lo;
                         self.state.i_max = hi;
@@ -338,6 +394,27 @@ impl Gfx {
             }
         }
         self.state.resident_points = self.points.resident();
+    }
+
+    /// Fold the MS1/MS2 density grids into the display grid per the MS toggle, when the
+    /// grids or the toggle changed. Returns true if the MS toggle itself changed (so the
+    /// caller can re-range the transfer function).
+    fn refresh_volume_grid(&mut self) -> bool {
+        let ms = (self.state.show_ms1, self.state.show_ms2);
+        let ms_changed = ms != self.last_ms;
+        if !self.grid_ms1.dirty() && !self.grid_ms2.dirty() && !ms_changed {
+            return false;
+        }
+        self.grid.combine(
+            &self.grid_ms1,
+            &self.grid_ms2,
+            ms.0 as u8 as f32,
+            ms.1 as u8 as f32,
+        );
+        self.grid_ms1.clear_dirty();
+        self.grid_ms2.clear_dirty();
+        self.last_ms = ms;
+        ms_changed
     }
 
     fn render(&mut self) {
@@ -403,14 +480,17 @@ impl Gfx {
         self.points.update_params(&self.queue, &params);
         self.annotations.update_camera(&self.queue, &cam);
         self.annotations
-            .update_filter(&self.queue, params.filter_min, params.filter_max);
+            .update_filter(&self.queue, params.filter_min, params.filter_max, params.focus);
+        self.axes.update_camera(&self.queue, &cam);
 
         // Volume mode: update the raycaster uniform (incl. the density scale) and
         // (re)upload the grid if it grew.
         if self.state.view_mode == ViewMode::Volume {
-            // On entering volume mode, auto-range the transfer fn to the density
-            // distribution (density sums differ in range from per-point intensity).
-            if self.last_view_mode != ViewMode::Volume {
+            // Fold MS1/MS2 density per the toggle (rebuilds the display grid if changed).
+            let ms_changed = self.refresh_volume_grid();
+            // Auto-range the transfer fn on entering volume mode or when the MS toggle
+            // changed the density (sums differ in range from per-point intensity).
+            if self.last_view_mode != ViewMode::Volume || ms_changed {
                 let (lo, hi) = self.grid.density_percentiles();
                 self.state.i_min = lo;
                 self.state.i_max = hi;
@@ -476,6 +556,9 @@ impl Gfx {
             match self.state.view_mode {
                 ViewMode::Points => self.points.render(&mut rpass, self.state.point_mode),
                 ViewMode::Volume => self.volume.render(&mut rpass),
+            }
+            if self.state.show_axes {
+                self.axes.render(&mut rpass);
             }
             if self.state.show_annotations {
                 self.annotations.render(&mut rpass);

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -84,6 +84,9 @@ struct Gfx {
     loader: LoaderHandle,
     /// The full run's metadata, retained so a refined region can revert to the whole run.
     full_meta: MetaIndex,
+    /// True for the built-in synthetic DEMO source: respawns must stay in demo mode rather
+    /// than trying to open a real `.d` at the placeholder data path.
+    is_demo: bool,
     /// CPU copy of the resident points (bounded by CLUSTER_CAP) so DBSCAN can run on them
     /// and write per-point cluster ids back into the GPU buffer.
     cpu_points: Vec<crate::data::point::GpuPoint>,
@@ -466,6 +469,7 @@ impl App {
             state,
             loader,
             full_meta,
+            is_demo: plan.is_demo,
             cpu_points: Vec::new(),
             modifiers: ModifiersState::empty(),
             left_down: false,
@@ -673,17 +677,19 @@ impl Gfx {
         filter: Option<crate::data::loader::RegionFilter>,
     ) {
         let capacity = self.state.capacity as usize;
-        self.loader = LoaderHandle::spawn(
+        // Stay in the source's mode: a DEMO session must respawn a synthetic source, not try
+        // to open a real `.d` at the placeholder path.
+        let mode = if self.is_demo {
+            LoaderMode::Demo(DemoSource::new(frame_ids.len(), total))
+        } else {
             LoaderMode::Real {
                 path: self.full_meta.data_path.clone(),
                 frame_ids,
                 filter,
-            },
-            bounds,
-            total,
-            capacity,
-            self.state.intensity_priority,
-        );
+            }
+        };
+        self.loader =
+            LoaderHandle::spawn(mode, bounds, total, capacity, self.state.intensity_priority);
         // Reset GPU/CPU buffers for a fresh stream.
         self.points.reset();
         self.cpu_points.clear();
@@ -1000,7 +1006,18 @@ impl Gfx {
                 occlusion_query_set: None,
             });
             match self.state.view_mode {
-                ViewMode::Points => self.points.render(&mut rpass, self.state.point_mode),
+                ViewMode::Points => {
+                    // Cluster coloring must use the opaque pipeline (REPLACE blend + depth
+                    // write): the additive pipeline would sum cluster hues regardless of the
+                    // fragment's alpha. Don't mutate point_mode, so the user's additive/opaque
+                    // choice is restored when they switch back to intensity coloring.
+                    let mode = if self.state.color_mode == crate::state::ColorMode::Cluster {
+                        crate::render::point_cloud::PointMode::StructuralOpaque
+                    } else {
+                        self.state.point_mode
+                    };
+                    self.points.render(&mut rpass, mode);
+                }
                 ViewMode::Volume => self.volume.render(&mut rpass),
             }
             if self.state.show_axes {

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -433,13 +433,7 @@ impl App {
                 filter: None,
             }
         };
-        let loader = LoaderHandle::spawn(
-            mode,
-            plan.meta.bounds,
-            total,
-            capacity as usize,
-            state.intensity_priority,
-        );
+        let loader = LoaderHandle::spawn(mode, plan.meta.bounds, total, capacity as usize);
 
         Ok(Gfx {
             window,
@@ -549,6 +543,20 @@ impl Gfx {
                     {
                         self.state.auto_transfer_points();
                     }
+                }
+                Ok(LoadMsg::Histograms { mz, im, rt, intensity, i_lo, i_hi }) => {
+                    // Distribution strips for the levels-style filters; the intensity slider
+                    // spans the data range, default filter = full (no cull).
+                    self.state.hist_mz = mz;
+                    self.state.hist_im = im;
+                    self.state.hist_rt = rt;
+                    self.state.hist_intensity = intensity;
+                    self.state.i_data_lo = i_lo;
+                    self.state.i_data_hi = i_hi;
+                    self.state.intensity_window = crate::state::Window {
+                        min: i_lo as f64,
+                        max: i_hi as f64,
+                    };
                 }
                 Ok(LoadMsg::Annotations { lines, groups, n_groups }) => {
                     // Suppress the selection overlay in a refined region: it is normalized to
@@ -688,11 +696,19 @@ impl Gfx {
                 filter,
             }
         };
-        self.loader =
-            LoaderHandle::spawn(mode, bounds, total, capacity, self.state.intensity_priority);
+        self.loader = LoaderHandle::spawn(mode, bounds, total, capacity);
         // Reset GPU/CPU buffers for a fresh stream.
         self.points.reset();
         self.cpu_points.clear();
+        // Drop stale distributions; the new load re-sends them and resets the filter.
+        self.state.hist_mz.clear();
+        self.state.hist_im.clear();
+        self.state.hist_rt.clear();
+        self.state.hist_intensity.clear();
+        self.state.intensity_window = crate::state::Window {
+            min: 0.0,
+            max: f64::INFINITY,
+        };
         self.state.color_mode = crate::state::ColorMode::Intensity;
         self.state.cluster_count = 0;
         self.state.cluster_noise = 0;
@@ -816,26 +832,6 @@ impl Gfx {
             match action {
                 crate::state::RefineAction::Refine => self.refine_to_window(),
                 crate::state::RefineAction::FullRun => self.load_full_run(),
-                // Re-stream the current scope (region or full run) with the new sampling.
-                crate::state::RefineAction::Restream => {
-                    if self.state.refined {
-                        self.refine_to_window();
-                    } else {
-                        // In-place re-stream of the full run: preserve the user's window
-                        // narrowing and focus (load_full_run otherwise resets them).
-                        let (rt, mz, im, focus) = (
-                            self.state.rt_window,
-                            self.state.mz_window,
-                            self.state.im_window,
-                            self.state.focus,
-                        );
-                        self.load_full_run();
-                        self.state.rt_window = rt;
-                        self.state.mz_window = mz;
-                        self.state.im_window = im;
-                        self.state.focus = focus;
-                    }
-                }
             }
         }
         // Clustering: run DBSCAN on the resident points and color by cluster id.

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -82,6 +82,8 @@ struct Gfx {
     camera: OrbitCamera,
     state: AppState,
     loader: LoaderHandle,
+    /// The full run's metadata, retained so a refined region can revert to the whole run.
+    full_meta: MetaIndex,
 
     // interaction
     modifiers: ModifiersState,
@@ -411,6 +413,9 @@ impl App {
         );
         let egui_renderer = egui_wgpu::Renderer::new(&device, format, None, 1, true);
 
+        // Keep the full run's metadata so a refined region can revert to the whole run.
+        let full_meta = plan.meta.clone();
+
         // Spawn the loader.
         let mode = if plan.is_demo {
             LoaderMode::Demo(DemoSource::new(plan.meta.frames.len(), total))
@@ -419,6 +424,7 @@ impl App {
             LoaderMode::Real {
                 path: plan.meta.data_path.clone(),
                 frame_ids,
+                filter: None,
             }
         };
         let loader = LoaderHandle::spawn(mode, plan.meta.bounds, total, capacity as usize);
@@ -450,6 +456,7 @@ impl App {
             camera: OrbitCamera::default(),
             state,
             loader,
+            full_meta,
             modifiers: ModifiersState::empty(),
             left_down: false,
             right_down: false,
@@ -514,10 +521,14 @@ impl Gfx {
                     }
                 }
                 Ok(LoadMsg::Annotations { lines, groups, n_groups }) => {
-                    self.anno_lines = lines;
-                    self.anno_groups = groups;
-                    self.state.n_window_groups = n_groups;
-                    self.reupload_annotations();
+                    // Suppress the selection overlay in a refined region: it is normalized to
+                    // the window, so off-region windows would clutter the cube edges.
+                    if !self.state.refined {
+                        self.anno_lines = lines;
+                        self.anno_groups = groups;
+                        self.state.n_window_groups = n_groups;
+                        self.reupload_annotations();
+                    }
                 }
                 Ok(LoadMsg::Done { .. }) => {
                     self.state.load_progress = 1.0;
@@ -625,8 +636,103 @@ impl Gfx {
         self.shown_grid = grid;
     }
 
+    /// Re-spawn the loader over `frame_ids` with `bounds`, `total` estimate and an optional
+    /// per-point region filter, resetting the point buffer, volume grids and load/transfer
+    /// state so the new selection streams in from scratch. Shared by refine and revert.
+    fn respawn_loader(
+        &mut self,
+        frame_ids: Vec<u32>,
+        bounds: crate::data::point::AxisBounds,
+        total: u64,
+        filter: Option<crate::data::loader::RegionFilter>,
+    ) {
+        let capacity = self.state.capacity as usize;
+        self.loader = LoaderHandle::spawn(
+            LoaderMode::Real {
+                path: self.full_meta.data_path.clone(),
+                frame_ids,
+                filter,
+            },
+            bounds,
+            total,
+            capacity,
+        );
+        // Reset GPU/CPU buffers for a fresh stream.
+        self.points.reset();
+        self.grid_ms1.clear();
+        self.grid_ms2.clear();
+        self.grid.clear();
+        self.last_ms = (true, true);
+        self.anno_lines.clear();
+        self.anno_groups.clear();
+        self.annotations.upload(&self.device, &[]);
+        self.last_group_mask = u32::MAX;
+        // Reset per-load state; re-derive the cube + transfer for the new bounds.
+        self.state.bounds = bounds;
+        self.state.reset_windows();
+        self.state.focus = false;
+        self.state.transfer_user_dirty = false;
+        self.state.n_window_groups = 0;
+        self.state.group_mask = u32::MAX;
+        self.state.load_progress = 0.0;
+        self.state.load_failed = false;
+        self.state.resident_points = 0;
+        self.state.downsample_stride = crate::data::loader::stride_for(total, capacity) as u32;
+        // Force a transfer re-range next frame and an axis-geometry rebuild (NaN never matches).
+        self.last_view_mode = ViewMode::Points;
+        self.shown_ranges = ((f64::NAN, 0.0), (0.0, 0.0), (0.0, 0.0));
+    }
+
+    /// Re-stream just the current RT/m-z/1-K0 window at full resolution. Frame selection
+    /// handles the RT window; a per-point m/z·1/K0 cull handles the rest, and the window
+    /// becomes the new cube — so the fixed budget now buys (often stride-1) detail there.
+    fn refine_to_window(&mut self) {
+        use crate::data::point::{AxisBounds, AxisTransform};
+        let (rt0, rt1) = (self.state.rt_window.min, self.state.rt_window.max);
+        let (mz0, mz1) = (self.state.mz_window.min, self.state.mz_window.max);
+        let (im0, im1) = (self.state.im_window.min, self.state.im_window.max);
+        let mut frame_ids = Vec::new();
+        let mut total: u64 = 0;
+        for f in &self.full_meta.frames {
+            if f.retention_time >= rt0 && f.retention_time <= rt1 {
+                frame_ids.push(f.id);
+                total = total.saturating_add(f.num_peaks);
+            }
+        }
+        if frame_ids.is_empty() {
+            return;
+        }
+        let bounds = AxisBounds {
+            mz: AxisTransform::new(mz0, mz1),
+            im: AxisTransform::new(im0, im1),
+            rt: AxisTransform::new(rt0, rt1),
+        };
+        let filter = Some(crate::data::loader::RegionFilter {
+            mz: (mz0, mz1),
+            im: (im0, im1),
+        });
+        self.respawn_loader(frame_ids, bounds, total, filter);
+        self.state.refined = true;
+    }
+
+    /// Revert a refinement: re-stream the whole run at the global downsample.
+    fn load_full_run(&mut self) {
+        let frame_ids: Vec<u32> = self.full_meta.frames.iter().map(|f| f.id).collect();
+        let bounds = self.full_meta.bounds;
+        let total = self.full_meta.total_points_estimate;
+        self.respawn_loader(frame_ids, bounds, total, None);
+        self.state.refined = false;
+    }
+
     fn render(&mut self) {
         self.pump_loader();
+        // Level-of-detail: consume any pending refine/revert request from the UI.
+        if let Some(action) = self.state.refine_request.take() {
+            match action {
+                crate::state::RefineAction::Refine => self.refine_to_window(),
+                crate::state::RefineAction::FullRun => self.load_full_run(),
+            }
+        }
         // Re-range when switching Volume->Points. The two modes live in completely different
         // value ranges (per-point intensity vs summed density), so a transfer range pinned in
         // one mode is meaningless in the other: always re-range on the switch and clear the

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -432,7 +432,9 @@ impl Gfx {
     /// in `state.group_mask` (ungrouped vertices, u32::MAX, are always kept).
     fn reupload_annotations(&mut self) {
         let mask = self.state.group_mask;
-        let visible = |g: u32| g == u32::MAX || g > 32 || (mask & (1u32 << g.saturating_sub(1))) != 0;
+        // Ungrouped (u32::MAX), an out-of-range group id (0, or > 32 for the 32-bit mask)
+        // are always shown; otherwise gate on the group's bit (groups are 1-based).
+        let visible = |g: u32| g == u32::MAX || g == 0 || g > 32 || (mask & (1u32 << (g - 1))) != 0;
         let filtered: Vec<LineVertex> = self
             .anno_lines
             .iter()

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -427,7 +427,13 @@ impl App {
                 filter: None,
             }
         };
-        let loader = LoaderHandle::spawn(mode, plan.meta.bounds, total, capacity as usize);
+        let loader = LoaderHandle::spawn(
+            mode,
+            plan.meta.bounds,
+            total,
+            capacity as usize,
+            state.intensity_priority,
+        );
 
         Ok(Gfx {
             window,
@@ -656,6 +662,7 @@ impl Gfx {
             bounds,
             total,
             capacity,
+            self.state.intensity_priority,
         );
         // Reset GPU/CPU buffers for a fresh stream.
         self.points.reset();
@@ -731,6 +738,14 @@ impl Gfx {
             match action {
                 crate::state::RefineAction::Refine => self.refine_to_window(),
                 crate::state::RefineAction::FullRun => self.load_full_run(),
+                // Re-stream the current scope (region or full run) with the new sampling.
+                crate::state::RefineAction::Restream => {
+                    if self.state.refined {
+                        self.refine_to_window();
+                    } else {
+                        self.load_full_run();
+                    }
+                }
             }
         }
         // Re-range when switching Volume->Points. The two modes live in completely different

--- a/tims-viewer/src/camera.rs
+++ b/tims-viewer/src/camera.rs
@@ -89,20 +89,23 @@ impl OrbitCamera {
     pub fn set_axis_view(&mut self, axis: AxisView) {
         self.target = Vec3::ZERO;
         self.distance = 4.0;
-        match axis {
-            AxisView::Mz => {
-                self.yaw = std::f32::consts::FRAC_PI_2;
-                self.pitch = 0.0;
-            }
-            AxisView::Mobility => {
-                self.yaw = 0.0;
-                self.pitch = PITCH_LIMIT;
-            }
-            AxisView::Rt => {
-                self.yaw = 0.0;
-                self.pitch = 0.0;
-            }
-        }
+        // `perm()` maps DATA axes onto WORLD axes under the current roll (m/z→[X,Y,Z], 1/K0→[Y,Z,X],
+        // RT→[Z,X,Y] for roll 0/1/2). The camera yaw/pitch are world-space, so snap to look down the
+        // WORLD axis the requested data axis currently occupies — otherwise, after "Roll up", the m/z
+        // button would look down whatever data axis happens to sit on world-X. roll 0 reduces to the
+        // identity mapping (Mz→X, Mobility→Y, Rt→Z), i.e. the original behavior, unchanged.
+        let world_axis = match (axis, self.roll % 3) {
+            (AxisView::Mz, 0) | (AxisView::Mobility, 2) | (AxisView::Rt, 1) => 0u8, // world X
+            (AxisView::Mz, 1) | (AxisView::Mobility, 0) | (AxisView::Rt, 2) => 1u8, // world Y (up)
+            _ => 2u8,                                                               // world Z
+        };
+        let (yaw, pitch) = match world_axis {
+            0 => (std::f32::consts::FRAC_PI_2, 0.0),
+            1 => (0.0, PITCH_LIMIT),
+            _ => (0.0, 0.0),
+        };
+        self.yaw = yaw;
+        self.pitch = pitch;
     }
 
     fn eye(&self) -> Vec3 {

--- a/tims-viewer/src/camera.rs
+++ b/tims-viewer/src/camera.rs
@@ -1,6 +1,6 @@
 //! Orbit camera around the normalized data cube.
 
-use glam::{Mat4, Vec3};
+use glam::{Mat3, Mat4, Vec3};
 
 use crate::render::uniforms::CameraUniform;
 
@@ -33,7 +33,13 @@ pub struct OrbitCamera {
     pub znear: f32,
     pub zfar: f32,
     pub projection: Projection,
+    /// Which data axis points up ("topple the dice"): 0 = 1/K0, 1 = m/z, 2 = RT. Applied as a
+    /// cyclic permutation of the data axes baked into the view-projection.
+    pub roll: u8,
 }
+
+/// Name of the data axis currently pointing up, for the UI.
+pub const ROLL_UP_AXIS: [&str; 3] = ["1/K0", "m/z", "RT"];
 
 impl Default for OrbitCamera {
     fn default() -> Self {
@@ -46,6 +52,7 @@ impl Default for OrbitCamera {
             znear: 0.05,
             zfar: 100.0,
             projection: Projection::Perspective,
+            roll: 0,
         }
     }
 }
@@ -54,9 +61,29 @@ const PITCH_LIMIT: f32 = 1.5533; // ~89 degrees
 
 impl OrbitCamera {
     pub fn reset(&mut self) {
-        let proj = self.projection;
+        let (proj, roll) = (self.projection, self.roll);
         *self = OrbitCamera::default();
         self.projection = proj;
+        self.roll = roll;
+    }
+
+    /// Cycle which data axis points up (0 → 1/K0, 1 → m/z, 2 → RT).
+    pub fn roll_axis(&mut self) {
+        self.roll = (self.roll + 1) % 3;
+    }
+
+    /// Cyclic axis-permutation matrix for the current roll, mapping data (x=m/z, y=1/K0, z=RT)
+    /// to world so the chosen axis lands on world-up (Y). Identity, or a proper rotation.
+    fn perm(&self) -> Mat4 {
+        let m3 = match self.roll % 3 {
+            // 1/K0 (data y) up: identity.
+            0 => Mat3::IDENTITY,
+            // m/z (data x) up: data x→world y, y→z, z→x.
+            1 => Mat3::from_cols(Vec3::Y, Vec3::Z, Vec3::X),
+            // RT (data z) up: data x→world z, y→x, z→y.
+            _ => Mat3::from_cols(Vec3::Z, Vec3::X, Vec3::Y),
+        };
+        Mat4::from_mat3(m3)
     }
 
     pub fn set_axis_view(&mut self, axis: AxisView) {
@@ -122,7 +149,10 @@ impl OrbitCamera {
                 Mat4::orthographic_rh(-half_w, half_w, -half_h, half_h, self.znear, self.zfar)
             }
         };
-        proj * view
+        // Bake the axis permutation in last: data positions are permuted, then viewed. The
+        // volume raycaster reconstructs data-space coords through the inverse, so it stays
+        // consistent automatically.
+        proj * view * self.perm()
     }
 
     /// Inverse view-projection (column-major arrays), for reconstructing world-space
@@ -133,6 +163,11 @@ impl OrbitCamera {
 
     pub fn to_uniform(&self, aspect: f32, viewport: [f32; 2]) -> CameraUniform {
         let (right, up, _) = self.basis();
+        // Billboards expand in DATA space (before the baked permutation), so counter-rotate the
+        // camera screen axes by perm⁻¹ — then perm maps them back to the world screen axes.
+        let inv = self.perm().inverse();
+        let right = inv.transform_vector3(right);
+        let up = inv.transform_vector3(up);
         CameraUniform {
             view_proj: self.view_proj(aspect).to_cols_array_2d(),
             right: [right.x, right.y, right.z, 0.0],

--- a/tims-viewer/src/camera.rs
+++ b/tims-viewer/src/camera.rs
@@ -7,6 +7,8 @@ use crate::render::uniforms::CameraUniform;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Projection {
     Perspective,
+    /// Hidden from the UI until its bugs are fixed; the projection math is kept.
+    #[allow(dead_code)]
     Orthographic,
 }
 

--- a/tims-viewer/src/cluster.rs
+++ b/tims-viewer/src/cluster.rs
@@ -15,6 +15,18 @@ pub const NOISE: i32 = -1;
 /// Run DBSCAN on `points` (normalized cube positions). Returns a per-point label
 /// (`NOISE` for noise, otherwise a 0-based contiguous cluster id) and the cluster count.
 pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize) {
+    dbscan_with_progress(points, eps, min_pts, |_| {})
+}
+
+/// Like [`dbscan`], but invokes `progress(visited_so_far)` roughly every 1% of points (and once at
+/// the end with `points.len()`). The visited count climbs monotonically — even inside one big
+/// cluster's flood-fill — so it's a smooth progress proxy for a long run.
+pub fn dbscan_with_progress(
+    points: &[[f32; 3]],
+    eps: f32,
+    min_pts: usize,
+    mut progress: impl FnMut(usize),
+) -> (Vec<i32>, usize) {
     let n = points.len();
     if n == 0 || eps <= 0.0 {
         return (vec![NOISE; n], 0);
@@ -71,11 +83,25 @@ pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize
     let mut nbj: Vec<u32> = Vec::new();
     let mut queue: VecDeque<u32> = VecDeque::new();
 
+    // Throttled progress on the visited count (~1% granularity).
+    let report_step = (n / 100).max(1);
+    let mut visited_count = 0usize;
+    let mut since_report = 0usize;
+    let bump = |count: &mut usize, since: &mut usize, progress: &mut dyn FnMut(usize)| {
+        *count += 1;
+        *since += 1;
+        if *since >= report_step {
+            *since = 0;
+            progress(*count);
+        }
+    };
+
     for i in 0..n {
         if visited[i] {
             continue;
         }
         visited[i] = true;
+        bump(&mut visited_count, &mut since_report, &mut progress);
         neighbors(i, &mut nb);
         if nb.len() < min_pts {
             continue; // noise (may still be claimed as a border point later)
@@ -96,6 +122,7 @@ pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize
             }
             if !visited[j] {
                 visited[j] = true;
+                bump(&mut visited_count, &mut since_report, &mut progress);
                 neighbors(j, &mut nbj);
                 if nbj.len() >= min_pts {
                     // j is a core point -> add its not-yet-queued neighbours to the frontier.
@@ -110,6 +137,7 @@ pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize
         }
         cid += 1;
     }
+    progress(n); // final 100%
     (labels, cid as usize)
 }
 

--- a/tims-viewer/src/cluster.rs
+++ b/tims-viewer/src/cluster.rs
@@ -141,6 +141,191 @@ pub fn dbscan_with_progress(
     (labels, cid as usize)
 }
 
+/// Per-axis multipliers applied to the normalized-cube coordinates (`x=m/z`, `y=1/K0`, `z=RT`) before
+/// DBSCAN, so the clustering metric is equi-distanced *and region-independent*: at the reference eps,
+/// the neighbourhood reach is a fixed physical amount on each axis — `rt_cycles` MS1 cycles,
+/// `im_scans` TIMS scans, `mz_peak_widths` TOF peak-widths — regardless of how the focus region is
+/// cropped. Each axis solves `reach = eps_ref · range / (2·scale)` for its target reach (the cube maps
+/// each real range onto width 2), anchoring the unit to a *run-level* physical constant. An axis whose
+/// anchor is unavailable (`<= 0`) falls back to `1.0` (uncalibrated, region-relative).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AxisScales {
+    pub mz: f32,
+    pub im: f32,
+    pub rt: f32,
+}
+
+/// Inputs for [`cluster_axis_scales`] — the focus region (real units) plus run-level anchors + knobs.
+#[derive(Clone, Copy, Debug)]
+pub struct ScaleInputs {
+    /// Real-unit focus-region bounds `[(mz_lo,hi), (im_lo,hi), (rt_lo,hi)]`.
+    pub bounds: [(f64, f64); 3],
+    /// Calibration reference eps (the live eps scales the reach proportionally about this).
+    pub eps_ref: f64,
+    /// Run-level seconds per MS1 cycle; `0` = unknown (RT left uncalibrated).
+    pub cycle_duration: f64,
+    /// Run-level 1/K0 per TIMS scan; `0` = unknown (1/K0 left uncalibrated).
+    pub im_per_scan: f64,
+    /// TOF resolution (peak width = m/z / resolution).
+    pub mz_resolution: f64,
+    pub rt_cycles: f64,
+    pub im_scans: f64,
+    pub mz_peak_widths: f64,
+}
+
+/// Compute the per-axis scales (see [`AxisScales`]).
+pub fn cluster_axis_scales(inp: &ScaleInputs) -> AxisScales {
+    // scale so the target real-unit reach maps to exactly `eps_ref` after normalize+scale.
+    let scale = |range: f64, target_reach: f64| -> f32 {
+        if range.is_finite() && range > 0.0 && target_reach.is_finite() && target_reach > 0.0 {
+            (inp.eps_ref * range / (2.0 * target_reach)) as f32
+        } else {
+            1.0 // anchor unavailable / degenerate range -> normalized (region-relative) fallback
+        }
+    };
+    let mz_range = (inp.bounds[0].1 - inp.bounds[0].0).abs();
+    let im_range = (inp.bounds[1].1 - inp.bounds[1].0).abs();
+    let rt_range = (inp.bounds[2].1 - inp.bounds[2].0).abs();
+    let mz_center = ((inp.bounds[0].0 + inp.bounds[0].1) * 0.5).abs();
+    let peak_width = if inp.mz_resolution > 0.0 { mz_center / inp.mz_resolution } else { 0.0 };
+    AxisScales {
+        mz: scale(mz_range, inp.mz_peak_widths.max(0.0) * peak_width),
+        im: scale(im_range, inp.im_scans.max(0.0) * inp.im_per_scan),
+        rt: scale(rt_range, inp.rt_cycles.max(0.0) * inp.cycle_duration),
+    }
+}
+
+/// The real-unit neighbourhood reach of `eps` on an axis, given its `scale` and the region's real
+/// `range`. Inverse of the calibration in [`cluster_axis_scales`].
+pub fn axis_reach(eps: f64, range: f64, scale: f32) -> f64 {
+    if scale > 0.0 {
+        eps * range / (2.0 * scale as f64)
+    } else {
+        f64::INFINITY
+    }
+}
+
+#[cfg(test)]
+mod scale_tests {
+    use super::*;
+
+    fn base(im: (f64, f64)) -> ScaleInputs {
+        ScaleInputs {
+            bounds: [(500.0, 520.0), im, (30.0, 60.0)],
+            eps_ref: 0.012,
+            cycle_duration: 0.1,  // s / cycle
+            im_per_scan: 0.0008,  // 1/K0 / scan
+            mz_resolution: 50_000.0,
+            rt_cycles: 2.0,
+            im_scans: 10.0,
+            mz_peak_widths: 1.5,
+        }
+    }
+
+    /// Normalize real points into `bounds`, apply the scales, cluster.
+    fn cluster_real(
+        real: &[[f64; 3]],
+        bounds: [(f64, f64); 3],
+        s: AxisScales,
+        eps: f32,
+        min_pts: usize,
+    ) -> Vec<i32> {
+        let pts: Vec<[f32; 3]> = real
+            .iter()
+            .map(|p| {
+                let mut q = [0f32; 3];
+                for a in 0..3 {
+                    let c = (bounds[a].0 + bounds[a].1) * 0.5;
+                    let h = (bounds[a].1 - bounds[a].0) * 0.5;
+                    q[a] = ((p[a] - c) / h) as f32;
+                }
+                [q[0] * s.mz, q[1] * s.im, q[2] * s.rt]
+            })
+            .collect();
+        dbscan(&pts, eps, min_pts).0
+    }
+
+    /// Re-label to first-seen order so cluster-id numbering doesn't matter; noise stays -1.
+    fn canonical(labels: &[i32]) -> Vec<i32> {
+        let mut map = std::collections::HashMap::new();
+        let mut next = 0i32;
+        labels
+            .iter()
+            .map(|&l| {
+                if l < 0 {
+                    -1
+                } else {
+                    *map.entry(l).or_insert_with(|| {
+                        let v = next;
+                        next += 1;
+                        v
+                    })
+                }
+            })
+            .collect()
+    }
+
+    /// The realized reach equals the configured physical target on every axis — and is invariant to
+    /// the focus-region width (the whole point of the calibration).
+    #[test]
+    fn reach_equals_target_and_is_region_independent() {
+        let eps = 0.012; // == eps_ref
+        for im in [(0.60, 1.50), (0.95, 1.05)] {
+            let inp = base(im);
+            let s = cluster_axis_scales(&inp);
+            let im_reach = axis_reach(eps, im.1 - im.0, s.im);
+            let rt_reach = axis_reach(eps, 60.0 - 30.0, s.rt);
+            let mz_reach = axis_reach(eps, 520.0 - 500.0, s.mz);
+            // Relative tolerance absorbs the f32 scale rounding; still 3 orders tighter than the ~9x
+            // region-dependence bug it guards against.
+            let close = |got: f64, want: f64| (got / want - 1.0).abs() < 1e-4;
+            assert!(close(im_reach, 10.0 * 0.0008), "im_reach={im_reach}");
+            assert!(close(rt_reach, 2.0 * 0.1), "rt_reach={rt_reach}");
+            let pw = 510.0 / 50_000.0;
+            assert!(close(mz_reach, 1.5 * pw), "mz_reach={mz_reach}");
+        }
+    }
+
+    /// Region-invariance at the clustering level: the SAME real-unit points, normalized into a wide vs
+    /// a tight IM region and scaled, produce identical DBSCAN labels.
+    #[test]
+    fn dbscan_labels_invariant_to_im_focus() {
+        // Four points spaced 0.004 1/K0 along mobility (same m/z + RT). reach = 10·0.0008 = 0.008 >
+        // 0.004, so they chain into one cluster — in BOTH regions, if the calibration is correct.
+        let real = [
+            [510.0, 1.000, 45.0],
+            [510.0, 1.004, 45.0],
+            [510.0, 1.008, 45.0],
+            [510.0, 1.012, 45.0],
+        ];
+        let wide = (0.60, 1.50);
+        let tight = (0.99, 1.02);
+        let lw = cluster_real(&real, [(500.0, 520.0), wide, (30.0, 60.0)], cluster_axis_scales(&base(wide)), 0.012, 2);
+        let lt = cluster_real(&real, [(500.0, 520.0), tight, (30.0, 60.0)], cluster_axis_scales(&base(tight)), 0.012, 2);
+        assert_eq!(canonical(&lw), canonical(&lt), "labels must be region-independent");
+        assert_eq!(*lw.iter().max().unwrap() + 1, 1, "expected exactly one cluster");
+    }
+
+    /// Documents the bug the calibration fixes: with 1/K0 left uncalibrated (`im` scale = 1, the old
+    /// behavior), the same points give DIFFERENT labels in a wide vs a tight IM region.
+    #[test]
+    fn uncalibrated_im_diverges_with_focus() {
+        let real = [
+            [510.0, 1.000, 45.0],
+            [510.0, 1.004, 45.0],
+            [510.0, 1.008, 45.0],
+            [510.0, 1.012, 45.0],
+        ];
+        let wide = (0.60, 1.50);
+        let tight = (0.99, 1.02);
+        let uncal = AxisScales { mz: 1.0, im: 1.0, rt: 1.0 };
+        let lw = cluster_real(&real, [(500.0, 520.0), wide, (30.0, 60.0)], uncal, 0.012, 2);
+        let lt = cluster_real(&real, [(500.0, 520.0), tight, (30.0, 60.0)], uncal, 0.012, 2);
+        // wide: spacing 2·0.004/0.9 ≈ 0.0089 < eps -> chains; tight: 2·0.004/0.03 ≈ 0.27 > eps -> shatters
+        assert_ne!(canonical(&lw), canonical(&lt), "uncalibrated 1/K0 is focus-dependent (the bug)");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tims-viewer/src/cluster.rs
+++ b/tims-viewer/src/cluster.rs
@@ -1,0 +1,126 @@
+//! Grid-accelerated DBSCAN over the normalized point cloud, for coloring points by cluster
+//! identity (the same analysis the proteolizard/imspy-vis Voila tool did, in the viewer).
+//!
+//! Points live in the normalized cube `[-1, 1]^3` (x=m/z, y=1/K0, z=RT), so a single `eps`
+//! in cube units is a sensible neighborhood radius. A uniform spatial hash of cell size `eps`
+//! makes each neighborhood query touch only the 27 adjacent cells, so the whole pass is about
+//! O(n) for the moderate point counts the viewer clusters (it is gated to a cap by the caller).
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+
+/// Label assigned to noise / unclustered points.
+pub const NOISE: i32 = -1;
+
+/// Run DBSCAN on `points` (normalized cube positions). Returns a per-point label
+/// (`NOISE` for noise, otherwise a 0-based contiguous cluster id) and the cluster count.
+pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize) {
+    let n = points.len();
+    if n == 0 || eps <= 0.0 {
+        return (vec![NOISE; n], 0);
+    }
+    let inv = 1.0 / eps;
+    let cell = |p: &[f32; 3]| -> (i32, i32, i32) {
+        (
+            (p[0] * inv).floor() as i32,
+            (p[1] * inv).floor() as i32,
+            (p[2] * inv).floor() as i32,
+        )
+    };
+    // Spatial hash: cell -> point indices.
+    let mut grid: HashMap<(i32, i32, i32), Vec<u32>> = HashMap::with_capacity(n / 4 + 1);
+    for (i, p) in points.iter().enumerate() {
+        grid.entry(cell(p)).or_default().push(i as u32);
+    }
+
+    let eps2 = eps * eps;
+    // Neighbors of point i within eps (inclusive), scanning the 27 surrounding cells.
+    let neighbors = |i: usize, out: &mut Vec<u32>| {
+        out.clear();
+        let p = points[i];
+        let (ci, cj, ck) = cell(&p);
+        for di in -1..=1 {
+            for dj in -1..=1 {
+                for dk in -1..=1 {
+                    if let Some(v) = grid.get(&(ci + di, cj + dj, ck + dk)) {
+                        for &j in v {
+                            let q = points[j as usize];
+                            let d = (p[0] - q[0]).powi(2)
+                                + (p[1] - q[1]).powi(2)
+                                + (p[2] - q[2]).powi(2);
+                            if d <= eps2 {
+                                out.push(j);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    let mut labels = vec![NOISE; n];
+    let mut visited = vec![false; n];
+    let mut cid: i32 = 0;
+    let mut nb: Vec<u32> = Vec::new();
+    let mut nbj: Vec<u32> = Vec::new();
+    let mut queue: VecDeque<u32> = VecDeque::new();
+
+    for i in 0..n {
+        if visited[i] {
+            continue;
+        }
+        visited[i] = true;
+        neighbors(i, &mut nb);
+        if nb.len() < min_pts {
+            continue; // noise (may still be claimed as a border point later)
+        }
+        // Seed a new cluster and flood-fill density-reachable points.
+        labels[i] = cid;
+        queue.clear();
+        queue.extend(nb.iter().copied());
+        while let Some(j) = queue.pop_front() {
+            let j = j as usize;
+            if !visited[j] {
+                visited[j] = true;
+                neighbors(j, &mut nbj);
+                if nbj.len() >= min_pts {
+                    queue.extend(nbj.iter().copied()); // j is a core point -> expand
+                }
+            }
+            if labels[j] == NOISE {
+                labels[j] = cid; // claim border (or previously-noise) point
+            }
+        }
+        cid += 1;
+    }
+    (labels, cid as usize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_dense_blobs_plus_noise() {
+        let mut pts = Vec::new();
+        // Blob A around (-0.5,-0.5,-0.5), blob B around (0.5,0.5,0.5).
+        for i in 0..50 {
+            let t = i as f32 * 0.001;
+            pts.push([-0.5 + t, -0.5 - t, -0.5 + t]);
+            pts.push([0.5 - t, 0.5 + t, 0.5 - t]);
+        }
+        // A lone outlier.
+        pts.push([0.95, -0.95, 0.0]);
+        let (labels, k) = dbscan(&pts, 0.05, 4);
+        assert_eq!(k, 2, "expected two clusters");
+        assert_eq!(*labels.last().unwrap(), NOISE, "outlier should be noise");
+    }
+
+    #[test]
+    fn empty_and_degenerate() {
+        assert_eq!(dbscan(&[], 0.1, 4), (vec![], 0));
+        let (l, k) = dbscan(&[[0.0, 0.0, 0.0]], 0.0, 1);
+        assert_eq!(k, 0);
+        assert_eq!(l, vec![NOISE]);
+    }
+}

--- a/tims-viewer/src/cluster.rs
+++ b/tims-viewer/src/cluster.rs
@@ -6,7 +6,7 @@
 //! makes each neighborhood query touch only the 27 adjacent cells, so the whole pass is about
 //! O(n) for the moderate point counts the viewer clusters (it is gated to a cap by the caller).
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 
 /// Label assigned to noise / unclustered points.
@@ -27,8 +27,10 @@ pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize
             (p[2] * inv).floor() as i32,
         )
     };
-    // Spatial hash: cell -> point indices.
-    let mut grid: HashMap<(i32, i32, i32), Vec<u32>> = HashMap::with_capacity(n / 4 + 1);
+    // Spatial hash: cell -> point indices. FxHashMap (not SipHash) — the grid is hashed n times on
+    // build and 27n times in neighbour queries, so the hash is a hot path, especially in wasm.
+    let mut grid: FxHashMap<(i32, i32, i32), Vec<u32>> =
+        FxHashMap::with_capacity_and_hasher(n / 4 + 1, Default::default());
     for (i, p) in points.iter().enumerate() {
         grid.entry(cell(p)).or_default().push(i as u32);
     }
@@ -60,6 +62,10 @@ pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize
 
     let mut labels = vec![NOISE; n];
     let mut visited = vec![false; n];
+    // `queued` dedups the BFS frontier: each point is enqueued at most once across the whole run, so
+    // the queue stays O(n) instead of O(sum of neighbourhood sizes) — which, on dense MS peaks, would
+    // otherwise balloon to billions of (mostly duplicate) entries.
+    let mut queued = vec![false; n];
     let mut cid: i32 = 0;
     let mut nb: Vec<u32> = Vec::new();
     let mut nbj: Vec<u32> = Vec::new();
@@ -77,18 +83,29 @@ pub fn dbscan(points: &[[f32; 3]], eps: f32, min_pts: usize) -> (Vec<i32>, usize
         // Seed a new cluster and flood-fill density-reachable points.
         labels[i] = cid;
         queue.clear();
-        queue.extend(nb.iter().copied());
+        for &j in &nb {
+            if !queued[j as usize] {
+                queued[j as usize] = true;
+                queue.push_back(j);
+            }
+        }
         while let Some(j) = queue.pop_front() {
             let j = j as usize;
+            if labels[j] == NOISE {
+                labels[j] = cid; // claim border (or previously-noise) point; first cluster wins
+            }
             if !visited[j] {
                 visited[j] = true;
                 neighbors(j, &mut nbj);
                 if nbj.len() >= min_pts {
-                    queue.extend(nbj.iter().copied()); // j is a core point -> expand
+                    // j is a core point -> add its not-yet-queued neighbours to the frontier.
+                    for &m in &nbj {
+                        if !queued[m as usize] {
+                            queued[m as usize] = true;
+                            queue.push_back(m);
+                        }
+                    }
                 }
-            }
-            if labels[j] == NOISE {
-                labels[j] = cid; // claim border (or previously-noise) point
             }
         }
         cid += 1;

--- a/tims-viewer/src/cluster.rs
+++ b/tims-viewer/src/cluster.rs
@@ -178,7 +178,12 @@ pub fn cluster_axis_scales(inp: &ScaleInputs) -> AxisScales {
     // scale so the target real-unit reach maps to exactly `eps_ref` after normalize+scale.
     let scale = |range: f64, target_reach: f64| -> f32 {
         if range.is_finite() && range > 0.0 && target_reach.is_finite() && target_reach > 0.0 {
-            (inp.eps_ref * range / (2.0 * target_reach)) as f32
+            let s = (inp.eps_ref * range / (2.0 * target_reach)) as f32;
+            if s.is_finite() && s > 0.0 {
+                s
+            } else {
+                1.0 // guard a malformed eps_ref (NaN / <=0) from producing a degenerate scale
+            }
         } else {
             1.0 // anchor unavailable / degenerate range -> normalized (region-relative) fallback
         }
@@ -323,6 +328,25 @@ mod scale_tests {
         let lt = cluster_real(&real, [(500.0, 520.0), tight, (30.0, 60.0)], uncal, 0.012, 2);
         // wide: spacing 2·0.004/0.9 ≈ 0.0089 < eps -> chains; tight: 2·0.004/0.03 ≈ 0.27 > eps -> shatters
         assert_ne!(canonical(&lw), canonical(&lt), "uncalibrated 1/K0 is focus-dependent (the bug)");
+    }
+
+    /// The live eps (not eps_ref) scales the reach proportionally: 2x eps -> 2x reach on every axis.
+    #[test]
+    fn live_eps_scales_reach_proportionally() {
+        let s = cluster_axis_scales(&base((0.60, 1.50)));
+        for (range, scale) in [(0.9, s.im), (30.0, s.rt), (20.0, s.mz)] {
+            let r1 = axis_reach(0.012, range, scale);
+            let r2 = axis_reach(0.024, range, scale);
+            assert!((r2 / r1 - 2.0).abs() < 1e-4, "reach should scale with eps");
+        }
+    }
+
+    /// A missing run-level anchor (`im_per_scan = 0`) falls back to the unscaled (normalized) axis.
+    #[test]
+    fn missing_im_anchor_falls_back_to_unscaled() {
+        let mut inp = base((0.60, 1.50));
+        inp.im_per_scan = 0.0;
+        assert_eq!(cluster_axis_scales(&inp).im, 1.0);
     }
 }
 

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -605,7 +605,7 @@ fn build_annotations(
                     let im1 = ims.get(1).copied().unwrap_or(im0);
                     let mz0 = w.isolation_mz - w.isolation_width * 0.5;
                     let mz1 = w.isolation_mz + w.isolation_width * 0.5;
-                    let color = group_color(w.window_group, n_groups);
+                    let color = crate::render::colormap::group_color(w.window_group, n_groups);
                     for i in 0..N_SLICES {
                         let rt =
                             rt_lo + (rt_hi - rt_lo) * (i as f64 + 0.5) / N_SLICES as f64;
@@ -642,29 +642,6 @@ fn push_cross(
     v([c[0], c[1] + h, c[2]]);
     v([c[0], c[1], c[2] - h]);
     v([c[0], c[1], c[2] + h]);
-}
-
-/// Distinct color per window group, by evenly spacing hue around the wheel.
-pub fn group_color(group: u32, n_groups: u32) -> [f32; 3] {
-    let h = (group.saturating_sub(1) as f32) / (n_groups.max(1) as f32);
-    hsv_to_rgb(h, 0.7, 1.0)
-}
-
-/// HSV (all in [0,1] except hue which wraps) to linear-ish RGB for line colors.
-fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
-    let i = (h * 6.0).floor();
-    let f = h * 6.0 - i;
-    let p = v * (1.0 - s);
-    let q = v * (1.0 - f * s);
-    let t = v * (1.0 - (1.0 - f) * s);
-    match (i as i32).rem_euclid(6) {
-        0 => [v, t, p],
-        1 => [q, v, p],
-        2 => [p, v, t],
-        3 => [p, q, v],
-        4 => [t, p, v],
-        _ => [v, p, q],
-    }
 }
 
 /// Append the 4 edges of an axis-aligned rectangle in the m/z x mobility plane at a fixed

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -52,6 +52,11 @@ pub enum LoadMsg {
         intensity: Vec<u32>,
         i_lo: f32,
         i_hi: f32,
+        /// 2D density projections (each `PROJ_BINS * PROJ_BINS`, row-major `x + PROJ_BINS*y`)
+        /// for the minimaps: m/z×1/K0, m/z×RT, 1/K0×RT.
+        proj_mz_im: Vec<u32>,
+        proj_mz_rt: Vec<u32>,
+        proj_im_rt: Vec<u32>,
     },
     /// Annotation overlay geometry: colored line-list vertices (pairs = segments) in the
     /// normalized cube (DDA precursor crosses / DIA isolation-window footprints). `groups`
@@ -174,6 +179,14 @@ fn hbin(n: f32) -> usize {
     (((n * 0.5 + 0.5).clamp(0.0, 1.0)) * (HIST_BINS as f32 - 1.0)) as usize
 }
 
+/// Side length of each 2D projection minimap (m/z·1/K0·RT plane heatmaps).
+pub const PROJ_BINS: usize = 96;
+/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, PROJ_BINS)`.
+#[inline]
+fn pbin(n: f32) -> usize {
+    (((n * 0.5 + 0.5).clamp(0.0, 1.0)) * (PROJ_BINS as f32 - 1.0)) as usize
+}
+
 /// Map a normalized-cube position to a coarse peak-grid cell index.
 #[inline]
 fn peak_cell(pos: [f32; 3]) -> u32 {
@@ -223,6 +236,10 @@ fn run_loader(
     let mut logi_fine = [0u32; LOGI_FINE];
     let mut i_lo_seen = f32::MAX;
     let mut i_hi_seen = 0.0f32;
+    // 2D density projections onto the coordinate planes (the "you are here" minimaps).
+    let mut proj_mz_im = vec![0u32; PROJ_BINS * PROJ_BINS]; // x = m/z, y = 1/K0
+    let mut proj_mz_rt = vec![0u32; PROJ_BINS * PROJ_BINS]; // x = m/z, y = RT
+    let mut proj_im_rt = vec![0u32; PROJ_BINS * PROJ_BINS]; // x = 1/K0, y = RT
 
     let mut chunk: Vec<GpuPoint> = Vec::with_capacity(CHUNK_POINTS);
 
@@ -326,6 +343,9 @@ fn run_loader(
                 hist_rt[hbin(pos[2])] += 1;
                 logi_fine[((intensity.max(1.0).log10() / LOGI_HI) * LOGI_FINE as f32)
                     .clamp(0.0, (LOGI_FINE - 1) as f32) as usize] += 1;
+                proj_mz_im[pbin(pos[0]) + PROJ_BINS * pbin(pos[1])] += 1;
+                proj_mz_rt[pbin(pos[0]) + PROJ_BINS * pbin(pos[2])] += 1;
+                proj_im_rt[pbin(pos[1]) + PROJ_BINS * pbin(pos[2])] += 1;
                 i_lo_seen = i_lo_seen.min(intensity);
                 i_hi_seen = i_hi_seen.max(intensity);
                 if chunk.len() >= CHUNK_POINTS {
@@ -405,6 +425,9 @@ fn run_loader(
             hist_rt[hbin(gp.pos[2])] += 1;
             logi_fine[((gp.intensity.max(1.0).log10() / LOGI_HI) * LOGI_FINE as f32)
                 .clamp(0.0, (LOGI_FINE - 1) as f32) as usize] += 1;
+            proj_mz_im[pbin(gp.pos[0]) + PROJ_BINS * pbin(gp.pos[1])] += 1;
+            proj_mz_rt[pbin(gp.pos[0]) + PROJ_BINS * pbin(gp.pos[2])] += 1;
+            proj_im_rt[pbin(gp.pos[1]) + PROJ_BINS * pbin(gp.pos[2])] += 1;
             i_lo_seen = i_lo_seen.min(gp.intensity);
             i_hi_seen = i_hi_seen.max(gp.intensity);
         }
@@ -462,6 +485,9 @@ fn run_loader(
             intensity: hist_i,
             i_lo,
             i_hi,
+            proj_mz_im,
+            proj_mz_rt,
+            proj_im_rt,
         });
     }
 

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -396,6 +396,18 @@ fn run_loader(
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
         peak_pts.truncate(peak_room);
+        // Fold peaks into the distributions + intensity range too: they are displayed points
+        // and are often the brightest in the run, so excluding them would make the default
+        // intensity filter (which uses i_lo/i_hi) cull the very peaks preservation kept.
+        for gp in &peak_pts {
+            hist_mz[hbin(gp.pos[0])] += 1;
+            hist_im[hbin(gp.pos[1])] += 1;
+            hist_rt[hbin(gp.pos[2])] += 1;
+            logi_fine[((gp.intensity.max(1.0).log10() / LOGI_HI) * LOGI_FINE as f32)
+                .clamp(0.0, (LOGI_FINE - 1) as f32) as usize] += 1;
+            i_lo_seen = i_lo_seen.min(gp.intensity);
+            i_hi_seen = i_hi_seen.max(gp.intensity);
+        }
         for batch in peak_pts.chunks(CHUNK_POINTS) {
             send_cancellable!(LoadMsg::PeakChunk {
                 points: batch.to_vec(),
@@ -533,10 +545,14 @@ fn build_annotations(
                 let (rt_lo, rt_hi) = (bounds.rt.min, bounds.rt.max);
                 for w in windows.iter().step_by(stride) {
                     let fid = grp_frame.get(&w.window_group).copied().unwrap_or(1);
-                    // Widen across the skipped scans so the rect stays a visible window;
-                    // clamp to the largest real scan so the last window can't overshoot.
-                    let scan_hi = (w.scan_num_end + stride as u32 / 2).min(max_scan.max(w.scan_num_end));
-                    let ims = ds.scan_to_inverse_mobility(fid, &vec![w.scan_num_begin, scan_hi]);
+                    // Widen SYMMETRICALLY across the skipped scans so the rect stays a visible
+                    // window AND stays centered on the real window's mobility: widening only the
+                    // high-scan end would shift the box's 1/K0 center toward lower mobility for a
+                    // subsampled MIDIA scheme. stride == 1 (conventional DIA) leaves it exact.
+                    let half = stride as u32 / 2;
+                    let scan_lo = w.scan_num_begin.saturating_sub(half);
+                    let scan_hi = (w.scan_num_end + half).min(max_scan.max(w.scan_num_end));
+                    let ims = ds.scan_to_inverse_mobility(fid, &vec![scan_lo, scan_hi]);
                     let im0 = ims.first().copied().unwrap_or(0.0);
                     let im1 = ims.get(1).copied().unwrap_or(im0);
                     let mz0 = w.isolation_mz - w.isolation_width * 0.5;

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -525,6 +525,68 @@ fn run_loader(
 }
 
 /// Build annotation-overlay line geometry (normalized cube) from the run's DDA/DIA
+/// Number of evenly spaced RT slices each DIA window footprint is drawn at.
+pub const DIA_WINDOW_RT_SLICES: usize = 6;
+
+/// One DIA/MIDIA isolation window's selection footprint in **real units**: an `(m/z × 1/K0)`
+/// rectangle (mobility already converted from scan numbers). Group ids color the interleaved
+/// isolation bands. The web `/windows` endpoint serves these; the web re-normalizes them to its
+/// region bounds (so they align with the cloud and off-region windows clip).
+#[derive(Clone, Copy, Debug)]
+pub struct WindowRect {
+    pub group: u32,
+    pub mz0: f64,
+    pub mz1: f64,
+    pub im0: f64,
+    pub im1: f64,
+}
+
+/// Read the DIA/MIDIA isolation windows and return their real-unit `(m/z × 1/K0)` footprints plus
+/// the max group id (the `group_color` denominator). Subsamples a fine MIDIA diagonal so it stays
+/// legible, widening each kept rect symmetrically across the skipped scans. Returns empty for
+/// non-DIA or unreadable runs.
+pub fn dia_window_rects(ds: &TimsDataset, path: &str) -> (Vec<WindowRect>, u32) {
+    let (windows, info) = match (read_dia_ms_ms_windows(path), read_dia_ms_ms_info(path)) {
+        (Ok(w), Ok(i)) => (w, i),
+        _ => return (Vec::new(), 0),
+    };
+    if windows.is_empty() {
+        return (Vec::new(), 0);
+    }
+    // A representative frame per window group, for scan->mobility conversion.
+    let mut grp_frame: std::collections::HashMap<u32, u32> = Default::default();
+    for di in &info {
+        grp_frame.entry(di.window_group).or_insert(di.frame_id);
+    }
+    // Subsample so a fine MIDIA diagonal (~15k windows) stays legible; a conventional DIA scheme
+    // (tens of windows) keeps every box (stride == 1).
+    const TARGET_WINDOWS: usize = 800;
+    let stride = (windows.len() / TARGET_WINDOWS).max(1);
+    let max_group = windows.iter().map(|w| w.window_group).max().unwrap_or(1).max(1);
+    let max_scan = windows.iter().map(|w| w.scan_num_end).max().unwrap_or(0);
+    let mut out = Vec::new();
+    for w in windows.iter().step_by(stride) {
+        let fid = grp_frame.get(&w.window_group).copied().unwrap_or(1);
+        // Widen SYMMETRICALLY across the skipped scans so the rect stays a visible window AND stays
+        // centered on the real window's mobility (widening only the high-scan end would shift the
+        // 1/K0 center). stride == 1 (conventional DIA) leaves it exact.
+        let half = stride as u32 / 2;
+        let scan_lo = w.scan_num_begin.saturating_sub(half);
+        let scan_hi = (w.scan_num_end + half).min(max_scan.max(w.scan_num_end));
+        let ims = ds.scan_to_inverse_mobility(fid, &vec![scan_lo, scan_hi]);
+        let im0 = ims.first().copied().unwrap_or(0.0);
+        let im1 = ims.get(1).copied().unwrap_or(im0);
+        out.push(WindowRect {
+            group: w.window_group,
+            mz0: w.isolation_mz - w.isolation_width * 0.5,
+            mz1: w.isolation_mz + w.isolation_width * 0.5,
+            im0,
+            im1,
+        });
+    }
+    (out, max_group)
+}
+
 /// metadata. DDA precursors -> small 3D crosses; DIA isolation windows -> wireframe
 /// boxes. Returns line-list vertices (consecutive pairs are segments).
 fn build_annotations(
@@ -568,58 +630,29 @@ fn build_annotations(
             }
         }
         AcquisitionMode::DIA => {
-            if let (Ok(windows), Ok(info)) =
-                (read_dia_ms_ms_windows(path), read_dia_ms_ms_info(path))
-            {
-                // A representative frame per window group, for scan->mobility conversion.
-                let mut grp_frame: std::collections::HashMap<u32, u32> = Default::default();
-                for di in &info {
-                    grp_frame.entry(di.window_group).or_insert(di.frame_id);
-                }
-                // The isolation scheme repeats every cycle. Drawing each window as one
-                // full-RT box piles every window face onto the two RT end-walls (leaving only
-                // thin edges through the middle), which reads as a slab beside the data.
-                // Instead draw the (m/z, mobility) selection footprint at several evenly
-                // spaced RT slices, so the recurring selection sits on the precursor signal
-                // through the whole run.
-                // The fine diagonal has ~950 touching windows per group; drawing every one
-                // fills the band solid and hides the data. Subsample to leave gaps you can
-                // see the cloud through, and span each drawn rect across the skipped scans so
-                // it stays a visible window outline rather than a sliver.
-                const N_SLICES: usize = 6;
-                const TARGET_WINDOWS: usize = 800;
-                // Subsample so a fine MIDIA diagonal (~15k windows) stays legible, but a
-                // conventional DIA scheme (tens of windows) keeps every box (stride == 1).
-                let stride = (windows.len() / TARGET_WINDOWS).max(1);
-                // Color each window by its group, so the interleaved isolation diagonals
-                // that tile the precursor space read as distinct bands.
-                let n_groups = windows.iter().map(|w| w.window_group).max().unwrap_or(1).max(1);
-                n_groups_out = n_groups;
-                let max_scan = windows.iter().map(|w| w.scan_num_end).max().unwrap_or(0);
-                let (rt_lo, rt_hi) = (bounds.rt.min, bounds.rt.max);
-                for w in windows.iter().step_by(stride) {
-                    let fid = grp_frame.get(&w.window_group).copied().unwrap_or(1);
-                    // Widen SYMMETRICALLY across the skipped scans so the rect stays a visible
-                    // window AND stays centered on the real window's mobility: widening only the
-                    // high-scan end would shift the box's 1/K0 center toward lower mobility for a
-                    // subsampled MIDIA scheme. stride == 1 (conventional DIA) leaves it exact.
-                    let half = stride as u32 / 2;
-                    let scan_lo = w.scan_num_begin.saturating_sub(half);
-                    let scan_hi = (w.scan_num_end + half).min(max_scan.max(w.scan_num_end));
-                    let ims = ds.scan_to_inverse_mobility(fid, &vec![scan_lo, scan_hi]);
-                    let im0 = ims.first().copied().unwrap_or(0.0);
-                    let im1 = ims.get(1).copied().unwrap_or(im0);
-                    let mz0 = w.isolation_mz - w.isolation_width * 0.5;
-                    let mz1 = w.isolation_mz + w.isolation_width * 0.5;
-                    let color = crate::render::colormap::group_color(w.window_group, n_groups);
-                    for i in 0..N_SLICES {
-                        let rt =
-                            rt_lo + (rt_hi - rt_lo) * (i as f64 + 0.5) / N_SLICES as f64;
-                        push_rect_mz_im(
-                            &mut lines, &mut groups, bounds, (mz0, mz1), (im0, im1), rt, color,
-                            w.window_group,
-                        );
-                    }
+            // The (m/z × 1/K0) selection footprints in real units, shared with the web overlay's
+            // `/windows` endpoint so the two never drift.
+            let (rects, max_group) = dia_window_rects(ds, path);
+            n_groups_out = max_group;
+            let (rt_lo, rt_hi) = (bounds.rt.min, bounds.rt.max);
+            for r in &rects {
+                let color = crate::render::colormap::group_color(r.group, max_group);
+                // Draw the footprint at several evenly spaced RT slices, so the recurring isolation
+                // scheme sits on the precursor signal through the whole run rather than piling onto
+                // the two RT end-walls.
+                for i in 0..DIA_WINDOW_RT_SLICES {
+                    let rt = rt_lo
+                        + (rt_hi - rt_lo) * (i as f64 + 0.5) / DIA_WINDOW_RT_SLICES as f64;
+                    push_rect_mz_im(
+                        &mut lines,
+                        &mut groups,
+                        bounds,
+                        (r.mz0, r.mz1),
+                        (r.im0, r.im1),
+                        rt,
+                        color,
+                        r.group,
+                    );
                 }
             }
         }

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -91,13 +91,22 @@ impl LoaderHandle {
         bounds: AxisBounds,
         total_estimate: u64,
         budget: usize,
+        intensity_priority: bool,
     ) -> Self {
         let (msg_tx, msg_rx) = bounded::<LoadMsg>(8);
         let (cmd_tx, cmd_rx) = bounded::<LoadCmd>(4);
         let handle = std::thread::Builder::new()
             .name("tims-loader".into())
             .spawn(move || {
-                run_loader(mode, bounds, total_estimate, budget, &msg_tx, &cmd_rx);
+                run_loader(
+                    mode,
+                    bounds,
+                    total_estimate,
+                    budget,
+                    intensity_priority,
+                    &msg_tx,
+                    &cmd_rx,
+                );
             })
             .expect("failed to spawn loader thread");
         LoaderHandle {
@@ -140,7 +149,7 @@ pub fn stride_for(total_estimate: u64, budget: usize) -> usize {
 }
 
 /// Coarse spatial grid for peak preservation (m/z, 1/K0, RT cells).
-const PEAK_DIMS: [u32; 3] = [128, 64, 128];
+const PEAK_DIMS: [u32; 3] = [192, 96, 192];
 /// Placeholder point for the peak-grid HashMap entry API.
 const ZERO_POINT: GpuPoint = GpuPoint {
     pos: [0.0; 3],
@@ -168,13 +177,17 @@ fn run_loader(
     bounds: AxisBounds,
     total_estimate: u64,
     budget: usize,
+    intensity_priority: bool,
     tx: &Sender<LoadMsg>,
     cmd_rx: &Receiver<LoadCmd>,
 ) {
-    // Stratified sampling: spend ~85% of the budget on a systematic density base, and
-    // reserve the rest for per-cell intensity PEAKS so sparse high-intensity features
-    // always survive (pure systematic sampling can statistically miss them).
-    let systematic_budget = ((budget * 85) / 100).max(1);
+    // Stratified sampling: spend part of the budget on a systematic density base (faithful
+    // cloud shape), and reserve the rest for per-cell intensity PEAKS — the brightest point
+    // in each grid cell — so sparse high-intensity features always survive. In intensity-
+    // priority mode almost the whole budget goes to peaks, so the brightest features fill
+    // the buffer and low-intensity points drop first (at the cost of density fidelity).
+    let systematic_pct = if intensity_priority { 8 } else { 65 };
+    let systematic_budget = ((budget * systematic_pct) / 100).max(1);
     let stride = stride_for(total_estimate, systematic_budget);
     let weight = stride as f32;
     let mut systematic_count: u64 = 0;
@@ -640,7 +653,7 @@ mod tests {
         let budget = 50_000usize;
         let demo = DemoSource::new(20, total);
         let handle =
-            LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget);
+            LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget, false);
 
         let mut points = 0usize;
         let mut saw_stats = false;

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -323,6 +323,11 @@ fn run_loader(
     // systematic sampling (count-bounded, RT-unbiased).
     let mut global_i: u64 = 0;
     let stride_u64 = stride as u64;
+    // Countdown replacing `global_i % stride_u64 == 0` in the hot per-point gate (a division over
+    // 100M+ points). Starts at 0 so survivor index 0 is kept, then resets to stride-1 — identical
+    // phase to the modulo (stride==1 -> always 0 -> keep all). `global_i` still advances every
+    // survivor (it tags the peak grid + drives the peak-tail dedup `gi % stride`).
+    let mut keep_in: u64 = 0;
 
     // Per-point handler shared by both sources: cull against the region filter first, then update
     // the peak grid for every SURVIVING point and emit every stride-th into the systematic base.
@@ -349,8 +354,9 @@ fn run_loader(
                 slot.1 = global_i;
                 slot.2 = GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [GpuPoint::NO_CLUSTER, 0] };
             }
-            // Systematic density base.
-            if global_i % stride_u64 == 0 {
+            // Systematic density base (every stride-th survivor, via the countdown above).
+            if keep_in == 0 {
+                keep_in = stride_u64 - 1;
                 chunk.push(GpuPoint { pos, intensity, weight, flags, _pad: [GpuPoint::NO_CLUSTER, 0] });
                 systematic_count += 1;
                 reservoir_push(&mut reservoir, &mut kept_counter, sample_every, intensity);
@@ -368,6 +374,8 @@ fn run_loader(
                 if chunk.len() >= CHUNK_POINTS {
                     flush!();
                 }
+            } else {
+                keep_in -= 1;
             }
             global_i += 1;
         }};
@@ -441,13 +449,17 @@ fn run_loader(
             .filter(|(i, gi, _)| *i >= 0.0 && gi % stride_u64 != 0)
             .map(|(_, _, gp)| gp)
             .collect();
-        // Strongest first.
-        peak_pts.sort_by(|a, b| {
-            b.intensity
-                .partial_cmp(&a.intensity)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        peak_pts.truncate(peak_room);
+        // Keep the strongest `peak_room` peaks. A partial select (O(n)) suffices — order within the
+        // kept set is irrelevant (everything is shuffled downstream). Guard peak_room < len:
+        // select_nth at index == len is out of bounds, and peak_room >= len already keeps all.
+        if peak_room < peak_pts.len() {
+            peak_pts.select_nth_unstable_by(peak_room, |a, b| {
+                b.intensity
+                    .partial_cmp(&a.intensity)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            peak_pts.truncate(peak_room);
+        }
         // Fold peaks into the distributions + intensity range too: they are displayed points
         // and are often the brightest in the run, so excluding them would make the default
         // intensity filter (which uses i_lo/i_hi) cull the very peaks preservation kept.

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -156,7 +156,7 @@ const ZERO_POINT: GpuPoint = GpuPoint {
     intensity: 0.0,
     weight: 1.0,
     flags: 0,
-    _pad: [0, 0],
+    _pad: [GpuPoint::NO_CLUSTER, 0],
 };
 
 /// Map a normalized-cube position to a coarse peak-grid cell index.
@@ -292,11 +292,11 @@ fn run_loader(
             if intensity > slot.0 {
                 slot.0 = intensity;
                 slot.1 = global_i;
-                slot.2 = GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [0, 0] };
+                slot.2 = GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [GpuPoint::NO_CLUSTER, 0] };
             }
             // Systematic density base.
             if global_i % stride_u64 == 0 {
-                chunk.push(GpuPoint { pos, intensity, weight, flags, _pad: [0, 0] });
+                chunk.push(GpuPoint { pos, intensity, weight, flags, _pad: [GpuPoint::NO_CLUSTER, 0] });
                 systematic_count += 1;
                 reservoir_push(&mut reservoir, &mut kept_counter, sample_every, intensity);
                 if chunk.len() >= CHUNK_POINTS {

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -42,6 +42,17 @@ pub enum LoadMsg {
     Progress(f32),
     /// Robust intensity percentiles (p1/p50/p99) for transfer-function defaults.
     Stats { i_min: f32, i_max: f32, i_med: f32 },
+    /// Per-axis distribution histograms (each `HIST_BINS` long) for the levels-style filter
+    /// UI. m/z·1/K0·RT bin linearly over the cube bounds; `intensity` is data-tight log,
+    /// spanning `[i_lo, i_hi]` (the kept sample's min/max intensity).
+    Histograms {
+        mz: Vec<u32>,
+        im: Vec<u32>,
+        rt: Vec<u32>,
+        intensity: Vec<u32>,
+        i_lo: f32,
+        i_hi: f32,
+    },
     /// Annotation overlay geometry: colored line-list vertices (pairs = segments) in the
     /// normalized cube (DDA precursor crosses / DIA isolation-window footprints). `groups`
     /// is a parallel per-vertex window-group id (u32::MAX = ungrouped); `n_groups` is the
@@ -91,22 +102,13 @@ impl LoaderHandle {
         bounds: AxisBounds,
         total_estimate: u64,
         budget: usize,
-        intensity_priority: bool,
     ) -> Self {
         let (msg_tx, msg_rx) = bounded::<LoadMsg>(8);
         let (cmd_tx, cmd_rx) = bounded::<LoadCmd>(4);
         let handle = std::thread::Builder::new()
             .name("tims-loader".into())
             .spawn(move || {
-                run_loader(
-                    mode,
-                    bounds,
-                    total_estimate,
-                    budget,
-                    intensity_priority,
-                    &msg_tx,
-                    &cmd_rx,
-                );
+                run_loader(mode, bounds, total_estimate, budget, &msg_tx, &cmd_rx);
             })
             .expect("failed to spawn loader thread");
         LoaderHandle {
@@ -149,7 +151,7 @@ pub fn stride_for(total_estimate: u64, budget: usize) -> usize {
 }
 
 /// Coarse spatial grid for peak preservation (m/z, 1/K0, RT cells).
-const PEAK_DIMS: [u32; 3] = [192, 96, 192];
+const PEAK_DIMS: [u32; 3] = [128, 64, 128];
 /// Placeholder point for the peak-grid HashMap entry API.
 const ZERO_POINT: GpuPoint = GpuPoint {
     pos: [0.0; 3],
@@ -158,6 +160,19 @@ const ZERO_POINT: GpuPoint = GpuPoint {
     flags: 0,
     _pad: [GpuPoint::NO_CLUSTER, 0],
 };
+
+/// Number of bins in each per-axis distribution histogram (for the levels-style filter UI).
+pub const HIST_BINS: usize = 80;
+/// Fine intermediate bins for the intensity log histogram before rebinning to the data range.
+const LOGI_FINE: usize = 256;
+/// Upper bound of the fixed intensity log range (log10), generous for timsTOF intensities.
+const LOGI_HI: f32 = 8.0;
+
+/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, HIST_BINS)`.
+#[inline]
+fn hbin(n: f32) -> usize {
+    (((n * 0.5 + 0.5).clamp(0.0, 1.0)) * (HIST_BINS as f32 - 1.0)) as usize
+}
 
 /// Map a normalized-cube position to a coarse peak-grid cell index.
 #[inline]
@@ -177,17 +192,13 @@ fn run_loader(
     bounds: AxisBounds,
     total_estimate: u64,
     budget: usize,
-    intensity_priority: bool,
     tx: &Sender<LoadMsg>,
     cmd_rx: &Receiver<LoadCmd>,
 ) {
-    // Stratified sampling: spend part of the budget on a systematic density base (faithful
-    // cloud shape), and reserve the rest for per-cell intensity PEAKS — the brightest point
-    // in each grid cell — so sparse high-intensity features always survive. In intensity-
-    // priority mode almost the whole budget goes to peaks, so the brightest features fill
-    // the buffer and low-intensity points drop first (at the cost of density fidelity).
-    let systematic_pct = if intensity_priority { 8 } else { 65 };
-    let systematic_budget = ((budget * systematic_pct) / 100).max(1);
+    // Stratified sampling: spend ~85% of the budget on a systematic density base, and
+    // reserve the rest for per-cell intensity PEAKS so sparse high-intensity features
+    // always survive (pure systematic sampling can statistically miss them).
+    let systematic_budget = ((budget * 85) / 100).max(1);
     let stride = stride_for(total_estimate, systematic_budget);
     let weight = stride as f32;
     let mut systematic_count: u64 = 0;
@@ -202,6 +213,16 @@ fn run_loader(
     let mut reservoir: Vec<f32> = Vec::with_capacity(RESERVOIR_CAP);
     let mut kept_counter: u64 = 0;
     let sample_every = (budget / RESERVOIR_CAP).max(1) as u64;
+
+    // Distribution histograms (over the kept systematic sample) for the levels-style filter
+    // UI. m/z·1/K0·RT bin over the normalized cube; intensity accumulates into a fine fixed
+    // log range, then rebins to the data's actual range at the end (so it is data-tight).
+    let mut hist_mz = [0u32; HIST_BINS];
+    let mut hist_im = [0u32; HIST_BINS];
+    let mut hist_rt = [0u32; HIST_BINS];
+    let mut logi_fine = [0u32; LOGI_FINE];
+    let mut i_lo_seen = f32::MAX;
+    let mut i_hi_seen = 0.0f32;
 
     let mut chunk: Vec<GpuPoint> = Vec::with_capacity(CHUNK_POINTS);
 
@@ -299,6 +320,14 @@ fn run_loader(
                 chunk.push(GpuPoint { pos, intensity, weight, flags, _pad: [GpuPoint::NO_CLUSTER, 0] });
                 systematic_count += 1;
                 reservoir_push(&mut reservoir, &mut kept_counter, sample_every, intensity);
+                // Distribution histograms over the kept (representative) sample.
+                hist_mz[hbin(pos[0])] += 1;
+                hist_im[hbin(pos[1])] += 1;
+                hist_rt[hbin(pos[2])] += 1;
+                logi_fine[((intensity.max(1.0).log10() / LOGI_HI) * LOGI_FINE as f32)
+                    .clamp(0.0, (LOGI_FINE - 1) as f32) as usize] += 1;
+                i_lo_seen = i_lo_seen.min(intensity);
+                i_hi_seen = i_hi_seen.max(intensity);
                 if chunk.len() >= CHUNK_POINTS {
                     flush!();
                 }
@@ -394,6 +423,34 @@ fn run_loader(
         let i_med = p(0.50).max(i_min);
         let i_max = p(0.99).max(i_med * 1.0001);
         send_cancellable!(LoadMsg::Stats { i_min, i_max, i_med });
+    }
+
+    // Rebin the fine fixed-range intensity histogram into the data's actual log range so the
+    // levels strip is data-tight, and ship all four distributions to the UI.
+    if i_hi_seen > 0.0 {
+        let i_lo = i_lo_seen.max(1.0);
+        let i_hi = i_hi_seen.max(i_lo * 1.0001);
+        let (llo, lhi) = (i_lo.log10(), i_hi.log10());
+        let span = (lhi - llo).max(1e-6);
+        let mut hist_i = vec![0u32; HIST_BINS];
+        for (src, &c) in logi_fine.iter().enumerate() {
+            if c == 0 {
+                continue;
+            }
+            let src_log = ((src as f32 + 0.5) / LOGI_FINE as f32) * LOGI_HI;
+            let t = (((src_log - llo) / span) * HIST_BINS as f32) as i32;
+            if t >= 0 && (t as usize) < HIST_BINS {
+                hist_i[t as usize] += c;
+            }
+        }
+        send_cancellable!(LoadMsg::Histograms {
+            mz: hist_mz.to_vec(),
+            im: hist_im.to_vec(),
+            rt: hist_rt.to_vec(),
+            intensity: hist_i,
+            i_lo,
+            i_hi,
+        });
     }
 
     send_cancellable!(LoadMsg::Done {
@@ -653,7 +710,7 @@ mod tests {
         let budget = 50_000usize;
         let demo = DemoSource::new(20, total);
         let handle =
-            LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget, false);
+            LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget);
 
         let mut points = 0usize;
         let mut saw_stats = false;
@@ -678,7 +735,9 @@ mod tests {
                     points += p.len();
                 }
                 Ok(LoadMsg::Error(e)) => panic!("loader error: {e}"),
-                Ok(LoadMsg::Progress(_)) | Ok(LoadMsg::Annotations { .. }) => {}
+                Ok(LoadMsg::Progress(_))
+                | Ok(LoadMsg::Annotations { .. })
+                | Ok(LoadMsg::Histograms { .. }) => {}
                 Err(e) => panic!("loader timed out / disconnected: {e}"),
             }
         }

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -43,8 +43,10 @@ pub enum LoadMsg {
     /// Robust intensity range (p1/p99) for transfer-function defaults.
     Stats { i_min: f32, i_max: f32 },
     /// Annotation overlay geometry: colored line-list vertices (pairs = segments) in the
-    /// normalized cube (DDA precursor crosses / DIA isolation-window footprints).
-    Annotations { lines: Vec<LineVertex> },
+    /// normalized cube (DDA precursor crosses / DIA isolation-window footprints). `groups`
+    /// is a parallel per-vertex window-group id (u32::MAX = ungrouped); `n_groups` is the
+    /// number of DIA/MIDIA window groups, for the per-group visibility UI.
+    Annotations { lines: Vec<LineVertex>, groups: Vec<u32>, n_groups: u32 },
     /// All frames for `generation` have been streamed.
     Done { generation: u64 },
     /// Fatal error; loading stopped.
@@ -342,9 +344,9 @@ fn run_loader(
     // Annotation overlay (real data only — needs the dataset's scan->mobility converter
     // and the DDA/DIA metadata tables).
     if let (LoaderMode::Real { path, .. }, Some(ds)) = (&mode, &dataset) {
-        let lines = build_annotations(ds, path, &bounds);
+        let (lines, groups, n_groups) = build_annotations(ds, path, &bounds);
         if !lines.is_empty() {
-            send_cancellable!(LoadMsg::Annotations { lines });
+            send_cancellable!(LoadMsg::Annotations { lines, groups, n_groups });
         }
     }
 
@@ -368,11 +370,15 @@ fn run_loader(
 /// Build annotation-overlay line geometry (normalized cube) from the run's DDA/DIA
 /// metadata. DDA precursors -> small 3D crosses; DIA isolation windows -> wireframe
 /// boxes. Returns line-list vertices (consecutive pairs are segments).
-fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<LineVertex> {
+fn build_annotations(
+    ds: &TimsDataset,
+    path: &str,
+    bounds: &AxisBounds,
+) -> (Vec<LineVertex>, Vec<u32>, u32) {
     // frame_id -> retention time (ids are contiguous 1..=N, validated at load).
     let meta = match read_meta_data_sql(path) {
         Ok(m) => m,
-        Err(_) => return Vec::new(),
+        Err(_) => return (Vec::new(), Vec::new(), 0),
     };
     let max_id = meta.iter().map(|m| m.id).max().unwrap_or(0).max(0) as usize;
     let mut rt_by = vec![0f64; max_id + 1];
@@ -383,7 +389,11 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<L
     }
     let rt_of = |fid: u32| rt_by.get(fid as usize).copied().unwrap_or(0.0);
 
+    // `groups` is a per-vertex window-group id, parallel to `lines`, for CPU-side group
+    // toggling. u32::MAX means "ungrouped, always shown" (DDA precursor crosses).
     let mut lines: Vec<LineVertex> = Vec::new();
+    let mut groups: Vec<u32> = Vec::new();
+    let mut n_groups_out: u32 = 0;
     match ds.get_acquisition_mode() {
         AcquisitionMode::DDA | AcquisitionMode::PRECURSOR => {
             if let Ok(precursors) = read_dda_precursor_meta(path) {
@@ -396,7 +406,7 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<L
                         .copied()
                         .unwrap_or(0.0);
                     let pos = bounds.normalize(p.precursor_mz_highest_intensity, im, rt_of(fid));
-                    push_cross(&mut lines, pos, 0.012, [0.1, 0.95, 0.95]);
+                    push_cross(&mut lines, &mut groups, pos, 0.012, [0.1, 0.95, 0.95], u32::MAX);
                 }
             }
         }
@@ -420,14 +430,21 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<L
                 // see the cloud through, and span each drawn rect across the skipped scans so
                 // it stays a visible window outline rather than a sliver.
                 const N_SLICES: usize = 6;
-                const WIN_STRIDE: usize = 16;
+                const TARGET_WINDOWS: usize = 800;
+                // Subsample so a fine MIDIA diagonal (~15k windows) stays legible, but a
+                // conventional DIA scheme (tens of windows) keeps every box (stride == 1).
+                let stride = (windows.len() / TARGET_WINDOWS).max(1);
                 // Color each window by its group, so the interleaved isolation diagonals
                 // that tile the precursor space read as distinct bands.
                 let n_groups = windows.iter().map(|w| w.window_group).max().unwrap_or(1).max(1);
+                n_groups_out = n_groups;
+                let max_scan = windows.iter().map(|w| w.scan_num_end).max().unwrap_or(0);
                 let (rt_lo, rt_hi) = (bounds.rt.min, bounds.rt.max);
-                for w in windows.iter().step_by(WIN_STRIDE) {
+                for w in windows.iter().step_by(stride) {
                     let fid = grp_frame.get(&w.window_group).copied().unwrap_or(1);
-                    let scan_hi = w.scan_num_end + WIN_STRIDE as u32 / 2;
+                    // Widen across the skipped scans so the rect stays a visible window;
+                    // clamp to the largest real scan so the last window can't overshoot.
+                    let scan_hi = (w.scan_num_end + stride as u32 / 2).min(max_scan.max(w.scan_num_end));
                     let ims = ds.scan_to_inverse_mobility(fid, &vec![w.scan_num_begin, scan_hi]);
                     let im0 = ims.first().copied().unwrap_or(0.0);
                     let im1 = ims.get(1).copied().unwrap_or(im0);
@@ -437,29 +454,43 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<L
                     for i in 0..N_SLICES {
                         let rt =
                             rt_lo + (rt_hi - rt_lo) * (i as f64 + 0.5) / N_SLICES as f64;
-                        push_rect_mz_im(&mut lines, bounds, (mz0, mz1), (im0, im1), rt, color);
+                        push_rect_mz_im(
+                            &mut lines, &mut groups, bounds, (mz0, mz1), (im0, im1), rt, color,
+                            w.window_group,
+                        );
                     }
                 }
             }
         }
         AcquisitionMode::Unknown => {}
     }
-    lines
+    (lines, groups, n_groups_out)
 }
 
-/// Append a 3-segment axis-aligned cross centered at `c` (half-length `h`), in `color`.
-fn push_cross(lines: &mut Vec<LineVertex>, c: [f32; 3], h: f32, color: [f32; 3]) {
-    let v = |p: [f32; 3]| LineVertex::new(p, color);
-    lines.push(v([c[0] - h, c[1], c[2]]));
-    lines.push(v([c[0] + h, c[1], c[2]]));
-    lines.push(v([c[0], c[1] - h, c[2]]));
-    lines.push(v([c[0], c[1] + h, c[2]]));
-    lines.push(v([c[0], c[1], c[2] - h]));
-    lines.push(v([c[0], c[1], c[2] + h]));
+/// Append a 3-segment axis-aligned cross centered at `c` (half-length `h`), in `color`,
+/// tagging each vertex with `group`.
+fn push_cross(
+    lines: &mut Vec<LineVertex>,
+    groups: &mut Vec<u32>,
+    c: [f32; 3],
+    h: f32,
+    color: [f32; 3],
+    group: u32,
+) {
+    let mut v = |p: [f32; 3]| {
+        lines.push(LineVertex::new(p, color));
+        groups.push(group);
+    };
+    v([c[0] - h, c[1], c[2]]);
+    v([c[0] + h, c[1], c[2]]);
+    v([c[0], c[1] - h, c[2]]);
+    v([c[0], c[1] + h, c[2]]);
+    v([c[0], c[1], c[2] - h]);
+    v([c[0], c[1], c[2] + h]);
 }
 
 /// Distinct color per window group, by evenly spacing hue around the wheel.
-fn group_color(group: u32, n_groups: u32) -> [f32; 3] {
+pub fn group_color(group: u32, n_groups: u32) -> [f32; 3] {
     let h = (group.saturating_sub(1) as f32) / (n_groups.max(1) as f32);
     hsv_to_rgb(h, 0.7, 1.0)
 }
@@ -485,11 +516,13 @@ fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
 /// retention time — one isolation window's footprint, drawn at a given RT slice.
 fn push_rect_mz_im(
     lines: &mut Vec<LineVertex>,
+    groups: &mut Vec<u32>,
     bounds: &AxisBounds,
     mz: (f64, f64),
     im: (f64, f64),
     rt: f64,
     color: [f32; 3],
+    group: u32,
 ) {
     let corner = |a: f64, b: f64| bounds.normalize(a, b, rt);
     let c = [
@@ -502,6 +535,8 @@ fn push_rect_mz_im(
     for (a, b) in EDGES {
         lines.push(LineVertex::new(c[a], color));
         lines.push(LineVertex::new(c[b], color));
+        groups.push(group);
+        groups.push(group);
     }
 }
 

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -318,8 +318,8 @@ fn run_loader(
     let mut global_i: u64 = 0;
     let stride_u64 = stride as u64;
 
-    // Per-point handler shared by both sources: update the peak grid for EVERY point,
-    // and emit every stride-th into the systematic density base.
+    // Per-point handler shared by both sources: cull against the region filter first, then update
+    // the peak grid for every SURVIVING point and emit every stride-th into the systematic base.
     macro_rules! handle_point {
         ($mz:expr, $im:expr, $rt:expr, $it:expr, $ms2:expr) => {{
             let intensity = $it;
@@ -832,12 +832,19 @@ mod tests {
         let (sys_full, _) =
             drain(LoaderHandle::spawn(LoaderMode::Demo(demo()), demo_bounds(), total, budget, region));
 
-        // 85% of the budget is the systematic base; region estimate should land near it.
-        assert!(
-            sys_region as f64 >= 0.6 * budget as f64,
-            "region estimate underfilled the budget: sys={sys_region} budget={budget}"
+        // Exact: the systematic base keeps every `stride`-th SURVIVOR, where the stride is sized to
+        // the survivor count. This equals ceil(survivors/stride) only if `global_i` advances solely
+        // for survivors — it would fail if culled points still advanced the index.
+        let systematic_budget = (budget * 85 / 100).max(1);
+        let stride = stride_for(survivors as u64, systematic_budget) as u64;
+        let expected = (survivors as u64).div_ceil(stride) as usize;
+        assert_eq!(
+            sys_region, expected,
+            "region systematic count must be exactly ceil(survivors/stride): \
+             survivors={survivors} stride={stride}"
         );
-        // Full-run estimate spends only ~(survivors/total) of it — far less.
+        // The full-run estimate sizes the stride to ~total, spending only ~(survivors/total) of the
+        // budget — far less than the region estimate. This is the blocker-1 regression guard.
         assert!(
             (sys_full as f64) < 0.5 * sys_region as f64,
             "full-run estimate did not under-spend (blocker-1 unfixed): full={sys_full} region={sys_region}"

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -41,7 +41,7 @@ pub enum LoadMsg {
     /// Fractional load progress in `[0, 1]`.
     Progress(f32),
     /// Robust intensity percentiles (p1/p50/p99) for transfer-function defaults.
-    Stats { i_min: f32, i_max: f32, i_med: f32 },
+    Stats { i_p1: f32, i_p99: f32, i_p50: f32 },
     /// Per-axis distribution histograms (each `HIST_BINS` long) for the levels-style filter
     /// UI. m/z·1/K0·RT bin linearly over the cube bounds; `intensity` is data-tight log,
     /// spanning `[i_lo, i_hi]` (the kept sample's min/max intensity).
@@ -482,10 +482,10 @@ fn run_loader(
             let i = ((reservoir.len() as f32 - 1.0) * q).round() as usize;
             reservoir[i.min(reservoir.len() - 1)]
         };
-        let i_min = p(0.01).max(1.0);
-        let i_med = p(0.50).max(i_min);
-        let i_max = p(0.99).max(i_med * 1.0001);
-        send_cancellable!(LoadMsg::Stats { i_min, i_max, i_med });
+        let i_p1 = p(0.01).max(1.0);
+        let i_p50 = p(0.50).max(i_p1);
+        let i_p99 = p(0.99).max(i_p50 * 1.0001);
+        send_cancellable!(LoadMsg::Stats { i_p1, i_p99, i_p50 });
     }
 
     // Rebin the fine fixed-range intensity histogram into the data's actual log range so the
@@ -804,9 +804,9 @@ mod tests {
                     }
                     points += p.len();
                 }
-                Ok(LoadMsg::Stats { i_min, i_max, i_med }) => {
-                    assert!(i_min > 0.0 && i_max > i_min);
-                    assert!(i_med >= i_min && i_med <= i_max);
+                Ok(LoadMsg::Stats { i_p1, i_p99, i_p50 }) => {
+                    assert!(i_p1 > 0.0 && i_p99 > i_p1);
+                    assert!(i_p50 >= i_p1 && i_p50 <= i_p99);
                     saw_stats = true;
                 }
                 // The only non-panic exit: reaching past the loop proves Done arrived.

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -75,22 +75,20 @@ pub enum LoadCmd {
     Cancel,
 }
 
-/// Optional real-unit m/z + 1/K0 window applied per-point during a region refinement load
-/// (frame selection already handles the RT window). Points outside are skipped at the source.
+/// Optional real-unit m/z + 1/K0 + intensity cull applied per-point during a region refinement
+/// load (frame selection already handles the RT window). Points outside are skipped at the source,
+/// so the budget concentrates on the focused region (the 4D lens — see FOCUS_LENS_PLAN.md).
 #[derive(Clone, Copy)]
 pub struct RegionFilter {
     pub mz: (f64, f64),
     pub im: (f64, f64),
+    /// Per-point intensity floor (real counts); points below are dropped at the source.
+    pub intensity_min: f32,
 }
 
 /// What to stream.
 pub enum LoaderMode {
-    Real {
-        path: String,
-        frame_ids: Vec<u32>,
-        /// Per-point m/z·1/K0 cull for region refinement (`None` for the full run).
-        filter: Option<RegionFilter>,
-    },
+    Real { path: String, frame_ids: Vec<u32> },
     Demo(DemoSource),
 }
 
@@ -107,13 +105,14 @@ impl LoaderHandle {
         bounds: AxisBounds,
         total_estimate: u64,
         budget: usize,
+        filter: Option<RegionFilter>,
     ) -> Self {
         let (msg_tx, msg_rx) = bounded::<LoadMsg>(8);
         let (cmd_tx, cmd_rx) = bounded::<LoadCmd>(4);
         let handle = std::thread::Builder::new()
             .name("tims-loader".into())
             .spawn(move || {
-                run_loader(mode, bounds, total_estimate, budget, &msg_tx, &cmd_rx);
+                run_loader(mode, bounds, total_estimate, budget, filter, &msg_tx, &cmd_rx);
             })
             .expect("failed to spawn loader thread");
         LoaderHandle {
@@ -205,6 +204,7 @@ fn run_loader(
     bounds: AxisBounds,
     total_estimate: u64,
     budget: usize,
+    filter: Option<RegionFilter>,
     tx: &Sender<LoadMsg>,
     cmd_rx: &Receiver<LoadCmd>,
 ) {
@@ -323,6 +323,17 @@ fn run_loader(
     macro_rules! handle_point {
         ($mz:expr, $im:expr, $rt:expr, $it:expr, $ms2:expr) => {{
             let intensity = $it;
+            // Region cull (the 4D lens): drop points outside the m/z·1/K0·intensity window at the
+            // source so the budget concentrates on the focused region. RT is handled by frame
+            // selection. `global_i` is not advanced for culled points, so the systematic stride
+            // counts only survivors.
+            if let Some(f) = &filter {
+                if $mz < f.mz.0 || $mz > f.mz.1 || $im < f.im.0 || $im > f.im.1
+                    || intensity < f.intensity_min
+                {
+                    continue;
+                }
+            }
             let pos = bounds.normalize($mz, $im, $rt);
             let flags = if $ms2 { GpuPoint::MS2_FLAG } else { 0 };
             // Peak: keep the highest-intensity point per coarse cell.
@@ -357,7 +368,7 @@ fn run_loader(
     }
 
     match &mode {
-        LoaderMode::Real { frame_ids, filter, .. } => {
+        LoaderMode::Real { frame_ids, .. } => {
             use rayon::prelude::*;
             let ds = dataset.as_ref().unwrap();
             // Decode frames in parallel batches (the heavy, CPU-bound part — every core helps),
@@ -383,13 +394,6 @@ fn run_loader(
                     // Validate parallel arrays — never zip past the shortest.
                     let n = mz.len().min(im.len()).min(it.len());
                     for j in 0..n {
-                        // Region refinement: drop points outside the m/z·1/K0 window at the
-                        // source so the budget is spent only on the focused region.
-                        if let Some(f) = filter {
-                            if mz[j] < f.mz.0 || mz[j] > f.mz.1 || im[j] < f.im.0 || im[j] > f.im.1 {
-                                continue;
-                            }
-                        }
                         handle_point!(mz[j], im[j], rt, it[j] as f32, is_ms2);
                     }
                 }
@@ -751,7 +755,7 @@ mod tests {
         let budget = 50_000usize;
         let demo = DemoSource::new(20, total);
         let handle =
-            LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget);
+            LoaderHandle::spawn(LoaderMode::Demo(demo), demo_bounds(), total, budget, None);
 
         let mut points = 0usize;
         let mut saw_stats = false;
@@ -786,5 +790,57 @@ mod tests {
         assert!(points > 0, "loader produced no points");
         // ~budget points (stride=2 over 100k); allow generous slack.
         assert!(points <= 70_000, "downsample exceeded budget: {points}");
+    }
+
+    /// Drain a loader run, returning (systematic base count, peak count).
+    fn drain(handle: LoaderHandle) -> (usize, usize) {
+        let (mut sys, mut pk) = (0usize, 0usize);
+        loop {
+            match handle.rx.recv_timeout(Duration::from_secs(30)) {
+                Ok(LoadMsg::Chunk { points, .. }) => sys += points.len(),
+                Ok(LoadMsg::PeakChunk { points }) => pk += points.len(),
+                Ok(LoadMsg::Done { .. }) => break,
+                Ok(LoadMsg::Error(e)) => panic!("loader error: {e}"),
+                Ok(_) => {}
+                Err(e) => panic!("loader timed out / disconnected: {e}"),
+            }
+        }
+        (sys, pk)
+    }
+
+    /// FOCUS_LENS_PLAN.md blocker-1 proof: a region load must spend its budget on the *region*,
+    /// not stay over-strided on the full-run estimate. Drives the systematic-base count.
+    #[test]
+    fn region_estimate_concentrates_budget() {
+        let total = 200_000u64;
+        let demo = || DemoSource::new(30, total);
+        // m/z sub-range; im wide open so only m/z culls (isolates a clean strict subset).
+        let region = Some(RegionFilter { mz: (100.0, 500.0), im: (-10.0, 10.0), intensity_min: 0.0 });
+
+        // True survivors in the region (stride 1: budget exceeds everything).
+        let (survivors, _) =
+            drain(LoaderHandle::spawn(LoaderMode::Demo(demo()), demo_bounds(), total, total as usize * 2, region));
+        assert!(survivors > 1000, "region too small to test: {survivors}");
+        assert!((survivors as u64) < total, "region should be a strict subset of the run");
+
+        let budget = (survivors / 2).max(2000); // below survivors so sampling is actually active
+
+        // Region-relative estimate (= survivors): the systematic base should ~fill the budget.
+        let (sys_region, _) =
+            drain(LoaderHandle::spawn(LoaderMode::Demo(demo()), demo_bounds(), survivors as u64, budget, region));
+        // Full-run estimate (the bug): stride stays coarse -> budget badly under-spent.
+        let (sys_full, _) =
+            drain(LoaderHandle::spawn(LoaderMode::Demo(demo()), demo_bounds(), total, budget, region));
+
+        // 85% of the budget is the systematic base; region estimate should land near it.
+        assert!(
+            sys_region as f64 >= 0.6 * budget as f64,
+            "region estimate underfilled the budget: sys={sys_region} budget={budget}"
+        );
+        // Full-run estimate spends only ~(survivors/total) of it — far less.
+        assert!(
+            (sys_full as f64) < 0.5 * sys_region as f64,
+            "full-run estimate did not under-spend (blocker-1 unfixed): full={sys_full} region={sys_region}"
+        );
     }
 }

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -211,7 +211,7 @@ fn run_loader(
     // Stratified sampling: spend ~85% of the budget on a systematic density base, and
     // reserve the rest for per-cell intensity PEAKS so sparse high-intensity features
     // always survive (pure systematic sampling can statistically miss them).
-    let systematic_budget = ((budget * 85) / 100).max(1);
+    let systematic_budget = (budget.saturating_mul(85) / 100).max(1);
     let stride = stride_for(total_estimate, systematic_budget);
     let weight = stride as f32;
     let mut systematic_count: u64 = 0;

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -172,18 +172,20 @@ const LOGI_FINE: usize = 256;
 /// Upper bound of the fixed intensity log range (log10), generous for timsTOF intensities.
 const LOGI_HI: f32 = 8.0;
 
-/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, HIST_BINS)`.
+/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, HIST_BINS)`. Equal-width cells: scale by
+/// the bin count and clamp, so every bin covers `1/N` of the range (vs `*(N-1)`, which leaves the
+/// last bin degenerate — only exactly `1.0` — and misaligns the strips/maps from UI fractions).
 #[inline]
 fn hbin(n: f32) -> usize {
-    (((n * 0.5 + 0.5).clamp(0.0, 1.0)) * (HIST_BINS as f32 - 1.0)) as usize
+    ((((n * 0.5 + 0.5).clamp(0.0, 1.0)) * HIST_BINS as f32) as usize).min(HIST_BINS - 1)
 }
 
 /// Side length of each 2D projection minimap (m/z·1/K0·RT plane heatmaps).
 pub const PROJ_BINS: usize = 96;
-/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, PROJ_BINS)`.
+/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, PROJ_BINS)` (equal-width cells).
 #[inline]
 fn pbin(n: f32) -> usize {
-    (((n * 0.5 + 0.5).clamp(0.0, 1.0)) * (PROJ_BINS as f32 - 1.0)) as usize
+    ((((n * 0.5 + 0.5).clamp(0.0, 1.0)) * PROJ_BINS as f32) as usize).min(PROJ_BINS - 1)
 }
 
 /// Map a normalized-cube position to a coarse peak-grid cell index.

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -40,8 +40,8 @@ pub enum LoadMsg {
     PeakChunk { points: Vec<GpuPoint> },
     /// Fractional load progress in `[0, 1]`.
     Progress(f32),
-    /// Robust intensity range (p1/p99) for transfer-function defaults.
-    Stats { i_min: f32, i_max: f32 },
+    /// Robust intensity percentiles (p1/p50/p99) for transfer-function defaults.
+    Stats { i_min: f32, i_max: f32, i_med: f32 },
     /// Annotation overlay geometry: colored line-list vertices (pairs = segments) in the
     /// normalized cube (DDA precursor crosses / DIA isolation-window footprints). `groups`
     /// is a parallel per-vertex window-group id (u32::MAX = ungrouped); `n_groups` is the
@@ -358,8 +358,9 @@ fn run_loader(
             reservoir[i.min(reservoir.len() - 1)]
         };
         let i_min = p(0.01).max(1.0);
-        let i_max = p(0.99).max(i_min * 1.0001);
-        send_cancellable!(LoadMsg::Stats { i_min, i_max });
+        let i_med = p(0.50).max(i_min);
+        let i_max = p(0.99).max(i_med * 1.0001);
+        send_cancellable!(LoadMsg::Stats { i_min, i_max, i_med });
     }
 
     send_cancellable!(LoadMsg::Done {
@@ -633,8 +634,9 @@ mod tests {
                     }
                     points += p.len();
                 }
-                Ok(LoadMsg::Stats { i_min, i_max }) => {
+                Ok(LoadMsg::Stats { i_min, i_max, i_med }) => {
                     assert!(i_min > 0.0 && i_max > i_min);
+                    assert!(i_med >= i_min && i_med <= i_max);
                     saw_stats = true;
                 }
                 // The only non-panic exit: reaching past the loop proves Done arrived.

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -172,12 +172,18 @@ const LOGI_FINE: usize = 256;
 /// Upper bound of the fixed intensity log range (log10), generous for timsTOF intensities.
 const LOGI_HI: f32 = 8.0;
 
-/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, HIST_BINS)`. Equal-width cells: scale by
-/// the bin count and clamp, so every bin covers `1/N` of the range (vs `*(N-1)`, which leaves the
-/// last bin degenerate — only exactly `1.0` — and misaligns the strips/maps from UI fractions).
+/// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, bins)`. Equal-width cells: scale by the
+/// bin count and clamp, so every bin covers `1/N` of the range (vs `*(N-1)`, which leaves the last
+/// bin degenerate — only exactly `1.0` — and misaligns the strips/maps from UI fractions). The one
+/// place this cube→bin-index convention lives; shared by hbin/pbin/peak_cell.
+#[inline]
+fn bin(n: f32, bins: usize) -> usize {
+    (((n * 0.5 + 0.5).clamp(0.0, 1.0) * bins as f32) as usize).min(bins.saturating_sub(1))
+}
+
 #[inline]
 fn hbin(n: f32) -> usize {
-    ((((n * 0.5 + 0.5).clamp(0.0, 1.0)) * HIST_BINS as f32) as usize).min(HIST_BINS - 1)
+    bin(n, HIST_BINS)
 }
 
 /// Side length of each 2D projection minimap (m/z·1/K0·RT plane heatmaps).
@@ -185,15 +191,13 @@ pub const PROJ_BINS: usize = 96;
 /// Bin a normalized-cube coordinate in `[-1, 1]` into `[0, PROJ_BINS)` (equal-width cells).
 #[inline]
 fn pbin(n: f32) -> usize {
-    ((((n * 0.5 + 0.5).clamp(0.0, 1.0)) * PROJ_BINS as f32) as usize).min(PROJ_BINS - 1)
+    bin(n, PROJ_BINS)
 }
 
 /// Map a normalized-cube position to a coarse peak-grid cell index.
 #[inline]
 fn peak_cell(pos: [f32; 3]) -> u32 {
-    let axis = |n: f32, dim: u32| -> u32 {
-        (((n * 0.5 + 0.5).clamp(0.0, 1.0) * dim as f32) as u32).min(dim - 1)
-    };
+    let axis = |n: f32, dim: u32| -> u32 { bin(n, dim as usize) as u32 };
     let x = axis(pos[0], PEAK_DIMS[0]);
     let y = axis(pos[1], PEAK_DIMS[1]);
     let z = axis(pos[2], PEAK_DIMS[2]);

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -528,22 +528,9 @@ fn run_loader(
     });
 }
 
-/// Build annotation-overlay line geometry (normalized cube) from the run's DDA/DIA
-/// Number of evenly spaced RT slices each DIA window footprint is drawn at.
-pub const DIA_WINDOW_RT_SLICES: usize = 6;
-
-/// One DIA/MIDIA isolation window's selection footprint in **real units**: an `(m/z × 1/K0)`
-/// rectangle (mobility already converted from scan numbers). Group ids color the interleaved
-/// isolation bands. The web `/windows` endpoint serves these; the web re-normalizes them to its
-/// region bounds (so they align with the cloud and off-region windows clip).
-#[derive(Clone, Copy, Debug)]
-pub struct WindowRect {
-    pub group: u32,
-    pub mz0: f64,
-    pub mz1: f64,
-    pub im0: f64,
-    pub im1: f64,
-}
+// DIA_WINDOW_RT_SLICES and WindowRect now live in `crate::data::point` (a both-targets module) so
+// the native loader and the wasm overlay share one definition; re-exported here for existing users.
+pub use crate::data::point::{WindowRect, DIA_WINDOW_RT_SLICES};
 
 /// Read the DIA/MIDIA isolation windows and return their real-unit `(m/z × 1/K0)` footprints plus
 /// the max group id (the `group_color` denominator). Subsamples a fine MIDIA diagonal so it stays

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -59,9 +59,22 @@ pub enum LoadCmd {
     Cancel,
 }
 
+/// Optional real-unit m/z + 1/K0 window applied per-point during a region refinement load
+/// (frame selection already handles the RT window). Points outside are skipped at the source.
+#[derive(Clone, Copy)]
+pub struct RegionFilter {
+    pub mz: (f64, f64),
+    pub im: (f64, f64),
+}
+
 /// What to stream.
 pub enum LoaderMode {
-    Real { path: String, frame_ids: Vec<u32> },
+    Real {
+        path: String,
+        frame_ids: Vec<u32>,
+        /// Per-point m/z·1/K0 cull for region refinement (`None` for the full run).
+        filter: Option<RegionFilter>,
+    },
     Demo(DemoSource),
 }
 
@@ -286,7 +299,7 @@ fn run_loader(
             return;
         }
         match &mode {
-            LoaderMode::Real { frame_ids, .. } => {
+            LoaderMode::Real { frame_ids, filter, .. } => {
                 let ds = dataset.as_ref().unwrap();
                 let frame = ds.get_frame(frame_ids[idx]);
                 let rt = frame.ims_frame.retention_time;
@@ -297,6 +310,13 @@ fn run_loader(
                 // Validate parallel arrays — never zip past the shortest.
                 let n = mz.len().min(im.len()).min(it.len());
                 for j in 0..n {
+                    // Region refinement: drop points outside the m/z·1/K0 window at the
+                    // source so the budget is spent only on the focused region.
+                    if let Some(f) = filter {
+                        if mz[j] < f.mz.0 || mz[j] > f.mz.1 || im[j] < f.im.0 || im[j] > f.im.1 {
+                            continue;
+                        }
+                    }
                     handle_point!(mz[j], im[j], rt, it[j] as f32, is_ms2);
                 }
             }

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -24,6 +24,7 @@ use rustdf::data::meta::{
 
 use super::demo::DemoSource;
 use super::point::{AxisBounds, GpuPoint};
+use crate::render::annotation::LineVertex;
 
 /// Messages from the loader thread to the render thread.
 ///
@@ -41,9 +42,9 @@ pub enum LoadMsg {
     Progress(f32),
     /// Robust intensity range (p1/p99) for transfer-function defaults.
     Stats { i_min: f32, i_max: f32 },
-    /// Annotation overlay geometry: line-list vertices (pairs = segments) in the
-    /// normalized cube (DDA precursor crosses / DIA isolation-window boxes).
-    Annotations { lines: Vec<[f32; 3]> },
+    /// Annotation overlay geometry: colored line-list vertices (pairs = segments) in the
+    /// normalized cube (DDA precursor crosses / DIA isolation-window footprints).
+    Annotations { lines: Vec<LineVertex> },
     /// All frames for `generation` have been streamed.
     Done { generation: u64 },
     /// Fatal error; loading stopped.
@@ -367,7 +368,7 @@ fn run_loader(
 /// Build annotation-overlay line geometry (normalized cube) from the run's DDA/DIA
 /// metadata. DDA precursors -> small 3D crosses; DIA isolation windows -> wireframe
 /// boxes. Returns line-list vertices (consecutive pairs are segments).
-fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<[f32; 3]> {
+fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<LineVertex> {
     // frame_id -> retention time (ids are contiguous 1..=N, validated at load).
     let meta = match read_meta_data_sql(path) {
         Ok(m) => m,
@@ -382,7 +383,7 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<[
     }
     let rt_of = |fid: u32| rt_by.get(fid as usize).copied().unwrap_or(0.0);
 
-    let mut lines: Vec<[f32; 3]> = Vec::new();
+    let mut lines: Vec<LineVertex> = Vec::new();
     match ds.get_acquisition_mode() {
         AcquisitionMode::DDA | AcquisitionMode::PRECURSOR => {
             if let Ok(precursors) = read_dda_precursor_meta(path) {
@@ -395,7 +396,7 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<[
                         .copied()
                         .unwrap_or(0.0);
                     let pos = bounds.normalize(p.precursor_mz_highest_intensity, im, rt_of(fid));
-                    push_cross(&mut lines, pos, 0.012);
+                    push_cross(&mut lines, pos, 0.012, [0.1, 0.95, 0.95]);
                 }
             }
         }
@@ -403,27 +404,41 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<[
             if let (Ok(windows), Ok(info)) =
                 (read_dia_ms_ms_windows(path), read_dia_ms_ms_info(path))
             {
-                // Per window group: RT span and a representative frame for scan->mobility.
-                let mut grp_rt: std::collections::HashMap<u32, (f64, f64)> = Default::default();
+                // A representative frame per window group, for scan->mobility conversion.
                 let mut grp_frame: std::collections::HashMap<u32, u32> = Default::default();
                 for di in &info {
-                    let rt = rt_of(di.frame_id);
-                    let e = grp_rt
-                        .entry(di.window_group)
-                        .or_insert((f64::INFINITY, f64::NEG_INFINITY));
-                    e.0 = e.0.min(rt);
-                    e.1 = e.1.max(rt);
                     grp_frame.entry(di.window_group).or_insert(di.frame_id);
                 }
-                for w in &windows {
+                // The isolation scheme repeats every cycle. Drawing each window as one
+                // full-RT box piles every window face onto the two RT end-walls (leaving only
+                // thin edges through the middle), which reads as a slab beside the data.
+                // Instead draw the (m/z, mobility) selection footprint at several evenly
+                // spaced RT slices, so the recurring selection sits on the precursor signal
+                // through the whole run.
+                // The fine diagonal has ~950 touching windows per group; drawing every one
+                // fills the band solid and hides the data. Subsample to leave gaps you can
+                // see the cloud through, and span each drawn rect across the skipped scans so
+                // it stays a visible window outline rather than a sliver.
+                const N_SLICES: usize = 6;
+                const WIN_STRIDE: usize = 16;
+                // Color each window by its group, so the interleaved isolation diagonals
+                // that tile the precursor space read as distinct bands.
+                let n_groups = windows.iter().map(|w| w.window_group).max().unwrap_or(1).max(1);
+                let (rt_lo, rt_hi) = (bounds.rt.min, bounds.rt.max);
+                for w in windows.iter().step_by(WIN_STRIDE) {
                     let fid = grp_frame.get(&w.window_group).copied().unwrap_or(1);
-                    let ims = ds.scan_to_inverse_mobility(fid, &vec![w.scan_num_begin, w.scan_num_end]);
+                    let scan_hi = w.scan_num_end + WIN_STRIDE as u32 / 2;
+                    let ims = ds.scan_to_inverse_mobility(fid, &vec![w.scan_num_begin, scan_hi]);
                     let im0 = ims.first().copied().unwrap_or(0.0);
                     let im1 = ims.get(1).copied().unwrap_or(im0);
-                    let (rt0, rt1) = grp_rt.get(&w.window_group).copied().unwrap_or((0.0, 0.0));
                     let mz0 = w.isolation_mz - w.isolation_width * 0.5;
                     let mz1 = w.isolation_mz + w.isolation_width * 0.5;
-                    push_box(&mut lines, bounds, (mz0, mz1), (im0, im1), (rt0, rt1));
+                    let color = group_color(w.window_group, n_groups);
+                    for i in 0..N_SLICES {
+                        let rt =
+                            rt_lo + (rt_hi - rt_lo) * (i as f64 + 0.5) / N_SLICES as f64;
+                        push_rect_mz_im(&mut lines, bounds, (mz0, mz1), (im0, im1), rt, color);
+                    }
                 }
             }
         }
@@ -432,45 +447,61 @@ fn build_annotations(ds: &TimsDataset, path: &str, bounds: &AxisBounds) -> Vec<[
     lines
 }
 
-/// Append a 3-segment axis-aligned cross centered at `c` (half-length `h`).
-fn push_cross(lines: &mut Vec<[f32; 3]>, c: [f32; 3], h: f32) {
-    lines.push([c[0] - h, c[1], c[2]]);
-    lines.push([c[0] + h, c[1], c[2]]);
-    lines.push([c[0], c[1] - h, c[2]]);
-    lines.push([c[0], c[1] + h, c[2]]);
-    lines.push([c[0], c[1], c[2] - h]);
-    lines.push([c[0], c[1], c[2] + h]);
+/// Append a 3-segment axis-aligned cross centered at `c` (half-length `h`), in `color`.
+fn push_cross(lines: &mut Vec<LineVertex>, c: [f32; 3], h: f32, color: [f32; 3]) {
+    let v = |p: [f32; 3]| LineVertex::new(p, color);
+    lines.push(v([c[0] - h, c[1], c[2]]));
+    lines.push(v([c[0] + h, c[1], c[2]]));
+    lines.push(v([c[0], c[1] - h, c[2]]));
+    lines.push(v([c[0], c[1] + h, c[2]]));
+    lines.push(v([c[0], c[1], c[2] - h]));
+    lines.push(v([c[0], c[1], c[2] + h]));
 }
 
-/// Append the 12 edges of an axis-aligned box spanning the given real-unit ranges.
-fn push_box(
-    lines: &mut Vec<[f32; 3]>,
+/// Distinct color per window group, by evenly spacing hue around the wheel.
+fn group_color(group: u32, n_groups: u32) -> [f32; 3] {
+    let h = (group.saturating_sub(1) as f32) / (n_groups.max(1) as f32);
+    hsv_to_rgb(h, 0.7, 1.0)
+}
+
+/// HSV (all in [0,1] except hue which wraps) to linear-ish RGB for line colors.
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
+    let i = (h * 6.0).floor();
+    let f = h * 6.0 - i;
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - f * s);
+    let t = v * (1.0 - (1.0 - f) * s);
+    match (i as i32).rem_euclid(6) {
+        0 => [v, t, p],
+        1 => [q, v, p],
+        2 => [p, v, t],
+        3 => [p, q, v],
+        4 => [t, p, v],
+        _ => [v, p, q],
+    }
+}
+
+/// Append the 4 edges of an axis-aligned rectangle in the m/z x mobility plane at a fixed
+/// retention time — one isolation window's footprint, drawn at a given RT slice.
+fn push_rect_mz_im(
+    lines: &mut Vec<LineVertex>,
     bounds: &AxisBounds,
     mz: (f64, f64),
     im: (f64, f64),
-    rt: (f64, f64),
+    rt: f64,
+    color: [f32; 3],
 ) {
-    // 8 corners (normalized).
-    let corner = |a: f64, b: f64, c: f64| bounds.normalize(a, b, c);
+    let corner = |a: f64, b: f64| bounds.normalize(a, b, rt);
     let c = [
-        corner(mz.0, im.0, rt.0),
-        corner(mz.1, im.0, rt.0),
-        corner(mz.1, im.1, rt.0),
-        corner(mz.0, im.1, rt.0),
-        corner(mz.0, im.0, rt.1),
-        corner(mz.1, im.0, rt.1),
-        corner(mz.1, im.1, rt.1),
-        corner(mz.0, im.1, rt.1),
+        corner(mz.0, im.0),
+        corner(mz.1, im.0),
+        corner(mz.1, im.1),
+        corner(mz.0, im.1),
     ];
-    // 12 edges as index pairs.
-    const EDGES: [(usize, usize); 12] = [
-        (0, 1), (1, 2), (2, 3), (3, 0), // bottom (rt0)
-        (4, 5), (5, 6), (6, 7), (7, 4), // top (rt1)
-        (0, 4), (1, 5), (2, 6), (3, 7), // verticals
-    ];
+    const EDGES: [(usize, usize); 4] = [(0, 1), (1, 2), (2, 3), (3, 0)];
     for (a, b) in EDGES {
-        lines.push(c[a]);
-        lines.push(c[b]);
+        lines.push(LineVertex::new(c[a], color));
+        lines.push(LineVertex::new(c[b], color));
     }
 }
 

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -356,43 +356,65 @@ fn run_loader(
         }};
     }
 
-    for idx in 0..n_frames {
-        if cancelled!() {
-            return;
-        }
-        match &mode {
-            LoaderMode::Real { frame_ids, filter, .. } => {
-                let ds = dataset.as_ref().unwrap();
-                let frame = ds.get_frame(frame_ids[idx]);
-                let rt = frame.ims_frame.retention_time;
-                let is_ms2 = !matches!(frame.ms_type, MsType::Precursor);
-                let mz = frame.ims_frame.mz.as_slice();
-                let im = frame.ims_frame.mobility.as_slice();
-                let it = frame.ims_frame.intensity.as_slice();
-                // Validate parallel arrays — never zip past the shortest.
-                let n = mz.len().min(im.len()).min(it.len());
-                for j in 0..n {
-                    // Region refinement: drop points outside the m/z·1/K0 window at the
-                    // source so the budget is spent only on the focused region.
-                    if let Some(f) = filter {
-                        if mz[j] < f.mz.0 || mz[j] > f.mz.1 || im[j] < f.im.0 || im[j] > f.im.1 {
-                            continue;
+    match &mode {
+        LoaderMode::Real { frame_ids, filter, .. } => {
+            use rayon::prelude::*;
+            let ds = dataset.as_ref().unwrap();
+            // Decode frames in parallel batches (the heavy, CPU-bound part — every core helps),
+            // then fold the decoded points in sequentially so the systematic sampler, peak grid
+            // and histograms stay exactly correct. One batch is in flight to bound memory.
+            const DECODE_BATCH: usize = 64;
+            let mut start = 0;
+            while start < n_frames {
+                if cancelled!() {
+                    return;
+                }
+                let end = (start + DECODE_BATCH).min(n_frames);
+                let frames: Vec<_> = frame_ids[start..end]
+                    .par_iter()
+                    .map(|&fid| ds.get_frame(fid))
+                    .collect();
+                for frame in &frames {
+                    let rt = frame.ims_frame.retention_time;
+                    let is_ms2 = !matches!(frame.ms_type, MsType::Precursor);
+                    let mz = frame.ims_frame.mz.as_slice();
+                    let im = frame.ims_frame.mobility.as_slice();
+                    let it = frame.ims_frame.intensity.as_slice();
+                    // Validate parallel arrays — never zip past the shortest.
+                    let n = mz.len().min(im.len()).min(it.len());
+                    for j in 0..n {
+                        // Region refinement: drop points outside the m/z·1/K0 window at the
+                        // source so the budget is spent only on the focused region.
+                        if let Some(f) = filter {
+                            if mz[j] < f.mz.0 || mz[j] > f.mz.1 || im[j] < f.im.0 || im[j] > f.im.1 {
+                                continue;
+                            }
                         }
+                        handle_point!(mz[j], im[j], rt, it[j] as f32, is_ms2);
                     }
-                    handle_point!(mz[j], im[j], rt, it[j] as f32, is_ms2);
+                }
+                start = end;
+                let progress = end as f32 / n_frames as f32;
+                if progress - last_progress >= 0.01 {
+                    let _ = tx.try_send(LoadMsg::Progress(progress));
+                    last_progress = progress;
                 }
             }
-            LoaderMode::Demo(d) => {
+        }
+        LoaderMode::Demo(d) => {
+            for idx in 0..n_frames {
+                if cancelled!() {
+                    return;
+                }
                 for p in d.frame(idx) {
                     handle_point!(p.mz, p.im, p.rt, p.intensity as f32, p.is_ms2);
                 }
+                let progress = (idx + 1) as f32 / n_frames as f32;
+                if progress - last_progress >= 0.01 {
+                    let _ = tx.try_send(LoadMsg::Progress(progress));
+                    last_progress = progress;
+                }
             }
-        }
-
-        let progress = (idx + 1) as f32 / n_frames as f32;
-        if progress - last_progress >= 0.01 {
-            let _ = tx.try_send(LoadMsg::Progress(progress));
-            last_progress = progress;
         }
     }
 

--- a/tims-viewer/src/data/meta.rs
+++ b/tims-viewer/src/data/meta.rs
@@ -29,6 +29,9 @@ pub struct MetaIndex {
     pub frames: Vec<FrameInfo>,
     pub bounds: AxisBounds,
     pub total_points_estimate: u64,
+    /// TIMS scans per frame (the mobility ramp length; constant across frames). Used to anchor the
+    /// clustering's 1/K0 reach to a fixed number of scans (run-level, focus-independent).
+    pub num_scans: u32,
 }
 
 impl MetaIndex {
@@ -105,11 +108,15 @@ impl MetaIndex {
             rt: AxisTransform::new(rt_min, rt_max),
         };
 
+        // The mobility ramp length (constant across frames); take the max to be robust to a stray 0.
+        let num_scans = meta.iter().map(|m| m.num_scans.max(0) as u32).max().unwrap_or(0);
+
         Ok(MetaIndex {
             data_path: data_path.to_string(),
             frames,
             bounds,
             total_points_estimate: total,
+            num_scans,
         })
     }
 
@@ -135,6 +142,7 @@ impl MetaIndex {
             frames,
             bounds,
             total_points_estimate: total_points,
+            num_scans: 709, // a typical timsTOF mobility ramp length
         }
     }
 }

--- a/tims-viewer/src/data/meta.rs
+++ b/tims-viewer/src/data/meta.rs
@@ -23,6 +23,7 @@ pub struct FrameInfo {
 }
 
 /// Lightweight index over a run's metadata.
+#[derive(Clone)]
 pub struct MetaIndex {
     pub data_path: String,
     pub frames: Vec<FrameInfo>,

--- a/tims-viewer/src/data/meta.rs
+++ b/tims-viewer/src/data/meta.rs
@@ -108,8 +108,18 @@ impl MetaIndex {
             rt: AxisTransform::new(rt_min, rt_max),
         };
 
-        // The mobility ramp length (constant across frames); take the max to be robust to a stray 0.
-        let num_scans = meta.iter().map(|m| m.num_scans.max(0) as u32).max().unwrap_or(0);
+        // The mobility ramp length (constant across frames). Use the mode (most common value) so a
+        // single corrupt frame — a stray 0 or an absurdly high count — can't skew the anchor.
+        let num_scans = {
+            let mut counts: std::collections::HashMap<u32, usize> = std::collections::HashMap::new();
+            for m in &meta {
+                let s = m.num_scans.max(0) as u32;
+                if s > 0 {
+                    *counts.entry(s).or_default() += 1;
+                }
+            }
+            counts.into_iter().max_by_key(|&(_, c)| c).map(|(s, _)| s).unwrap_or(0)
+        };
 
         Ok(MetaIndex {
             data_path: data_path.to_string(),

--- a/tims-viewer/src/data/mod.rs
+++ b/tims-viewer/src/data/mod.rs
@@ -1,6 +1,9 @@
 //! Data layer: metadata, streaming loader, GPU point format, and the synthetic source.
 
 pub mod demo;
-pub mod loader;
-pub mod meta;
 pub mod point;
+// Native-only: the Bruker `.d` reader (rustdf/SQLite) and its metadata index.
+#[cfg(feature = "native")]
+pub mod loader;
+#[cfg(feature = "native")]
+pub mod meta;

--- a/tims-viewer/src/data/point.rs
+++ b/tims-viewer/src/data/point.rs
@@ -21,19 +21,24 @@ pub struct GpuPoint {
     pub weight: f32,
     /// Bit flags. bit0: 0 = MS1/precursor, 1 = MS2/fragment.
     pub flags: u32,
+    /// `_pad[0]` doubles as the DBSCAN cluster id for cluster coloring (`NO_CLUSTER` =
+    /// noise/unclustered); `_pad[1]` is reserved padding to keep the 32-byte layout.
     pub _pad: [u32; 2],
 }
 
 impl GpuPoint {
     pub const MS2_FLAG: u32 = 1;
+    /// Cluster-id sentinel for noise / not-yet-clustered points (rendered grey).
+    pub const NO_CLUSTER: u32 = u32::MAX;
 
     /// `wgpu` vertex-buffer layout describing the instance step-mode attributes.
     pub fn layout() -> wgpu::VertexBufferLayout<'static> {
-        const ATTRS: [wgpu::VertexAttribute; 4] = wgpu::vertex_attr_array![
+        const ATTRS: [wgpu::VertexAttribute; 5] = wgpu::vertex_attr_array![
             0 => Float32x3, // pos
             1 => Float32,   // intensity
             2 => Float32,   // weight
             3 => Uint32,    // flags
+            4 => Uint32,    // cluster id (_pad[0])
         ];
         wgpu::VertexBufferLayout {
             array_stride: std::mem::size_of::<GpuPoint>() as wgpu::BufferAddress,

--- a/tims-viewer/src/data/point.rs
+++ b/tims-viewer/src/data/point.rs
@@ -2,6 +2,25 @@
 
 use bytemuck::{Pod, Zeroable};
 
+/// Number of evenly spaced RT slices each DIA window footprint is drawn at. Shared here (a
+/// both-targets module) so the native loader and the wasm overlay use one value — the geometry
+/// must match on both sides of the `/windows` endpoint.
+pub const DIA_WINDOW_RT_SLICES: usize = 6;
+
+/// One DIA/MIDIA isolation window's selection footprint in **real units**: an `(m/z × 1/K0)`
+/// rectangle (mobility already converted from scan numbers). Group ids color the interleaved
+/// isolation bands. The native loader produces these for the `/windows` endpoint; the wasm client
+/// re-normalizes them to its region bounds (so they align with the cloud and off-region windows
+/// clip). Shared here so both sides use one struct definition.
+#[derive(Clone, Copy, Debug)]
+pub struct WindowRect {
+    pub group: u32,
+    pub mz0: f64,
+    pub mz1: f64,
+    pub im0: f64,
+    pub im1: f64,
+}
+
 /// One renderable data point, packed for the GPU as instance data.
 ///
 /// Layout is 32 bytes, 16-byte aligned, so a `Vec<GpuPoint>` uploads directly as a

--- a/tims-viewer/src/lib.rs
+++ b/tims-viewer/src/lib.rs
@@ -1,0 +1,23 @@
+//! tims-viewer library: the GPU renderer and view state.
+//!
+//! Split into a **render-safe** core (compiles for `wasm32` too: GPU pipelines, point format,
+//! camera, colormap, UI panel) and **native-only** modules behind the `native` feature
+//! (`app`, `offscreen`, plus `data::loader`/`data::meta`, which pull rustdf/SQLite/threads).
+//! See `NATIVE_WEB.md` for the web-embedding plan this split enables.
+
+// Render-safe core.
+pub mod camera;
+pub mod cluster;
+pub mod data;
+pub mod render;
+pub mod state;
+pub mod ticks;
+pub mod ui;
+
+// Native-only: window/event-loop orchestration, headless PNG export, point-streaming server.
+#[cfg(feature = "native")]
+pub mod app;
+#[cfg(feature = "native")]
+pub mod offscreen;
+#[cfg(feature = "native")]
+pub mod serve;

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -5,6 +5,8 @@
 //!   tims-viewer DEMO                 synthetic point cloud (no Bruker data needed)
 //!   tims-viewer DEMO --budget 25000000
 
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
 use clap::Parser;
 use winit::event_loop::{ControlFlow, EventLoop};
@@ -61,6 +63,45 @@ struct Args {
     exposure: Option<f32>,
 }
 
+/// Is `p` a Bruker `.d` dataset folder (named `*.d`, or containing `analysis.tdf`)?
+fn is_dataset_dir(p: &Path) -> bool {
+    p.is_dir()
+        && (p.extension().is_some_and(|e| e.eq_ignore_ascii_case("d"))
+            || p.join("analysis.tdf").exists())
+}
+
+/// Recursively collect `.d` datasets under `dir` (pruning at each `.d` — it holds files, not nested
+/// datasets — and bounded in depth so a deep tree can't blow up the scan).
+fn collect_datasets(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
+    if depth > 4 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    for p in entries.filter_map(|e| e.ok().map(|e| e.path())) {
+        if is_dataset_dir(&p) {
+            out.push(p); // a .d — collect it, don't descend
+        } else if p.is_dir() {
+            collect_datasets(&p, depth + 1, out);
+        }
+    }
+}
+
+/// Resolve the server's selectable datasets from the launch input: a single `.d` → just it; a
+/// directory → every `.d` beneath it (flat `runs/a.d` or nested `runs/a/a.d` both work). The launch
+/// directory is the confinement root.
+fn discover_datasets(input: &str) -> Result<Vec<PathBuf>> {
+    let p = Path::new(input);
+    if is_dataset_dir(p) {
+        return Ok(vec![p.to_path_buf()]);
+    }
+    anyhow::ensure!(p.is_dir(), "{input} is not a .d folder or a directory of them");
+    let mut v = Vec::new();
+    collect_datasets(p, 0, &mut v);
+    v.sort();
+    anyhow::ensure!(!v.is_empty(), "no .d datasets found under {input}");
+    Ok(v)
+}
+
 fn main() -> Result<()> {
     // Keep our own INFO logs, but silence the very chatty wgpu/naga internals (e.g.
     // "Device::maintain: waiting for submission index ..." every frame). RUST_LOG overrides.
@@ -69,6 +110,19 @@ fn main() -> Result<()> {
     ))
     .init();
     let args = Args::parse();
+
+    // Point-streaming server mode (no window/GPU): serve packed points to the web shell. Multi-dataset
+    // + lazy — discover the selectable `.d`s (a single `.d`, or every `.d` under a directory) and let
+    // the frontend pick; don't eagerly load any one's metadata here.
+    if let Some(port) = args.serve {
+        let source = if args.input.eq_ignore_ascii_case("DEMO") {
+            log::info!("DEMO mode: {} frames, {} points", args.demo_frames, args.demo_points);
+            tims_viewer::serve::ServeSource::Demo(MetaIndex::demo(args.demo_frames, args.demo_points))
+        } else {
+            tims_viewer::serve::ServeSource::Datasets(discover_datasets(&args.input)?)
+        };
+        return tims_viewer::serve::serve(source, args.budget, port);
+    }
 
     let (meta, is_demo) = if args.input.eq_ignore_ascii_case("DEMO") {
         log::info!(
@@ -95,11 +149,6 @@ fn main() -> Result<()> {
     };
 
     let plan = Plan::new(meta, is_demo, args.budget);
-
-    // Point-streaming server mode (no window/GPU): serve packed points to the web shell.
-    if let Some(port) = args.serve {
-        return tims_viewer::serve::serve(plan, port);
-    }
 
     // Headless one-frame render mode (no window).
     if let Some(path) = args.render_png {

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -78,6 +78,9 @@ fn collect_datasets(dir: &Path, depth: usize, out: &mut Vec<PathBuf>) {
     }
     let Ok(entries) = std::fs::read_dir(dir) else { return };
     for p in entries.filter_map(|e| e.ok().map(|e| e.path())) {
+        if p.is_symlink() {
+            continue; // don't follow symlinks — keeps discovery within the real root (no escape/loops)
+        }
         if is_dataset_dir(&p) {
             out.push(p); // a .d — collect it, don't descend
         } else if p.is_dir() {

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -37,6 +37,10 @@ struct Args {
     /// block. No window/GPU needed; works with a `.d` path or `DEMO`.
     #[arg(long)]
     serve: Option<u16>,
+    /// With --serve: zstd-compress the /points payload when the client advertises it (Accept-Encoding).
+    /// Cuts the over-the-wire size ~3-4x for remote serving; leave off for localhost (raw is faster).
+    #[arg(long)]
+    compress: bool,
     /// With --render-png: render the volume raycaster instead of the point cloud.
     #[arg(long)]
     volume: bool,
@@ -124,7 +128,7 @@ fn main() -> Result<()> {
         } else {
             tims_viewer::serve::ServeSource::Datasets(discover_datasets(&args.input)?)
         };
-        return tims_viewer::serve::serve(source, args.budget, port);
+        return tims_viewer::serve::serve(source, args.budget, port, args.compress);
     }
 
     let (meta, is_demo) = if args.input.eq_ignore_ascii_case("DEMO") {

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -7,6 +7,7 @@
 
 mod app;
 mod camera;
+mod cluster;
 mod data;
 mod offscreen;
 mod render;

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -41,6 +41,11 @@ struct Args {
     /// Cuts the over-the-wire size ~3-4x for remote serving; leave off for localhost (raw is faster).
     #[arg(long)]
     compress: bool,
+    /// With --serve (PROD): enable in-app error telemetry + user feedback, appended as JSONL to this
+    /// directory (telemetry.jsonl / feedback.jsonl). Omit for local dev — the endpoints stay off and
+    /// the frontend hides the feedback widget and sends nothing.
+    #[arg(long)]
+    telemetry_dir: Option<std::path::PathBuf>,
     /// With --render-png: render the volume raycaster instead of the point cloud.
     #[arg(long)]
     volume: bool,
@@ -128,7 +133,7 @@ fn main() -> Result<()> {
         } else {
             tims_viewer::serve::ServeSource::Datasets(discover_datasets(&args.input)?)
         };
-        return tims_viewer::serve::serve(source, args.budget, port, args.compress);
+        return tims_viewer::serve::serve(source, args.budget, port, args.compress, args.telemetry_dir);
     }
 
     let (meta, is_demo) = if args.input.eq_ignore_ascii_case("DEMO") {

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -11,6 +11,7 @@ mod data;
 mod offscreen;
 mod render;
 mod state;
+mod ticks;
 mod ui;
 
 use anyhow::Result;

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -67,7 +67,12 @@ struct Args {
 }
 
 fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    // Keep our own INFO logs, but silence the very chatty wgpu/naga internals (e.g.
+    // "Device::maintain: waiting for submission index ..." every frame). RUST_LOG overrides.
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(
+        "info,wgpu_core=warn,wgpu_hal=warn,wgpu=warn,naga=warn",
+    ))
+    .init();
     let args = Args::parse();
 
     let (meta, is_demo) = if args.input.eq_ignore_ascii_case("DEMO") {

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -5,22 +5,13 @@
 //!   tims-viewer DEMO                 synthetic point cloud (no Bruker data needed)
 //!   tims-viewer DEMO --budget 25000000
 
-mod app;
-mod camera;
-mod cluster;
-mod data;
-mod offscreen;
-mod render;
-mod state;
-mod ticks;
-mod ui;
-
 use anyhow::Result;
 use clap::Parser;
 use winit::event_loop::{ControlFlow, EventLoop};
 
-use app::{App, Plan};
-use data::meta::MetaIndex;
+use tims_viewer::app::{App, Plan};
+use tims_viewer::data::meta::MetaIndex;
+use tims_viewer::offscreen;
 
 /// Command-line arguments.
 #[derive(Parser, Debug)]
@@ -40,6 +31,10 @@ struct Args {
     /// Headless: render one frame to this PNG path and exit (no window needed).
     #[arg(long)]
     render_png: Option<String>,
+    /// Serve the loaded slice's packed points over HTTP on this port (for the web shell), then
+    /// block. No window/GPU needed; works with a `.d` path or `DEMO`.
+    #[arg(long)]
+    serve: Option<u16>,
     /// With --render-png: render the volume raycaster instead of the point cloud.
     #[arg(long)]
     volume: bool,
@@ -100,6 +95,11 @@ fn main() -> Result<()> {
     };
 
     let plan = Plan::new(meta, is_demo, args.budget);
+
+    // Point-streaming server mode (no window/GPU): serve packed points to the web shell.
+    if let Some(port) = args.serve {
+        return tims_viewer::serve::serve(plan, port);
+    }
 
     // Headless one-frame render mode (no window).
     if let Some(path) = args.render_png {

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -110,6 +110,9 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
         crate::data::loader::stride_for(total, capacity as usize) as u32;
     state.view_mode = if opts.volume { ViewMode::Volume } else { ViewMode::Points };
     state.vol_style = if opts.mip { VolStyle::Mip } else { VolStyle::Composite };
+    // MS selection is applied at upload time via `opts.ms`; let the shader pass everything
+    // that was uploaded (don't double-filter with the interactive MS1-only default).
+    state.show_ms2 = true;
 
     // Load the whole run synchronously by draining the streaming loader.
     let mode = if plan.is_demo {

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -121,7 +121,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
             filter: None,
         }
     };
-    let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize, false);
+    let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize);
     let keep = |p: &GpuPoint| match opts.ms {
         MsFilter::All => true,
         MsFilter::Ms1 => p.flags & GpuPoint::MS2_FLAG == 0,
@@ -163,6 +163,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
                 points.append(&queue, &pts);
             }
             Ok(LoadMsg::Stats { .. }) => {} // recomputed below from retained points
+            Ok(LoadMsg::Histograms { .. }) => {} // UI-only; headless ignores
             Ok(LoadMsg::Annotations { lines, .. }) => {
                 if opts.annotations {
                     annotations.upload(&device, &lines);

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -106,6 +106,8 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
     let bounds = plan.meta.bounds;
     let mut state = AppState::new(bounds, total, COLORMAP_NAMES.len() as u32);
     state.capacity = capacity;
+    state.downsample_stride =
+        crate::data::loader::stride_for(total, capacity as usize) as u32;
     state.view_mode = if opts.volume { ViewMode::Volume } else { ViewMode::Points };
     state.vol_style = if opts.mip { VolStyle::Mip } else { VolStyle::Composite };
 
@@ -183,13 +185,16 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
     // cloud uses the retained-intensity percentiles.
     if opts.volume {
         let (lo, hi) = grid.density_percentiles();
-        state.i_min = lo;
-        state.i_max = hi;
+        state.auto_transfer_volume(lo, hi);
     } else if !reservoir.is_empty() {
         reservoir.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let pct = |q: f32| reservoir[(((reservoir.len() - 1) as f32) * q) as usize];
-        state.i_min = pct(0.01).max(1.0);
-        state.i_max = pct(0.99).max(state.i_min * 1.0001);
+        // Feed the same auto-exposure heuristic the interactive viewer uses, so the
+        // headless render is legible (median mid-LUT, additive cloud not blown out).
+        state.i_p1 = pct(0.01).max(1.0);
+        state.i_med = pct(0.50).max(state.i_p1);
+        state.i_p99 = pct(0.99).max(state.i_med * 1.0001);
+        state.auto_transfer_points();
     }
     // Apply transfer-function overrides (e.g. raise i_min to threshold out noise).
     if let Some(v) = opts.i_min {

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -118,6 +118,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
         LoaderMode::Real {
             path: plan.meta.data_path.clone(),
             frame_ids: plan.meta.frames.iter().map(|f| f.id).collect(),
+            filter: None,
         }
     };
     let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize);

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -121,10 +121,9 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
         LoaderMode::Real {
             path: plan.meta.data_path.clone(),
             frame_ids: plan.meta.frames.iter().map(|f| f.id).collect(),
-            filter: None,
         }
     };
-    let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize);
+    let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize, None);
     let keep = |p: &GpuPoint| match opts.ms {
         MsFilter::All => true,
         MsFilter::Ms1 => p.flags & GpuPoint::MS2_FLAG == 0,

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -217,7 +217,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
     points.update_camera(&queue, &cam_uniform);
     points.update_params(&queue, &params);
     annotations.update_camera(&queue, &cam_uniform);
-    annotations.update_filter(&queue, params.filter_min, params.filter_max);
+    annotations.update_filter(&queue, params.filter_min, params.filter_max, params.focus);
     if opts.volume {
         let mut vu = state.volume_uniform(camera.inv_view_proj(aspect));
         vu.density_scale = grid.density_scale();

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -160,7 +160,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
                 points.append(&queue, &pts);
             }
             Ok(LoadMsg::Stats { .. }) => {} // recomputed below from retained points
-            Ok(LoadMsg::Annotations { lines }) => {
+            Ok(LoadMsg::Annotations { lines, .. }) => {
                 if opts.annotations {
                     annotations.upload(&device, &lines);
                 }
@@ -222,7 +222,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
         let mut vu = state.volume_uniform(camera.inv_view_proj(aspect));
         vu.density_scale = grid.density_scale();
         volume.update_uniform(&queue, &vu);
-        volume.upload(&queue, &grid.to_f16_scaled());
+        volume.upload(&queue, grid.to_f16_scaled());
     }
 
     // Offscreen targets.

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -121,7 +121,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
             filter: None,
         }
     };
-    let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize);
+    let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize, false);
     let keep = |p: &GpuPoint| match opts.ms {
         MsFilter::All => true,
         MsFilter::Ms1 => p.flags & GpuPoint::MS2_FLAG == 0,

--- a/tims-viewer/src/render/annotation.rs
+++ b/tims-viewer/src/render/annotation.rs
@@ -6,6 +6,21 @@ use wgpu::util::DeviceExt;
 
 use super::uniforms::CameraUniform;
 
+/// A colored line vertex (pairs form segments). Color is per-vertex so the overlay can
+/// distinguish e.g. DIA window groups.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct LineVertex {
+    pub pos: [f32; 3],
+    pub color: [f32; 3],
+}
+
+impl LineVertex {
+    pub fn new(pos: [f32; 3], color: [f32; 3]) -> Self {
+        LineVertex { pos, color }
+    }
+}
+
 /// Normalized-cube window the overlay is clipped to (xyz; w unused).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
@@ -92,9 +107,9 @@ impl AnnotationRenderer {
                 module: &shader,
                 entry_point: "vs_main",
                 buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: 12,
+                    array_stride: 24,
                     step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &wgpu::vertex_attr_array![0 => Float32x3],
+                    attributes: &wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x3],
                 }],
                 compilation_options: Default::default(),
             },
@@ -138,17 +153,20 @@ impl AnnotationRenderer {
         queue.write_buffer(&self.camera_buf, 0, bytemuck::bytes_of(cam));
     }
 
-    /// Set the normalized-cube window the overlay is clipped to.
-    pub fn update_filter(&self, queue: &wgpu::Queue, min: [f32; 4], max: [f32; 4]) {
+    /// Set the normalized-cube window the overlay is clipped to. `focus` (0.0/1.0) re-fits
+    /// that window to the full cube — carried in the unused `min.w` slot for the shader.
+    pub fn update_filter(&self, queue: &wgpu::Queue, min: [f32; 4], max: [f32; 4], focus: f32) {
+        let mut m = min;
+        m[3] = focus;
         queue.write_buffer(
             &self.filter_buf,
             0,
-            bytemuck::bytes_of(&FilterUniform { min, max }),
+            bytemuck::bytes_of(&FilterUniform { min: m, max }),
         );
     }
 
-    /// Upload line-list vertices (pairs = segments). Recreates the buffer.
-    pub fn upload(&mut self, device: &wgpu::Device, verts: &[[f32; 3]]) {
+    /// Upload colored line-list vertices (pairs = segments). Recreates the buffer.
+    pub fn upload(&mut self, device: &wgpu::Device, verts: &[LineVertex]) {
         if verts.is_empty() {
             self.vbuf = None;
             self.vcount = 0;

--- a/tims-viewer/src/render/colormap.rs
+++ b/tims-viewer/src/render/colormap.rs
@@ -125,12 +125,20 @@ pub fn create_lut_texture(
     (texture, view, sampler)
 }
 
-/// Distinct color per window group, by evenly spacing hue around the wheel. Shared by the
-/// annotation overlay (DIA isolation windows) and the egui group legend. Render-safe (no
-/// native deps), so it lives here rather than in the native loader.
-pub fn group_color(group: u32, n_groups: u32) -> [f32; 3] {
-    let h = (group.saturating_sub(1) as f32) / (n_groups.max(1) as f32);
-    hsv_to_rgb(h, 0.7, 1.0)
+/// Distinct color per window group. Shared by the annotation overlay (DIA isolation windows) and
+/// the egui group legend. Render-safe (no native deps), so it lives here rather than in the native
+/// loader.
+///
+/// Hue advances by the GOLDEN ANGLE per group rather than a plain `group/n` ramp: a linear ramp
+/// gives adjacent groups nearly-identical hues (indistinguishable when a run has many windows),
+/// whereas the golden angle lands consecutive groups ~137° apart on the wheel while still covering
+/// it evenly. A parity brightness step adds a second cue so neighbours differ in value too. The
+/// color depends only on `group`, so the overlay and legend stay in lockstep regardless of `n_groups`.
+pub fn group_color(group: u32, _n_groups: u32) -> [f32; 3] {
+    let g = group.saturating_sub(1) as f32;
+    let h = (g * 0.618_034).fract(); // golden-ratio conjugate ≈ 137.5° steps
+    let v = if group % 2 == 0 { 0.82 } else { 1.0 };
+    hsv_to_rgb(h, 0.7, v)
 }
 
 /// HSV (all in [0,1] except hue which wraps) to linear-ish RGB for line colors.

--- a/tims-viewer/src/render/colormap.rs
+++ b/tims-viewer/src/render/colormap.rs
@@ -125,6 +125,31 @@ pub fn create_lut_texture(
     (texture, view, sampler)
 }
 
+/// Distinct color per window group, by evenly spacing hue around the wheel. Shared by the
+/// annotation overlay (DIA isolation windows) and the egui group legend. Render-safe (no
+/// native deps), so it lives here rather than in the native loader.
+pub fn group_color(group: u32, n_groups: u32) -> [f32; 3] {
+    let h = (group.saturating_sub(1) as f32) / (n_groups.max(1) as f32);
+    hsv_to_rgb(h, 0.7, 1.0)
+}
+
+/// HSV (all in [0,1] except hue which wraps) to linear-ish RGB for line colors.
+fn hsv_to_rgb(h: f32, s: f32, v: f32) -> [f32; 3] {
+    let i = (h * 6.0).floor();
+    let f = h * 6.0 - i;
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - f * s);
+    let t = v * (1.0 - (1.0 - f) * s);
+    match (i as i32).rem_euclid(6) {
+        0 => [v, t, p],
+        1 => [q, v, p],
+        2 => [p, v, t],
+        3 => [p, q, v],
+        4 => [t, p, v],
+        _ => [v, p, q],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tims-viewer/src/render/colormap.rs
+++ b/tims-viewer/src/render/colormap.rs
@@ -38,27 +38,33 @@ fn anchors(map: usize) -> &'static [[u8; 3]] {
     }
 }
 
+/// RGB at normalized position `t∈[0,1]` for colormap `map` (CPU mirror of the LUT).
+/// The egui colorbar and the GPU LUT both go through this anchor-lerp so they can't drift.
+pub fn sample(map: usize, t: f32) -> [u8; 3] {
+    let a = anchors(map);
+    let segs = a.len() - 1;
+    let t = t.clamp(0.0, 1.0);
+    let fseg = t * segs as f32;
+    let seg = (fseg.floor() as usize).min(segs - 1);
+    let local = fseg - seg as f32;
+    let c0 = a[seg];
+    let c1 = a[seg + 1];
+    let lerp = |i: usize| (c0[i] as f32 + (c1[i] as f32 - c0[i] as f32) * local).round() as u8;
+    [lerp(0), lerp(1), lerp(2)]
+}
+
 /// Build the RGBA8 LUT pixel data, row-major (`width=256`, `height=N`).
 pub fn build_lut_rgba8() -> (Vec<u8>, u32, u32) {
     let n = COLORMAP_NAMES.len();
     let mut data = vec![0u8; LUT_WIDTH * n * 4];
     for map in 0..n {
-        let a = anchors(map);
-        let segs = a.len() - 1;
         for x in 0..LUT_WIDTH {
             let t = x as f32 / (LUT_WIDTH - 1) as f32;
-            let fseg = t * segs as f32;
-            let seg = (fseg.floor() as usize).min(segs - 1);
-            let local = fseg - seg as f32;
-            let c0 = a[seg];
-            let c1 = a[seg + 1];
-            let lerp = |i: usize| {
-                (c0[i] as f32 + (c1[i] as f32 - c0[i] as f32) * local).round() as u8
-            };
+            let rgb = sample(map, t);
             let idx = (map * LUT_WIDTH + x) * 4;
-            data[idx] = lerp(0);
-            data[idx + 1] = lerp(1);
-            data[idx + 2] = lerp(2);
+            data[idx] = rgb[0];
+            data[idx + 1] = rgb[1];
+            data[idx + 2] = rgb[2];
             data[idx + 3] = 255;
         }
     }
@@ -117,4 +123,19 @@ pub fn create_lut_texture(
         ..Default::default()
     });
     (texture, view, sampler)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_endpoints_match_anchors() {
+        // Viridis anchors run [68,1,84] -> ... -> [253,231,37].
+        assert_eq!(sample(0, 0.0), [68, 1, 84]);
+        assert_eq!(sample(0, 1.0), [253, 231, 37]);
+        // Out-of-range t clamps to the endpoints.
+        assert_eq!(sample(0, -1.0), [68, 1, 84]);
+        assert_eq!(sample(0, 2.0), [253, 231, 37]);
+    }
 }

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -26,10 +26,6 @@ const WORKGROUP_SIZE: u32 = 256;
 pub struct PointCloudRenderer {
     /// Master instance buffer (all resident points), sized to the budget.
     master: wgpu::Buffer,
-    /// Compacted visible points written by the compute pass (compaction path only).
-    compacted: wgpu::Buffer,
-    /// Indirect draw args: [vertex_count, instance_count, first_vertex, first_instance].
-    draw_args: wgpu::Buffer,
 
     capacity: u32,
     resident: u32,
@@ -49,9 +45,16 @@ pub struct PointCloudRenderer {
     _lut_texture: wgpu::Texture,
 }
 
+/// Compaction resources, present only when the device supports compute + indirect execution.
+/// These carry `STORAGE`/`INDIRECT` usage, which the WebGL2 fallback cannot allocate — so they
+/// (and `master`'s `STORAGE` usage) live here and are simply never created on that path.
 struct ComputeStage {
     pipeline: wgpu::ComputePipeline,
     bind_group: wgpu::BindGroup,
+    /// Compacted visible points written by the compute pass.
+    compacted: wgpu::Buffer,
+    /// Indirect draw args: [vertex_count, instance_count, first_vertex, first_instance].
+    draw_args: wgpu::Buffer,
 }
 
 impl PointCloudRenderer {
@@ -64,29 +67,21 @@ impl PointCloudRenderer {
         supports_compaction: bool,
     ) -> Self {
         let point_bytes = capacity as u64 * std::mem::size_of::<GpuPoint>() as u64;
-        // Master is read as storage by the compute pass and (in fallback) drawn as a
-        // vertex buffer; mark both usages.
+        // Master holds all resident points, always drawn as an instance buffer. With compaction
+        // it is ALSO read as a storage buffer by the compute pass; WebGL2 can't allocate storage
+        // buffers, so request STORAGE only on the compaction path.
+        let master_usage = wgpu::BufferUsages::VERTEX
+            | wgpu::BufferUsages::COPY_DST
+            | if supports_compaction {
+                wgpu::BufferUsages::STORAGE
+            } else {
+                wgpu::BufferUsages::empty()
+            };
         let master = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("point-master"),
             size: point_bytes,
-            usage: wgpu::BufferUsages::VERTEX
-                | wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_DST,
+            usage: master_usage,
             mapped_at_creation: false,
-        });
-        let compacted = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("point-compacted"),
-            size: point_bytes.max(std::mem::size_of::<GpuPoint>() as u64),
-            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-        let draw_args = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("point-draw-args"),
-            // vertex_count=4 (quad strip), instance_count=0, first_vertex=0, first_instance=0
-            contents: bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]),
-            usage: wgpu::BufferUsages::INDIRECT
-                | wgpu::BufferUsages::STORAGE
-                | wgpu::BufferUsages::COPY_DST,
         });
 
         let camera_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -231,11 +226,26 @@ impl PointCloudRenderer {
         );
 
         let compute = if supports_compaction {
+            // STORAGE/INDIRECT buffers: created only here, so the WebGL2 fallback allocates none.
+            let compacted = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("point-compacted"),
+                size: point_bytes.max(std::mem::size_of::<GpuPoint>() as u64),
+                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::STORAGE,
+                mapped_at_creation: false,
+            });
+            let draw_args = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("point-draw-args"),
+                // vertex_count=4 (quad strip), instance_count=0, first_vertex=0, first_instance=0
+                contents: bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]),
+                usage: wgpu::BufferUsages::INDIRECT
+                    | wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST,
+            });
             Some(build_compute_stage(
                 device,
                 &master,
-                &compacted,
-                &draw_args,
+                compacted,
+                draw_args,
                 &camera_buf,
                 &params_buf,
                 &compaction_buf,
@@ -246,8 +256,6 @@ impl PointCloudRenderer {
 
         PointCloudRenderer {
             master,
-            compacted,
-            draw_args,
             capacity,
             resident: 0,
             camera_buf,
@@ -311,7 +319,7 @@ impl PointCloudRenderer {
         }
         // Reset the survivor counter every frame (atomicAdd accumulates otherwise);
         // keep vertex_count=4 for the quad strip.
-        queue.write_buffer(&self.draw_args, 0, bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]));
+        queue.write_buffer(&compute.draw_args, 0, bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]));
         // 2D dispatch grid: a single dispatch dimension is capped at 65535 workgroups, which
         // a 1D dispatch exceeds once resident points pass ~65535*256 (~16.8M). Spread the
         // workgroups across x and y and let the shader rebuild the linear index from
@@ -349,12 +357,12 @@ impl PointCloudRenderer {
         };
         rpass.set_pipeline(pipeline);
         rpass.set_bind_group(0, &self.bind_group, &[]);
-        if self.compute.is_some() {
+        if let Some(compute) = &self.compute {
             // Draw only the compacted visible set; count comes from the indirect args.
-            rpass.set_vertex_buffer(0, self.compacted.slice(..));
-            rpass.draw_indirect(&self.draw_args, 0);
+            rpass.set_vertex_buffer(0, compute.compacted.slice(..));
+            rpass.draw_indirect(&compute.draw_args, 0);
         } else {
-            // Fallback: draw all resident points, cull in the vertex shader.
+            // Fallback (e.g. WebGL2): draw all resident points, cull in the vertex shader.
             rpass.set_vertex_buffer(0, self.master.slice(..));
             rpass.draw(0..4, 0..self.resident);
         }
@@ -404,8 +412,8 @@ fn compute_uniform_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
 fn build_compute_stage(
     device: &wgpu::Device,
     master: &wgpu::Buffer,
-    compacted: &wgpu::Buffer,
-    draw_args: &wgpu::Buffer,
+    compacted: wgpu::Buffer,
+    draw_args: wgpu::Buffer,
     camera_buf: &wgpu::Buffer,
     params_buf: &wgpu::Buffer,
     compaction_buf: &wgpu::Buffer,
@@ -471,6 +479,8 @@ fn build_compute_stage(
     ComputeStage {
         pipeline,
         bind_group,
+        compacted,
+        draw_args,
     }
 }
 
@@ -483,8 +493,10 @@ mod tests {
     /// Build the pipelines (forcing WGSL compilation for both the draw and, when
     /// supported, the compaction compute shader), upload points, run prepare() +
     /// render offscreen in both modes. Skips cleanly if no GPU adapter is available.
-    #[test]
-    fn offscreen_render_smoke() {
+    ///
+    /// `force_compaction`: `None` uses the device's real capability; `Some(false)` exercises the
+    /// WebGL2-shaped fallback (no storage/indirect buffers, plain instanced draw).
+    fn run_smoke(force_compaction: Option<bool>) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::PRIMARY | wgpu::Backends::GL,
             ..Default::default()
@@ -511,8 +523,9 @@ mod tests {
         .expect("request_device failed");
 
         let flags = adapter.get_downlevel_capabilities().flags;
-        let supports_compaction = flags.contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
+        let device_compaction = flags.contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
             && flags.contains(wgpu::DownlevelFlags::INDIRECT_EXECUTION);
+        let supports_compaction = force_compaction.unwrap_or(device_compaction);
 
         let color_format = wgpu::TextureFormat::Rgba8UnormSrgb;
         let depth_format = wgpu::TextureFormat::Depth32Float;
@@ -592,5 +605,18 @@ mod tests {
             queue.submit(std::iter::once(enc.finish()));
             device.poll(wgpu::Maintain::Wait);
         }
+    }
+
+    /// Smoke test on the device's real capabilities (compaction path where supported).
+    #[test]
+    fn offscreen_render_smoke() {
+        run_smoke(None);
+    }
+
+    /// Force the no-compute fallback (the WebGL2-shaped path): the renderer must build with no
+    /// storage/indirect buffers and the plain instanced draw must render without validation errors.
+    #[test]
+    fn offscreen_render_smoke_webgl2_fallback() {
+        run_smoke(Some(false));
     }
 }

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -29,6 +29,9 @@ pub struct PointCloudRenderer {
 
     capacity: u32,
     resident: u32,
+    /// How many of the resident points to actually draw (perf vs. detail at runtime). `u32::MAX`
+    /// means "all". Points are stored shuffled, so any prefix is a representative subsample.
+    draw_count: u32,
 
     camera_buf: wgpu::Buffer,
     params_buf: wgpu::Buffer,
@@ -258,6 +261,7 @@ impl PointCloudRenderer {
             master,
             capacity,
             resident: 0,
+            draw_count: u32::MAX,
             camera_buf,
             params_buf,
             compaction_buf,
@@ -300,6 +304,16 @@ impl PointCloudRenderer {
         n
     }
 
+    /// Set how many resident points to draw (clamped to resident when rendering).
+    pub fn set_draw_count(&mut self, n: u32) {
+        self.draw_count = n;
+    }
+
+    /// Points actually drawn this frame = `min(draw_count, resident)`.
+    fn effective(&self) -> u32 {
+        self.draw_count.min(self.resident)
+    }
+
     pub fn update_camera(&self, queue: &wgpu::Queue, cam: &CameraUniform) {
         queue.write_buffer(&self.camera_buf, 0, bytemuck::bytes_of(cam));
     }
@@ -314,18 +328,20 @@ impl PointCloudRenderer {
         let Some(compute) = &self.compute else {
             return;
         };
-        if self.resident == 0 {
+        let n = self.effective();
+        if n == 0 {
             return;
         }
         // Reset the survivor counter every frame (atomicAdd accumulates otherwise);
         // keep vertex_count=4 for the quad strip.
         queue.write_buffer(&compute.draw_args, 0, bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]));
         // 2D dispatch grid: a single dispatch dimension is capped at 65535 workgroups, which
-        // a 1D dispatch exceeds once resident points pass ~65535*256 (~16.8M). Spread the
+        // a 1D dispatch exceeds once the point count passes ~65535*256 (~16.8M). Spread the
         // workgroups across x and y and let the shader rebuild the linear index from
-        // row_stride (= invocations per row).
+        // row_stride (= invocations per row). Only the first `n` points are considered, so the
+        // shader's `i >= point_count` cull also enforces the runtime draw count.
         const MAX_DIM: u32 = 65535;
-        let groups = self.resident.div_ceil(WORKGROUP_SIZE);
+        let groups = n.div_ceil(WORKGROUP_SIZE);
         let groups_x = groups.min(MAX_DIM);
         let groups_y = groups.div_ceil(groups_x);
         let row_stride = groups_x * WORKGROUP_SIZE;
@@ -333,7 +349,7 @@ impl PointCloudRenderer {
             &self.compaction_buf,
             0,
             bytemuck::bytes_of(&CompactionUniform {
-                point_count: self.resident,
+                point_count: n,
                 row_stride,
                 _pad: [0; 2],
             }),
@@ -348,7 +364,8 @@ impl PointCloudRenderer {
     }
 
     pub fn render(&self, rpass: &mut wgpu::RenderPass<'_>, mode: PointMode) {
-        if self.resident == 0 {
+        let n = self.effective();
+        if n == 0 {
             return;
         }
         let pipeline = match mode {
@@ -362,9 +379,9 @@ impl PointCloudRenderer {
             rpass.set_vertex_buffer(0, compute.compacted.slice(..));
             rpass.draw_indirect(&compute.draw_args, 0);
         } else {
-            // Fallback (e.g. WebGL2): draw all resident points, cull in the vertex shader.
+            // Fallback (e.g. WebGL2): draw the first `n` resident points, cull in the vertex shader.
             rpass.set_vertex_buffer(0, self.master.slice(..));
-            rpass.draw(0..4, 0..self.resident);
+            rpass.draw(0..4, 0..n);
         }
     }
 }

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -314,6 +314,11 @@ impl PointCloudRenderer {
         self.draw_count.min(self.resident)
     }
 
+    /// Public view of `effective()` (the drawn-instance count) for HUD/displayed-count accounting.
+    pub fn drawn(&self) -> u32 {
+        self.effective()
+    }
+
     pub fn update_camera(&self, queue: &wgpu::Queue, cam: &CameraUniform) {
         queue.write_buffer(&self.camera_buf, 0, bytemuck::bytes_of(cam));
     }

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -312,12 +312,22 @@ impl PointCloudRenderer {
         // Reset the survivor counter every frame (atomicAdd accumulates otherwise);
         // keep vertex_count=4 for the quad strip.
         queue.write_buffer(&self.draw_args, 0, bytemuck::cast_slice(&[4u32, 0u32, 0u32, 0u32]));
+        // 2D dispatch grid: a single dispatch dimension is capped at 65535 workgroups, which
+        // a 1D dispatch exceeds once resident points pass ~65535*256 (~16.8M). Spread the
+        // workgroups across x and y and let the shader rebuild the linear index from
+        // row_stride (= invocations per row).
+        const MAX_DIM: u32 = 65535;
+        let groups = self.resident.div_ceil(WORKGROUP_SIZE);
+        let groups_x = groups.min(MAX_DIM);
+        let groups_y = groups.div_ceil(groups_x);
+        let row_stride = groups_x * WORKGROUP_SIZE;
         queue.write_buffer(
             &self.compaction_buf,
             0,
             bytemuck::bytes_of(&CompactionUniform {
                 point_count: self.resident,
-                _pad: [0; 3],
+                row_stride,
+                _pad: [0; 2],
             }),
         );
         let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
@@ -326,8 +336,7 @@ impl PointCloudRenderer {
         });
         cpass.set_pipeline(&compute.pipeline);
         cpass.set_bind_group(0, &compute.bind_group, &[]);
-        let groups = self.resident.div_ceil(WORKGROUP_SIZE);
-        cpass.dispatch_workgroups(groups, 1, 1);
+        cpass.dispatch_workgroups(groups_x, groups_y, 1);
     }
 
     pub fn render(&self, rpass: &mut wgpu::RenderPass<'_>, mode: PointMode) {

--- a/tims-viewer/src/render/point_cloud.rs
+++ b/tims-viewer/src/render/point_cloud.rs
@@ -32,6 +32,12 @@ pub struct PointCloudRenderer {
     /// How many of the resident points to actually draw (perf vs. detail at runtime). `u32::MAX`
     /// means "all". Points are stored shuffled, so any prefix is a representative subsample.
     draw_count: u32,
+    /// Ring mode (acquisition playback): `append` wraps and overwrites the oldest points instead of
+    /// stopping at capacity, so an unbounded stream stays bounded to the last `capacity` points.
+    ring: bool,
+    /// Cumulative points *written* in ring mode = the wrap cursor (next write offset is
+    /// `write_total % capacity`). Over-capacity batches contribute only their retained tail.
+    write_total: u64,
 
     camera_buf: wgpu::Buffer,
     params_buf: wgpu::Buffer,
@@ -262,6 +268,8 @@ impl PointCloudRenderer {
             capacity,
             resident: 0,
             draw_count: u32::MAX,
+            ring: false,
+            write_total: 0,
             camera_buf,
             params_buf,
             compaction_buf,
@@ -287,17 +295,46 @@ impl PointCloudRenderer {
     #[allow(dead_code)]
     pub fn reset(&mut self) {
         self.resident = 0;
+        self.write_total = 0;
     }
 
-    /// Append packed points at the running offset, clamping to capacity. Returns the
-    /// number actually written.
+    /// Switch to ring mode: subsequent `append`s wrap and overwrite the oldest points (for the
+    /// unbounded acquisition stream). Resets the buffer.
+    pub fn enable_ring(&mut self) {
+        self.ring = true;
+        self.resident = 0;
+        self.write_total = 0;
+    }
+
+    /// Append packed points. In normal mode, writes at the running offset and clamps to capacity. In
+    /// ring mode, wraps at capacity (overwriting the oldest), so a long stream stays bounded to the
+    /// last `capacity` points. Returns the number written.
     pub fn append(&mut self, queue: &wgpu::Queue, points: &[GpuPoint]) -> usize {
-        if points.is_empty() || self.resident >= self.capacity {
+        if points.is_empty() {
+            return 0;
+        }
+        let stride = std::mem::size_of::<GpuPoint>() as u64;
+        if self.ring {
+            let cap = self.capacity as usize;
+            // Only the last `cap` points of a too-large batch can survive the wrap; keep its tail.
+            let pts = if points.len() > cap { &points[points.len() - cap..] } else { points };
+            let n = pts.len();
+            let start = (self.write_total % self.capacity as u64) as usize;
+            let first = (cap - start).min(n); // up to the buffer end…
+            queue.write_buffer(&self.master, start as u64 * stride, bytemuck::cast_slice(&pts[..first]));
+            if first < n {
+                // …then wrap the remainder to the front.
+                queue.write_buffer(&self.master, 0, bytemuck::cast_slice(&pts[first..n]));
+            }
+            self.write_total += n as u64;
+            self.resident = self.capacity.min(self.write_total.min(u32::MAX as u64) as u32);
+            return n;
+        }
+        if self.resident >= self.capacity {
             return 0;
         }
         let room = (self.capacity - self.resident) as usize;
         let n = points.len().min(room);
-        let stride = std::mem::size_of::<GpuPoint>() as u64;
         let offset = self.resident as u64 * stride; // checked-range: resident <= capacity
         queue.write_buffer(&self.master, offset, bytemuck::cast_slice(&points[..n]));
         self.resident += n as u32;

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -40,7 +40,8 @@ pub struct ParamsUniform {
     pub opacity: f32,
     /// 1.0 = re-fit the window box to the full cube (zoom to selection); 0.0 = no remap.
     pub focus: f32,
-    pub _pad1: f32,
+    /// 0 = color by intensity colormap, 1 = color by DBSCAN cluster id.
+    pub color_mode: u32,
     /// Bit mask: bit0 show MS1, bit1 show MS2.
     pub ms_mask: u32,
     pub colormap_id: u32,
@@ -114,7 +115,7 @@ impl Default for ParamsUniform {
             point_size: 2.5,
             opacity: 0.6,
             focus: 0.0,
-            _pad1: 0.0,
+            color_mode: 0,
             ms_mask: 0b11,
             colormap_id: 0,
             render_mode: 0,

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -116,7 +116,7 @@ impl Default for ParamsUniform {
             opacity: 0.6,
             focus: 0.0,
             color_mode: 0,
-            ms_mask: 0b11,
+            ms_mask: 0b01, // MS1-only by default (matches AppState)
             colormap_id: 0,
             render_mode: 0,
             n_colormaps: 1,

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -38,7 +38,8 @@ pub struct ParamsUniform {
     pub transfer: [f32; 4],
     pub point_size: f32,
     pub opacity: f32,
-    pub _pad0: f32,
+    /// 1.0 = re-fit the window box to the full cube (zoom to selection); 0.0 = no remap.
+    pub focus: f32,
     pub _pad1: f32,
     /// Bit mask: bit0 show MS1, bit1 show MS2.
     pub ms_mask: u32,
@@ -68,7 +69,9 @@ pub struct VolumeUniform {
     /// Multiplier applied to the sampled (normalized) voxel value to recover raw
     /// intensity before the transfer function (mirrors VolumeGrid::density_scale).
     pub density_scale: f32,
-    pub _pad: [f32; 3],
+    /// 1.0 = re-fit the window box to the full cube (zoom to selection); 0.0 = no remap.
+    pub focus: f32,
+    pub _pad: [f32; 2],
 }
 
 impl Default for VolumeUniform {
@@ -83,7 +86,8 @@ impl Default for VolumeUniform {
             colormap_id: 0,
             n_colormaps: 1,
             density_scale: 1.0,
-            _pad: [0.0; 3],
+            focus: 0.0,
+            _pad: [0.0; 2],
         }
     }
 }
@@ -93,7 +97,12 @@ impl Default for VolumeUniform {
 #[derive(Clone, Copy, Debug, Default, Pod, Zeroable)]
 pub struct CompactionUniform {
     pub point_count: u32,
-    pub _pad: [u32; 3],
+    /// Invocations per dispatch row (`groups_x * workgroup_size`). The compaction is
+    /// dispatched as a 2D workgroup grid so neither dimension exceeds wgpu's 65535 limit
+    /// at large point counts; the shader rebuilds the linear index as
+    /// `gid.x + gid.y * row_stride`.
+    pub row_stride: u32,
+    pub _pad: [u32; 2],
 }
 
 impl Default for ParamsUniform {
@@ -104,7 +113,7 @@ impl Default for ParamsUniform {
             transfer: [2.0, 1.0, 1e5, 1.0],
             point_size: 2.5,
             opacity: 0.6,
-            _pad0: 0.0,
+            focus: 0.0,
             _pad1: 0.0,
             ms_mask: 0b11,
             colormap_id: 0,

--- a/tims-viewer/src/render/uniforms.rs
+++ b/tims-viewer/src/render/uniforms.rs
@@ -110,7 +110,9 @@ impl Default for ParamsUniform {
     fn default() -> Self {
         ParamsUniform {
             filter_min: [-1.0, -1.0, -1.0, 0.0],
-            filter_max: [1.0, 1.0, 1.0, 0.0],
+            // .w = intensity range; default to pass-through (max = +inf) so the shader's
+            // intensity cull never rejects everything before state.params() sets a real range.
+            filter_max: [1.0, 1.0, 1.0, f32::INFINITY],
             transfer: [2.0, 1.0, 1e5, 1.0],
             point_size: 2.5,
             opacity: 0.6,

--- a/tims-viewer/src/render/volume.rs
+++ b/tims-viewer/src/render/volume.rs
@@ -126,10 +126,17 @@ impl VolumeGrid {
         if nz.is_empty() {
             return (1.0, 2.0);
         }
-        nz.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let pct = |q: f32| nz[(((nz.len() - 1) as f32) * q) as usize];
-        let lo = pct(0.50).max(1e-6); // median: voxels below it are sparse fringe
-        let hi = pct(0.999).max(lo * 1.0001);
+        // Two order statistics (median, p99.9) via partial select (O(n)) instead of a full sort of
+        // up to ~6.3M voxels on every re-voxel. select_nth places the k-th smallest at index k, so
+        // nz[k] equals the sorted value — same result as before. Indices are < len (empty handled).
+        let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal);
+        let lo_i = (((nz.len() - 1) as f32) * 0.50) as usize;
+        let hi_i = (((nz.len() - 1) as f32) * 0.999) as usize;
+        nz.select_nth_unstable_by(hi_i, cmp);
+        let hi_raw = nz[hi_i];
+        nz.select_nth_unstable_by(lo_i, cmp); // reorders, but hi_raw is already read
+        let lo = nz[lo_i].max(1e-6); // median: voxels below it are sparse fringe
+        let hi = hi_raw.max(lo * 1.0001);
         (lo, hi)
     }
 

--- a/tims-viewer/src/render/volume.rs
+++ b/tims-viewer/src/render/volume.rs
@@ -59,6 +59,14 @@ impl VolumeGrid {
         self.dirty = false;
     }
 
+    /// Zero all density (and the running max) — used when re-streaming a refined region so
+    /// the grid rebuilds from scratch.
+    pub fn clear(&mut self) {
+        self.data.iter_mut().for_each(|v| *v = 0.0);
+        self.max_density = 0.0;
+        self.dirty = true;
+    }
+
     /// Deposit a point (normalized cube position in [-1,1], raw intensity) using
     /// trilinear cloud-in-cell weighting: the intensity is split across the 8 nearest
     /// voxels by their interpolation weights and ADDED. This is conservative (the 8

--- a/tims-viewer/src/render/volume.rs
+++ b/tims-viewer/src/render/volume.rs
@@ -122,6 +122,23 @@ impl VolumeGrid {
         (lo, hi)
     }
 
+    /// Rebuild this grid as `wa*a + wb*b` of two same-dim source grids. Used to fold the
+    /// separate MS1 / MS2 density grids into the displayed volume per the MS1/MS2 toggle
+    /// (weights are 1.0 or 0.0), so the volume raycaster honors the same filter as points.
+    pub fn combine(&mut self, a: &VolumeGrid, b: &VolumeGrid, wa: f32, wb: f32) {
+        assert!(self.data.len() == a.data.len() && self.data.len() == b.data.len());
+        let mut max = 0.0f32;
+        for (i, d) in self.data.iter_mut().enumerate() {
+            let v = a.data[i] * wa + b.data[i] * wb;
+            *d = v;
+            if v > max {
+                max = v;
+            }
+        }
+        self.max_density = max;
+        self.dirty = true;
+    }
+
     /// Normalize by `density_scale` and convert to f16. The shader multiplies back by
     /// `density_scale` before the transfer function.
     pub fn to_f16_scaled(&self) -> Vec<f16> {

--- a/tims-viewer/src/render/volume.rs
+++ b/tims-viewer/src/render/volume.rs
@@ -28,6 +28,8 @@ pub struct VolumeGrid {
     /// Largest accumulated voxel density (drives the normalization scale).
     max_density: f32,
     dirty: bool,
+    /// Reusable f16 staging buffer for uploads, to avoid a per-frame allocation.
+    scratch: Vec<f16>,
 }
 
 impl VolumeGrid {
@@ -45,6 +47,7 @@ impl VolumeGrid {
             data: vec![0.0; n],
             max_density: 0.0,
             dirty: false,
+            scratch: Vec::new(),
         }
     }
 
@@ -139,14 +142,18 @@ impl VolumeGrid {
         self.dirty = true;
     }
 
-    /// Normalize by `density_scale` and convert to f16. The shader multiplies back by
+    /// Normalize by `density_scale` and convert to f16 into the reusable scratch buffer
+    /// (avoids a fresh multi-MB allocation per upload). The shader multiplies back by
     /// `density_scale` before the transfer function.
-    pub fn to_f16_scaled(&self) -> Vec<f16> {
+    pub fn to_f16_scaled(&mut self) -> &[f16] {
         let inv = 1.0 / self.density_scale();
-        self.data
-            .iter()
-            .map(|&v| f16::from_f32((v * inv).min(F16_TARGET_MAX)))
-            .collect()
+        if self.scratch.len() != self.data.len() {
+            self.scratch = vec![f16::from_f32(0.0); self.data.len()];
+        }
+        for (s, &v) in self.scratch.iter_mut().zip(self.data.iter()) {
+            *s = f16::from_f32((v * inv).min(F16_TARGET_MAX));
+        }
+        &self.scratch
     }
 }
 
@@ -468,7 +475,7 @@ mod tests {
             let t = i as f32 / 15.0 * 2.0 - 1.0;
             grid.deposit([t, 0.0, 0.0], 500.0 + i as f32 * 100.0);
         }
-        r.upload(&queue, &grid.to_f16_scaled());
+        r.upload(&queue, grid.to_f16_scaled());
         let cam = crate::camera::OrbitCamera::default();
         let mut u = VolumeUniform {
             inv_view_proj: cam.inv_view_proj(1.0),

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -423,12 +423,23 @@ fn build_load_result(
         Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points).to_vec().into_boxed_slice());
     drop(points);
 
+    // Cycle duration: the run-level mean RT gap between consecutive MS1 (precursor) frames. The web
+    // uses it to cluster RT in cycle units, so precursor points across cycles stay density-connected
+    // regardless of how tightly the RT range is focused. 0 when unknown (demo / no MS1 frames).
+    let ms1_rt: Vec<f64> = meta.frames.iter().filter(|f| !f.is_ms2).map(|f| f.retention_time).collect();
+    let cycle_duration = if ms1_rt.len() >= 2 {
+        (ms1_rt[ms1_rt.len() - 1] - ms1_rt[0]) / (ms1_rt.len() - 1) as f64
+    } else {
+        0.0
+    };
+
     let fin = |x: f64| if x.is_finite() { x } else { 0.0 };
     let meta_json = serde_json::json!({
         "version": 1,
         "point_stride": std::mem::size_of::<GpuPoint>(),
         "n_points": n_points,
         "downsample_stride": stride,
+        "cycle_duration": fin(cycle_duration),
         // Region bounds in real units — the client re-normalizes axes/crops/strips to these.
         "bounds": {
             "mz": [fin(region.mz.0), fin(region.mz.1)],

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -1,0 +1,176 @@
+//! Point-streaming server (NATIVE_WEB.md Phase 2).
+//!
+//! Drains the streaming loader into a `Vec<GpuPoint>` (no GPU needed — the loader is pure CPU
+//! and packs points already normalized to the `[-1, 1]` cube) and serves the raw bytes over
+//! HTTP so the browser shell (`tims-viewer-web`) can `fetch()` and render them. A `.d` path or
+//! `DEMO` both work, so this is testable without Bruker data.
+//!
+//! Wire format (v1, deliberately minimal): `GET /points` returns the raw little-endian
+//! `GpuPoint` array (`application/octet-stream`); the client reinterprets it as 32-byte points.
+//! `GET /meta` returns small JSON (point count + cube bounds, for axis labels later). Bound to
+//! localhost only. Phase 2.x will frame this as a proper message protocol (stats/histograms/
+//! annotations, version/stride negotiation, websocket) — see NATIVE_WEB.md.
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+
+use crate::app::Plan;
+use crate::data::demo::DemoSource;
+use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
+use crate::data::point::GpuPoint;
+
+/// Collect the whole slice as packed points, then serve it on `127.0.0.1:port` until killed.
+pub fn serve(plan: Plan, port: u16) -> Result<()> {
+    anyhow::ensure!(
+        cfg!(target_endian = "little"),
+        "the point wire format is little-endian; --serve is unsupported on this big-endian target"
+    );
+
+    let bounds = plan.meta.bounds;
+    let total = plan.meta.total_points_estimate;
+    let capacity = plan.budget.max(1).min((total as usize).max(1));
+    let stride = crate::data::loader::stride_for(total, capacity) as u64;
+    let points = collect_points(plan)?;
+    let n_points = points.len();
+    let (i_p1, i_p50, i_p99) = intensity_percentiles(&points);
+    // One copy into an owned byte buffer, then share it (no per-request copy) via Arc + Cursor.
+    let body: Arc<[u8]> =
+        Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points).to_vec().into_boxed_slice());
+    drop(points); // keep only the byte body
+
+    // Real-unit + exposure context for the client (axis labels, auto-transfer). serde_json emits
+    // non-finite floats as null, so guard every value to keep the JSON valid.
+    let fin = |x: f64| if x.is_finite() { x } else { 0.0 };
+    let meta = serde_json::json!({
+        "version": 1,
+        "point_stride": std::mem::size_of::<GpuPoint>(),
+        "n_points": n_points,
+        "downsample_stride": stride,
+        "bounds": {
+            "mz": [fin(bounds.mz.min), fin(bounds.mz.max)],
+            "im": [fin(bounds.im.min), fin(bounds.im.max)],
+            "rt": [fin(bounds.rt.min), fin(bounds.rt.max)],
+        },
+        "intensity": {
+            "p1": fin(i_p1 as f64), "p50": fin(i_p50 as f64), "p99": fin(i_p99 as f64),
+        },
+    })
+    .to_string();
+    let meta: Arc<[u8]> = Arc::from(meta.into_bytes().into_boxed_slice());
+
+    let server = Server::http(("127.0.0.1", port)).map_err(|e| anyhow::anyhow!("bind {port}: {e}"))?;
+    log::info!(
+        "serving {n_points} points ({:.1} MB) on http://localhost:{port}/points (localhost only)",
+        body.len() as f64 / 1e6,
+    );
+
+    for req in server.incoming_requests() {
+        let is_get = *req.method() == Method::Get;
+        // Route by path only — ignore any `?query` (owned so `req` can move into the responder).
+        let path = req.url().split('?').next().unwrap_or("").to_string();
+        let result = if path == "/points" && is_get {
+            respond_bytes(req, body.clone(), "application/octet-stream")
+        } else if path == "/meta" && is_get {
+            respond_bytes(req, meta.clone(), "application/json")
+        } else if *req.method() == Method::Options {
+            // CORS preflight (the trunk page is served from a different port).
+            req.respond(
+                Response::empty(204)
+                    .with_header(cors())
+                    .with_header(header("Access-Control-Allow-Methods", "GET, OPTIONS"))
+                    .with_header(header("Access-Control-Allow-Headers", "*")),
+            )
+        } else {
+            req.respond(
+                Response::from_string(
+                    "tims-viewer point server\nGET /points -> GpuPoint bytes\nGET /meta -> JSON\n",
+                )
+                .with_header(cors()),
+            )
+        };
+        if let Err(e) = result {
+            log::warn!("HTTP respond failed: {e}");
+        }
+    }
+    Ok(())
+}
+
+/// Serve a shared byte buffer without copying it per request (Cursor over the `Arc`).
+fn respond_bytes(req: Request, body: Arc<[u8]>, content_type: &str) -> std::io::Result<()> {
+    let len = body.len();
+    let resp = Response::new(
+        StatusCode(200),
+        vec![cors(), header("Content-Type", content_type)],
+        Cursor::new(body),
+        Some(len),
+        None,
+    );
+    req.respond(resp)
+}
+
+fn collect_points(plan: Plan) -> Result<Vec<GpuPoint>> {
+    let total = plan.meta.total_points_estimate;
+    let bounds = plan.meta.bounds;
+    let capacity = plan.budget.max(1).min((total as usize).max(1));
+
+    let mode = if plan.is_demo {
+        LoaderMode::Demo(DemoSource::new(plan.meta.frames.len(), total))
+    } else {
+        LoaderMode::Real {
+            path: plan.meta.data_path.clone(),
+            frame_ids: plan.meta.frames.iter().map(|f| f.id).collect(),
+            filter: None,
+        }
+    };
+    let loader = LoaderHandle::spawn(mode, bounds, total, capacity);
+
+    let mut points: Vec<GpuPoint> = Vec::with_capacity(capacity);
+    let mut done = false;
+    loop {
+        match loader.rx.recv() {
+            // Both carry `points`; bound the buffer at `capacity` but keep draining so the loader
+            // thread can finish (and signal Done) instead of blocking on a full channel.
+            Ok(LoadMsg::Chunk { points: pts, .. }) | Ok(LoadMsg::PeakChunk { points: pts }) => {
+                let room = capacity.saturating_sub(points.len());
+                if room > 0 {
+                    points.extend(pts.into_iter().take(room));
+                }
+            }
+            Ok(LoadMsg::Done { .. }) => {
+                done = true;
+                break;
+            }
+            Ok(LoadMsg::Error(e)) => anyhow::bail!("loader error: {e}"),
+            Ok(_) => {} // Stats/Histograms/Annotations/Progress: not part of the v1 point stream
+            Err(_) => break,
+        }
+    }
+    anyhow::ensure!(done, "loader thread ended before completing the load");
+    Ok(points)
+}
+
+/// Intensity (p1, p50, p99), nearest-rank, for the client's auto-transfer/exposure (mirrors the
+/// native viewer). Non-finite values are dropped.
+fn intensity_percentiles(points: &[GpuPoint]) -> (f32, f32, f32) {
+    let mut v: Vec<f32> = points.iter().map(|p| p.intensity).filter(|x| x.is_finite()).collect();
+    if v.is_empty() {
+        return (1.0, 1.0, 1.0);
+    }
+    v.sort_by(|a, b| a.total_cmp(b));
+    let pct = |q: f32| {
+        let idx = ((v.len() as f32 * q).ceil() as usize).saturating_sub(1).min(v.len() - 1);
+        v[idx].max(1.0)
+    };
+    (pct(0.01), pct(0.50), pct(0.99))
+}
+
+fn cors() -> Header {
+    header("Access-Control-Allow-Origin", "*")
+}
+
+fn header(name: &str, value: &str) -> Header {
+    Header::from_bytes(name.as_bytes(), value.as_bytes()).expect("valid header")
+}

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -12,7 +12,7 @@
 //! `(region, budget)` and shared between `/points` and `/meta`. Several worker threads serve
 //! concurrently so a multi-second region load can't stall other requests. Localhost only.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::Cursor;
 use std::sync::{Arc, Mutex};
 
@@ -82,6 +82,41 @@ impl LoadKey {
     }
 }
 
+/// Max distinct (region, budget) loads kept resident. Each can be hundreds of MB, so bound it; the
+/// pinned full-run base is never evicted (instant Reset).
+const CACHE_MAX: usize = 8;
+
+/// Bounded FIFO cache of built loads. The pinned key (full run) is never evicted.
+struct Cache {
+    map: HashMap<LoadKey, Arc<LoadResult>>,
+    order: VecDeque<LoadKey>,
+    pinned: LoadKey,
+}
+
+impl Cache {
+    fn get(&self, k: &LoadKey) -> Option<Arc<LoadResult>> {
+        self.map.get(k).cloned()
+    }
+    fn insert(&mut self, k: LoadKey, v: Arc<LoadResult>) {
+        if self.map.insert(k, v).is_none() {
+            self.order.push_back(k);
+        }
+        while self.map.len() > CACHE_MAX {
+            // Evict the oldest non-pinned entry; drop stale/pinned keys from the order queue.
+            let mut evicted = false;
+            while let Some(old) = self.order.pop_front() {
+                if old != self.pinned && self.map.remove(&old).is_some() {
+                    evicted = true;
+                    break;
+                }
+            }
+            if !evicted {
+                break;
+            }
+        }
+    }
+}
+
 struct State {
     meta: MetaIndex,
     is_demo: bool,
@@ -89,7 +124,7 @@ struct State {
     /// Full-run intensity distribution, for estimating region survivor counts vs an intensity floor.
     full_i_hist: Vec<u32>,
     full_i_p99: f32,
-    cache: Mutex<HashMap<LoadKey, Arc<LoadResult>>>,
+    cache: Mutex<Cache>,
 }
 
 /// Build the full run eagerly (fast first paint + the estimate reference), then serve region
@@ -106,19 +141,21 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     let built = build_load_result(&meta, is_demo, &full, budget, None)?;
     let n0 = built.result.n_points;
     let bytes0 = built.result.points.len();
+    let full_key = LoadKey::of(&full, budget);
+    let mut map = HashMap::new();
+    map.insert(full_key, Arc::new(built.result));
     let state = Arc::new(State {
         meta,
         is_demo,
         default_budget: budget,
         full_i_hist: built.i_hist,
         full_i_p99: built.i_p99,
-        cache: Mutex::new(HashMap::new()),
+        cache: Mutex::new(Cache {
+            map,
+            order: VecDeque::new(),
+            pinned: full_key,
+        }),
     });
-    state
-        .cache
-        .lock()
-        .unwrap()
-        .insert(LoadKey::of(&full, budget), Arc::new(built.result));
 
     let server = Arc::new(
         Server::http(("127.0.0.1", port)).map_err(|e| anyhow::anyhow!("bind {port}: {e}"))?,
@@ -195,16 +232,20 @@ fn parse_query(url: &str, state: &State) -> (Region4D, usize) {
             match k {
                 "n" => {
                     if let Ok(n) = v.parse::<usize>() {
-                        budget = n.max(1);
+                        budget = n;
                     }
                 }
                 "imin" => {
                     if let Ok(x) = v.parse::<f32>() {
-                        r.imin = x.max(0.0);
+                        if x.is_finite() {
+                            r.imin = x.max(0.0);
+                        }
                     }
                 }
                 _ => {
-                    if let Ok(x) = v.parse::<f64>() {
+                    // Ignore non-finite (NaN/inf) coordinates rather than letting them reach the
+                    // cube transform / cache key / normalization.
+                    if let Some(x) = v.parse::<f64>().ok().filter(|x| x.is_finite()) {
                         match k {
                             "mz0" => r.mz.0 = x,
                             "mz1" => r.mz.1 = x,
@@ -219,19 +260,44 @@ fn parse_query(url: &str, state: &State) -> (Region4D, usize) {
             }
         }
     }
+    // The demo loader generates frames 0..N starting at RT 0 and ignores frame ids, so it can't
+    // honor an RT sub-window — use the full RT range for demo sessions (m/z·1/K0·intensity focus
+    // still works). Real data realizes RT via frame selection.
+    if state.is_demo {
+        r.rt = full.rt;
+    }
     r.mz = clamp_range(r.mz, full.mz);
     r.im = clamp_range(r.im, full.im);
     r.rt = clamp_range(r.rt, full.rt);
-    (r, budget)
+    // Snap to the cache-key grid so the reported bounds exactly match the key (no aliasing where
+    // two distinct requests round to the same key but expect different results).
+    r = snap_region(r);
+    // Cap the budget to the server pool (also guards the downstream `budget * 85` from overflow).
+    (r, budget.clamp(1, state.default_budget))
+}
+
+/// Round a region onto the same grid the cache key quantizes to, so key and bounds stay consistent.
+fn snap_region(mut r: Region4D) -> Region4D {
+    let snap = |x: f64, s: f64| (x * s).round() / s;
+    r.mz = (snap(r.mz.0, 1e3), snap(r.mz.1, 1e3));
+    r.im = (snap(r.im.0, 1e6), snap(r.im.1, 1e6));
+    r.rt = (snap(r.rt.0, 1e3), snap(r.rt.1, 1e3));
+    r.imin = snap(r.imin as f64, 1e3) as f32;
+    r
 }
 
 /// Look up a cached load or build (and cache) it. The build runs outside the lock so concurrent
 /// requests for *other* regions are not blocked; a rare double-build of the same region is harmless.
 fn get_or_build(state: &State, region: &Region4D, budget: usize) -> Result<Arc<LoadResult>> {
     let key = LoadKey::of(region, budget);
-    if let Some(lr) = state.cache.lock().unwrap().get(&key).cloned() {
+    // Poison-safe: a panicked worker must not wedge the others.
+    let lock = || state.cache.lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(lr) = lock().get(&key) {
         return Ok(lr);
     }
+    // Build outside the lock (a multi-second load mustn't block other regions). Builds are
+    // deterministic, so a rare concurrent double-build of the same key yields identical bytes —
+    // `/meta` and `/points` stay coherent regardless of which build each request observes.
     let built = build_load_result(
         &state.meta,
         state.is_demo,
@@ -240,7 +306,7 @@ fn get_or_build(state: &State, region: &Region4D, budget: usize) -> Result<Arc<L
         Some((&state.full_i_hist, state.full_i_p99)),
     )?;
     let lr = Arc::new(built.result);
-    state.cache.lock().unwrap().insert(key, lr.clone());
+    lock().insert(key, lr.clone());
     Ok(lr)
 }
 
@@ -264,6 +330,12 @@ fn build_load_result(
             frame_ids.push(f.id);
             rt_total = rt_total.saturating_add(f.num_peaks);
         }
+    }
+
+    // A region with no frames in its RT window is valid — return an empty result (the loader would
+    // otherwise error on a zero-frame run). Frames-but-zero-survivors flows through normally below.
+    if frame_ids.is_empty() {
+        return Ok(empty_result(region));
     }
 
     // Region-relative survivor estimate -> stride (FOCUS_LENS_PLAN.md blocker-1): scale the RT
@@ -406,12 +478,27 @@ fn collect(
     let mut stats: Option<(f32, f32, f32)> = None;
     let mut hist: Option<Hist> = None;
     let mut done = false;
+    // Reservoir-sample the emitted stream to `capacity` rather than truncating its prefix: if the
+    // region estimate under-counts and the loader over-emits, truncation would keep an RT-ordered
+    // prefix (bias). A reservoir keeps a uniform sample regardless of how wrong the estimate was.
+    let mut seen: u64 = 0;
+    let mut rng: u64 = 0xD1B5_4A32_D192_ED03;
     loop {
         match loader.rx.recv() {
             Ok(LoadMsg::Chunk { points: pts, .. }) | Ok(LoadMsg::PeakChunk { points: pts }) => {
-                let room = capacity.saturating_sub(points.len());
-                if room > 0 {
-                    points.extend(pts.into_iter().take(room));
+                for p in pts {
+                    seen += 1;
+                    if points.len() < capacity {
+                        points.push(p);
+                    } else {
+                        rng ^= rng << 13;
+                        rng ^= rng >> 7;
+                        rng ^= rng << 17;
+                        let j = (rng % seen) as usize;
+                        if j < capacity {
+                            points[j] = p;
+                        }
+                    }
                 }
             }
             Ok(LoadMsg::Stats { i_min, i_max, i_med }) => stats = Some((i_min, i_med, i_max)),
@@ -427,6 +514,34 @@ fn collect(
     }
     anyhow::ensure!(done, "loader thread ended before completing the load");
     Ok((points, stats, hist))
+}
+
+/// A valid empty load for a region with no points (e.g. an RT window selecting no frames).
+fn empty_result(region: &Region4D) -> Built {
+    let fin = |x: f64| if x.is_finite() { x } else { 0.0 };
+    let meta_json = serde_json::json!({
+        "version": 1,
+        "point_stride": std::mem::size_of::<GpuPoint>(),
+        "n_points": 0,
+        "downsample_stride": 1,
+        "bounds": {
+            "mz": [fin(region.mz.0), fin(region.mz.1)],
+            "im": [fin(region.im.0), fin(region.im.1)],
+            "rt": [fin(region.rt.0), fin(region.rt.1)],
+        },
+        "intensity": { "p1": 1.0, "p50": 1.0, "p99": 1.0, "hist": vec![0u32; I_HIST_BINS] },
+        "hist": serde_json::Value::Null,
+    })
+    .to_string();
+    Built {
+        result: LoadResult {
+            points: Arc::from(Vec::<u8>::new().into_boxed_slice()),
+            meta: Arc::from(meta_json.into_bytes().into_boxed_slice()),
+            n_points: 0,
+        },
+        i_hist: vec![0u32; I_HIST_BINS],
+        i_p99: 1.0,
+    }
 }
 
 fn full_region(meta: &MetaIndex) -> Region4D {

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -677,35 +677,62 @@ fn intensity_frac(imin: f32, i_ref: Option<(&[u32], f32)>) -> f64 {
     (above as f64 / total as f64).max(1.0 / total as f64)
 }
 
+/// Does the request actually accept `zstd`? Token-correct: matches the `zstd` coding exactly (not a
+/// substring like `x-zstd`) across a `gzip, zstd, br` list and rejects an explicit `q=0`.
+fn accepts_zstd(req: &Request) -> bool {
+    req.headers().iter().filter(|h| h.field.equiv("Accept-Encoding")).any(|h| {
+        h.value.as_str().split(',').any(|tok| {
+            let mut parts = tok.split(';').map(str::trim);
+            let coding = parts.next().unwrap_or("");
+            coding.eq_ignore_ascii_case("zstd")
+                // accept unless an explicit q=0 disqualifies it
+                && parts.all(|p| {
+                    p.strip_prefix("q=")
+                        .or_else(|| p.strip_prefix("Q="))
+                        .and_then(|v| v.parse::<f64>().ok())
+                        .map_or(true, |q| q > 0.0)
+                })
+        })
+    })
+}
+
 /// Serve the `/points` payload, zstd-compressing it when `--compress` is on AND the client advertises
 /// `Accept-Encoding: zstd` (the browser then decompresses `Content-Encoding: zstd` transparently — no
-/// client code). Falls back to the raw body if disabled, not negotiated, or on any encode error.
+/// client code). When compression is enabled the response carries `Vary: Accept-Encoding` so a shared
+/// cache/proxy can't hand a zstd body to a client that didn't ask. Falls back to raw on encode error.
 fn respond_points(req: Request, body: Arc<[u8]>, compress: bool) -> std::io::Result<()> {
-    let want_zstd = compress
-        && req.headers().iter().any(|h| {
-            h.field.equiv("Accept-Encoding") && h.value.as_str().to_ascii_lowercase().contains("zstd")
-        });
-    if want_zstd {
+    if !compress {
+        return respond_bytes(req, body, "application/octet-stream");
+    }
+    if accepts_zstd(&req) {
         match zstd::encode_all(&body[..], 3) {
             Ok(z) => {
                 let len = z.len();
-                let resp = Response::new(
+                return req.respond(Response::new(
                     StatusCode(200),
                     vec![
                         cors(),
                         header("Content-Type", "application/octet-stream"),
                         header("Content-Encoding", "zstd"),
+                        header("Vary", "Accept-Encoding"),
                     ],
                     Cursor::new(z),
                     Some(len),
                     None,
-                );
-                return req.respond(resp);
+                ));
             }
             Err(e) => log::warn!("zstd encode failed ({e}); sending raw points"),
         }
     }
-    respond_bytes(req, body, "application/octet-stream")
+    // Raw, but still Vary — this route negotiates, so caches must key on Accept-Encoding.
+    let len = body.len();
+    req.respond(Response::new(
+        StatusCode(200),
+        vec![cors(), header("Content-Type", "application/octet-stream"), header("Vary", "Accept-Encoding")],
+        Cursor::new(body),
+        Some(len),
+        None,
+    ))
 }
 
 /// Serve a shared byte buffer without copying it per request (Cursor over the `Arc`).

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -67,17 +67,23 @@ struct LoadKey {
     budget: u64,
 }
 
+/// Per-field quantization grid `[mz, im, rt, imin]`, shared by `LoadKey::of` (key rounding) and
+/// `snap_region` (reported bounds). These MUST use the same scales: if a request rounded to one key
+/// but reported bounds that snap to a different key, `/points` and `/meta` could disagree. 1/K0 spans
+/// ~1 unit so it's quantized finely (1e6); the rest to 1e3.
+const QUANT: [f64; 4] = [1e3, 1e6, 1e3, 1e3];
+
 impl LoadKey {
     fn of(r: &Region4D, budget: usize) -> Self {
         let q = |x: f64, s: f64| (x * s).round() as i64;
         LoadKey {
-            mz0: q(r.mz.0, 1e3),
-            mz1: q(r.mz.1, 1e3),
-            im0: q(r.im.0, 1e6), // 1/K0 spans ~1 unit — quantize finely
-            im1: q(r.im.1, 1e6),
-            rt0: q(r.rt.0, 1e3),
-            rt1: q(r.rt.1, 1e3),
-            imin: q(r.imin as f64, 1e3),
+            mz0: q(r.mz.0, QUANT[0]),
+            mz1: q(r.mz.1, QUANT[0]),
+            im0: q(r.im.0, QUANT[1]),
+            im1: q(r.im.1, QUANT[1]),
+            rt0: q(r.rt.0, QUANT[2]),
+            rt1: q(r.rt.1, QUANT[2]),
+            imin: q(r.imin as f64, QUANT[3]),
             budget: budget as u64,
         }
     }
@@ -511,10 +517,10 @@ fn parse_query(url: &str, state: &State) -> (Region4D, usize) {
 /// Round a region onto the same grid the cache key quantizes to, so key and bounds stay consistent.
 fn snap_region(mut r: Region4D) -> Region4D {
     let snap = |x: f64, s: f64| (x * s).round() / s;
-    r.mz = (snap(r.mz.0, 1e3), snap(r.mz.1, 1e3));
-    r.im = (snap(r.im.0, 1e6), snap(r.im.1, 1e6));
-    r.rt = (snap(r.rt.0, 1e3), snap(r.rt.1, 1e3));
-    r.imin = snap(r.imin as f64, 1e3) as f32;
+    r.mz = (snap(r.mz.0, QUANT[0]), snap(r.mz.1, QUANT[0]));
+    r.im = (snap(r.im.0, QUANT[1]), snap(r.im.1, QUANT[1]));
+    r.rt = (snap(r.rt.0, QUANT[2]), snap(r.rt.1, QUANT[2]));
+    r.imin = snap(r.imin as f64, QUANT[3]) as f32;
     r
 }
 
@@ -584,7 +590,7 @@ fn build_load_result(
     // A region with no frames in its RT window is valid — return an empty result (the loader would
     // otherwise error on a zero-frame run). Frames-but-zero-survivors flows through normally below.
     if frame_ids.is_empty() {
-        return Ok(empty_result(region));
+        return Ok(empty_result(meta, region));
     }
 
     // Region-relative survivor estimate -> stride (FOCUS_LENS_PLAN.md blocker-1): scale the RT
@@ -650,7 +656,6 @@ fn build_load_result(
         0.0
     };
 
-    let fin = |x: f64| if x.is_finite() { x } else { 0.0 };
     // Run-level 1/K0 per TIMS scan: the FULL-run mobility span over the ramp length. Run-level (not
     // region-scoped) so the client's IM clustering reach is focus-independent.
     let im_per_scan = if meta.num_scans > 1 {
@@ -658,35 +663,10 @@ fn build_load_result(
     } else {
         0.0
     };
-    let meta_json = serde_json::json!({
-        "version": 1,
-        "point_stride": std::mem::size_of::<GpuPoint>(),
-        "n_points": n_points,
-        "downsample_stride": stride,
-        "cycle_duration": fin(cycle_duration),
-        "im_per_scan_1k0": fin(im_per_scan),
-        "num_scans": meta.num_scans,
-        // Region bounds in real units — the client re-normalizes axes/crops/strips to these.
-        "bounds": {
-            "mz": [fin(region.mz.0), fin(region.mz.1)],
-            "im": [fin(region.im.0), fin(region.im.1)],
-            "rt": [fin(region.rt.0), fin(region.rt.1)],
-        },
-        "intensity": {
-            "p1": fin(i_p1 as f64), "p50": fin(i_p50 as f64), "p99": fin(i_p99 as f64),
-            "hist": i_hist.clone(),
-        },
-        // Sample-based per-axis density histograms (over the kept systematic sample + peak tail).
-        "hist": hist.as_ref().map(|h| serde_json::json!({
-            "mz": h.mz, "im": h.im, "rt": h.rt,
-        })),
-        // Sample-based 2D density projections for the box-select minimaps.
-        "proj": hist.as_ref().map(|h| serde_json::json!({
-            "bins": PROJ_BINS,
-            "mz_im": h.proj_mz_im, "mz_rt": h.proj_mz_rt, "im_rt": h.proj_im_rt,
-        })),
-    })
-    .to_string();
+    let meta_json = build_meta_json(
+        region, n_points, stride, cycle_duration, im_per_scan, meta.num_scans, i_p1, i_p50, i_p99,
+        &i_hist, hist.as_ref(),
+    );
 
     Ok(Built {
         result: LoadResult {
@@ -900,23 +880,64 @@ fn collect(
 }
 
 /// A valid empty load for a region with no points (e.g. an RT window selecting no frames).
-fn empty_result(region: &Region4D) -> Built {
+/// Build the `/meta` JSON string. The single source of the meta schema, shared by the normal load
+/// path and the empty-region path so a field can't be added to one and silently omitted from the
+/// other. `hist: None` emits null hist/proj (empty region).
+#[allow(clippy::too_many_arguments)]
+fn build_meta_json(
+    region: &Region4D,
+    n_points: usize,
+    downsample_stride: usize,
+    cycle_duration: f64,
+    im_per_scan: f64,
+    num_scans: u32,
+    i_p1: f32,
+    i_p50: f32,
+    i_p99: f32,
+    i_hist: &[u32],
+    hist: Option<&Hist>,
+) -> String {
     let fin = |x: f64| if x.is_finite() { x } else { 0.0 };
-    let meta_json = serde_json::json!({
+    serde_json::json!({
         "version": 1,
         "point_stride": std::mem::size_of::<GpuPoint>(),
-        "n_points": 0,
-        "downsample_stride": 1,
+        "n_points": n_points,
+        "downsample_stride": downsample_stride,
+        "cycle_duration": fin(cycle_duration),
+        "im_per_scan_1k0": fin(im_per_scan),
+        "num_scans": num_scans,
+        // Region bounds in real units — the client re-normalizes axes/crops/strips to these.
         "bounds": {
             "mz": [fin(region.mz.0), fin(region.mz.1)],
             "im": [fin(region.im.0), fin(region.im.1)],
             "rt": [fin(region.rt.0), fin(region.rt.1)],
         },
-        "intensity": { "p1": 1.0, "p50": 1.0, "p99": 1.0, "hist": vec![0u32; I_HIST_BINS] },
-        "hist": serde_json::Value::Null,
-        "proj": serde_json::Value::Null,
+        "intensity": {
+            "p1": fin(i_p1 as f64), "p50": fin(i_p50 as f64), "p99": fin(i_p99 as f64),
+            "hist": i_hist,
+        },
+        // Sample-based per-axis density histograms (over the kept systematic sample + peak tail).
+        "hist": hist.map(|h| serde_json::json!({ "mz": h.mz, "im": h.im, "rt": h.rt })),
+        // Sample-based 2D density projections for the box-select minimaps.
+        "proj": hist.map(|h| serde_json::json!({
+            "bins": PROJ_BINS,
+            "mz_im": h.proj_mz_im, "mz_rt": h.proj_mz_rt, "im_rt": h.proj_im_rt,
+        })),
     })
-    .to_string();
+    .to_string()
+}
+
+fn empty_result(meta: &MetaIndex, region: &Region4D) -> Built {
+    // Run-level fields are still meaningful for an empty region (no frames in the RT window); route
+    // through the shared builder so the schema can't drift from the normal path.
+    let im_per_scan = if meta.num_scans > 1 {
+        (meta.bounds.im.max - meta.bounds.im.min).abs() / (meta.num_scans as f64 - 1.0)
+    } else {
+        0.0
+    };
+    let meta_json = build_meta_json(
+        region, 0, 1, 0.0, im_per_scan, meta.num_scans, 1.0, 1.0, 1.0, &vec![0u32; I_HIST_BINS], None,
+    );
     Built {
         result: LoadResult {
             points: Arc::from(Vec::<u8>::new().into_boxed_slice()),

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -38,9 +38,9 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     // Prefer the loader's systematic-base percentiles (matches the native viewer's Stats); fall
     // back to computing over the served points (incl. the peak tail) only if Stats never arrived.
     let (i_p1, i_p50, i_p99) = stats.unwrap_or_else(|| intensity_percentiles(&points));
-    // Cbrt-binned intensity histogram over [0, p99] for the floor control's distribution (log is
-    // too compressive; cbrt keeps the low-intensity region — where the noise floor sits — readable).
-    let i_hist = intensity_cbrt_hist(&points, i_p99);
+    // Linear intensity histogram over [0, p99], in real observed counts (the floor slider is linear
+    // in the same units, so both read in the values actually observed).
+    let i_hist = intensity_linear_hist(&points, i_p99);
     // One copy into an owned byte buffer, then share it (no per-request copy) via Arc + Cursor.
     let body: Arc<[u8]> =
         Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points).to_vec().into_boxed_slice());
@@ -61,7 +61,7 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
         },
         "intensity": {
             "p1": fin(i_p1 as f64), "p50": fin(i_p50 as f64), "p99": fin(i_p99 as f64),
-            // cbrt-binned distribution over [0, p99]; the client's floor slider is cbrt-mapped to it.
+            // Linear distribution over [0, p99] in real counts; the floor slider spans the same.
             "hist": i_hist,
         },
         // Per-axis density histograms (HIST_BINS bins over the full cube range, same mapping as the
@@ -192,16 +192,16 @@ fn intensity_percentiles(points: &[GpuPoint]) -> (f32, f32, f32) {
     (pct(0.01), pct(0.50), pct(0.99))
 }
 
-/// Cbrt-binned intensity histogram over `[0, hi]` (80 bins), so the client's cbrt-mapped floor
-/// slider aligns with it. Intensity 0 lands in bin 0; values above `hi` clamp to the last bin.
-fn intensity_cbrt_hist(points: &[GpuPoint], hi: f32) -> Vec<u32> {
+/// Linear intensity histogram over `[0, hi]` (80 bins) in real counts; values above `hi` clamp to
+/// the last bin. Aligns with the client's linear floor slider over the same range.
+fn intensity_linear_hist(points: &[GpuPoint], hi: f32) -> Vec<u32> {
     const BINS: usize = 80;
-    let cbrt_hi = hi.max(1.0).cbrt();
+    let hi = hi.max(1.0);
     let mut h = vec![0u32; BINS];
     for p in points {
         let i = p.intensity;
         let bin = if i.is_finite() && i > 0.0 {
-            ((i.cbrt() / cbrt_hi).clamp(0.0, 1.0) * (BINS as f32 - 1.0)) as usize
+            ((i / hi).clamp(0.0, 1.0) * (BINS as f32 - 1.0)) as usize
         } else {
             0
         };

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -38,6 +38,9 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     // Prefer the loader's systematic-base percentiles (matches the native viewer's Stats); fall
     // back to computing over the served points (incl. the peak tail) only if Stats never arrived.
     let (i_p1, i_p50, i_p99) = stats.unwrap_or_else(|| intensity_percentiles(&points));
+    // Cbrt-binned intensity histogram over [0, p99] for the floor control's distribution (log is
+    // too compressive; cbrt keeps the low-intensity region — where the noise floor sits — readable).
+    let i_hist = intensity_cbrt_hist(&points, i_p99);
     // One copy into an owned byte buffer, then share it (no per-request copy) via Arc + Cursor.
     let body: Arc<[u8]> =
         Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points).to_vec().into_boxed_slice());
@@ -58,6 +61,8 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
         },
         "intensity": {
             "p1": fin(i_p1 as f64), "p50": fin(i_p50 as f64), "p99": fin(i_p99 as f64),
+            // cbrt-binned distribution over [0, p99]; the client's floor slider is cbrt-mapped to it.
+            "hist": i_hist,
         },
         // Per-axis density histograms (HIST_BINS bins over the full cube range, same mapping as the
         // crop sliders) so the client can draw the distribution behind each filter.
@@ -185,6 +190,24 @@ fn intensity_percentiles(points: &[GpuPoint]) -> (f32, f32, f32) {
         v[idx].max(1.0)
     };
     (pct(0.01), pct(0.50), pct(0.99))
+}
+
+/// Cbrt-binned intensity histogram over `[0, hi]` (80 bins), so the client's cbrt-mapped floor
+/// slider aligns with it. Intensity 0 lands in bin 0; values above `hi` clamp to the last bin.
+fn intensity_cbrt_hist(points: &[GpuPoint], hi: f32) -> Vec<u32> {
+    const BINS: usize = 80;
+    let cbrt_hi = hi.max(1.0).cbrt();
+    let mut h = vec![0u32; BINS];
+    for p in points {
+        let i = p.intensity;
+        let bin = if i.is_finite() && i > 0.0 {
+            ((i.cbrt() / cbrt_hi).clamp(0.0, 1.0) * (BINS as f32 - 1.0)) as usize
+        } else {
+            0
+        };
+        h[bin] += 1;
+    }
+    h
 }
 
 fn cors() -> Header {

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -183,6 +183,8 @@ struct Hub {
     source: ServeSource,
     entries: Vec<DatasetEntry>,
     budget: Option<usize>,
+    /// zstd-compress the /points payload when the client advertises Accept-Encoding: zstd.
+    compress: bool,
     states: Mutex<StateCache>,
     /// Per-dataset build locks: a dataset switch fires `/meta` + `/points` + `/windows` near-
     /// simultaneously, so serialize concurrent builds of the *same* id (the rest re-check the cache
@@ -286,7 +288,7 @@ fn build_datasets_json(entries: &[DatasetEntry]) -> Arc<[u8]> {
 
 /// Build the registry, eagerly build the default dataset (fast first paint), then serve region
 /// queries — and dataset switches — on demand from `WORKERS` threads.
-pub fn serve(source: ServeSource, budget: Option<usize>, port: u16) -> Result<()> {
+pub fn serve(source: ServeSource, budget: Option<usize>, port: u16, compress: bool) -> Result<()> {
     anyhow::ensure!(
         cfg!(target_endian = "little"),
         "the point wire format is little-endian; --serve is unsupported on this big-endian target"
@@ -306,10 +308,14 @@ pub fn serve(source: ServeSource, budget: Option<usize>, port: u16) -> Result<()
         source,
         entries,
         budget,
+        compress,
         states: Mutex::new(StateCache::default()),
         build_locks: Mutex::new(HashMap::new()),
         datasets_json,
     });
+    if compress {
+        log::info!("over-the-wire zstd compression enabled for /points (Accept-Encoding negotiated)");
+    }
 
     // Eagerly build the default dataset so its first paint is instant.
     get_or_build_state(&hub, 0)?;
@@ -388,7 +394,7 @@ fn handle(req: Request, hub: &Hub) -> std::io::Result<()> {
         let (region, budget) = parse_query(&url, &state);
         return match get_or_build(&state, &region, budget) {
             Ok(lr) if want_points => {
-                respond_bytes(req, lr.points.clone(), "application/octet-stream")
+                respond_points(req, lr.points.clone(), hub.compress)
             }
             Ok(lr) => respond_bytes(req, lr.meta.clone(), "application/json"),
             Err(e) => req.respond(
@@ -669,6 +675,37 @@ fn intensity_frac(imin: f32, i_ref: Option<(&[u32], f32)>) -> f64 {
     let above: u64 = hist[bin..].iter().map(|&c| c as u64).sum();
     // Never 0: a tiny estimate yields stride 1 and we keep all (few) survivors anyway.
     (above as f64 / total as f64).max(1.0 / total as f64)
+}
+
+/// Serve the `/points` payload, zstd-compressing it when `--compress` is on AND the client advertises
+/// `Accept-Encoding: zstd` (the browser then decompresses `Content-Encoding: zstd` transparently — no
+/// client code). Falls back to the raw body if disabled, not negotiated, or on any encode error.
+fn respond_points(req: Request, body: Arc<[u8]>, compress: bool) -> std::io::Result<()> {
+    let want_zstd = compress
+        && req.headers().iter().any(|h| {
+            h.field.equiv("Accept-Encoding") && h.value.as_str().to_ascii_lowercase().contains("zstd")
+        });
+    if want_zstd {
+        match zstd::encode_all(&body[..], 3) {
+            Ok(z) => {
+                let len = z.len();
+                let resp = Response::new(
+                    StatusCode(200),
+                    vec![
+                        cors(),
+                        header("Content-Type", "application/octet-stream"),
+                        header("Content-Encoding", "zstd"),
+                    ],
+                    Cursor::new(z),
+                    Some(len),
+                    None,
+                );
+                return req.respond(resp);
+            }
+            Err(e) => log::warn!("zstd encode failed ({e}); sending raw points"),
+        }
+    }
+    respond_bytes(req, body, "application/octet-stream")
 }
 
 /// Serve a shared byte buffer without copying it per request (Cursor over the `Arc`).

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -212,7 +212,9 @@ impl Hub {
 /// Resolve the `State` for dataset `id`, building (and caching, LRU-evicting) it on first request.
 /// The build runs outside the lock so a multi-second load can't block other datasets' requests.
 fn get_or_build_state(hub: &Hub, id: usize) -> Result<Arc<State>> {
-    if let Some(s) = hub.states.lock().unwrap().get(id) {
+    // Poison-safe throughout (like the cache lock in get_or_build): a build that panics on a corrupt
+    // `.d` must not poison these mutexes and take every later request for this — or any — dataset down.
+    if let Some(s) = hub.states.lock().unwrap_or_else(|p| p.into_inner()).get(id) {
         return Ok(s);
     }
     // Single-flight per dataset: hold this id's build lock so concurrent first-touches (a switch's
@@ -220,17 +222,23 @@ fn get_or_build_state(hub: &Hub, id: usize) -> Result<Arc<State>> {
     let build_lock = hub
         .build_locks
         .lock()
-        .unwrap()
+        .unwrap_or_else(|p| p.into_inner())
         .entry(id)
         .or_default()
         .clone();
-    let _guard = build_lock.lock().unwrap();
+    let _guard = build_lock.lock().unwrap_or_else(|p| p.into_inner());
     // Re-check: another thread may have built it while we waited on the build lock.
-    if let Some(s) = hub.states.lock().unwrap().get(id) {
+    if let Some(s) = hub.states.lock().unwrap_or_else(|p| p.into_inner()).get(id) {
         return Ok(s);
     }
-    let state = Arc::new(build_state(hub.plan_for(id)?)?);
-    hub.states.lock().unwrap().insert(id, state.clone());
+    let plan = hub.plan_for(id)?;
+    // Contain a build panic (malformed run → rustdf/loader/bytemuck can panic) as an error instead
+    // of unwinding through the held build_lock (which would poison it and cascade the worker pool
+    // down). Catching here also lets the guard drop cleanly, leaving the lock usable for a retry.
+    let state = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| build_state(plan)))
+        .map_err(|_| anyhow::anyhow!("dataset {id} build panicked (corrupt or unreadable data)"))??;
+    let state = Arc::new(state);
+    hub.states.lock().unwrap_or_else(|p| p.into_inner()).insert(id, state.clone());
     Ok(state)
 }
 
@@ -466,7 +474,8 @@ fn parse_query(url: &str, state: &State) -> (Region4D, usize) {
     // two distinct requests round to the same key but expect different results).
     r = snap_region(r);
     // Cap the budget to the server pool (also guards the downstream `budget * 85` from overflow).
-    (r, budget.clamp(1, state.default_budget))
+    // `.max(1)` on the ceiling so a `--budget 0` misconfig can't make clamp(1, 0) panic (min > max).
+    (r, budget.clamp(1, state.default_budget.max(1)))
 }
 
 /// Round a region onto the same grid the cache key quantizes to, so key and bounds stay consistent.
@@ -798,7 +807,7 @@ fn collect(
                     }
                 }
             }
-            Ok(LoadMsg::Stats { i_min, i_max, i_med }) => stats = Some((i_min, i_med, i_max)),
+            Ok(LoadMsg::Stats { i_p1, i_p99, i_p50 }) => stats = Some((i_p1, i_p50, i_p99)),
             Ok(LoadMsg::Histograms {
                 mz, im, rt, proj_mz_im, proj_mz_rt, proj_im_rt, ..
             }) => {

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -146,10 +146,9 @@ fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>,
         LoaderMode::Real {
             path: plan.meta.data_path.clone(),
             frame_ids: plan.meta.frames.iter().map(|f| f.id).collect(),
-            filter: None,
         }
     };
-    let loader = LoaderHandle::spawn(mode, bounds, total, capacity);
+    let loader = LoaderHandle::spawn(mode, bounds, total, capacity, None);
 
     let mut points: Vec<GpuPoint> = Vec::with_capacity(capacity);
     let mut stats: Option<(f32, f32, f32)> = None;

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -642,8 +642,11 @@ fn build_load_result(
     let (i_p1, i_p50, i_p99) = stats.unwrap_or_else(|| intensity_percentiles(&points));
     let i_hist = intensity_linear_hist(&points, i_p99);
 
-    let body: Arc<[u8]> =
-        Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points).to_vec().into_boxed_slice());
+    // One copy into the Arc allocation, not two: `Arc::from(&[u8])` copies the byte view directly,
+    // vs the old `.to_vec().into_boxed_slice()` which memcpy'd the whole 356 MB into a Vec first and
+    // then again into the Arc. (Can't reinterpret the Vec<GpuPoint> allocation as Vec<u8> in place —
+    // bytemuck::cast_vec requires equal alignment, and GpuPoint is align-4.)
+    let body: Arc<[u8]> = Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points));
     drop(points);
 
     // Cycle duration: the run-level mean RT gap between consecutive MS1 (precursor) frames. The web

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -33,7 +33,10 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     let total = plan.meta.total_points_estimate;
     let capacity = plan.budget.max(1).min((total as usize).max(1));
     let stride = crate::data::loader::stride_for(total, capacity) as u64;
-    let (points, stats, hist) = collect_points(plan)?;
+    let (mut points, stats, hist) = collect_points(plan)?;
+    // Shuffle so any prefix is a representative subsample: the client can then trade detail for
+    // performance by drawing just the first K points (and a buffer-size cap keeps a fair sample).
+    shuffle_points(&mut points);
     let n_points = points.len();
     // Prefer the loader's systematic-base percentiles (matches the native viewer's Stats); fall
     // back to computing over the served points (incl. the peak tail) only if Stats never arrived.
@@ -190,6 +193,21 @@ fn intensity_percentiles(points: &[GpuPoint]) -> (f32, f32, f32) {
         v[idx].max(1.0)
     };
     (pct(0.01), pct(0.50), pct(0.99))
+}
+
+/// In-place Fisher-Yates shuffle with a seeded xorshift64 (deterministic, no `rand` dependency).
+/// Decorrelates the loader's RT-ordered emission so a prefix of the array is a uniform subsample.
+fn shuffle_points(points: &mut [GpuPoint]) {
+    let mut s: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut next = || {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        s
+    };
+    for i in (1..points.len()).rev() {
+        points.swap(i, (next() % (i as u64 + 1)) as usize);
+    }
 }
 
 /// Linear intensity histogram over `[0, hi]` (80 bins) in real counts; values above `hi` clamp to

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -1,116 +1,373 @@
-//! Point-streaming server (NATIVE_WEB.md Phase 2).
+//! Point-serving HTTP server with on-demand region queries (FOCUS_LENS_PLAN.md A1).
 //!
-//! Drains the streaming loader into a `Vec<GpuPoint>` (no GPU needed — the loader is pure CPU
-//! and packs points already normalized to the `[-1, 1]` cube) and serves the raw bytes over
-//! HTTP so the browser shell (`tims-viewer-web`) can `fetch()` and render them. A `.d` path or
-//! `DEMO` both work, so this is testable without Bruker data.
+//! Holds the full run's metadata and answers region-scoped loads on demand:
 //!
-//! Wire format (v1, deliberately minimal): `GET /points` returns the raw little-endian
-//! `GpuPoint` array (`application/octet-stream`); the client reinterprets it as 32-byte points.
-//! `GET /meta` returns small JSON (point count + cube bounds, for axis labels later). Bound to
-//! localhost only. Phase 2.x will frame this as a proper message protocol (stats/histograms/
-//! annotations, version/stride negotiation, websocket) — see NATIVE_WEB.md.
+//! ```text
+//!   GET /points[?n=&mz0=&mz1=&im0=&im1=&rt0=&rt1=&imin=]  -> packed little-endian GpuPoint bytes
+//!   GET /meta  [same query]                               -> JSON (region bounds, percentiles, hists)
+//! ```
+//!
+//! No query => the full run. A query selects a 4D region (RT realized by frame selection; m/z·1/K0·
+//! intensity culled at the source) and the budget concentrates on it. Each built load is cached by
+//! `(region, budget)` and shared between `/points` and `/meta`. Several worker threads serve
+//! concurrently so a multi-second region load can't stall other requests. Localhost only.
 
+use std::collections::HashMap;
 use std::io::Cursor;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 
 use crate::app::Plan;
 use crate::data::demo::DemoSource;
-use crate::data::loader::{LoadMsg, LoaderHandle, LoaderMode};
-use crate::data::point::GpuPoint;
+use crate::data::loader::{stride_for, LoadMsg, LoaderHandle, LoaderMode, RegionFilter};
+use crate::data::meta::MetaIndex;
+use crate::data::point::{AxisBounds, AxisTransform, GpuPoint};
 
-/// Collect the whole slice as packed points, then serve it on `127.0.0.1:port` until killed.
+/// Worker threads pulling requests off the shared server (so one slow load can't block others).
+const WORKERS: usize = 4;
+const I_HIST_BINS: usize = 80;
+
+/// A 4D region of the run in real units (RT is realized via frame selection).
+#[derive(Clone, Copy)]
+struct Region4D {
+    mz: (f64, f64),
+    im: (f64, f64),
+    rt: (f64, f64),
+    imin: f32,
+}
+
+/// A built, cached load: shared bytes for `/points` and `/meta`, plus the point count.
+struct LoadResult {
+    points: Arc<[u8]>,
+    meta: Arc<[u8]>,
+    n_points: usize,
+}
+
+/// Output of a build: the cacheable result plus the intensity reference the full-run build seeds
+/// for later region survivor estimates.
+struct Built {
+    result: LoadResult,
+    i_hist: Vec<u32>,
+    i_p99: f32,
+}
+
+/// Quantized cache key (regions are f64, so not directly Hash/Eq).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct LoadKey {
+    mz0: i64,
+    mz1: i64,
+    im0: i64,
+    im1: i64,
+    rt0: i64,
+    rt1: i64,
+    imin: i64,
+    budget: u64,
+}
+
+impl LoadKey {
+    fn of(r: &Region4D, budget: usize) -> Self {
+        let q = |x: f64, s: f64| (x * s).round() as i64;
+        LoadKey {
+            mz0: q(r.mz.0, 1e3),
+            mz1: q(r.mz.1, 1e3),
+            im0: q(r.im.0, 1e6), // 1/K0 spans ~1 unit — quantize finely
+            im1: q(r.im.1, 1e6),
+            rt0: q(r.rt.0, 1e3),
+            rt1: q(r.rt.1, 1e3),
+            imin: q(r.imin as f64, 1e3),
+            budget: budget as u64,
+        }
+    }
+}
+
+struct State {
+    meta: MetaIndex,
+    is_demo: bool,
+    default_budget: usize,
+    /// Full-run intensity distribution, for estimating region survivor counts vs an intensity floor.
+    full_i_hist: Vec<u32>,
+    full_i_p99: f32,
+    cache: Mutex<HashMap<LoadKey, Arc<LoadResult>>>,
+}
+
+/// Build the full run eagerly (fast first paint + the estimate reference), then serve region
+/// queries on demand from `WORKERS` threads.
 pub fn serve(plan: Plan, port: u16) -> Result<()> {
     anyhow::ensure!(
         cfg!(target_endian = "little"),
         "the point wire format is little-endian; --serve is unsupported on this big-endian target"
     );
+    let Plan { meta, is_demo, budget } = plan;
+    let full = full_region(&meta);
 
-    let bounds = plan.meta.bounds;
-    let total = plan.meta.total_points_estimate;
-    let capacity = plan.budget.max(1).min((total as usize).max(1));
-    let stride = crate::data::loader::stride_for(total, capacity) as u64;
-    let (mut points, stats, hist) = collect_points(plan)?;
-    // Shuffle so any prefix is a representative subsample: the client can then trade detail for
-    // performance by drawing just the first K points (and a buffer-size cap keeps a fair sample).
+    // Eager full-run build (filter=None): seeds the cache and the intensity reference.
+    let built = build_load_result(&meta, is_demo, &full, budget, None)?;
+    let n0 = built.result.n_points;
+    let bytes0 = built.result.points.len();
+    let state = Arc::new(State {
+        meta,
+        is_demo,
+        default_budget: budget,
+        full_i_hist: built.i_hist,
+        full_i_p99: built.i_p99,
+        cache: Mutex::new(HashMap::new()),
+    });
+    state
+        .cache
+        .lock()
+        .unwrap()
+        .insert(LoadKey::of(&full, budget), Arc::new(built.result));
+
+    let server = Arc::new(
+        Server::http(("127.0.0.1", port)).map_err(|e| anyhow::anyhow!("bind {port}: {e}"))?,
+    );
+    log::info!(
+        "serving {n0} points ({:.1} MB) + on-demand region queries on http://localhost:{port} (localhost only)",
+        bytes0 as f64 / 1e6,
+    );
+
+    let mut handles = Vec::with_capacity(WORKERS);
+    for _ in 0..WORKERS {
+        let (server, state) = (server.clone(), state.clone());
+        handles.push(std::thread::spawn(move || worker(&server, &state)));
+    }
+    for h in handles {
+        let _ = h.join();
+    }
+    Ok(())
+}
+
+fn worker(server: &Server, state: &State) {
+    while let Ok(req) = server.recv() {
+        if let Err(e) = handle(req, state) {
+            log::warn!("HTTP respond failed: {e}");
+        }
+    }
+}
+
+fn handle(req: Request, state: &State) -> std::io::Result<()> {
+    if *req.method() == Method::Options {
+        // CORS preflight (the trunk page is served from a different origin).
+        return req.respond(
+            Response::empty(204)
+                .with_header(cors())
+                .with_header(header("Access-Control-Allow-Methods", "GET, OPTIONS"))
+                .with_header(header("Access-Control-Allow-Headers", "*")),
+        );
+    }
+    let url = req.url().to_string();
+    let path = url.split('?').next().unwrap_or("");
+    let (want_points, want_meta) = (path == "/points", path == "/meta");
+    if *req.method() == Method::Get && (want_points || want_meta) {
+        let (region, budget) = parse_query(&url, state);
+        return match get_or_build(state, &region, budget) {
+            Ok(lr) if want_points => {
+                respond_bytes(req, lr.points.clone(), "application/octet-stream")
+            }
+            Ok(lr) => respond_bytes(req, lr.meta.clone(), "application/json"),
+            Err(e) => req.respond(
+                Response::from_string(format!("load failed: {e}"))
+                    .with_status_code(500)
+                    .with_header(cors()),
+            ),
+        };
+    }
+    req.respond(
+        Response::from_string(
+            "tims-viewer point server\n\
+             GET /points|/meta[?n=&mz0=&mz1=&im0=&im1=&rt0=&rt1=&imin=]\n",
+        )
+        .with_header(cors()),
+    )
+}
+
+/// Parse the region + budget from a query string, defaulting to the full run. Ranges are clamped to
+/// the full bounds and ordered (lo <= hi).
+fn parse_query(url: &str, state: &State) -> (Region4D, usize) {
+    let full = full_region(&state.meta);
+    let mut r = full;
+    let mut budget = state.default_budget;
+    if let Some(q) = url.split('?').nth(1) {
+        for kv in q.split('&') {
+            let Some((k, v)) = kv.split_once('=') else { continue };
+            match k {
+                "n" => {
+                    if let Ok(n) = v.parse::<usize>() {
+                        budget = n.max(1);
+                    }
+                }
+                "imin" => {
+                    if let Ok(x) = v.parse::<f32>() {
+                        r.imin = x.max(0.0);
+                    }
+                }
+                _ => {
+                    if let Ok(x) = v.parse::<f64>() {
+                        match k {
+                            "mz0" => r.mz.0 = x,
+                            "mz1" => r.mz.1 = x,
+                            "im0" => r.im.0 = x,
+                            "im1" => r.im.1 = x,
+                            "rt0" => r.rt.0 = x,
+                            "rt1" => r.rt.1 = x,
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+    r.mz = clamp_range(r.mz, full.mz);
+    r.im = clamp_range(r.im, full.im);
+    r.rt = clamp_range(r.rt, full.rt);
+    (r, budget)
+}
+
+/// Look up a cached load or build (and cache) it. The build runs outside the lock so concurrent
+/// requests for *other* regions are not blocked; a rare double-build of the same region is harmless.
+fn get_or_build(state: &State, region: &Region4D, budget: usize) -> Result<Arc<LoadResult>> {
+    let key = LoadKey::of(region, budget);
+    if let Some(lr) = state.cache.lock().unwrap().get(&key).cloned() {
+        return Ok(lr);
+    }
+    let built = build_load_result(
+        &state.meta,
+        state.is_demo,
+        region,
+        budget,
+        Some((&state.full_i_hist, state.full_i_p99)),
+    )?;
+    let lr = Arc::new(built.result);
+    state.cache.lock().unwrap().insert(key, lr.clone());
+    Ok(lr)
+}
+
+/// Run one region load: select frames, size the stride to the region survivor estimate, stream
+/// through the loader (normalized to the region so it fills the cube), shuffle, and pack the
+/// `/points` bytes + `/meta` JSON.
+fn build_load_result(
+    meta: &MetaIndex,
+    is_demo: bool,
+    region: &Region4D,
+    budget: usize,
+    i_ref: Option<(&[u32], f32)>,
+) -> Result<Built> {
+    let full = full_region(meta);
+
+    // RT window -> frame ids + the RT-region source size (all m/z·1/K0, pre-cull).
+    let mut frame_ids: Vec<u32> = Vec::new();
+    let mut rt_total: u64 = 0;
+    for f in &meta.frames {
+        if f.retention_time >= region.rt.0 && f.retention_time <= region.rt.1 {
+            frame_ids.push(f.id);
+            rt_total = rt_total.saturating_add(f.num_peaks);
+        }
+    }
+
+    // Region-relative survivor estimate -> stride (FOCUS_LENS_PLAN.md blocker-1): scale the RT
+    // source size by the m/z·1/K0 window fraction and the intensity floor's surviving fraction.
+    let span = |r: (f64, f64), f: (f64, f64)| ((r.1 - r.0) / (f.1 - f.0).max(1e-9)).clamp(0.0, 1.0);
+    let i_frac = intensity_frac(region.imin, i_ref);
+    let estimate =
+        (((rt_total as f64) * span(region.mz, full.mz) * span(region.im, full.im) * i_frac).ceil()
+            as u64)
+            .max(1);
+
+    // Re-normalize: the loader maps points to [-1,1] over the region bounds (so the region fills
+    // the view). For the full run this equals the run bounds (unchanged behavior).
+    let bounds = AxisBounds {
+        mz: AxisTransform::new(region.mz.0, region.mz.1),
+        im: AxisTransform::new(region.im.0, region.im.1),
+        rt: AxisTransform::new(region.rt.0, region.rt.1),
+    };
+
+    // No-op spatial culls (the full run) skip the per-point filter entirely.
+    const EPS: f64 = 1e-6;
+    let no_spatial = region.mz.0 <= full.mz.0 + EPS
+        && region.mz.1 >= full.mz.1 - EPS
+        && region.im.0 <= full.im.0 + EPS
+        && region.im.1 >= full.im.1 - EPS;
+    let filter = if no_spatial && region.imin <= 0.0 {
+        None
+    } else {
+        Some(RegionFilter {
+            mz: region.mz,
+            im: region.im,
+            intensity_min: region.imin,
+        })
+    };
+
+    let mode = if is_demo {
+        LoaderMode::Demo(DemoSource::new(frame_ids.len(), rt_total))
+    } else {
+        LoaderMode::Real {
+            path: meta.data_path.clone(),
+            frame_ids,
+        }
+    };
+
+    let (mut points, stats, hist) = collect(mode, bounds, estimate, budget, filter)?;
     shuffle_points(&mut points);
     let n_points = points.len();
-    // Prefer the loader's systematic-base percentiles (matches the native viewer's Stats); fall
-    // back to computing over the served points (incl. the peak tail) only if Stats never arrived.
+    let stride = stride_for(estimate, budget.max(1));
     let (i_p1, i_p50, i_p99) = stats.unwrap_or_else(|| intensity_percentiles(&points));
-    // Linear intensity histogram over [0, p99], in real observed counts (the floor slider is linear
-    // in the same units, so both read in the values actually observed).
     let i_hist = intensity_linear_hist(&points, i_p99);
-    // One copy into an owned byte buffer, then share it (no per-request copy) via Arc + Cursor.
+
     let body: Arc<[u8]> =
         Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points).to_vec().into_boxed_slice());
-    drop(points); // keep only the byte body
+    drop(points);
 
-    // Real-unit + exposure context for the client (axis labels, auto-transfer). serde_json emits
-    // non-finite floats as null, so guard every value to keep the JSON valid.
     let fin = |x: f64| if x.is_finite() { x } else { 0.0 };
-    let meta = serde_json::json!({
+    let meta_json = serde_json::json!({
         "version": 1,
         "point_stride": std::mem::size_of::<GpuPoint>(),
         "n_points": n_points,
         "downsample_stride": stride,
+        // Region bounds in real units — the client re-normalizes axes/crops/strips to these.
         "bounds": {
-            "mz": [fin(bounds.mz.min), fin(bounds.mz.max)],
-            "im": [fin(bounds.im.min), fin(bounds.im.max)],
-            "rt": [fin(bounds.rt.min), fin(bounds.rt.max)],
+            "mz": [fin(region.mz.0), fin(region.mz.1)],
+            "im": [fin(region.im.0), fin(region.im.1)],
+            "rt": [fin(region.rt.0), fin(region.rt.1)],
         },
         "intensity": {
             "p1": fin(i_p1 as f64), "p50": fin(i_p50 as f64), "p99": fin(i_p99 as f64),
-            // Linear distribution over [0, p99] in real counts; the floor slider spans the same.
-            "hist": i_hist,
+            "hist": i_hist.clone(),
         },
-        // Per-axis density histograms (HIST_BINS bins over the full cube range, same mapping as the
-        // crop sliders) so the client can draw the distribution behind each filter.
+        // Sample-based per-axis density histograms (over the kept systematic sample + peak tail).
         "hist": hist.as_ref().map(|h| serde_json::json!({
             "mz": h.mz, "im": h.im, "rt": h.rt,
         })),
     })
     .to_string();
-    let meta: Arc<[u8]> = Arc::from(meta.into_bytes().into_boxed_slice());
 
-    let server = Server::http(("127.0.0.1", port)).map_err(|e| anyhow::anyhow!("bind {port}: {e}"))?;
-    log::info!(
-        "serving {n_points} points ({:.1} MB) on http://localhost:{port}/points (localhost only)",
-        body.len() as f64 / 1e6,
-    );
+    Ok(Built {
+        result: LoadResult {
+            points: body,
+            meta: Arc::from(meta_json.into_bytes().into_boxed_slice()),
+            n_points,
+        },
+        i_hist,
+        i_p99,
+    })
+}
 
-    for req in server.incoming_requests() {
-        let is_get = *req.method() == Method::Get;
-        // Route by path only — ignore any `?query` (owned so `req` can move into the responder).
-        let path = req.url().split('?').next().unwrap_or("").to_string();
-        let result = if path == "/points" && is_get {
-            respond_bytes(req, body.clone(), "application/octet-stream")
-        } else if path == "/meta" && is_get {
-            respond_bytes(req, meta.clone(), "application/json")
-        } else if *req.method() == Method::Options {
-            // CORS preflight (the trunk page is served from a different port).
-            req.respond(
-                Response::empty(204)
-                    .with_header(cors())
-                    .with_header(header("Access-Control-Allow-Methods", "GET, OPTIONS"))
-                    .with_header(header("Access-Control-Allow-Headers", "*")),
-            )
-        } else {
-            req.respond(
-                Response::from_string(
-                    "tims-viewer point server\nGET /points -> GpuPoint bytes\nGET /meta -> JSON\n",
-                )
-                .with_header(cors()),
-            )
-        };
-        if let Err(e) = result {
-            log::warn!("HTTP respond failed: {e}");
-        }
+/// Surviving fraction of points at or above an intensity floor, estimated from the full-run linear
+/// intensity histogram over `[0, p99]`. `imin <= 0` (or no reference) => everything survives.
+fn intensity_frac(imin: f32, i_ref: Option<(&[u32], f32)>) -> f64 {
+    if imin <= 0.0 {
+        return 1.0;
     }
-    Ok(())
+    let Some((hist, p99)) = i_ref else { return 1.0 };
+    let total: u64 = hist.iter().map(|&c| c as u64).sum();
+    if total == 0 || hist.is_empty() {
+        return 1.0;
+    }
+    let bin = ((imin / p99.max(1.0)).clamp(0.0, 1.0) * (hist.len() as f32 - 1.0)) as usize;
+    let above: u64 = hist[bin..].iter().map(|&c| c as u64).sum();
+    // Never 0: a tiny estimate yields stride 1 and we keep all (few) survivors anyway.
+    (above as f64 / total as f64).max(1.0 / total as f64)
 }
 
 /// Serve a shared byte buffer without copying it per request (Cursor over the `Arc`).
@@ -126,38 +383,31 @@ fn respond_bytes(req: Request, body: Arc<[u8]>, content_type: &str) -> std::io::
     req.respond(resp)
 }
 
-/// Per-axis density histograms from the loader (each `HIST_BINS` bins over the cube range).
+/// Per-axis density histograms from the loader (each `HIST_BINS` bins over the region range).
 struct Hist {
     mz: Vec<u32>,
     im: Vec<u32>,
     rt: Vec<u32>,
 }
 
-/// Drain the loader into a point buffer; also capture the loader's intensity `Stats`
-/// (systematic-base p1/p50/p99 as `(i_min, i_med, i_max)`) and the per-axis histograms.
-fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>, Option<Hist>)> {
-    let total = plan.meta.total_points_estimate;
-    let bounds = plan.meta.bounds;
-    let capacity = plan.budget.max(1).min((total as usize).max(1));
+/// Drain the loader (with `total_estimate` already sized to the region) into a bounded point
+/// buffer, capturing the intensity `Stats` and per-axis histograms.
+fn collect(
+    mode: LoaderMode,
+    bounds: AxisBounds,
+    estimate: u64,
+    budget: usize,
+    filter: Option<RegionFilter>,
+) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>, Option<Hist>)> {
+    let capacity = budget.max(1);
+    let loader = LoaderHandle::spawn(mode, bounds, estimate, capacity, filter);
 
-    let mode = if plan.is_demo {
-        LoaderMode::Demo(DemoSource::new(plan.meta.frames.len(), total))
-    } else {
-        LoaderMode::Real {
-            path: plan.meta.data_path.clone(),
-            frame_ids: plan.meta.frames.iter().map(|f| f.id).collect(),
-        }
-    };
-    let loader = LoaderHandle::spawn(mode, bounds, total, capacity, None);
-
-    let mut points: Vec<GpuPoint> = Vec::with_capacity(capacity);
+    let mut points: Vec<GpuPoint> = Vec::with_capacity(capacity.min(1 << 20));
     let mut stats: Option<(f32, f32, f32)> = None;
     let mut hist: Option<Hist> = None;
     let mut done = false;
     loop {
         match loader.rx.recv() {
-            // Both carry `points`; bound the buffer at `capacity` but keep draining so the loader
-            // thread can finish (and signal Done) instead of blocking on a full channel.
             Ok(LoadMsg::Chunk { points: pts, .. }) | Ok(LoadMsg::PeakChunk { points: pts }) => {
                 let room = capacity.saturating_sub(points.len());
                 if room > 0 {
@@ -171,7 +421,7 @@ fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>,
                 break;
             }
             Ok(LoadMsg::Error(e)) => anyhow::bail!("loader error: {e}"),
-            Ok(_) => {} // Annotations/Progress: not part of the v1 point stream
+            Ok(_) => {}
             Err(_) => break,
         }
     }
@@ -179,8 +429,28 @@ fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>,
     Ok((points, stats, hist))
 }
 
-/// Intensity (p1, p50, p99), nearest-rank, for the client's auto-transfer/exposure (mirrors the
-/// native viewer). Non-finite values are dropped.
+fn full_region(meta: &MetaIndex) -> Region4D {
+    let b = &meta.bounds;
+    Region4D {
+        mz: (b.mz.min, b.mz.max),
+        im: (b.im.min, b.im.max),
+        rt: (b.rt.min, b.rt.max),
+        imin: 0.0,
+    }
+}
+
+/// Clamp a range into `full` and order it (lo <= hi).
+fn clamp_range(r: (f64, f64), full: (f64, f64)) -> (f64, f64) {
+    let lo = r.0.clamp(full.0, full.1);
+    let hi = r.1.clamp(full.0, full.1);
+    if lo <= hi {
+        (lo, hi)
+    } else {
+        (hi, lo)
+    }
+}
+
+/// Intensity (p1, p50, p99), nearest-rank, fallback when the loader Stats are absent.
 fn intensity_percentiles(points: &[GpuPoint]) -> (f32, f32, f32) {
     let mut v: Vec<f32> = points.iter().map(|p| p.intensity).filter(|x| x.is_finite()).collect();
     if v.is_empty() {
@@ -209,16 +479,14 @@ fn shuffle_points(points: &mut [GpuPoint]) {
     }
 }
 
-/// Linear intensity histogram over `[0, hi]` (80 bins) in real counts; values above `hi` clamp to
-/// the last bin. Aligns with the client's linear floor slider over the same range.
+/// Linear intensity histogram over `[0, hi]` (real counts); values above `hi` clamp to the last bin.
 fn intensity_linear_hist(points: &[GpuPoint], hi: f32) -> Vec<u32> {
-    const BINS: usize = 80;
     let hi = hi.max(1.0);
-    let mut h = vec![0u32; BINS];
+    let mut h = vec![0u32; I_HIST_BINS];
     for p in points {
         let i = p.intensity;
         let bin = if i.is_finite() && i > 0.0 {
-            ((i / hi).clamp(0.0, 1.0) * (BINS as f32 - 1.0)) as usize
+            ((i / hi).clamp(0.0, 1.0) * (I_HIST_BINS as f32 - 1.0)) as usize
         } else {
             0
         };

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -184,6 +184,10 @@ struct Hub {
     entries: Vec<DatasetEntry>,
     budget: Option<usize>,
     states: Mutex<StateCache>,
+    /// Per-dataset build locks: a dataset switch fires `/meta` + `/points` + `/windows` near-
+    /// simultaneously, so serialize concurrent builds of the *same* id (the rest re-check the cache
+    /// and hit it) — without serializing builds of *different* datasets.
+    build_locks: Mutex<HashMap<usize, Arc<Mutex<()>>>>,
     datasets_json: Arc<[u8]>,
 }
 
@@ -206,6 +210,20 @@ impl Hub {
 /// Resolve the `State` for dataset `id`, building (and caching, LRU-evicting) it on first request.
 /// The build runs outside the lock so a multi-second load can't block other datasets' requests.
 fn get_or_build_state(hub: &Hub, id: usize) -> Result<Arc<State>> {
+    if let Some(s) = hub.states.lock().unwrap().get(id) {
+        return Ok(s);
+    }
+    // Single-flight per dataset: hold this id's build lock so concurrent first-touches (a switch's
+    // /meta + /points + /windows) don't each build the same hundreds-of-MB state.
+    let build_lock = hub
+        .build_locks
+        .lock()
+        .unwrap()
+        .entry(id)
+        .or_default()
+        .clone();
+    let _guard = build_lock.lock().unwrap();
+    // Re-check: another thread may have built it while we waited on the build lock.
     if let Some(s) = hub.states.lock().unwrap().get(id) {
         return Ok(s);
     }
@@ -255,29 +273,15 @@ fn dataset_name(path: &std::path::Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
-/// `/datasets` JSON: `[{"id":0,"name":"run5"}, ...]`.
+/// `/datasets` JSON: `[{"id":0,"name":"run5"}, ...]`. Built via serde_json so any folder name
+/// (control chars, quotes, unicode) is escaped correctly.
 fn build_datasets_json(entries: &[DatasetEntry]) -> Arc<[u8]> {
-    let items: Vec<String> = entries
+    let items: Vec<serde_json::Value> = entries
         .iter()
         .enumerate()
-        .map(|(i, e)| format!("{{\"id\":{i},\"name\":{}}}", json_str(&e.name)))
+        .map(|(i, e)| serde_json::json!({ "id": i, "name": e.name }))
         .collect();
-    format!("[{}]", items.join(",")).into_bytes().into()
-}
-
-/// Minimal JSON string escaping (quotes + backslashes) for dataset names.
-fn json_str(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            c => out.push(c),
-        }
-    }
-    out.push('"');
-    out
+    serde_json::to_vec(&items).unwrap_or_else(|_| b"[]".to_vec()).into()
 }
 
 /// Build the registry, eagerly build the default dataset (fast first paint), then serve region
@@ -303,6 +307,7 @@ pub fn serve(source: ServeSource, budget: Option<usize>, port: u16) -> Result<()
         entries,
         budget,
         states: Mutex::new(StateCache::default()),
+        build_locks: Mutex::new(HashMap::new()),
         datasets_json,
     });
 

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::io::Cursor;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
@@ -130,31 +131,108 @@ struct State {
     cache: Mutex<Cache>,
 }
 
-/// Build the full run eagerly (fast first paint + the estimate reference), then serve region
-/// queries on demand from `WORKERS` threads.
-pub fn serve(plan: Plan, port: u16) -> Result<()> {
-    anyhow::ensure!(
-        cfg!(target_endian = "little"),
-        "the point wire format is little-endian; --serve is unsupported on this big-endian target"
-    );
+/// What the server can offer: a single synthetic dataset, or a set of discovered `.d` paths
+/// (confined to the launch root) the frontend can choose between via `/datasets` + `?dataset=N`.
+pub enum ServeSource {
+    Demo(MetaIndex),
+    Datasets(Vec<PathBuf>),
+}
+
+/// One selectable dataset in the registry (the paths themselves live in `Hub::source`).
+struct DatasetEntry {
+    name: String,
+}
+
+/// Max datasets kept resident at once — each holds a full-run load (hundreds of MB) plus its region
+/// cache, so switching evicts the least-recently-built (it rebuilds in seconds if revisited).
+const MAX_RESIDENT_DATASETS: usize = 2;
+
+/// LRU of built per-dataset `State`s, keyed by dataset id.
+#[derive(Default)]
+struct StateCache {
+    map: HashMap<usize, Arc<State>>,
+    order: VecDeque<usize>,
+}
+
+impl StateCache {
+    fn get(&mut self, id: usize) -> Option<Arc<State>> {
+        let s = self.map.get(&id).cloned();
+        if s.is_some() {
+            self.order.retain(|&x| x != id);
+            self.order.push_back(id); // mark most-recently-used
+        }
+        s
+    }
+    fn insert(&mut self, id: usize, s: Arc<State>) {
+        if self.map.insert(id, s).is_none() {
+            self.order.push_back(id);
+        }
+        while self.map.len() > MAX_RESIDENT_DATASETS {
+            match self.order.pop_front() {
+                Some(old) if old != id => {
+                    self.map.remove(&old);
+                }
+                Some(_) | None => break,
+            }
+        }
+    }
+}
+
+/// The multi-dataset server: a registry + a lazily-built, LRU-bounded set of per-dataset states.
+struct Hub {
+    source: ServeSource,
+    entries: Vec<DatasetEntry>,
+    budget: Option<usize>,
+    states: Mutex<StateCache>,
+    datasets_json: Arc<[u8]>,
+}
+
+impl Hub {
+    /// Build the load Plan for dataset `id` (loads its metadata; cheap relative to the full build).
+    fn plan_for(&self, id: usize) -> Result<Plan> {
+        match &self.source {
+            ServeSource::Demo(meta) => Ok(Plan::new(meta.clone(), true, self.budget)),
+            ServeSource::Datasets(paths) => {
+                let p = paths
+                    .get(id)
+                    .ok_or_else(|| anyhow::anyhow!("dataset {id} out of range"))?;
+                let meta = MetaIndex::load(&p.display().to_string())?;
+                Ok(Plan::new(meta, false, self.budget))
+            }
+        }
+    }
+}
+
+/// Resolve the `State` for dataset `id`, building (and caching, LRU-evicting) it on first request.
+/// The build runs outside the lock so a multi-second load can't block other datasets' requests.
+fn get_or_build_state(hub: &Hub, id: usize) -> Result<Arc<State>> {
+    if let Some(s) = hub.states.lock().unwrap().get(id) {
+        return Ok(s);
+    }
+    let state = Arc::new(build_state(hub.plan_for(id)?)?);
+    hub.states.lock().unwrap().insert(id, state.clone());
+    Ok(state)
+}
+
+/// Eagerly build one dataset's `State`: the full-run load (first paint + intensity reference), the
+/// DIA window footprints, and a fresh region cache pinned on the full run.
+fn build_state(plan: Plan) -> Result<State> {
     let Plan { meta, is_demo, budget } = plan;
     // Snap the eager full region onto the cache grid so a client's explicit full-bounds query
     // (also snapped in parse_query) resolves to this same cached entry instead of rebuilding.
     let full = snap_region(full_region(&meta));
-
-    // Eager full-run build (filter=None): seeds the cache and the intensity reference.
     let built = build_load_result(&meta, is_demo, &full, budget, None)?;
-    let n0 = built.result.n_points;
-    let bytes0 = built.result.points.len();
+    log::info!(
+        "built dataset '{}': {} points ({:.1} MB)",
+        meta.data_path,
+        built.result.n_points,
+        built.result.points.len() as f64 / 1e6,
+    );
     let full_key = LoadKey::of(&full, budget);
     let mut map = HashMap::new();
     map.insert(full_key, Arc::new(built.result));
-
-    // The DIA isolation-window footprints are run-level — read them once (opening one dataset) and
-    // serve them statically from `/windows`. Demo / non-DIA runs serve an empty set.
     let windows_json = build_windows_json(is_demo, &meta.data_path);
-
-    let state = Arc::new(State {
+    Ok(State {
         meta,
         is_demo,
         default_budget: budget,
@@ -166,20 +244,83 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
             order: VecDeque::new(),
             pinned: full_key,
         }),
+    })
+}
+
+/// Display name for a dataset path: the `.d` folder's stem (e.g. `/data/run5.d` → `run5`).
+fn dataset_name(path: &std::path::Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// `/datasets` JSON: `[{"id":0,"name":"run5"}, ...]`.
+fn build_datasets_json(entries: &[DatasetEntry]) -> Arc<[u8]> {
+    let items: Vec<String> = entries
+        .iter()
+        .enumerate()
+        .map(|(i, e)| format!("{{\"id\":{i},\"name\":{}}}", json_str(&e.name)))
+        .collect();
+    format!("[{}]", items.join(",")).into_bytes().into()
+}
+
+/// Minimal JSON string escaping (quotes + backslashes) for dataset names.
+fn json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Build the registry, eagerly build the default dataset (fast first paint), then serve region
+/// queries — and dataset switches — on demand from `WORKERS` threads.
+pub fn serve(source: ServeSource, budget: Option<usize>, port: u16) -> Result<()> {
+    anyhow::ensure!(
+        cfg!(target_endian = "little"),
+        "the point wire format is little-endian; --serve is unsupported on this big-endian target"
+    );
+    let entries: Vec<DatasetEntry> = match &source {
+        ServeSource::Demo(_) => vec![DatasetEntry { name: "DEMO".into() }],
+        ServeSource::Datasets(paths) => {
+            anyhow::ensure!(!paths.is_empty(), "no datasets to serve");
+            paths.iter().map(|p| DatasetEntry { name: dataset_name(p) }).collect()
+        }
+    };
+    let datasets_json = build_datasets_json(&entries);
+    let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+    log::info!("registry: {} dataset(s): {}", entries.len(), names.join(", "));
+
+    let hub = Arc::new(Hub {
+        source,
+        entries,
+        budget,
+        states: Mutex::new(StateCache::default()),
+        datasets_json,
     });
+
+    // Eagerly build the default dataset so its first paint is instant.
+    get_or_build_state(&hub, 0)?;
 
     let server = Arc::new(
         Server::http(("127.0.0.1", port)).map_err(|e| anyhow::anyhow!("bind {port}: {e}"))?,
     );
     log::info!(
-        "serving {n0} points ({:.1} MB) + on-demand region queries on http://localhost:{port} (localhost only)",
-        bytes0 as f64 / 1e6,
+        "serving default '{}' + on-demand region/dataset queries on http://localhost:{port} (localhost only)",
+        hub.entries[0].name,
     );
 
     let mut handles = Vec::with_capacity(WORKERS);
     for _ in 0..WORKERS {
-        let (server, state) = (server.clone(), state.clone());
-        handles.push(std::thread::spawn(move || worker(&server, &state)));
+        let (server, hub) = (server.clone(), hub.clone());
+        handles.push(std::thread::spawn(move || worker(&server, &hub)));
     }
     for h in handles {
         let _ = h.join();
@@ -187,15 +328,24 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     Ok(())
 }
 
-fn worker(server: &Server, state: &State) {
+fn worker(server: &Server, hub: &Hub) {
     while let Ok(req) = server.recv() {
-        if let Err(e) = handle(req, state) {
+        if let Err(e) = handle(req, hub) {
             log::warn!("HTTP respond failed: {e}");
         }
     }
 }
 
-fn handle(req: Request, state: &State) -> std::io::Result<()> {
+/// Dataset id from `?dataset=N` (default 0), clamped to the registry size.
+fn parse_dataset_id(url: &str, n_datasets: usize) -> usize {
+    let q = url.split('?').nth(1).unwrap_or("");
+    q.split('&')
+        .find_map(|kv| kv.strip_prefix("dataset=").and_then(|v| v.parse::<usize>().ok()))
+        .unwrap_or(0)
+        .min(n_datasets.saturating_sub(1))
+}
+
+fn handle(req: Request, hub: &Hub) -> std::io::Result<()> {
     if *req.method() == Method::Options {
         // CORS preflight (the trunk page is served from a different origin).
         return req.respond(
@@ -207,14 +357,31 @@ fn handle(req: Request, state: &State) -> std::io::Result<()> {
     }
     let url = req.url().to_string();
     let path = url.split('?').next().unwrap_or("");
-    if *req.method() == Method::Get && path == "/windows" {
-        // Run-level DIA isolation-window footprints (static JSON; region-independent).
-        return respond_bytes(req, state.windows_json.clone(), "application/json");
+    if *req.method() == Method::Get && path == "/datasets" {
+        // The selectable-dataset registry (the frontend renders this as a dropdown).
+        return respond_bytes(req, hub.datasets_json.clone(), "application/json");
     }
+    let want_windows = path == "/windows";
     let (want_points, want_meta) = (path == "/points", path == "/meta");
-    if *req.method() == Method::Get && (want_points || want_meta) {
-        let (region, budget) = parse_query(&url, state);
-        return match get_or_build(state, &region, budget) {
+    if *req.method() == Method::Get && (want_windows || want_points || want_meta) {
+        // Resolve (and lazily build) the selected dataset's state.
+        let id = parse_dataset_id(&url, hub.entries.len());
+        let state = match get_or_build_state(hub, id) {
+            Ok(s) => s,
+            Err(e) => {
+                return req.respond(
+                    Response::from_string(format!("dataset load failed: {e}"))
+                        .with_status_code(StatusCode(500))
+                        .with_header(cors()),
+                );
+            }
+        };
+        if want_windows {
+            // Run-level DIA isolation-window footprints (static JSON; region-independent).
+            return respond_bytes(req, state.windows_json.clone(), "application/json");
+        }
+        let (region, budget) = parse_query(&url, &state);
+        return match get_or_build(&state, &region, budget) {
             Ok(lr) if want_points => {
                 respond_bytes(req, lr.points.clone(), "application/octet-stream")
             }

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -33,7 +33,7 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     let total = plan.meta.total_points_estimate;
     let capacity = plan.budget.max(1).min((total as usize).max(1));
     let stride = crate::data::loader::stride_for(total, capacity) as u64;
-    let (points, stats) = collect_points(plan)?;
+    let (points, stats, hist) = collect_points(plan)?;
     let n_points = points.len();
     // Prefer the loader's systematic-base percentiles (matches the native viewer's Stats); fall
     // back to computing over the served points (incl. the peak tail) only if Stats never arrived.
@@ -59,6 +59,11 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
         "intensity": {
             "p1": fin(i_p1 as f64), "p50": fin(i_p50 as f64), "p99": fin(i_p99 as f64),
         },
+        // Per-axis density histograms (HIST_BINS bins over the full cube range, same mapping as the
+        // crop sliders) so the client can draw the distribution behind each filter.
+        "hist": hist.as_ref().map(|h| serde_json::json!({
+            "mz": h.mz, "im": h.im, "rt": h.rt,
+        })),
     })
     .to_string();
     let meta: Arc<[u8]> = Arc::from(meta.into_bytes().into_boxed_slice());
@@ -113,9 +118,16 @@ fn respond_bytes(req: Request, body: Arc<[u8]>, content_type: &str) -> std::io::
     req.respond(resp)
 }
 
+/// Per-axis density histograms from the loader (each `HIST_BINS` bins over the cube range).
+struct Hist {
+    mz: Vec<u32>,
+    im: Vec<u32>,
+    rt: Vec<u32>,
+}
+
 /// Drain the loader into a point buffer; also capture the loader's intensity `Stats`
-/// (systematic-base p1/p50/p99 as `(i_min, i_med, i_max)`) for the client's auto-transfer.
-fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>)> {
+/// (systematic-base p1/p50/p99 as `(i_min, i_med, i_max)`) and the per-axis histograms.
+fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>, Option<Hist>)> {
     let total = plan.meta.total_points_estimate;
     let bounds = plan.meta.bounds;
     let capacity = plan.budget.max(1).min((total as usize).max(1));
@@ -133,6 +145,7 @@ fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>)
 
     let mut points: Vec<GpuPoint> = Vec::with_capacity(capacity);
     let mut stats: Option<(f32, f32, f32)> = None;
+    let mut hist: Option<Hist> = None;
     let mut done = false;
     loop {
         match loader.rx.recv() {
@@ -145,17 +158,18 @@ fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>)
                 }
             }
             Ok(LoadMsg::Stats { i_min, i_max, i_med }) => stats = Some((i_min, i_med, i_max)),
+            Ok(LoadMsg::Histograms { mz, im, rt, .. }) => hist = Some(Hist { mz, im, rt }),
             Ok(LoadMsg::Done { .. }) => {
                 done = true;
                 break;
             }
             Ok(LoadMsg::Error(e)) => anyhow::bail!("loader error: {e}"),
-            Ok(_) => {} // Histograms/Annotations/Progress: not part of the v1 point stream
+            Ok(_) => {} // Annotations/Progress: not part of the v1 point stream
             Err(_) => break,
         }
     }
     anyhow::ensure!(done, "loader thread ended before completing the load");
-    Ok((points, stats))
+    Ok((points, stats, hist))
 }
 
 /// Intensity (p1, p50, p99), nearest-rank, for the client's auto-transfer/exposure (mirrors the

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -191,6 +191,11 @@ struct Hub {
     /// and hit it) — without serializing builds of *different* datasets.
     build_locks: Mutex<HashMap<usize, Arc<Mutex<()>>>>,
     datasets_json: Arc<[u8]>,
+    /// PROD only: directory the /telemetry + /feedback endpoints append JSONL to. `None` in dev —
+    /// both endpoints report "disabled" and the frontend hides the feedback widget. The lock
+    /// serializes appends across worker threads.
+    telemetry_dir: Option<PathBuf>,
+    telemetry_lock: Mutex<()>,
 }
 
 impl Hub {
@@ -296,7 +301,13 @@ fn build_datasets_json(entries: &[DatasetEntry]) -> Arc<[u8]> {
 
 /// Build the registry, eagerly build the default dataset (fast first paint), then serve region
 /// queries — and dataset switches — on demand from `WORKERS` threads.
-pub fn serve(source: ServeSource, budget: Option<usize>, port: u16, compress: bool) -> Result<()> {
+pub fn serve(
+    source: ServeSource,
+    budget: Option<usize>,
+    port: u16,
+    compress: bool,
+    telemetry_dir: Option<PathBuf>,
+) -> Result<()> {
     anyhow::ensure!(
         cfg!(target_endian = "little"),
         "the point wire format is little-endian; --serve is unsupported on this big-endian target"
@@ -320,9 +331,18 @@ pub fn serve(source: ServeSource, budget: Option<usize>, port: u16, compress: bo
         states: Mutex::new(StateCache::default()),
         build_locks: Mutex::new(HashMap::new()),
         datasets_json,
+        telemetry_dir,
+        telemetry_lock: Mutex::new(()),
     });
     if compress {
         log::info!("over-the-wire zstd compression enabled for /points (Accept-Encoding negotiated)");
+    }
+    if let Some(dir) = &hub.telemetry_dir {
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            log::warn!("telemetry dir {} not writable ({e}); telemetry/feedback will 500", dir.display());
+        } else {
+            log::info!("telemetry + feedback enabled -> {}", dir.display());
+        }
     }
 
     // Eagerly build the default dataset so its first paint is instant.
@@ -370,7 +390,7 @@ fn handle(req: Request, hub: &Hub) -> std::io::Result<()> {
         return req.respond(
             Response::empty(204)
                 .with_header(cors())
-                .with_header(header("Access-Control-Allow-Methods", "GET, OPTIONS"))
+                .with_header(header("Access-Control-Allow-Methods", "GET, POST, OPTIONS"))
                 .with_header(header("Access-Control-Allow-Headers", "*")),
         );
     }
@@ -379,6 +399,16 @@ fn handle(req: Request, hub: &Hub) -> std::io::Result<()> {
     if *req.method() == Method::Get && path == "/datasets" {
         // The selectable-dataset registry (the frontend renders this as a dropdown).
         return respond_bytes(req, hub.datasets_json.clone(), "application/json");
+    }
+    if *req.method() == Method::Get && path == "/clientconfig" {
+        // Tells the frontend whether to wire error telemetry + show the feedback widget (PROD only).
+        let on = hub.telemetry_dir.is_some();
+        let json = format!("{{\"telemetry\":{on},\"feedback\":{on}}}");
+        return respond_bytes(req, json.into_bytes().into(), "application/json");
+    }
+    if *req.method() == Method::Post && (path == "/telemetry" || path == "/feedback") {
+        let file = if path == "/telemetry" { "telemetry.jsonl" } else { "feedback.jsonl" };
+        return log_client_event(req, hub, file);
     }
     let want_windows = path == "/windows";
     let (want_points, want_meta) = (path == "/points", path == "/meta");
@@ -742,6 +772,52 @@ fn respond_points(req: Request, body: Arc<[u8]>, compress: bool) -> std::io::Res
         Some(len),
         None,
     ))
+}
+
+/// Append a client-posted JSON event (error telemetry or user feedback) as one JSONL line to the
+/// configured telemetry dir, stamped with a server-side unix time. PROD only: 404 when no dir is
+/// configured. Body is bounded and must be valid JSON so the log stays one-object-per-line.
+fn log_client_event(mut req: Request, hub: &Hub, file: &str) -> std::io::Result<()> {
+    use std::io::{Read, Write};
+    let Some(dir) = hub.telemetry_dir.clone() else {
+        return req.respond(
+            Response::from_string("telemetry disabled").with_status_code(404).with_header(cors()),
+        );
+    };
+    const MAX: usize = 64 * 1024;
+    if req.body_length().unwrap_or(0) > MAX {
+        return req.respond(
+            Response::from_string("payload too large").with_status_code(413).with_header(cors()),
+        );
+    }
+    let mut buf = String::new();
+    let _ = req.as_reader().take(MAX as u64).read_to_string(&mut buf);
+    let event: serde_json::Value = match serde_json::from_str(&buf) {
+        Ok(v) => v,
+        Err(_) => {
+            return req
+                .respond(Response::from_string("invalid json").with_status_code(400).with_header(cors()));
+        }
+    };
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let line = serde_json::json!({ "ts_unix": ts, "event": event }).to_string();
+    {
+        let _g = hub.telemetry_lock.lock().unwrap_or_else(|p| p.into_inner());
+        let path = dir.join(file);
+        match std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(mut f) => {
+                let _ = writeln!(f, "{line}");
+            }
+            Err(e) => {
+                log::warn!("telemetry append to {} failed: {e}", path.display());
+                return req.respond(Response::empty(500).with_header(cors()));
+            }
+        }
+    }
+    req.respond(Response::empty(204).with_header(cors()))
 }
 
 /// Serve a shared byte buffer without copying it per request (Cursor over the `Arc`).

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -606,12 +606,21 @@ fn build_load_result(
     };
 
     let fin = |x: f64| if x.is_finite() { x } else { 0.0 };
+    // Run-level 1/K0 per TIMS scan: the FULL-run mobility span over the ramp length. Run-level (not
+    // region-scoped) so the client's IM clustering reach is focus-independent.
+    let im_per_scan = if meta.num_scans > 1 {
+        (meta.bounds.im.max - meta.bounds.im.min).abs() / (meta.num_scans as f64 - 1.0)
+    } else {
+        0.0
+    };
     let meta_json = serde_json::json!({
         "version": 1,
         "point_stride": std::mem::size_of::<GpuPoint>(),
         "n_points": n_points,
         "downsample_stride": stride,
         "cycle_duration": fin(cycle_duration),
+        "im_per_scan_1k0": fin(im_per_scan),
+        "num_scans": meta.num_scans,
         // Region bounds in real units — the client re-normalizes axes/crops/strips to these.
         "bounds": {
             "mz": [fin(region.mz.0), fin(region.mz.1)],

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -21,7 +21,7 @@ use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 
 use crate::app::Plan;
 use crate::data::demo::DemoSource;
-use crate::data::loader::{stride_for, LoadMsg, LoaderHandle, LoaderMode, RegionFilter};
+use crate::data::loader::{stride_for, LoadMsg, LoaderHandle, LoaderMode, RegionFilter, PROJ_BINS};
 use crate::data::meta::MetaIndex;
 use crate::data::point::{AxisBounds, AxisTransform, GpuPoint};
 
@@ -415,7 +415,7 @@ fn build_load_result(
         })),
         // Sample-based 2D density projections for the box-select minimaps.
         "proj": hist.as_ref().map(|h| serde_json::json!({
-            "bins": (h.proj_mz_im.len() as f64).sqrt().round() as u32,
+            "bins": PROJ_BINS,
             "mz_im": h.proj_mz_im, "mz_rt": h.proj_mz_rt, "im_rt": h.proj_im_rt,
         })),
     })

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -135,7 +135,9 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
         "the point wire format is little-endian; --serve is unsupported on this big-endian target"
     );
     let Plan { meta, is_demo, budget } = plan;
-    let full = full_region(&meta);
+    // Snap the eager full region onto the cache grid so a client's explicit full-bounds query
+    // (also snapped in parse_query) resolves to this same cached entry instead of rebuilding.
+    let full = snap_region(full_region(&meta));
 
     // Eager full-run build (filter=None): seeds the cache and the intensity reference.
     let built = build_load_result(&meta, is_demo, &full, budget, None)?;

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -44,6 +44,10 @@ struct LoadResult {
     points: Arc<[u8]>,
     meta: Arc<[u8]>,
     n_points: usize,
+    /// Lazily-populated zstd-compressed `points` (only when `--compress` + a zstd client). The raw
+    /// body is cached; without this the compressed form is re-encoded (level 3 over ~356 MB,
+    /// 0.3–0.9 s) on every request. Encoded once on first compressed request; a race re-encodes once.
+    points_zstd: std::sync::OnceLock<Arc<[u8]>>,
 }
 
 /// Output of a build: the cacheable result plus the intensity reference the full-run build seeds
@@ -438,7 +442,7 @@ fn handle(req: Request, hub: &Hub) -> std::io::Result<()> {
         let (region, budget) = parse_query(&url, &state);
         return match get_or_build(&state, &region, budget) {
             Ok(lr) if want_points => {
-                respond_points(req, lr.points.clone(), hub.compress)
+                respond_points(req, lr.clone(), hub.compress)
             }
             Ok(lr) => respond_bytes(req, lr.meta.clone(), "application/json"),
             Err(e) => req.respond(
@@ -676,6 +680,7 @@ fn build_load_result(
             points: body,
             meta: Arc::from(meta_json.into_bytes().into_boxed_slice()),
             n_points,
+            points_zstd: std::sync::OnceLock::new(),
         },
         i_hist,
         i_p99,
@@ -722,31 +727,45 @@ fn accepts_zstd(req: &Request) -> bool {
 /// `Accept-Encoding: zstd` (the browser then decompresses `Content-Encoding: zstd` transparently — no
 /// client code). When compression is enabled the response carries `Vary: Accept-Encoding` so a shared
 /// cache/proxy can't hand a zstd body to a client that didn't ask. Falls back to raw on encode error.
-fn respond_points(req: Request, body: Arc<[u8]>, compress: bool) -> std::io::Result<()> {
+fn respond_points(req: Request, lr: Arc<LoadResult>, compress: bool) -> std::io::Result<()> {
     if !compress {
-        return respond_bytes(req, body, "application/octet-stream");
+        return respond_bytes(req, lr.points.clone(), "application/octet-stream");
     }
     if accepts_zstd(&req) {
-        match zstd::encode_all(&body[..], 3) {
-            Ok(z) => {
-                let len = z.len();
-                return req.respond(Response::new(
-                    StatusCode(200),
-                    vec![
-                        cors(),
-                        header("Content-Type", "application/octet-stream"),
-                        header("Content-Encoding", "zstd"),
-                        header("Vary", "Accept-Encoding"),
-                    ],
-                    Cursor::new(z),
-                    Some(len),
-                    None,
-                ));
-            }
-            Err(e) => log::warn!("zstd encode failed ({e}); sending raw points"),
+        // Serve (and memoize) the compressed body from the cache — encode at most once per cached
+        // (region,budget) instead of re-zstd'ing ~356 MB on every request.
+        let z = match lr.points_zstd.get() {
+            Some(z) => Some(z.clone()),
+            None => match zstd::encode_all(&lr.points[..], 3) {
+                Ok(v) => {
+                    let z: Arc<[u8]> = Arc::from(v.into_boxed_slice());
+                    let _ = lr.points_zstd.set(z.clone()); // first writer wins; a race re-encodes once
+                    Some(z)
+                }
+                Err(e) => {
+                    log::warn!("zstd encode failed ({e}); sending raw points");
+                    None
+                }
+            },
+        };
+        if let Some(z) = z {
+            let len = z.len();
+            return req.respond(Response::new(
+                StatusCode(200),
+                vec![
+                    cors(),
+                    header("Content-Type", "application/octet-stream"),
+                    header("Content-Encoding", "zstd"),
+                    header("Vary", "Accept-Encoding"),
+                ],
+                Cursor::new(z),
+                Some(len),
+                None,
+            ));
         }
     }
     // Raw, but still Vary — this route negotiates, so caches must key on Accept-Encoding.
+    let body = lr.points.clone();
     let len = body.len();
     req.respond(Response::new(
         StatusCode(200),
@@ -946,6 +965,7 @@ fn empty_result(meta: &MetaIndex, region: &Region4D) -> Built {
             points: Arc::from(Vec::<u8>::new().into_boxed_slice()),
             meta: Arc::from(meta_json.into_bytes().into_boxed_slice()),
             n_points: 0,
+            points_zstd: std::sync::OnceLock::new(),
         },
         i_hist: vec![0u32; I_HIST_BINS],
         i_p99: 1.0,

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -124,6 +124,9 @@ struct State {
     /// Full-run intensity distribution, for estimating region survivor counts vs an intensity floor.
     full_i_hist: Vec<u32>,
     full_i_p99: f32,
+    /// Precomputed `/windows` JSON: the run's DIA isolation-window footprints in real units (static;
+    /// the web re-normalizes them to whatever region it has focused). Empty for demo / non-DIA runs.
+    windows_json: Arc<[u8]>,
     cache: Mutex<Cache>,
 }
 
@@ -146,12 +149,18 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     let full_key = LoadKey::of(&full, budget);
     let mut map = HashMap::new();
     map.insert(full_key, Arc::new(built.result));
+
+    // The DIA isolation-window footprints are run-level — read them once (opening one dataset) and
+    // serve them statically from `/windows`. Demo / non-DIA runs serve an empty set.
+    let windows_json = build_windows_json(is_demo, &meta.data_path);
+
     let state = Arc::new(State {
         meta,
         is_demo,
         default_budget: budget,
         full_i_hist: built.i_hist,
         full_i_p99: built.i_p99,
+        windows_json,
         cache: Mutex::new(Cache {
             map,
             order: VecDeque::new(),
@@ -198,6 +207,10 @@ fn handle(req: Request, state: &State) -> std::io::Result<()> {
     }
     let url = req.url().to_string();
     let path = url.split('?').next().unwrap_or("");
+    if *req.method() == Method::Get && path == "/windows" {
+        // Run-level DIA isolation-window footprints (static JSON; region-independent).
+        return respond_bytes(req, state.windows_json.clone(), "application/json");
+    }
     let (want_points, want_meta) = (path == "/points", path == "/meta");
     if *req.method() == Method::Get && (want_points || want_meta) {
         let (region, budget) = parse_query(&url, state);
@@ -315,6 +328,23 @@ fn get_or_build(state: &State, region: &Region4D, budget: usize) -> Result<Arc<L
 /// Run one region load: select frames, size the stride to the region survivor estimate, stream
 /// through the loader (normalized to the region so it fills the cube), shuffle, and pack the
 /// `/points` bytes + `/meta` JSON.
+/// Build the static `/windows` JSON: `{ max_window_group, windows: [[group, mz0, mz1, im0, im1], …] }`
+/// in real units. Demo or non-DIA runs yield an empty set.
+fn build_windows_json(is_demo: bool, data_path: &str) -> Arc<[u8]> {
+    let json = if is_demo {
+        serde_json::json!({ "max_window_group": 0, "windows": [] })
+    } else {
+        let ds = rustdf::data::dataset::TimsDataset::new("NO_SDK", data_path, false, false);
+        let (rects, max_group) = crate::data::loader::dia_window_rects(&ds, data_path);
+        let windows: Vec<[f64; 5]> = rects
+            .iter()
+            .map(|r| [r.group as f64, r.mz0, r.mz1, r.im0, r.im1])
+            .collect();
+        serde_json::json!({ "max_window_group": max_group, "windows": windows })
+    };
+    Arc::from(json.to_string().into_bytes().into_boxed_slice())
+}
+
 fn build_load_result(
     meta: &MetaIndex,
     is_demo: bool,

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -33,9 +33,11 @@ pub fn serve(plan: Plan, port: u16) -> Result<()> {
     let total = plan.meta.total_points_estimate;
     let capacity = plan.budget.max(1).min((total as usize).max(1));
     let stride = crate::data::loader::stride_for(total, capacity) as u64;
-    let points = collect_points(plan)?;
+    let (points, stats) = collect_points(plan)?;
     let n_points = points.len();
-    let (i_p1, i_p50, i_p99) = intensity_percentiles(&points);
+    // Prefer the loader's systematic-base percentiles (matches the native viewer's Stats); fall
+    // back to computing over the served points (incl. the peak tail) only if Stats never arrived.
+    let (i_p1, i_p50, i_p99) = stats.unwrap_or_else(|| intensity_percentiles(&points));
     // One copy into an owned byte buffer, then share it (no per-request copy) via Arc + Cursor.
     let body: Arc<[u8]> =
         Arc::from(bytemuck::cast_slice::<GpuPoint, u8>(&points).to_vec().into_boxed_slice());
@@ -111,7 +113,9 @@ fn respond_bytes(req: Request, body: Arc<[u8]>, content_type: &str) -> std::io::
     req.respond(resp)
 }
 
-fn collect_points(plan: Plan) -> Result<Vec<GpuPoint>> {
+/// Drain the loader into a point buffer; also capture the loader's intensity `Stats`
+/// (systematic-base p1/p50/p99 as `(i_min, i_med, i_max)`) for the client's auto-transfer.
+fn collect_points(plan: Plan) -> Result<(Vec<GpuPoint>, Option<(f32, f32, f32)>)> {
     let total = plan.meta.total_points_estimate;
     let bounds = plan.meta.bounds;
     let capacity = plan.budget.max(1).min((total as usize).max(1));
@@ -128,6 +132,7 @@ fn collect_points(plan: Plan) -> Result<Vec<GpuPoint>> {
     let loader = LoaderHandle::spawn(mode, bounds, total, capacity);
 
     let mut points: Vec<GpuPoint> = Vec::with_capacity(capacity);
+    let mut stats: Option<(f32, f32, f32)> = None;
     let mut done = false;
     loop {
         match loader.rx.recv() {
@@ -139,17 +144,18 @@ fn collect_points(plan: Plan) -> Result<Vec<GpuPoint>> {
                     points.extend(pts.into_iter().take(room));
                 }
             }
+            Ok(LoadMsg::Stats { i_min, i_max, i_med }) => stats = Some((i_min, i_med, i_max)),
             Ok(LoadMsg::Done { .. }) => {
                 done = true;
                 break;
             }
             Ok(LoadMsg::Error(e)) => anyhow::bail!("loader error: {e}"),
-            Ok(_) => {} // Stats/Histograms/Annotations/Progress: not part of the v1 point stream
+            Ok(_) => {} // Histograms/Annotations/Progress: not part of the v1 point stream
             Err(_) => break,
         }
     }
     anyhow::ensure!(done, "loader thread ended before completing the load");
-    Ok(points)
+    Ok((points, stats))
 }
 
 /// Intensity (p1, p50, p99), nearest-rank, for the client's auto-transfer/exposure (mirrors the

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -797,10 +797,7 @@ fn collect(
                     if points.len() < capacity {
                         points.push(p);
                     } else {
-                        rng ^= rng << 13;
-                        rng ^= rng >> 7;
-                        rng ^= rng << 17;
-                        let j = (rng % seen) as usize;
+                        let j = (xorshift64(&mut rng) % seen) as usize;
                         if j < capacity {
                             points[j] = p;
                         }
@@ -890,18 +887,22 @@ fn intensity_percentiles(points: &[GpuPoint]) -> (f32, f32, f32) {
     (pct(0.01), pct(0.50), pct(0.99))
 }
 
-/// In-place Fisher-Yates shuffle with a seeded xorshift64 (deterministic, no `rand` dependency).
-/// Decorrelates the loader's RT-ordered emission so a prefix of the array is a uniform subsample.
+/// One step of a xorshift64 PRNG (deterministic, no `rand` dependency). Shared by the reservoir
+/// sampler in `collect` and the Fisher-Yates shuffle below.
+#[inline]
+fn xorshift64(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+/// In-place Fisher-Yates shuffle with a seeded xorshift64. Decorrelates the loader's RT-ordered
+/// emission so a prefix of the array is a uniform subsample.
 fn shuffle_points(points: &mut [GpuPoint]) {
     let mut s: u64 = 0x9E37_79B9_7F4A_7C15;
-    let mut next = || {
-        s ^= s << 13;
-        s ^= s >> 7;
-        s ^= s << 17;
-        s
-    };
     for i in (1..points.len()).rev() {
-        points.swap(i, (next() % (i as u64 + 1)) as usize);
+        points.swap(i, (xorshift64(&mut s) % (i as u64 + 1)) as usize);
     }
 }
 

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -413,6 +413,11 @@ fn build_load_result(
         "hist": hist.as_ref().map(|h| serde_json::json!({
             "mz": h.mz, "im": h.im, "rt": h.rt,
         })),
+        // Sample-based 2D density projections for the box-select minimaps.
+        "proj": hist.as_ref().map(|h| serde_json::json!({
+            "bins": (h.proj_mz_im.len() as f64).sqrt().round() as u32,
+            "mz_im": h.proj_mz_im, "mz_rt": h.proj_mz_rt, "im_rt": h.proj_im_rt,
+        })),
     })
     .to_string();
 
@@ -457,11 +462,15 @@ fn respond_bytes(req: Request, body: Arc<[u8]>, content_type: &str) -> std::io::
     req.respond(resp)
 }
 
-/// Per-axis density histograms from the loader (each `HIST_BINS` bins over the region range).
+/// Per-axis density histograms (each `HIST_BINS` bins over the region range) plus the three 2D
+/// density projections (`PROJ_BINS²`, row-major `x + bins*y`) for the box-select minimaps.
 struct Hist {
     mz: Vec<u32>,
     im: Vec<u32>,
     rt: Vec<u32>,
+    proj_mz_im: Vec<u32>,
+    proj_mz_rt: Vec<u32>,
+    proj_im_rt: Vec<u32>,
 }
 
 /// Drain the loader (with `total_estimate` already sized to the region) into a bounded point
@@ -504,7 +513,11 @@ fn collect(
                 }
             }
             Ok(LoadMsg::Stats { i_min, i_max, i_med }) => stats = Some((i_min, i_med, i_max)),
-            Ok(LoadMsg::Histograms { mz, im, rt, .. }) => hist = Some(Hist { mz, im, rt }),
+            Ok(LoadMsg::Histograms {
+                mz, im, rt, proj_mz_im, proj_mz_rt, proj_im_rt, ..
+            }) => {
+                hist = Some(Hist { mz, im, rt, proj_mz_im, proj_mz_rt, proj_im_rt });
+            }
             Ok(LoadMsg::Done { .. }) => {
                 done = true;
                 break;
@@ -533,6 +546,7 @@ fn empty_result(region: &Region4D) -> Built {
         },
         "intensity": { "p1": 1.0, "p50": 1.0, "p99": 1.0, "hist": vec![0u32; I_HIST_BINS] },
         "hist": serde_json::Value::Null,
+        "proj": serde_json::Value::Null,
     })
     .to_string();
     Built {

--- a/tims-viewer/src/shaders/annotation.wgsl
+++ b/tims-viewer/src/shaders/annotation.wgsl
@@ -16,17 +16,33 @@ struct Filter {
 @group(0) @binding(0) var<uniform> cam : Camera;
 @group(0) @binding(1) var<uniform> flt : Filter;
 
+struct VsOut {
+    @builtin(position) clip : vec4<f32>,
+    @location(0) color : vec3<f32>,
+};
+
 @vertex
-fn vs_main(@location(0) pos : vec3<f32>) -> @builtin(position) vec4<f32> {
+fn vs_main(@location(0) pos : vec3<f32>, @location(1) color : vec3<f32>) -> VsOut {
+    var out : VsOut;
+    out.color = color;
     // Clip annotations to the active window so narrowing a range filters them too.
     if (any(pos < flt.min.xyz) || any(pos > flt.max.xyz)) {
-        return vec4<f32>(2.0, 2.0, 2.0, 1.0); // outside clip volume -> culled
+        out.clip = vec4<f32>(2.0, 2.0, 2.0, 1.0); // outside clip volume -> culled
+        return out;
     }
-    return cam.view_proj * vec4<f32>(pos, 1.0);
+    // Focus (flt.min.w): re-fit the window box to the full cube, matching the points.
+    var fpos = pos;
+    if (flt.min.w > 0.5) {
+        let center = (flt.min.xyz + flt.max.xyz) * 0.5;
+        let halfspan = max((flt.max.xyz - flt.min.xyz) * 0.5, vec3<f32>(1e-6));
+        fpos = (pos - center) / halfspan;
+    }
+    out.clip = cam.view_proj * vec4<f32>(fpos, 1.0);
+    return out;
 }
 
 @fragment
-fn fs_main() -> @location(0) vec4<f32> {
-    // Bright cyan, fully opaque so markers read clearly over points or volume.
-    return vec4<f32>(0.1, 0.95, 0.95, 1.0);
+fn fs_main(in : VsOut) -> @location(0) vec4<f32> {
+    // Per-vertex color, fully opaque so markers read clearly over points or volume.
+    return vec4<f32>(in.color, 1.0);
 }

--- a/tims-viewer/src/shaders/compact.wgsl
+++ b/tims-viewer/src/shaders/compact.wgsl
@@ -43,7 +43,7 @@ struct DrawArgs {
 
 struct Compaction {
     point_count : u32,
-    _p0 : u32,
+    row_stride : u32,   // invocations per dispatch row (groups_x * workgroup_size)
     _p1 : u32,
     _p2 : u32,
 };
@@ -57,7 +57,8 @@ struct Compaction {
 
 @compute @workgroup_size(256)
 fn cs_main(@builtin(global_invocation_id) gid : vec3<u32>) {
-    let i = gid.x;
+    // 2D dispatch grid: rebuild the linear point index from the row stride.
+    let i = gid.x + gid.y * comp.row_stride;
     if (i >= comp.point_count) {
         return;
     }

--- a/tims-viewer/src/shaders/compact.wgsl
+++ b/tims-viewer/src/shaders/compact.wgsl
@@ -24,8 +24,8 @@ struct Params {
     transfer   : vec4<f32>,
     point_size : f32,
     opacity    : f32,
-    _pad0      : f32,
-    _pad1      : f32,
+    focus      : f32,      // mirrors ParamsUniform; unused here
+    color_mode : u32,      // mirrors ParamsUniform; unused here
     ms_mask     : u32,
     colormap_id : u32,
     render_mode : u32,

--- a/tims-viewer/src/shaders/compact.wgsl
+++ b/tims-viewer/src/shaders/compact.wgsl
@@ -76,8 +76,17 @@ fn cs_main(@builtin(global_invocation_id) gid : vec3<u32>) {
         return;
     }
 
-    // Frustum cull (with a margin so splats near the edge aren't clipped early).
-    let clip = cam.view_proj * vec4<f32>(p.pos, 1.0);
+    // Frustum cull (with a margin so splats near the edge aren't clipped early). Cull against the
+    // SAME position the draw shader renders: when "focus to window" is on it refits points into the
+    // focus box, so a point can be on-screen after the refit while its raw pos is outside the frustum.
+    // Culling raw pos here would silently drop those visible points before the draw pass.
+    var fpos = p.pos;
+    if (params.focus > 0.5) {
+        let center = (params.filter_min.xyz + params.filter_max.xyz) * 0.5;
+        let halfspan = max((params.filter_max.xyz - params.filter_min.xyz) * 0.5, vec3<f32>(1e-6));
+        fpos = (p.pos - center) / halfspan;
+    }
+    let clip = cam.view_proj * vec4<f32>(fpos, 1.0);
     if (clip.w <= 0.0) {
         return;
     }

--- a/tims-viewer/src/shaders/point_cloud.wgsl
+++ b/tims-viewer/src/shaders/point_cloud.wgsl
@@ -142,7 +142,9 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
         color = textureSample(lut_tex, lut_smp, vec2<f32>(t, row)).rgb;
     }
 
-    if (params.render_mode == 1u) {
+    // Cluster coloring always renders opaque: additive blending would mix distinct cluster
+    // hues into mush and dim them by the 1/p weight, so cluster ids would read as noise.
+    if (params.render_mode == 1u || params.color_mode == 1u) {
         // Structural opaque: round point via alpha cutout, depth-written.
         if (falloff < 0.5) {
             discard;

--- a/tims-viewer/src/shaders/point_cloud.wgsl
+++ b/tims-viewer/src/shaders/point_cloud.wgsl
@@ -15,7 +15,7 @@ struct Params {
     point_size : f32,
     opacity    : f32,
     focus      : f32,
-    color_mode : u32,   // 0 = intensity colormap, 1 = cluster id
+    color_mode : u32,   // 0 = intensity colormap, 1 = cluster id, 2 = hide-noise, 3 = acquisition (id + size-by-intensity)
     ms_mask     : u32,
     colormap_id : u32,
     render_mode : u32,
@@ -124,7 +124,12 @@ fn vs_main(
     }
 
     // World-space billboard so size attenuates with distance (perspective).
-    let bb = params.point_size * 0.0015;
+    var bb = params.point_size * 0.0015;
+    // Acquisition playback (color_mode 3): scale the splat by intensity so faint peaks recede and
+    // the bright precursor/fragment signals stand out as the run builds up.
+    if (params.color_mode == 3u) {
+        bb = bb * mix(0.18, 1.0, transfer(intensity));
+    }
     let world = fpos + (corner.x * cam.right.xyz + corner.y * cam.up.xyz) * bb;
     out.clip = cam.view_proj * vec4<f32>(world, 1.0);
     out.uv = corner;

--- a/tims-viewer/src/shaders/point_cloud.wgsl
+++ b/tims-viewer/src/shaders/point_cloud.wgsl
@@ -15,7 +15,7 @@ struct Params {
     point_size : f32,
     opacity    : f32,
     focus      : f32,
-    _pad1      : f32,
+    color_mode : u32,   // 0 = intensity colormap, 1 = cluster id
     ms_mask     : u32,
     colormap_id : u32,
     render_mode : u32,
@@ -33,7 +33,22 @@ struct VsOut {
     @location(1) intensity : f32,
     @location(2) weight : f32,
     @location(3) visible : f32,
+    @location(4) @interpolate(flat) cluster : u32,
 };
+
+fn hsv2rgb(h: f32, s: f32, v: f32) -> vec3<f32> {
+    let k = vec3<f32>(5.0, 3.0, 1.0) / 6.0;
+    let p = abs(fract(vec3<f32>(h) + k) * 6.0 - 3.0);
+    return v * mix(vec3<f32>(1.0), clamp(p - 1.0, vec3<f32>(0.0), vec3<f32>(1.0)), s);
+}
+
+// Cluster id -> color: golden-ratio hue spacing; the noise sentinel renders grey.
+fn cluster_color(id: u32) -> vec3<f32> {
+    if (id == 0xffffffffu) {
+        return vec3<f32>(0.32, 0.32, 0.38);
+    }
+    return hsv2rgb(fract(f32(id) * 0.6180339887), 0.65, 1.0);
+}
 
 fn transfer(i: f32) -> f32 {
     let mode = params.transfer.x;
@@ -61,8 +76,10 @@ fn vs_main(
     @location(1) intensity : f32,
     @location(2) weight : f32,
     @location(3) flags : u32,
+    @location(4) cluster : u32,
 ) -> VsOut {
     var out : VsOut;
+    out.cluster = cluster;
 
     // Window + MS-type filtering -> collapse off-screen if rejected.
     let in_window =
@@ -116,9 +133,14 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     if (falloff <= 0.0) {
         discard;
     }
-    let t = transfer(in.intensity);
-    let row = (f32(params.colormap_id) + 0.5) / f32(params.n_colormaps);
-    let color = textureSample(lut_tex, lut_smp, vec2<f32>(t, row)).rgb;
+    var color : vec3<f32>;
+    if (params.color_mode == 1u) {
+        color = cluster_color(in.cluster);
+    } else {
+        let t = transfer(in.intensity);
+        let row = (f32(params.colormap_id) + 0.5) / f32(params.n_colormaps);
+        color = textureSample(lut_tex, lut_smp, vec2<f32>(t, row)).rgb;
+    }
 
     if (params.render_mode == 1u) {
         // Structural opaque: round point via alpha cutout, depth-written.

--- a/tims-viewer/src/shaders/point_cloud.wgsl
+++ b/tims-viewer/src/shaders/point_cloud.wgsl
@@ -96,6 +96,15 @@ fn vs_main(
         out.weight = 0.0;
         return out;
     }
+    // Hide-noise mode (color_mode == 2): cull points that didn't cluster (NO_CLUSTER sentinel).
+    if (params.color_mode == 2u && cluster == 0xffffffffu) {
+        out.clip = vec4<f32>(2.0, 2.0, 2.0, 1.0);
+        out.visible = 0.0;
+        out.uv = vec2<f32>(0.0, 0.0);
+        out.intensity = 0.0;
+        out.weight = 0.0;
+        return out;
+    }
 
     // Quad corners for a 4-vertex triangle strip.
     var corners = array<vec2<f32>, 4>(
@@ -136,7 +145,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
         discard;
     }
     var color : vec3<f32>;
-    if (params.color_mode == 1u) {
+    if (params.color_mode >= 1u) {
         color = cluster_color(in.cluster);
     } else {
         let t = transfer(in.intensity);
@@ -146,7 +155,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
 
     // Cluster coloring always renders opaque: additive blending would mix distinct cluster
     // hues into mush and dim them by the 1/p weight, so cluster ids would read as noise.
-    if (params.render_mode == 1u || params.color_mode == 1u) {
+    if (params.render_mode == 1u || params.color_mode >= 1u) {
         // Structural opaque: round point via alpha cutout, depth-written.
         if (falloff < 0.5) {
             discard;

--- a/tims-viewer/src/shaders/point_cloud.wgsl
+++ b/tims-viewer/src/shaders/point_cloud.wgsl
@@ -81,9 +81,11 @@ fn vs_main(
     var out : VsOut;
     out.cluster = cluster;
 
-    // Window + MS-type filtering -> collapse off-screen if rejected.
+    // Window + intensity-range + MS-type filtering -> collapse off-screen if rejected.
+    // The intensity range rides filter_min.w / filter_max.w (real intensity units).
     let in_window =
-        all(pos >= params.filter_min.xyz) && all(pos <= params.filter_max.xyz);
+        all(pos >= params.filter_min.xyz) && all(pos <= params.filter_max.xyz)
+        && intensity >= params.filter_min.w && intensity <= params.filter_max.w;
     let is_ms2 = (flags & 1u) != 0u;
     let show = select((params.ms_mask & 1u) != 0u, (params.ms_mask & 2u) != 0u, is_ms2);
     if (!in_window || !show) {

--- a/tims-viewer/src/shaders/point_cloud.wgsl
+++ b/tims-viewer/src/shaders/point_cloud.wgsl
@@ -14,7 +14,7 @@ struct Params {
     transfer   : vec4<f32>, // mode, i_min, i_max, exposure
     point_size : f32,
     opacity    : f32,
-    _pad0      : f32,
+    focus      : f32,
     _pad1      : f32,
     ms_mask     : u32,
     colormap_id : u32,
@@ -87,9 +87,17 @@ fn vs_main(
     );
     let corner = corners[vid];
 
+    // Focus: re-fit the active window box to the full cube (zoom to selection).
+    var fpos = pos;
+    if (params.focus > 0.5) {
+        let center = (params.filter_min.xyz + params.filter_max.xyz) * 0.5;
+        let halfspan = max((params.filter_max.xyz - params.filter_min.xyz) * 0.5, vec3<f32>(1e-6));
+        fpos = (pos - center) / halfspan;
+    }
+
     // World-space billboard so size attenuates with distance (perspective).
-    let half = params.point_size * 0.0015;
-    let world = pos + (corner.x * cam.right.xyz + corner.y * cam.up.xyz) * half;
+    let bb = params.point_size * 0.0015;
+    let world = fpos + (corner.x * cam.right.xyz + corner.y * cam.up.xyz) * bb;
     out.clip = cam.view_proj * vec4<f32>(world, 1.0);
     out.uv = corner;
     out.intensity = intensity;

--- a/tims-viewer/src/shaders/volume.wgsl
+++ b/tims-viewer/src/shaders/volume.wgsl
@@ -13,7 +13,7 @@ struct Volume {
     colormap_id : u32,
     n_colormaps : u32,
     density_scale : f32,  // recover raw intensity from the normalized texture
-    _pad0 : f32,
+    focus : f32,          // 1.0 = re-fit the window box to the full cube (zoom to selection)
     _pad1 : f32,
     _pad2 : f32,
 };
@@ -95,7 +95,15 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     let o = near.xyz / near.w;
     let dir = normalize(far.xyz / far.w - o);
 
-    let hit = intersect_box(o, dir, vol.box_min.xyz, vol.box_max.xyz);
+    // Focus: re-fit the window box to the full cube. The ray then marches the whole cube
+    // and each marched position maps back into the window box for texture sampling.
+    let focus = vol.focus > 0.5;
+    let center = (vol.box_min.xyz + vol.box_max.xyz) * 0.5;
+    let halfspan = max((vol.box_max.xyz - vol.box_min.xyz) * 0.5, vec3<f32>(1e-6));
+    let march_min = select(vol.box_min.xyz, vec3<f32>(-1.0), focus);
+    let march_max = select(vol.box_max.xyz, vec3<f32>(1.0), focus);
+
+    let hit = intersect_box(o, dir, march_min, march_max);
     let t_enter = max(hit.x, 0.0);
     let t_exit = hit.y;
     if (t_exit <= t_enter) {
@@ -112,7 +120,8 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
         var maxt = 0.0;
         for (var i = 0u; i < steps; i = i + 1u) {
             let p = o + dir * (t_enter + dt * (f32(i) + 0.5));
-            let uvw = p * 0.5 + vec3<f32>(0.5);
+            let sp = select(p, center + p * halfspan, focus);
+            let uvw = sp * 0.5 + vec3<f32>(0.5);
             let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r * vol.density_scale;
             maxt = max(maxt, transfer(dens));
         }
@@ -127,7 +136,8 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     var alpha = 0.0;
     for (var i = 0u; i < steps; i = i + 1u) {
         let p = o + dir * (t_enter + dt * (f32(i) + 0.5));
-        let uvw = p * 0.5 + vec3<f32>(0.5);
+        let sp = select(p, center + p * halfspan, focus);
+        let uvw = sp * 0.5 + vec3<f32>(0.5);
         let dens = textureSampleLevel(vol_tex, vol_smp, uvw, 0.0).r * vol.density_scale;
         let tval = transfer(dens);
         if (tval > 0.0) {

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -42,6 +42,15 @@ pub struct Window {
     pub max: f64,
 }
 
+/// A request from the UI for the app to re-stream the loader (level-of-detail refinement).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefineAction {
+    /// Re-stream only the current RT/m-z/1-K0 window at full resolution.
+    Refine,
+    /// Re-stream the whole run (revert a refinement).
+    FullRun,
+}
+
 pub struct AppState {
     pub bounds: AxisBounds,
 
@@ -90,6 +99,10 @@ pub struct AppState {
     pub im_window: Window,
     /// Re-fit the window box to the full cube (zoom to selection) instead of just culling.
     pub focus: bool,
+    /// True while showing a re-streamed sub-region (vs the full run).
+    pub refined: bool,
+    /// Pending level-of-detail request from the UI; the app consumes it each frame.
+    pub refine_request: Option<RefineAction>,
 
     // Readouts
     pub fps: f32,
@@ -145,6 +158,8 @@ impl AppState {
                 max: bounds.im.max,
             },
             focus: false,
+            refined: false,
+            refine_request: None,
             fps: 0.0,
             resident_points: 0,
             capacity: 0,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -55,6 +55,16 @@ pub struct AppState {
     pub i_min: f32,
     pub i_max: f32,
     pub exposure: f32,
+    /// Raw p1 of retained point intensity, from LoadMsg::Stats. 0.0 until known.
+    /// Stored unstretched so a mode switch can re-run the heuristic from scratch.
+    pub i_p1: f32,
+    /// p50 (median) of retained point intensity, from LoadMsg::Stats. 0.0 until known.
+    pub i_med: f32,
+    /// Raw p99 of retained point intensity, from LoadMsg::Stats. 0.0 until known.
+    pub i_p99: f32,
+    /// True once the user has manually edited transfer/exposure/range this session;
+    /// suppresses further auto-ranging so we never clobber manual edits.
+    pub transfer_user_dirty: bool,
     pub colormap_id: u32,
     pub n_colormaps: u32,
     pub point_size: f32,
@@ -67,6 +77,10 @@ pub struct AppState {
     pub show_annotations: bool,
     /// Show the data-cube wireframe + axis labels (m/z, 1/K0, RT).
     pub show_axes: bool,
+    /// Draw faint gridlines across the three far cube faces for depth reference.
+    pub show_grid_backfaces: bool,
+    /// Draw the intensity colorbar overlay (active colormap + range + transfer tag).
+    pub show_colorbar: bool,
     /// Per-window-group visibility bitmask (bit g-1 = group g); used by the selection overlay.
     pub group_mask: u32,
     /// Number of DIA/MIDIA window groups in the loaded run (0 until known).
@@ -100,6 +114,10 @@ impl AppState {
             i_min: 1.0,
             i_max: 1e5,
             exposure: 1.0,
+            i_p1: 0.0,
+            i_med: 0.0,
+            i_p99: 0.0,
+            transfer_user_dirty: false,
             colormap_id: 1, // Inferno
             n_colormaps,
             point_size: 2.5,
@@ -108,10 +126,14 @@ impl AppState {
             show_ms2: true,
             show_annotations: true,
             show_axes: true,
+            show_grid_backfaces: false,
+            show_colorbar: true,
             group_mask: u32::MAX,
             n_window_groups: 0,
             rt_window: Window {
-                min: bounds.rt.min,
+                // Skip the first ~15% of the run by default: the early gradient is usually
+                // near-empty (no peptides eluting yet). "Reset windows" restores the full range.
+                min: bounds.rt.min + 0.15 * (bounds.rt.max - bounds.rt.min),
                 max: bounds.rt.max,
             },
             mz_window: Window {
@@ -146,6 +168,63 @@ impl AppState {
             min: self.bounds.im.min,
             max: self.bounds.im.max,
         };
+    }
+
+    /// Auto-set transfer mode + range + exposure for POINT mode from the stored intensity
+    /// percentiles (`i_p1`/`i_med`/`i_p99`) so the median maps to a legible mid-tone and the
+    /// additive cloud never saturates. No-op until percentiles are known (`i_med > 0`).
+    pub fn auto_transfer_points(&mut self) {
+        if self.i_med <= 0.0 {
+            return;
+        }
+        let p1 = self.i_p1.max(1.0);
+        // Derive the working median into a LOCAL: `i_med` is the pristine raw p50 from
+        // LoadMsg::Stats and must stay untouched so a later mode switch / Auto click can
+        // re-run this heuristic from scratch (see field doc). Writing back here would
+        // ratchet the anchor upward if p1 ever exceeds the raw median.
+        let p50 = self.i_med.max(p1);
+        let p99 = self.i_p99.max(p50 * 1.0001);
+        self.i_min = p1;
+        // Headroom above p99 so the few brightest peaks still gain color but the bulk maps
+        // below 1.0. 4x ~= one extra decade for lognormal tails.
+        self.i_max = (p99 * 4.0).max(p50 * 1.0001);
+
+        // timsTOF intensity is lognormal -> Log transfer puts the median mid-LUT.
+        self.transfer = TransferMode::Log;
+
+        // Exposure controls additive COVERAGE (alpha), independent of the LUT index.
+        // contrib = falloff(center=1) * opacity * exposure * weight, with weight == stride
+        // (the loader deposits weight = 1/p = stride). Solve exposure so a single median
+        // splat lands at ~TARGET_ALPHA so overlapping medians ramp toward (not past) white.
+        let weight = self.downsample_stride.max(1) as f32;
+        const TARGET_ALPHA: f32 = 0.35;
+        self.exposure =
+            (TARGET_ALPHA / (self.opacity.max(0.05) * weight)).clamp(0.02, 4.0);
+    }
+
+    /// Auto-set transfer range for VOLUME mode from density percentiles
+    /// (p50 .. p99.9 from VolumeGrid::density_percentiles). Volume composite alpha is
+    /// integrated in-shader, so exposure stays at its tuned default.
+    pub fn auto_transfer_volume(&mut self, lo: f32, hi: f32) {
+        self.transfer = TransferMode::Log;
+        self.i_min = lo.max(1e-6);
+        self.i_max = hi.max(self.i_min * 1.0001);
+        self.exposure = 1.0;
+    }
+
+    /// True when auto-ranging is allowed (no manual transfer edits yet).
+    pub fn may_auto_transfer(&self) -> bool {
+        !self.transfer_user_dirty
+    }
+
+    /// Re-enable auto-ranging and immediately re-apply the heuristic for the active mode.
+    /// `volume_range` is the density percentile pair, used only in volume mode.
+    pub fn reset_transfer_auto(&mut self, volume_range: (f32, f32)) {
+        self.transfer_user_dirty = false;
+        match self.view_mode {
+            ViewMode::Points => self.auto_transfer_points(),
+            ViewMode::Volume => self.auto_transfer_volume(volume_range.0, volume_range.1),
+        }
     }
 
     /// Build the GPU params uniform from the current UI state.

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -65,9 +65,13 @@ pub struct AppState {
     pub show_ms2: bool,
     /// Show the DDA-precursor / DIA-window annotation overlay.
     pub show_annotations: bool,
+    /// Show the data-cube wireframe + axis labels (m/z, 1/K0, RT).
+    pub show_axes: bool,
     pub rt_window: Window,
     pub mz_window: Window,
     pub im_window: Window,
+    /// Re-fit the window box to the full cube (zoom to selection) instead of just culling.
+    pub focus: bool,
 
     // Readouts
     pub fps: f32,
@@ -92,13 +96,14 @@ impl AppState {
             i_min: 1.0,
             i_max: 1e5,
             exposure: 1.0,
-            colormap_id: 0,
+            colormap_id: 1, // Inferno
             n_colormaps,
             point_size: 2.5,
             opacity: 0.5,
             show_ms1: true,
             show_ms2: true,
             show_annotations: true,
+            show_axes: true,
             rt_window: Window {
                 min: bounds.rt.min,
                 max: bounds.rt.max,
@@ -111,6 +116,7 @@ impl AppState {
                 min: bounds.im.min,
                 max: bounds.im.max,
             },
+            focus: false,
             fps: 0.0,
             resident_points: 0,
             capacity: 0,
@@ -159,7 +165,7 @@ impl AppState {
             transfer: [self.transfer.as_f32(), self.i_min, self.i_max, self.exposure],
             point_size: self.point_size,
             opacity: self.opacity,
-            _pad0: 0.0,
+            focus: if self.focus { 1.0 } else { 0.0 },
             _pad1: 0.0,
             ms_mask,
             colormap_id: self.colormap_id,
@@ -195,7 +201,8 @@ impl AppState {
             n_colormaps: self.n_colormaps.max(1),
             // Overwritten by the app from VolumeGrid::density_scale() each frame.
             density_scale: 1.0,
-            _pad: [0.0; 3],
+            focus: if self.focus { 1.0 } else { 0.0 },
+            _pad: [0.0; 2],
         }
     }
 }

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -179,7 +179,9 @@ impl AppState {
             point_size: 2.5,
             opacity: 0.5,
             show_ms1: true,
-            show_ms2: true,
+            // Default to MS1-only: the precursor map is the cleaner first view; MS2 fragments
+            // can be toggled on in the Filters panel.
+            show_ms2: false,
             show_annotations: true,
             show_axes: true,
             show_grid_backfaces: false,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -128,6 +128,10 @@ pub struct AppState {
     pub hist_im: Vec<u32>,
     pub hist_rt: Vec<u32>,
     pub hist_intensity: Vec<u32>,
+    /// 2D projection minimaps (uploaded egui textures), the "you are here" overview planes.
+    pub proj_mz_im: Option<egui::TextureHandle>,
+    pub proj_mz_rt: Option<egui::TextureHandle>,
+    pub proj_im_rt: Option<egui::TextureHandle>,
     /// Re-fit the window box to the full cube (zoom to selection) instead of just culling.
     pub focus: bool,
     /// True while showing a re-streamed sub-region (vs the full run).
@@ -211,6 +215,9 @@ impl AppState {
             hist_im: Vec::new(),
             hist_rt: Vec::new(),
             hist_intensity: Vec::new(),
+            proj_mz_im: None,
+            proj_mz_rt: None,
+            proj_im_rt: None,
             focus: false,
             refined: false,
             color_mode: ColorMode::Intensity,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -136,6 +136,8 @@ pub struct AppState {
     pub focus: bool,
     /// True while showing a re-streamed sub-region (vs the full run).
     pub refined: bool,
+    /// Active panel tab (0 = Filter, 1 = Render, 2 = Analyze).
+    pub ui_tab: u8,
 
     // Clustering (color points by DBSCAN cluster id)
     pub color_mode: ColorMode,
@@ -223,6 +225,7 @@ impl AppState {
             proj_im_rt: None,
             focus: false,
             refined: false,
+            ui_tab: 0,
             color_mode: ColorMode::Intensity,
             cluster_eps: 0.012,
             cluster_min_pts: 8,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -25,6 +25,27 @@ pub enum TransferMode {
     Log,
 }
 
+/// How points are colored.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ColorMode {
+    /// Intensity through the active colormap.
+    Intensity,
+    /// DBSCAN cluster id (golden-ratio hues, noise grey).
+    Cluster,
+}
+
+impl ColorMode {
+    pub fn as_u32(self) -> u32 {
+        match self {
+            ColorMode::Intensity => 0,
+            ColorMode::Cluster => 1,
+        }
+    }
+}
+
+/// Max resident points DBSCAN will run on; above this, clustering is disabled (refine first).
+pub const CLUSTER_CAP: u32 = 600_000;
+
 impl TransferMode {
     fn as_f32(self) -> f32 {
         match self {
@@ -106,6 +127,18 @@ pub struct AppState {
     /// Bias the load toward high-intensity points (brightest fill the budget first) instead
     /// of density-faithful uniform sampling. Applied at load time; toggling re-streams.
     pub intensity_priority: bool,
+
+    // Clustering (color points by DBSCAN cluster id)
+    pub color_mode: ColorMode,
+    /// DBSCAN neighborhood radius in normalized-cube units.
+    pub cluster_eps: f32,
+    /// DBSCAN minimum points to form a dense region.
+    pub cluster_min_pts: u32,
+    /// Last clustering result: number of clusters and noise points (0 until run).
+    pub cluster_count: usize,
+    pub cluster_noise: usize,
+    /// Set by the UI "Cluster" button; the app runs DBSCAN and consumes it.
+    pub cluster_request: bool,
     /// Pending level-of-detail request from the UI; the app consumes it each frame.
     pub refine_request: Option<RefineAction>,
 
@@ -163,6 +196,12 @@ impl AppState {
             focus: false,
             refined: false,
             intensity_priority: false,
+            color_mode: ColorMode::Intensity,
+            cluster_eps: 0.012,
+            cluster_min_pts: 8,
+            cluster_count: 0,
+            cluster_noise: 0,
+            cluster_request: false,
             refine_request: None,
             fps: 0.0,
             resident_points: 0,
@@ -270,7 +309,7 @@ impl AppState {
             point_size: self.point_size,
             opacity: self.opacity,
             focus: if self.focus { 1.0 } else { 0.0 },
-            _pad1: 0.0,
+            color_mode: self.color_mode.as_u32(),
             ms_mask,
             colormap_id: self.colormap_id,
             render_mode,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -146,6 +146,8 @@ pub struct AppState {
     /// Last clustering result: number of clusters and noise points (0 until run).
     pub cluster_count: usize,
     pub cluster_noise: usize,
+    /// Live count of resident points passing the active filter (the DBSCAN input size).
+    pub cluster_input_count: usize,
     /// Set by the UI "Cluster" button; the app runs DBSCAN and consumes it.
     pub cluster_request: bool,
     /// Pending level-of-detail request from the UI; the app consumes it each frame.
@@ -226,6 +228,7 @@ impl AppState {
             cluster_min_pts: 8,
             cluster_count: 0,
             cluster_noise: 0,
+            cluster_input_count: 0,
             cluster_request: false,
             refine_request: None,
             fps: 0.0,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -70,8 +70,6 @@ pub enum RefineAction {
     Refine,
     /// Re-stream the whole run (revert a refinement).
     FullRun,
-    /// Re-stream the current scope (used when the intensity-priority sampling toggles).
-    Restream,
 }
 
 pub struct AppState {
@@ -120,13 +118,20 @@ pub struct AppState {
     pub rt_window: Window,
     pub mz_window: Window,
     pub im_window: Window,
+    /// Intensity range filter (real units, log-scaled UI). Points outside are culled.
+    pub intensity_window: Window,
+    /// Data intensity range (kept-sample min/max), the slider bounds; set from Histograms.
+    pub i_data_lo: f32,
+    pub i_data_hi: f32,
+    /// Per-axis distribution histograms for the levels-style filters (empty until loaded).
+    pub hist_mz: Vec<u32>,
+    pub hist_im: Vec<u32>,
+    pub hist_rt: Vec<u32>,
+    pub hist_intensity: Vec<u32>,
     /// Re-fit the window box to the full cube (zoom to selection) instead of just culling.
     pub focus: bool,
     /// True while showing a re-streamed sub-region (vs the full run).
     pub refined: bool,
-    /// Bias the load toward high-intensity points (brightest fill the budget first) instead
-    /// of density-faithful uniform sampling. Applied at load time; toggling re-streams.
-    pub intensity_priority: bool,
 
     // Clustering (color points by DBSCAN cluster id)
     pub color_mode: ColorMode,
@@ -161,7 +166,7 @@ impl AppState {
             point_mode: PointMode::AdditiveDensity,
             vol_style: VolStyle::Composite,
             vol_steps: 256,
-            transfer: TransferMode::Log,
+            transfer: TransferMode::Sqrt,
             i_min: 1.0,
             i_max: 1e5,
             exposure: 1.0,
@@ -193,9 +198,19 @@ impl AppState {
                 min: bounds.im.min,
                 max: bounds.im.max,
             },
+            // Intensity range unknown until the first Histograms message; default pass-all.
+            intensity_window: Window {
+                min: 0.0,
+                max: f64::INFINITY,
+            },
+            i_data_lo: 1.0,
+            i_data_hi: 1.0e6,
+            hist_mz: Vec::new(),
+            hist_im: Vec::new(),
+            hist_rt: Vec::new(),
+            hist_intensity: Vec::new(),
             focus: false,
             refined: false,
-            intensity_priority: false,
             color_mode: ColorMode::Intensity,
             cluster_eps: 0.012,
             cluster_min_pts: 8,
@@ -226,6 +241,10 @@ impl AppState {
             min: self.bounds.im.min,
             max: self.bounds.im.max,
         };
+        self.intensity_window = Window {
+            min: self.i_data_lo as f64,
+            max: self.i_data_hi as f64,
+        };
     }
 
     /// Auto-set transfer mode + range + exposure for POINT mode from the stored intensity
@@ -247,8 +266,9 @@ impl AppState {
         // below 1.0. 4x ~= one extra decade for lognormal tails.
         self.i_max = (p99 * 4.0).max(p50 * 1.0001);
 
-        // timsTOF intensity is lognormal -> Log transfer puts the median mid-LUT.
-        self.transfer = TransferMode::Log;
+        // Sqrt transfer is the default for point intensity: gentler than log, it lifts the
+        // mid-range without flattening the bright peaks.
+        self.transfer = TransferMode::Sqrt;
 
         // Exposure controls additive COVERAGE (alpha), independent of the LUT index.
         // contrib = falloff(center=1) * opacity * exposure * weight, with weight == stride
@@ -302,9 +322,11 @@ impl AppState {
             PointMode::AdditiveDensity => 0,
             PointMode::StructuralOpaque => 1,
         };
+        // Intensity range filter rides the unused .w of the spatial filter vectors (real
+        // intensity units; the shader culls points outside).
         ParamsUniform {
-            filter_min: [fmin[0], fmin[1], fmin[2], 0.0],
-            filter_max: [fmax[0], fmax[1], fmax[2], 0.0],
+            filter_min: [fmin[0], fmin[1], fmin[2], self.intensity_window.min as f32],
+            filter_max: [fmax[0], fmax[1], fmax[2], self.intensity_window.max as f32],
             transfer: [self.transfer.as_f32(), self.i_min, self.i_max, self.exposure],
             point_size: self.point_size,
             opacity: self.opacity,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -186,7 +186,8 @@ impl AppState {
             // Default to MS1-only: the precursor map is the cleaner first view; MS2 fragments
             // can be toggled on in the Filters panel.
             show_ms2: false,
-            show_annotations: true,
+            // The DIA/MIDIA window overlay is off by default (toggle on in the Filters panel).
+            show_annotations: false,
             show_axes: true,
             show_grid_backfaces: false,
             show_colorbar: true,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -43,8 +43,9 @@ impl ColorMode {
     }
 }
 
-/// Max resident points DBSCAN will run on; above this, clustering is disabled (refine first).
-pub const CLUSTER_CAP: u32 = 600_000;
+/// Max filtered points DBSCAN will run on; above this, clustering is disabled (filter/refine
+/// down first). DBSCAN is grid-accelerated (~O(n)), so a couple million is a few seconds.
+pub const CLUSTER_CAP: u32 = 2_000_000;
 
 impl TransferMode {
     fn as_f32(self) -> f32 {

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -49,6 +49,8 @@ pub enum RefineAction {
     Refine,
     /// Re-stream the whole run (revert a refinement).
     FullRun,
+    /// Re-stream the current scope (used when the intensity-priority sampling toggles).
+    Restream,
 }
 
 pub struct AppState {
@@ -101,6 +103,9 @@ pub struct AppState {
     pub focus: bool,
     /// True while showing a re-streamed sub-region (vs the full run).
     pub refined: bool,
+    /// Bias the load toward high-intensity points (brightest fill the budget first) instead
+    /// of density-faithful uniform sampling. Applied at load time; toggling re-streams.
+    pub intensity_priority: bool,
     /// Pending level-of-detail request from the UI; the app consumes it each frame.
     pub refine_request: Option<RefineAction>,
 
@@ -144,9 +149,7 @@ impl AppState {
             group_mask: u32::MAX,
             n_window_groups: 0,
             rt_window: Window {
-                // Skip the first ~15% of the run by default: the early gradient is usually
-                // near-empty (no peptides eluting yet). "Reset windows" restores the full range.
-                min: bounds.rt.min + 0.15 * (bounds.rt.max - bounds.rt.min),
+                min: bounds.rt.min,
                 max: bounds.rt.max,
             },
             mz_window: Window {
@@ -159,6 +162,7 @@ impl AppState {
             },
             focus: false,
             refined: false,
+            intensity_priority: false,
             refine_request: None,
             fps: 0.0,
             resident_points: 0,

--- a/tims-viewer/src/state.rs
+++ b/tims-viewer/src/state.rs
@@ -67,6 +67,10 @@ pub struct AppState {
     pub show_annotations: bool,
     /// Show the data-cube wireframe + axis labels (m/z, 1/K0, RT).
     pub show_axes: bool,
+    /// Per-window-group visibility bitmask (bit g-1 = group g); used by the selection overlay.
+    pub group_mask: u32,
+    /// Number of DIA/MIDIA window groups in the loaded run (0 until known).
+    pub n_window_groups: u32,
     pub rt_window: Window,
     pub mz_window: Window,
     pub im_window: Window,
@@ -104,6 +108,8 @@ impl AppState {
             show_ms2: true,
             show_annotations: true,
             show_axes: true,
+            group_mask: u32::MAX,
+            n_window_groups: 0,
             rt_window: Window {
                 min: bounds.rt.min,
                 max: bounds.rt.max,

--- a/tims-viewer/src/ticks.rs
+++ b/tims-viewer/src/ticks.rs
@@ -1,0 +1,184 @@
+//! "Nice" axis tick selection: 1/2/5 × 10^k steps, 4–6 ticks across a range.
+//!
+//! Pure, testable tick math with no egui/wgpu deps. The renderer (`app.rs`) and the
+//! overlay (`ui.rs`) consume these to draw 3D tick marks plus numeric labels.
+
+/// A computed tick: real-unit value plus its normalized cube coordinate in [-1,1].
+#[derive(Clone, Copy, Debug)]
+pub struct Tick {
+    pub value: f64,
+    pub norm: f32,
+}
+
+/// Axis identity, for per-axis label formatting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Axis {
+    Mz,
+    Im,
+    Rt,
+}
+
+/// RT spans wider than this (seconds) are labeled in minutes instead of seconds.
+pub const RT_MINUTES_SPAN: f64 = 600.0;
+
+/// Choose a "nice" step so that [lo,hi] is covered by ~4–6 ticks.
+/// Step ∈ {1,2,5}·10^k. Returns the step size (>0). `target` is the desired tick count.
+pub fn nice_step(lo: f64, hi: f64, target: u32) -> f64 {
+    let span = (hi - lo).abs();
+    if span <= 0.0 || !span.is_finite() {
+        return 1.0; // degenerate guard
+    }
+    let raw = span / target.max(1) as f64; // ideal step if steps were continuous
+    let mag = 10f64.powf(raw.log10().floor()); // power-of-ten below raw
+    let norm = raw / mag; // in [1,10)
+    let nice = if norm < 1.5 {
+        1.0
+    } else if norm < 3.0 {
+        2.0
+    } else if norm < 7.0 {
+        5.0
+    } else {
+        10.0
+    };
+    nice * mag
+}
+
+/// Generate ticks across [lo,hi] (auto-orders lo/hi). First tick = ceil(lo/step)*step,
+/// stepping by `step` while <= hi (+epsilon). Each tick's `norm` is computed by `to_norm`
+/// (pass the axis's AxisTransform::normalize, or a window-aware normalizer).
+pub fn ticks_for<F: Fn(f64) -> f32>(lo: f64, hi: f64, target: u32, to_norm: F) -> Vec<Tick> {
+    let (lo, hi) = (lo.min(hi), lo.max(hi));
+    let step = nice_step(lo, hi, target);
+    let first = (lo / step).ceil() * step; // first tick >= lo on the grid
+    let eps = step * 1e-6; // avoid dropping the last tick to fp error
+    let mut out = Vec::new();
+    let mut v = first;
+    while v <= hi + eps {
+        // snap near-zero to exactly 0 so formatting shows "0" not "-0"/"1e-13".
+        let vs = if v.abs() < eps { 0.0 } else { v };
+        out.push(Tick {
+            value: vs,
+            norm: to_norm(vs),
+        });
+        v += step;
+        if out.len() > 64 {
+            break; // hard safety cap
+        }
+    }
+    out
+}
+
+/// Decimal places needed to distinguish adjacent ticks at the given step size.
+/// A step of 200 needs 0; 0.2 needs 1; 0.02 needs 2, etc. Clamped to [0, 6].
+fn decimals_for_step(step: f64) -> usize {
+    if !step.is_finite() || step <= 0.0 {
+        return 0;
+    }
+    // Digits after the point so the step is resolvable (e.g. step 0.2 -> 1, 0.05 -> 2).
+    let d = -step.log10().floor();
+    (d.max(0.0) as usize).min(6)
+}
+
+/// Format a tick value for the given axis and the visible span (span chooses RT units and,
+/// together with the tick count, the decimal precision so adjacent ticks render distinctly).
+pub fn fmt_tick(axis: Axis, value: f64, span: f64) -> String {
+    // Recover the per-axis step from the span so a narrow focus window (sub-unit steps)
+    // gets enough decimals; ~5 ticks across the span matches `ticks_for`'s target.
+    let step = nice_step(0.0, span, 5);
+    match axis {
+        // m/z: integer Th normally, but a narrow focus window can need sub-Th precision.
+        Axis::Mz => format!("{:.*}", decimals_for_step(step), value),
+        // 1/K0: at least 2 decimals (its native scale), more if the window is very narrow.
+        Axis::Im => format!("{:.*}", decimals_for_step(step).max(2), value),
+        Axis::Rt => {
+            if span <= RT_MINUTES_SPAN {
+                format!("{:.*}", decimals_for_step(step), value)
+            } else {
+                // Minutes: span/60 sets the resolvable precision (floor at 1 decimal).
+                format!("{:.*}", decimals_for_step(step / 60.0).max(1), value / 60.0)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Is `v` of the form {1,2,5}·10^k (within fp tolerance)?
+    fn is_nice(v: f64) -> bool {
+        if v <= 0.0 || !v.is_finite() {
+            return false;
+        }
+        let mag = 10f64.powf(v.log10().floor());
+        let mantissa = v / mag;
+        [1.0, 2.0, 5.0, 10.0]
+            .iter()
+            .any(|m| (mantissa - m).abs() < 1e-6)
+    }
+
+    #[test]
+    fn nice_step_is_one_two_five() {
+        for &(lo, hi) in &[(0.0, 1600.0), (0.0, 0.8), (0.0, 12.0), (100.0, 1700.0)] {
+            let s = nice_step(lo, hi, 5);
+            assert!(is_nice(s), "step {s} for [{lo},{hi}] is not 1/2/5·10^k");
+        }
+        // span 1600 / 5 = 320 -> raw mag 100, norm 3.2 -> 5 -> 500.
+        assert_eq!(nice_step(0.0, 1600.0, 5), 500.0);
+        // span 0.8 / 5 = 0.16 -> raw mag 0.1, norm 1.6 -> 2 -> 0.2.
+        assert!((nice_step(0.0, 0.8, 5) - 0.2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ticks_span_range_monotonic() {
+        let ticks = ticks_for(100.0, 1700.0, 5, |v| v as f32);
+        // target=5 with the {1,2,5} snap yields ~4–6; a span landing on a step boundary
+        // (here step=500 over [100,1700] -> 500/1000/1500) bottoms out at 3, which the
+        // spec documents as acceptable and the 64-cap bounds the top end.
+        assert!(
+            (3..=7).contains(&ticks.len()),
+            "expected 3–7 ticks, got {}",
+            ticks.len()
+        );
+        let step = nice_step(100.0, 1700.0, 5);
+        let first = (100.0_f64 / step).ceil() * step;
+        assert!((ticks[0].value - first).abs() < 1e-6);
+        for t in &ticks {
+            assert!(t.value >= 100.0 - 1e-6 && t.value <= 1700.0 + 1e-6);
+        }
+        for w in ticks.windows(2) {
+            assert!(w[1].value > w[0].value, "ticks not increasing");
+        }
+    }
+
+    #[test]
+    fn degenerate_range_does_not_loop() {
+        let ticks = ticks_for(5.0, 5.0, 5, |v| v as f32);
+        assert!(!ticks.is_empty());
+        assert!(ticks.iter().all(|t| t.value.is_finite()));
+        assert!(ticks.len() <= 65);
+    }
+
+    #[test]
+    fn fmt_tick_per_axis() {
+        assert_eq!(fmt_tick(Axis::Mz, 412.7, 1600.0), "413");
+        assert_eq!(fmt_tick(Axis::Im, 1.234, 1.0), "1.23");
+        // RT seconds branch (span <= 600).
+        assert_eq!(fmt_tick(Axis::Rt, 120.0, 300.0), "120");
+        // RT minutes branch (span > 600): 1800 s -> 30.0 min.
+        assert_eq!(fmt_tick(Axis::Rt, 1800.0, 3600.0), "30.0");
+    }
+
+    #[test]
+    fn fmt_tick_narrow_window_gains_precision() {
+        // Narrow m/z focus window (~2 Th span -> step 0.5): adjacent ticks must NOT
+        // collapse to the same integer label.
+        let a = fmt_tick(Axis::Mz, 412.4, 2.0);
+        let b = fmt_tick(Axis::Mz, 412.6, 2.0);
+        assert_ne!(a, b, "narrow m/z ticks collapsed to the same label: {a} == {b}");
+        assert_eq!(a, "412.4");
+        assert_eq!(b, "412.6");
+        // Narrow 1/K0 window (~0.04 span -> step 0.01): needs 2 decimals minimum.
+        assert_ne!(fmt_tick(Axis::Im, 0.812, 0.04), fmt_tick(Axis::Im, 0.818, 0.04));
+    }
+}

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -67,6 +67,7 @@ pub fn build(
                 selection_section(ui, state);
                 rendering_section(ui, state, vol_range);
                 clustering_section(ui, state);
+                projections_section(ui, state);
                 view_section(ui, state, camera);
             });
         });
@@ -333,6 +334,58 @@ fn clustering_section(ui: &mut egui::Ui, state: &mut AppState) {
                 ));
             }
         });
+}
+
+/// **Projections**: 2D density minimaps of the full run onto the coordinate planes, with the
+/// current filter window drawn as a rectangle ("you are here").
+fn projections_section(ui: &mut egui::Ui, state: &mut AppState) {
+    if state.proj_mz_im.is_none() {
+        return; // nothing loaded yet
+    }
+    egui::CollapsingHeader::new("Projections (you are here)")
+        .default_open(false)
+        .show(ui, |ui| {
+            let (mz, im, rt) = (state.bounds.mz, state.bounds.im, state.bounds.rt);
+            minimap(ui, &state.proj_mz_im, "m/z × 1/K0",
+                (mz.min, mz.max), (state.mz_window.min, state.mz_window.max),
+                (im.min, im.max), (state.im_window.min, state.im_window.max));
+            minimap(ui, &state.proj_mz_rt, "m/z × RT",
+                (mz.min, mz.max), (state.mz_window.min, state.mz_window.max),
+                (rt.min, rt.max), (state.rt_window.min, state.rt_window.max));
+            minimap(ui, &state.proj_im_rt, "1/K0 × RT",
+                (im.min, im.max), (state.im_window.min, state.im_window.max),
+                (rt.min, rt.max), (state.rt_window.min, state.rt_window.max));
+        });
+}
+
+/// Draw one projection minimap (`tex`) with the current window drawn as a rectangle. `*b` are
+/// the axis bounds, `*w` the current window; the vertical axis low end is at the image bottom.
+fn minimap(
+    ui: &mut egui::Ui,
+    tex: &Option<egui::TextureHandle>,
+    label: &str,
+    xb: (f64, f64),
+    xw: (f64, f64),
+    yb: (f64, f64),
+    yw: (f64, f64),
+) {
+    let Some(t) = tex else { return };
+    ui.label(label);
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(150.0, 150.0), egui::Sense::hover());
+    let uv = egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0));
+    ui.painter().image(t.id(), rect, uv, egui::Color32::WHITE);
+    let fr = |v: f64, b: (f64, f64)| (((v - b.0) / (b.1 - b.0).max(1e-12)).clamp(0.0, 1.0)) as f32;
+    let x0 = rect.left() + fr(xw.0, xb) * rect.width();
+    let x1 = rect.left() + fr(xw.1, xb) * rect.width();
+    // Low value at the image bottom; egui screen y grows downward.
+    let y_top = rect.bottom() - fr(yw.1, yb) * rect.height();
+    let y_bot = rect.bottom() - fr(yw.0, yb) * rect.height();
+    let wr = egui::Rect::from_min_max(egui::pos2(x0, y_top), egui::pos2(x1, y_bot));
+    ui.painter().rect_stroke(
+        wr,
+        egui::Rounding::ZERO,
+        egui::Stroke::new(1.5, egui::Color32::from_rgb(120, 200, 255)),
+    );
 }
 
 /// **View / Camera**: axis frame · back-face grid · ortho · m/z|mob|RT snaps.

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -119,6 +119,16 @@ fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
             {
                 state.refine_request = Some(RefineAction::Refine);
             }
+            if ui
+                .checkbox(&mut state.intensity_priority, "Intensity priority (brightest first)")
+                .on_hover_text(
+                    "Fill the budget with high-intensity points so the strongest features \
+                     survive; re-streams. Off = density-faithful uniform sampling.",
+                )
+                .changed()
+            {
+                state.refine_request = Some(RefineAction::Restream);
+            }
         });
 }
 

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -113,7 +113,8 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
                 ui.checkbox(&mut state.show_ms1, "MS1");
                 ui.checkbox(&mut state.show_ms2, "MS2");
             });
-            ui.checkbox(&mut state.show_annotations, "Annotations (precursors / DIA windows)");
+            ui.checkbox(&mut state.show_annotations, "Selection windows (DIA/MIDIA)");
+            ui.checkbox(&mut state.show_axes, "Axis frame + labels");
             ui.separator();
 
             // ---- Axis windows ----
@@ -121,6 +122,7 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
             axis_window(ui, "RT (s)", &mut state.rt_window, state.bounds.rt.min, state.bounds.rt.max);
             axis_window(ui, "m/z (Th)", &mut state.mz_window, state.bounds.mz.min, state.bounds.mz.max);
             axis_window(ui, "1/K0", &mut state.im_window, state.bounds.im.min, state.bounds.im.max);
+            ui.checkbox(&mut state.focus, "Focus to window (zoom in)");
             if ui.button("Reset windows").clicked() {
                 state.reset_windows();
             }
@@ -153,6 +155,84 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
                 }
             });
         });
+
+    // Axis labels are drawn as a screen-space overlay (outside the panel) so they sit at
+    // the projected ends of the data cube and rotate with it.
+    if state.show_axes {
+        draw_axis_labels(ctx, state, camera);
+    }
+}
+
+/// Project the data cube's axis ends to screen and label them (name + real-unit range),
+/// so the orientation of m/z, 1/K0 and RT is always readable.
+fn draw_axis_labels(ctx: &egui::Context, state: &AppState, camera: &OrbitCamera) {
+    let rect = ctx.screen_rect();
+    let (w, h) = (rect.width(), rect.height());
+    if w < 1.0 || h < 1.0 {
+        return;
+    }
+    let vp = camera.view_proj(w / h);
+    let project = |p: glam::Vec3| -> Option<egui::Pos2> {
+        let clip = vp * p.extend(1.0);
+        if clip.w <= 1e-4 {
+            return None; // behind the camera
+        }
+        let nx = clip.x / clip.w;
+        let ny = clip.y / clip.w;
+        Some(egui::pos2((nx * 0.5 + 0.5) * w, (1.0 - (ny * 0.5 + 0.5)) * h))
+    };
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("axis_labels"),
+    ));
+    let font = egui::FontId::proportional(14.0);
+    let mut label = |end: glam::Vec3, text: String, color: egui::Color32| {
+        if let Some(p) = project(end) {
+            // Drop shadow so labels stay legible over a bright cloud.
+            painter.text(
+                p + egui::vec2(1.0, 1.0),
+                egui::Align2::CENTER_CENTER,
+                &text,
+                font.clone(),
+                egui::Color32::from_black_alpha(200),
+            );
+            painter.text(p, egui::Align2::CENTER_CENTER, text, font.clone(), color);
+        }
+    };
+    // When focused, the cube represents the window, so label it with the window range.
+    let (mz, im, rt) = if state.focus {
+        (
+            (state.mz_window.min, state.mz_window.max),
+            (state.im_window.min, state.im_window.max),
+            (state.rt_window.min, state.rt_window.max),
+        )
+    } else {
+        (
+            (state.bounds.mz.min, state.bounds.mz.max),
+            (state.bounds.im.min, state.bounds.im.max),
+            (state.bounds.rt.min, state.bounds.rt.max),
+        )
+    };
+    // Each label sits just past the far end of its axis (from the shared min-corner).
+    label(
+        glam::vec3(1.16, -1.0, -1.0),
+        format!("m/z {:.0}–{:.0}", mz.0, mz.1),
+        egui::Color32::from_rgb(255, 150, 90),
+    );
+    label(
+        glam::vec3(-1.0, 1.16, -1.0),
+        format!("1/K0 {:.2}–{:.2}", im.0, im.1),
+        egui::Color32::from_rgb(120, 220, 255),
+    );
+    label(
+        glam::vec3(-1.0, -1.0, 1.16),
+        format!("RT {:.0}–{:.0}s", rt.0, rt.1),
+        egui::Color32::from_rgb(150, 235, 150),
+    );
+    // Mark the shared origin (min of all three axes).
+    if let Some(p) = project(glam::vec3(-1.0, -1.0, -1.0)) {
+        painter.circle_filled(p, 3.0, egui::Color32::from_white_alpha(170));
+    }
 }
 
 fn axis_window(
@@ -163,19 +243,9 @@ fn axis_window(
     hi: f64,
 ) {
     ui.label(label);
-    ui.horizontal(|ui| {
-        ui.add(
-            egui::DragValue::new(&mut win.min)
-                .speed((hi - lo) / 500.0)
-                .range(lo..=hi),
-        );
-        ui.label("–");
-        ui.add(
-            egui::DragValue::new(&mut win.max)
-                .speed((hi - lo) / 500.0)
-                .range(lo..=hi),
-        );
-    });
+    ui.add(egui::Slider::new(&mut win.min, lo..=hi).text("min"));
+    ui.add(egui::Slider::new(&mut win.max, lo..=hi).text("max"));
+    // Keep the range ordered (dragging min past max pushes max along).
     if win.min > win.max {
         win.max = win.min;
     }

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -1,6 +1,6 @@
 //! egui control panel.
 
-use crate::camera::{AxisView, OrbitCamera, Projection};
+use crate::camera::{AxisView, OrbitCamera};
 use crate::render::colormap::{sample, COLORMAP_NAMES};
 use crate::render::point_cloud::PointMode;
 use crate::state::{
@@ -399,14 +399,7 @@ fn view_section(ui: &mut egui::Ui, state: &mut AppState, camera: &mut OrbitCamer
                 if ui.button("Reset").clicked() {
                     camera.reset();
                 }
-                let mut ortho = camera.projection == Projection::Orthographic;
-                if ui.checkbox(&mut ortho, "Ortho").changed() {
-                    camera.projection = if ortho {
-                        Projection::Orthographic
-                    } else {
-                        Projection::Perspective
-                    };
-                }
+                // Orthographic projection is hidden until its bugs are sorted; keep perspective.
             });
             ui.horizontal(|ui| {
                 if ui.button("m/z view").clicked() {

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -1,12 +1,37 @@
 //! egui control panel.
 
 use crate::camera::{AxisView, OrbitCamera, Projection};
-use crate::render::colormap::COLORMAP_NAMES;
+use crate::render::colormap::{sample, COLORMAP_NAMES};
 use crate::render::point_cloud::PointMode;
 use crate::state::{AppState, TransferMode, ViewMode, VolStyle};
+use crate::ticks::RT_MINUTES_SPAN;
+
+/// A numeric axis-tick label for the screen-space overlay: a world-space anchor (just
+/// outside the cube), its formatted value, and the axis color it is drawn in. Built by
+/// `app::axis_geometry` and consumed by `draw_axis_ticks`.
+pub struct TickLabel {
+    pub world: glam::Vec3,
+    pub text: String,
+    pub axis_color: egui::Color32,
+}
+
+// Axis label colors, shared by the name labels and the per-tick numbers.
+const MZ_COL: egui::Color32 = egui::Color32::from_rgb(255, 150, 90);
+const IM_COL: egui::Color32 = egui::Color32::from_rgb(120, 220, 255);
+const RT_COL: egui::Color32 = egui::Color32::from_rgb(150, 235, 150);
 
 /// Build the left control panel; mutates state and camera in place.
-pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera) {
+/// `tick_labels` are the numeric axis-tick labels (rebuilt by the app on range change),
+/// `vol_range` lazily yields the volume density percentile pair; it is invoked ONLY when
+/// the user clicks the "Auto" transfer button, so the (multi-million-voxel) percentile
+/// scan never runs on the per-frame render path.
+pub fn build(
+    ctx: &egui::Context,
+    state: &mut AppState,
+    camera: &mut OrbitCamera,
+    tick_labels: &[TickLabel],
+    vol_range: impl FnOnce() -> (f32, f32),
+) {
     egui::SidePanel::left("controls")
         .resizable(true)
         .default_width(280.0)
@@ -14,7 +39,7 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
             ui.heading("tims-viewer");
             ui.separator();
 
-            // ---- Readouts ----
+            // ---- Readouts (always visible) ----
             ui.label(format!("FPS: {:.0}", state.fps));
             ui.label(format!(
                 "Points: {} / {} (cap)",
@@ -35,85 +60,60 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
             }
             ui.separator();
 
-            // ---- Render mode ----
-            ui.label("Render mode");
-            ui.horizontal(|ui| {
-                ui.radio_value(&mut state.view_mode, ViewMode::Points, "Points");
-                ui.radio_value(&mut state.view_mode, ViewMode::Volume, "Volume");
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                filters_section(ui, state);
+                selection_section(ui, state);
+                rendering_section(ui, state, vol_range);
+                view_section(ui, state, camera);
             });
-            match state.view_mode {
-                ViewMode::Points => {
-                    ui.horizontal(|ui| {
-                        ui.radio_value(
-                            &mut state.point_mode,
-                            PointMode::AdditiveDensity,
-                            "Additive",
-                        );
-                        ui.radio_value(
-                            &mut state.point_mode,
-                            PointMode::StructuralOpaque,
-                            "Opaque",
-                        );
-                    });
-                }
-                ViewMode::Volume => {
-                    ui.horizontal(|ui| {
-                        ui.radio_value(&mut state.vol_style, VolStyle::Composite, "Composite");
-                        ui.radio_value(&mut state.vol_style, VolStyle::Mip, "MIP");
-                    });
-                    ui.add(
-                        egui::Slider::new(&mut state.vol_steps, 32..=1024).text("ray steps"),
-                    );
-                }
-            }
-            ui.separator();
+        });
 
-            // ---- Intensity transfer function ----
-            ui.label("Intensity transfer");
-            ui.horizontal(|ui| {
-                ui.radio_value(&mut state.transfer, TransferMode::Linear, "Lin");
-                ui.radio_value(&mut state.transfer, TransferMode::Sqrt, "Sqrt");
-                ui.radio_value(&mut state.transfer, TransferMode::Log, "Log");
-            });
-            ui.add(
-                egui::Slider::new(&mut state.i_min, 1.0..=1e6)
-                    .logarithmic(true)
-                    .text("i_min"),
-            );
-            ui.add(
-                egui::Slider::new(&mut state.i_max, 10.0..=1e8)
-                    .logarithmic(true)
-                    .text("i_max"),
-            );
-            if state.i_max <= state.i_min {
-                state.i_max = state.i_min * 1.0001;
-            }
-            ui.add(
-                egui::Slider::new(&mut state.exposure, 0.001..=5.0)
-                    .logarithmic(true)
-                    .text("exposure"),
-            );
+    // Screen-space overlays (outside the panel): axis names/units + numeric ticks at the
+    // projected cube edges, the intensity colorbar, and the group-color legend.
+    // Bail once on a degenerate-size frame (window minimize / 0-height transient): the
+    // projector would map every element to None anyway, so skip the painter/font/iteration
+    // work entirely rather than spinning the full overlay machinery per element.
+    let screen = ctx.screen_rect();
+    if screen.width() < 1.0 || screen.height() < 1.0 {
+        return;
+    }
+    if state.show_axes {
+        draw_axis_labels(ctx, state, camera);
+        draw_axis_ticks(ctx, camera, tick_labels);
+    }
+    if state.show_colorbar {
+        draw_colorbar(ctx, state);
+    }
+    draw_group_legend(ctx, state);
+}
 
-            egui::ComboBox::from_label("colormap")
-                .selected_text(COLORMAP_NAMES[state.colormap_id as usize])
-                .show_ui(ui, |ui| {
-                    for (i, name) in COLORMAP_NAMES.iter().enumerate() {
-                        ui.selectable_value(&mut state.colormap_id, i as u32, *name);
-                    }
-                });
-            ui.separator();
-
-            // ---- Appearance ----
-            ui.add(egui::Slider::new(&mut state.point_size, 0.5..=12.0).text("point size"));
-            ui.add(egui::Slider::new(&mut state.opacity, 0.02..=1.0).text("opacity"));
-            ui.separator();
-
-            // ---- MS filter ----
+/// **Filters**: MS1/MS2 · RT/m-z/1-K0 range sliders · Focus to window · Reset.
+fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
+    egui::CollapsingHeader::new("Filters")
+        .default_open(true)
+        .show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.checkbox(&mut state.show_ms1, "MS1");
                 ui.checkbox(&mut state.show_ms2, "MS2");
             });
-            ui.checkbox(&mut state.show_annotations, "Selection windows (DIA/MIDIA)");
+            ui.separator();
+            ui.label("Windows (real units)");
+            axis_window(ui, "RT (s)", &mut state.rt_window, state.bounds.rt.min, state.bounds.rt.max);
+            axis_window(ui, "m/z (Th)", &mut state.mz_window, state.bounds.mz.min, state.bounds.mz.max);
+            axis_window(ui, "1/K0", &mut state.im_window, state.bounds.im.min, state.bounds.im.max);
+            ui.checkbox(&mut state.focus, "Focus to window (zoom in)");
+            if ui.button("Reset windows").clicked() {
+                state.reset_windows();
+            }
+        });
+}
+
+/// **Selection windows**: show toggle · per-group colored checkboxes · all/none.
+fn selection_section(ui: &mut egui::Ui, state: &mut AppState) {
+    egui::CollapsingHeader::new("Selection windows")
+        .default_open(false)
+        .show(ui, |ui| {
+            ui.checkbox(&mut state.show_annotations, "Show DIA/MIDIA windows");
             if state.show_annotations && state.n_window_groups > 0 {
                 let n = state.n_window_groups;
                 ui.horizontal(|ui| {
@@ -147,22 +147,129 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
                     }
                 });
             }
-            ui.checkbox(&mut state.show_axes, "Axis frame + labels");
-            ui.separator();
+        });
+}
 
-            // ---- Axis windows ----
-            ui.label("Windows (real units)");
-            axis_window(ui, "RT (s)", &mut state.rt_window, state.bounds.rt.min, state.bounds.rt.max);
-            axis_window(ui, "m/z (Th)", &mut state.mz_window, state.bounds.mz.min, state.bounds.mz.max);
-            axis_window(ui, "1/K0", &mut state.im_window, state.bounds.im.min, state.bounds.im.max);
-            ui.checkbox(&mut state.focus, "Focus to window (zoom in)");
-            if ui.button("Reset windows").clicked() {
-                state.reset_windows();
+/// **Rendering**: mode · transfer · colormap · appearance.
+fn rendering_section(
+    ui: &mut egui::Ui,
+    state: &mut AppState,
+    vol_range: impl FnOnce() -> (f32, f32),
+) {
+    egui::CollapsingHeader::new("Rendering")
+        .default_open(true)
+        .show(ui, |ui| {
+            ui.label("Render mode");
+            ui.horizontal(|ui| {
+                ui.radio_value(&mut state.view_mode, ViewMode::Points, "Points");
+                ui.radio_value(&mut state.view_mode, ViewMode::Volume, "Volume");
+            });
+            match state.view_mode {
+                ViewMode::Points => {
+                    ui.horizontal(|ui| {
+                        ui.radio_value(
+                            &mut state.point_mode,
+                            PointMode::AdditiveDensity,
+                            "Additive",
+                        );
+                        ui.radio_value(
+                            &mut state.point_mode,
+                            PointMode::StructuralOpaque,
+                            "Opaque",
+                        );
+                    });
+                }
+                ViewMode::Volume => {
+                    ui.horizontal(|ui| {
+                        ui.radio_value(&mut state.vol_style, VolStyle::Composite, "Composite");
+                        ui.radio_value(&mut state.vol_style, VolStyle::Mip, "MIP");
+                    });
+                    ui.add(egui::Slider::new(&mut state.vol_steps, 32..=1024).text("ray steps"));
+                }
             }
             ui.separator();
 
-            // ---- Camera ----
-            ui.label("Camera");
+            // ---- Intensity transfer function ----
+            ui.horizontal(|ui| {
+                ui.label("Intensity transfer");
+                // One-click return to auto-exposure: clears the dirty flag and re-applies.
+                if ui.button("Auto").clicked() {
+                    // Compute the density percentiles lazily, only on this click.
+                    state.reset_transfer_auto(vol_range());
+                }
+            });
+            ui.horizontal(|ui| {
+                let mut changed = false;
+                changed |= ui
+                    .radio_value(&mut state.transfer, TransferMode::Linear, "Lin")
+                    .changed();
+                changed |= ui
+                    .radio_value(&mut state.transfer, TransferMode::Sqrt, "Sqrt")
+                    .changed();
+                changed |= ui
+                    .radio_value(&mut state.transfer, TransferMode::Log, "Log")
+                    .changed();
+                if changed {
+                    state.transfer_user_dirty = true;
+                }
+            });
+            if ui
+                .add(
+                    egui::Slider::new(&mut state.i_min, 1.0..=1e6)
+                        .logarithmic(true)
+                        .text("i_min"),
+                )
+                .changed()
+            {
+                state.transfer_user_dirty = true;
+            }
+            if ui
+                .add(
+                    egui::Slider::new(&mut state.i_max, 10.0..=1e8)
+                        .logarithmic(true)
+                        .text("i_max"),
+                )
+                .changed()
+            {
+                state.transfer_user_dirty = true;
+            }
+            if state.i_max <= state.i_min {
+                state.i_max = state.i_min * 1.0001;
+            }
+            if ui
+                .add(
+                    egui::Slider::new(&mut state.exposure, 0.001..=5.0)
+                        .logarithmic(true)
+                        .text("exposure"),
+                )
+                .changed()
+            {
+                state.transfer_user_dirty = true;
+            }
+
+            egui::ComboBox::from_label("colormap")
+                .selected_text(COLORMAP_NAMES[state.colormap_id as usize])
+                .show_ui(ui, |ui| {
+                    for (i, name) in COLORMAP_NAMES.iter().enumerate() {
+                        ui.selectable_value(&mut state.colormap_id, i as u32, *name);
+                    }
+                });
+            ui.separator();
+
+            // ---- Appearance ----
+            ui.add(egui::Slider::new(&mut state.point_size, 0.5..=12.0).text("point size"));
+            ui.add(egui::Slider::new(&mut state.opacity, 0.02..=1.0).text("opacity"));
+            ui.checkbox(&mut state.show_colorbar, "Colorbar");
+        });
+}
+
+/// **View / Camera**: axis frame · back-face grid · ortho · m/z|mob|RT snaps.
+fn view_section(ui: &mut egui::Ui, state: &mut AppState, camera: &mut OrbitCamera) {
+    egui::CollapsingHeader::new("View / Camera")
+        .default_open(false)
+        .show(ui, |ui| {
+            ui.checkbox(&mut state.show_axes, "Axis frame + labels");
+            ui.checkbox(&mut state.show_grid_backfaces, "Back-face grid");
             ui.horizontal(|ui| {
                 if ui.button("Reset").clicked() {
                     camera.reset();
@@ -188,24 +295,22 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
                 }
             });
         });
-
-    // Axis labels are drawn as a screen-space overlay (outside the panel) so they sit at
-    // the projected ends of the data cube and rotate with it.
-    if state.show_axes {
-        draw_axis_labels(ctx, state, camera);
-    }
 }
 
-/// Project the data cube's axis ends to screen and label them (name + real-unit range),
-/// so the orientation of m/z, 1/K0 and RT is always readable.
-fn draw_axis_labels(ctx: &egui::Context, state: &AppState, camera: &OrbitCamera) {
+/// World→screen projector for the current camera/viewport (perspective divide + viewport
+/// flip). Returns `None` for points behind the camera. Shared by the axis-label, tick, and
+/// (future) probe overlays so they all agree on the projection.
+pub(crate) fn screen_projector(
+    ctx: &egui::Context,
+    camera: &OrbitCamera,
+) -> impl Fn(glam::Vec3) -> Option<egui::Pos2> {
     let rect = ctx.screen_rect();
     let (w, h) = (rect.width(), rect.height());
-    if w < 1.0 || h < 1.0 {
-        return;
-    }
     let vp = camera.view_proj(w / h);
-    let project = |p: glam::Vec3| -> Option<egui::Pos2> {
+    move |p: glam::Vec3| -> Option<egui::Pos2> {
+        if w < 1.0 || h < 1.0 {
+            return None;
+        }
         let clip = vp * p.extend(1.0);
         if clip.w <= 1e-4 {
             return None; // behind the camera
@@ -213,58 +318,259 @@ fn draw_axis_labels(ctx: &egui::Context, state: &AppState, camera: &OrbitCamera)
         let nx = clip.x / clip.w;
         let ny = clip.y / clip.w;
         Some(egui::pos2((nx * 0.5 + 0.5) * w, (1.0 - (ny * 0.5 + 0.5)) * h))
-    };
+    }
+}
+
+/// Project the data cube's axis ends to screen and label them (name + units only; the
+/// per-tick numbers carry the values), so the orientation of m/z, 1/K0 and RT is readable.
+fn draw_axis_labels(ctx: &egui::Context, state: &AppState, camera: &OrbitCamera) {
+    let project = screen_projector(ctx, camera);
     let painter = ctx.layer_painter(egui::LayerId::new(
         egui::Order::Foreground,
         egui::Id::new("axis_labels"),
     ));
     let font = egui::FontId::proportional(14.0);
-    let mut label = |end: glam::Vec3, text: String, color: egui::Color32| {
+    let label = |end: glam::Vec3, text: &str, color: egui::Color32| {
         if let Some(p) = project(end) {
             // Drop shadow so labels stay legible over a bright cloud.
             painter.text(
                 p + egui::vec2(1.0, 1.0),
                 egui::Align2::CENTER_CENTER,
-                &text,
+                text,
                 font.clone(),
                 egui::Color32::from_black_alpha(200),
             );
             painter.text(p, egui::Align2::CENTER_CENTER, text, font.clone(), color);
         }
     };
-    // When focused, the cube represents the window, so label it with the window range.
-    let (mz, im, rt) = if state.focus {
-        (
-            (state.mz_window.min, state.mz_window.max),
-            (state.im_window.min, state.im_window.max),
-            (state.rt_window.min, state.rt_window.max),
-        )
+    // RT span chooses the unit suffix (seconds vs minutes) to match the tick formatting.
+    let rt_span = if state.focus {
+        (state.rt_window.max - state.rt_window.min).abs()
     } else {
-        (
-            (state.bounds.mz.min, state.bounds.mz.max),
-            (state.bounds.im.min, state.bounds.im.max),
-            (state.bounds.rt.min, state.bounds.rt.max),
-        )
+        (state.bounds.rt.max - state.bounds.rt.min).abs()
+    };
+    let rt_unit = if rt_span <= RT_MINUTES_SPAN {
+        "RT (s)"
+    } else {
+        "RT (min)"
     };
     // Each label sits just past the far end of its axis (from the shared min-corner).
-    label(
-        glam::vec3(1.16, -1.0, -1.0),
-        format!("m/z {:.0}–{:.0}", mz.0, mz.1),
-        egui::Color32::from_rgb(255, 150, 90),
-    );
-    label(
-        glam::vec3(-1.0, 1.16, -1.0),
-        format!("1/K0 {:.2}–{:.2}", im.0, im.1),
-        egui::Color32::from_rgb(120, 220, 255),
-    );
-    label(
-        glam::vec3(-1.0, -1.0, 1.16),
-        format!("RT {:.0}–{:.0}s", rt.0, rt.1),
-        egui::Color32::from_rgb(150, 235, 150),
-    );
+    label(glam::vec3(1.16, -1.0, -1.0), "m/z (Th)", MZ_COL);
+    label(glam::vec3(-1.0, 1.16, -1.0), "1/K0", IM_COL);
+    label(glam::vec3(-1.0, -1.0, 1.16), rt_unit, RT_COL);
     // Mark the shared origin (min of all three axes).
     if let Some(p) = project(glam::vec3(-1.0, -1.0, -1.0)) {
         painter.circle_filled(p, 3.0, egui::Color32::from_white_alpha(170));
+    }
+}
+
+/// Draw the numeric axis-tick values at their projected world anchors, colored per axis.
+fn draw_axis_ticks(ctx: &egui::Context, camera: &OrbitCamera, ticks: &[TickLabel]) {
+    if ticks.is_empty() {
+        return;
+    }
+    let project = screen_projector(ctx, camera);
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("axis_ticks"),
+    ));
+    let font = egui::FontId::proportional(11.0);
+    for t in ticks {
+        if let Some(p) = project(t.world) {
+            painter.text(
+                p + egui::vec2(1.0, 1.0),
+                egui::Align2::CENTER_CENTER,
+                &t.text,
+                font.clone(),
+                egui::Color32::from_black_alpha(200),
+            );
+            painter.text(
+                p,
+                egui::Align2::CENTER_CENTER,
+                &t.text,
+                font.clone(),
+                t.axis_color,
+            );
+        }
+    }
+}
+
+/// Vertical intensity colorbar (top-right): the active colormap gradient, i_min/i_max end
+/// labels, and a transfer-mode tag. Pure screen-space; reflects the active colormap/transfer.
+fn draw_colorbar(ctx: &egui::Context, state: &AppState) {
+    let screen = ctx.screen_rect();
+    if screen.width() < 80.0 || screen.height() < 220.0 {
+        return; // too small to place legibly
+    }
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("colorbar"),
+    ));
+    const BAR_W: f32 = 18.0;
+    const BAR_H: f32 = 180.0;
+    const INSET: f32 = 16.0;
+    let right = screen.right() - INSET;
+    let top = screen.top() + INSET + 16.0; // leave room for the transfer tag above
+    let bar = egui::Rect::from_min_max(
+        egui::pos2(right - BAR_W, top),
+        egui::pos2(right, top + BAR_H),
+    );
+
+    // Gradient: ~64 stacked slices, t=1 (i_max) at the top.
+    const SLICES: usize = 64;
+    let map = state.colormap_id as usize;
+    for i in 0..SLICES {
+        let t = i as f32 / (SLICES - 1) as f32;
+        let rgb = sample(map, t);
+        let y1 = bar.bottom() - (i as f32 / SLICES as f32) * BAR_H;
+        let y0 = bar.bottom() - ((i + 1) as f32 / SLICES as f32) * BAR_H;
+        painter.rect_filled(
+            egui::Rect::from_min_max(egui::pos2(bar.left(), y0), egui::pos2(bar.right(), y1)),
+            0.0,
+            egui::Color32::from_rgb(rgb[0], rgb[1], rgb[2]),
+        );
+    }
+    painter.rect_stroke(
+        bar,
+        0.0,
+        egui::Stroke::new(1.0, egui::Color32::from_gray(120)),
+    );
+
+    let font = egui::FontId::proportional(11.0);
+    let text = |pos: egui::Pos2, anchor: egui::Align2, s: String| {
+        painter.text(
+            pos + egui::vec2(1.0, 1.0),
+            anchor,
+            &s,
+            font.clone(),
+            egui::Color32::from_black_alpha(200),
+        );
+        painter.text(pos, anchor, s, font.clone(), egui::Color32::WHITE);
+    };
+    // End labels just left of the bar.
+    text(
+        egui::pos2(bar.left() - 4.0, bar.top()),
+        egui::Align2::RIGHT_CENTER,
+        fmt_intensity(state.i_max),
+    );
+    text(
+        egui::pos2(bar.left() - 4.0, bar.bottom()),
+        egui::Align2::RIGHT_CENTER,
+        fmt_intensity(state.i_min),
+    );
+    // Transfer tag above the bar (density suffix in volume mode, where the range comes
+    // from the grid percentiles rather than per-point intensity).
+    let mode = match state.transfer {
+        TransferMode::Linear => "lin",
+        TransferMode::Sqrt => "sqrt",
+        TransferMode::Log => "log",
+    };
+    let tag = if state.view_mode == ViewMode::Volume {
+        format!("{mode} (density)")
+    } else {
+        mode.to_string()
+    };
+    text(
+        egui::pos2(bar.right(), bar.top() - 14.0),
+        egui::Align2::RIGHT_CENTER,
+        tag,
+    );
+}
+
+/// Format an intensity/density value with k/M suffixes. Fractional values below 1 (volume
+/// density transfer ends) keep decimals so the colorbar legend doesn't collapse them to "0".
+fn fmt_intensity(v: f32) -> String {
+    let v = v as f64;
+    if v >= 1_000_000.0 {
+        format!("{:.1}M", v / 1e6)
+    } else if v >= 1_000.0 {
+        format!("{:.1}k", v / 1e3)
+    } else if v >= 1.0 {
+        format!("{v:.0}")
+    } else if v >= 0.01 {
+        format!("{v:.2}")
+    } else if v > 0.0 {
+        // Very small density floors (e.g. i_min = 1e-6) -> compact scientific.
+        format!("{v:.0e}")
+    } else {
+        "0".to_string()
+    }
+}
+
+/// Compact legend mapping window-group number → swatch (same `group_color` as the boxes).
+/// Only shown when selection windows are active.
+fn draw_group_legend(ctx: &egui::Context, state: &AppState) {
+    if !state.show_annotations || state.n_window_groups == 0 {
+        return;
+    }
+    let screen = ctx.screen_rect();
+    if screen.width() < 80.0 || screen.height() < 120.0 {
+        return;
+    }
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("group_legend"),
+    ));
+
+    // Visible groups (mirror the overlay's per-group mask: only groups whose bit is set).
+    let mask = state.group_mask;
+    let visible: Vec<u32> = (1..=state.n_window_groups.min(32))
+        .filter(|&g| mask & (1u32 << (g - 1)) != 0)
+        .collect();
+    if visible.is_empty() {
+        return;
+    }
+
+    const SWATCH: f32 = 11.0;
+    const ROW_H: f32 = 15.0;
+    const COL_W: f32 = 38.0;
+    const PAD: f32 = 6.0;
+    const ROWS_PER_COL: usize = 16;
+    let title_h = 16.0;
+    let n = visible.len();
+    let cols = ((n + ROWS_PER_COL - 1) / ROWS_PER_COL).max(1);
+    let rows = n.min(ROWS_PER_COL);
+    let panel_w = cols as f32 * COL_W + PAD * 2.0;
+    let panel_h = title_h + rows as f32 * ROW_H + PAD * 2.0;
+
+    // Bottom-right, below where the colorbar sits.
+    let right = screen.right() - 16.0;
+    let bottom = screen.bottom() - 16.0;
+    let panel = egui::Rect::from_min_max(
+        egui::pos2(right - panel_w, bottom - panel_h),
+        egui::pos2(right, bottom),
+    );
+    // Translucent backdrop for contrast over the cloud.
+    painter.rect_filled(panel, 4.0, egui::Color32::from_black_alpha(120));
+
+    let font = egui::FontId::proportional(11.0);
+    painter.text(
+        egui::pos2(panel.left() + PAD, panel.top() + PAD),
+        egui::Align2::LEFT_TOP,
+        "groups",
+        font.clone(),
+        egui::Color32::from_gray(210),
+    );
+
+    for (idx, &g) in visible.iter().enumerate() {
+        let col = idx / ROWS_PER_COL;
+        let row = idx % ROWS_PER_COL;
+        let x = panel.left() + PAD + col as f32 * COL_W;
+        let y = panel.top() + PAD + title_h + row as f32 * ROW_H;
+        let [r, gg, b] = crate::data::loader::group_color(g, state.n_window_groups);
+        let sw = egui::Rect::from_min_size(egui::pos2(x, y), egui::vec2(SWATCH, SWATCH));
+        painter.rect_filled(
+            sw,
+            0.0,
+            egui::Color32::from_rgb((r * 255.0) as u8, (gg * 255.0) as u8, (b * 255.0) as u8),
+        );
+        painter.text(
+            egui::pos2(x + SWATCH + 4.0, y + SWATCH * 0.5),
+            egui::Align2::LEFT_CENTER,
+            format!("{g}"),
+            font.clone(),
+            egui::Color32::WHITE,
+        );
     }
 }
 

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -114,6 +114,39 @@ pub fn build(ctx: &egui::Context, state: &mut AppState, camera: &mut OrbitCamera
                 ui.checkbox(&mut state.show_ms2, "MS2");
             });
             ui.checkbox(&mut state.show_annotations, "Selection windows (DIA/MIDIA)");
+            if state.show_annotations && state.n_window_groups > 0 {
+                let n = state.n_window_groups;
+                ui.horizontal(|ui| {
+                    ui.label("groups:");
+                    if ui.small_button("all").clicked() {
+                        state.group_mask = u32::MAX;
+                    }
+                    if ui.small_button("none").clicked() {
+                        state.group_mask = 0;
+                    }
+                });
+                ui.horizontal_wrapped(|ui| {
+                    for g in 1..=n.min(32) {
+                        let bit = 1u32 << (g - 1);
+                        let mut on = state.group_mask & bit != 0;
+                        let [r, gg, b] = crate::data::loader::group_color(g, n);
+                        let label = egui::RichText::new(format!("{g}")).color(
+                            egui::Color32::from_rgb(
+                                (r * 255.0) as u8,
+                                (gg * 255.0) as u8,
+                                (b * 255.0) as u8,
+                            ),
+                        );
+                        if ui.checkbox(&mut on, label).changed() {
+                            if on {
+                                state.group_mask |= bit;
+                            } else {
+                                state.group_mask &= !bit;
+                            }
+                        }
+                    }
+                });
+            }
             ui.checkbox(&mut state.show_axes, "Axis frame + labels");
             ui.separator();
 
@@ -245,10 +278,14 @@ fn axis_window(
     ui.label(label);
     ui.add(egui::Slider::new(&mut win.min, lo..=hi).text("min"));
     ui.add(egui::Slider::new(&mut win.max, lo..=hi).text("max"));
-    // Keep the range ordered (dragging min past max pushes max along).
-    if win.min > win.max {
-        win.max = win.min;
+    // Keep the range ordered AND non-degenerate: a zero-width window would collapse the
+    // focus (zoom-to-window) remap onto a single line via the shader's 1e-6 halfspan clamp.
+    let eps = (hi - lo) * 1e-3;
+    win.min = win.min.clamp(lo, hi - eps);
+    if win.max < win.min + eps {
+        win.max = win.min + eps;
     }
+    win.max = win.max.min(hi);
 }
 
 fn fmt_count(n: u64) -> String {

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -3,7 +3,7 @@
 use crate::camera::{AxisView, OrbitCamera, Projection};
 use crate::render::colormap::{sample, COLORMAP_NAMES};
 use crate::render::point_cloud::PointMode;
-use crate::state::{AppState, TransferMode, ViewMode, VolStyle};
+use crate::state::{AppState, RefineAction, TransferMode, ViewMode, VolStyle};
 use crate::ticks::RT_MINUTES_SPAN;
 
 /// A numeric axis-tick label for the screen-space overlay: a world-space anchor (just
@@ -104,6 +104,20 @@ fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
             ui.checkbox(&mut state.focus, "Focus to window (zoom in)");
             if ui.button("Reset windows").clicked() {
                 state.reset_windows();
+            }
+            ui.separator();
+            // Level-of-detail: re-stream just this window at full resolution.
+            if state.refined {
+                ui.colored_label(egui::Color32::LIGHT_GREEN, "● refined region (full res)");
+                if ui.button("⟲ Back to full run").clicked() {
+                    state.refine_request = Some(RefineAction::FullRun);
+                }
+            } else if ui
+                .button("⤢ Refine to window (full res)")
+                .on_hover_text("Re-stream only this RT / m-z / mobility window at full resolution")
+                .clicked()
+            {
+                state.refine_request = Some(RefineAction::Refine);
             }
         });
 }

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -307,12 +307,15 @@ fn clustering_section(ui: &mut egui::Ui, state: &mut AppState) {
             );
             ui.add(egui::Slider::new(&mut state.cluster_min_pts, 2..=50).text("min pts"));
             let too_many = state.resident_points > CLUSTER_CAP;
-            ui.add_enabled_ui(!too_many, |ui| {
+            let loading = state.load_progress < 1.0;
+            ui.add_enabled_ui(!too_many && !loading, |ui| {
                 if ui.button("Cluster (DBSCAN)").clicked() {
                     state.cluster_request = true;
                 }
             });
-            if too_many {
+            if loading {
+                ui.label("loading…");
+            } else if too_many {
                 ui.colored_label(
                     egui::Color32::from_rgb(230, 180, 80),
                     format!(

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -3,7 +3,9 @@
 use crate::camera::{AxisView, OrbitCamera, Projection};
 use crate::render::colormap::{sample, COLORMAP_NAMES};
 use crate::render::point_cloud::PointMode;
-use crate::state::{AppState, RefineAction, TransferMode, ViewMode, VolStyle};
+use crate::state::{
+    AppState, ColorMode, RefineAction, TransferMode, ViewMode, VolStyle, CLUSTER_CAP,
+};
 use crate::ticks::RT_MINUTES_SPAN;
 
 /// A numeric axis-tick label for the screen-space overlay: a world-space anchor (just
@@ -64,6 +66,7 @@ pub fn build(
                 filters_section(ui, state);
                 selection_section(ui, state);
                 rendering_section(ui, state, vol_range);
+                clustering_section(ui, state);
                 view_section(ui, state, camera);
             });
         });
@@ -284,6 +287,47 @@ fn rendering_section(
             ui.add(egui::Slider::new(&mut state.point_size, 0.5..=12.0).text("point size"));
             ui.add(egui::Slider::new(&mut state.opacity, 0.02..=1.0).text("opacity"));
             ui.checkbox(&mut state.show_colorbar, "Colorbar");
+        });
+}
+
+/// **Clustering**: color points by DBSCAN cluster id (refine to a small region first).
+fn clustering_section(ui: &mut egui::Ui, state: &mut AppState) {
+    egui::CollapsingHeader::new("Clustering")
+        .default_open(false)
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("color by:");
+                ui.radio_value(&mut state.color_mode, ColorMode::Intensity, "Intensity");
+                ui.radio_value(&mut state.color_mode, ColorMode::Cluster, "Cluster");
+            });
+            ui.add(
+                egui::Slider::new(&mut state.cluster_eps, 0.002..=0.1)
+                    .logarithmic(true)
+                    .text("eps"),
+            );
+            ui.add(egui::Slider::new(&mut state.cluster_min_pts, 2..=50).text("min pts"));
+            let too_many = state.resident_points > CLUSTER_CAP;
+            ui.add_enabled_ui(!too_many, |ui| {
+                if ui.button("Cluster (DBSCAN)").clicked() {
+                    state.cluster_request = true;
+                }
+            });
+            if too_many {
+                ui.colored_label(
+                    egui::Color32::from_rgb(230, 180, 80),
+                    format!(
+                        "Refine to ≤ {} pts to cluster ({} shown)",
+                        fmt_count(CLUSTER_CAP as u64),
+                        fmt_count(state.resident_points as u64)
+                    ),
+                );
+            } else if state.cluster_count > 0 || state.cluster_noise > 0 {
+                ui.label(format!(
+                    "{} clusters · {} noise",
+                    state.cluster_count,
+                    fmt_count(state.cluster_noise as u64)
+                ));
+            }
         });
 }
 

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -121,18 +121,23 @@ fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
                 state.reset_windows();
             }
             ui.separator();
-            // Level-of-detail: re-stream just this window at full resolution.
-            if state.refined {
-                ui.colored_label(egui::Color32::LIGHT_GREEN, "● refined region (full res)");
-                if ui.button("⟲ Back to full run").clicked() {
-                    state.refine_request = Some(RefineAction::FullRun);
-                }
-            } else if ui
+            // Level-of-detail: re-stream just this window at full resolution. "Refine" is
+            // always available so you can zoom in further from an already-refined region
+            // (nested refinement) without first resetting back to the full run.
+            if ui
                 .button("⤢ Refine to window (full res)")
                 .on_hover_text("Re-stream only this RT / m-z / mobility window at full resolution")
                 .clicked()
             {
                 state.refine_request = Some(RefineAction::Refine);
+            }
+            if state.refined {
+                ui.horizontal(|ui| {
+                    ui.colored_label(egui::Color32::LIGHT_GREEN, "● refined");
+                    if ui.button("⟲ Back to full run").clicked() {
+                        state.refine_request = Some(RefineAction::FullRun);
+                    }
+                });
             }
         });
 }
@@ -308,23 +313,23 @@ fn clustering_section(ui: &mut egui::Ui, state: &mut AppState) {
                     .text("eps"),
             );
             ui.add(egui::Slider::new(&mut state.cluster_min_pts, 2..=50).text("min pts"));
-            let too_many = state.resident_points > CLUSTER_CAP;
+            // Gate on the FILTERED input size: tighten the intensity/window filters to bring a
+            // dense region under the cap instead of having to shrink the spatial window.
+            let n = state.cluster_input_count;
+            let too_many = n as u32 > CLUSTER_CAP;
             let loading = state.load_progress < 1.0;
-            ui.add_enabled_ui(!too_many && !loading, |ui| {
+            ui.add_enabled_ui(!too_many && n > 0 && !loading, |ui| {
                 if ui.button("Cluster (DBSCAN)").clicked() {
                     state.cluster_request = true;
                 }
             });
+            ui.label(format!("{} points in filter", fmt_count(n as u64)));
             if loading {
                 ui.label("loading…");
             } else if too_many {
                 ui.colored_label(
                     egui::Color32::from_rgb(230, 180, 80),
-                    format!(
-                        "Refine to ≤ {} pts to cluster ({} shown)",
-                        fmt_count(CLUSTER_CAP as u64),
-                        fmt_count(state.resident_points as u64)
-                    ),
+                    format!("filter down to ≤ {} to cluster", fmt_count(CLUSTER_CAP as u64)),
                 );
             } else if state.cluster_count > 0 || state.cluster_noise > 0 {
                 ui.label(format!(

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -100,10 +100,21 @@ fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
                 ui.checkbox(&mut state.show_ms2, "MS2");
             });
             ui.separator();
-            ui.label("Windows (real units)");
-            axis_window(ui, "RT (s)", &mut state.rt_window, state.bounds.rt.min, state.bounds.rt.max);
-            axis_window(ui, "m/z (Th)", &mut state.mz_window, state.bounds.mz.min, state.bounds.mz.max);
-            axis_window(ui, "1/K0", &mut state.im_window, state.bounds.im.min, state.bounds.im.max);
+            ui.label("Windows (distribution + range)");
+            let (rb, mb, ib) = (state.bounds.rt, state.bounds.mz, state.bounds.im);
+            hist_filter(ui, "RT (s)", &mut state.rt_window, rb.min, rb.max, &state.hist_rt, false);
+            hist_filter(ui, "m/z (Th)", &mut state.mz_window, mb.min, mb.max, &state.hist_mz, false);
+            hist_filter(ui, "1/K0", &mut state.im_window, ib.min, ib.max, &state.hist_im, false);
+            let (idlo, idhi) = (state.i_data_lo as f64, state.i_data_hi as f64);
+            hist_filter(
+                ui,
+                "intensity (log)",
+                &mut state.intensity_window,
+                idlo,
+                idhi,
+                &state.hist_intensity,
+                true,
+            );
             ui.checkbox(&mut state.focus, "Focus to window (zoom in)");
             if ui.button("Reset windows").clicked() {
                 state.reset_windows();
@@ -121,16 +132,6 @@ fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
                 .clicked()
             {
                 state.refine_request = Some(RefineAction::Refine);
-            }
-            if ui
-                .checkbox(&mut state.intensity_priority, "Intensity priority (brightest first)")
-                .on_hover_text(
-                    "Fill the budget with high-intensity points so the strongest features \
-                     survive; re-streams. Off = density-faithful uniform sampling.",
-                )
-                .changed()
-            {
-                state.refine_request = Some(RefineAction::Restream);
             }
         });
 }
@@ -645,16 +646,64 @@ fn draw_group_legend(ctx: &egui::Context, state: &AppState) {
     }
 }
 
-fn axis_window(
+/// A range filter backed by a distribution histogram (image-"levels" style): a strip of bars
+/// with the selected range highlighted, above min/max sliders. `log` scales both the slider
+/// and the value→x mapping logarithmically (for the intensity axis). `hist` may be empty
+/// (before data lands) — then only the sliders show.
+fn hist_filter(
     ui: &mut egui::Ui,
     label: &str,
     win: &mut crate::state::Window,
     lo: f64,
     hi: f64,
+    hist: &[u32],
+    log: bool,
 ) {
     ui.label(label);
-    ui.add(egui::Slider::new(&mut win.min, lo..=hi).text("min"));
-    ui.add(egui::Slider::new(&mut win.max, lo..=hi).text("max"));
+    if !hist.is_empty() && hi > lo {
+        let height = 26.0;
+        let (rect, _) =
+            ui.allocate_exact_size(egui::vec2(ui.available_width(), height), egui::Sense::hover());
+        let painter = ui.painter_at(rect);
+        painter.rect_filled(rect, egui::Rounding::same(2.0), egui::Color32::from_gray(22));
+        // Value -> x fraction in [0,1], honoring the log axis.
+        let to_frac = |v: f64| -> f32 {
+            let f = if log {
+                (v.max(lo).ln() - lo.ln()) / (hi.ln() - lo.ln())
+            } else {
+                (v - lo) / (hi - lo)
+            };
+            f.clamp(0.0, 1.0) as f32
+        };
+        let (wmin, wmax) = (to_frac(win.min), to_frac(win.max));
+        let maxc = hist.iter().copied().max().unwrap_or(1).max(1) as f32;
+        let n = hist.len();
+        let bw = rect.width() / n as f32;
+        for (i, &c) in hist.iter().enumerate() {
+            let frac = (i as f32 + 0.5) / n as f32;
+            // sqrt keeps low-count bins visible without flattening the peaks.
+            let bh = (c as f32 / maxc).sqrt() * (height - 2.0);
+            let x0 = rect.left() + i as f32 * bw;
+            let bar = egui::Rect::from_min_max(
+                egui::pos2(x0, rect.bottom() - bh),
+                egui::pos2(x0 + bw.max(1.0), rect.bottom()),
+            );
+            let color = if frac >= wmin && frac <= wmax {
+                egui::Color32::from_rgb(95, 170, 240)
+            } else {
+                egui::Color32::from_gray(72)
+            };
+            painter.rect_filled(bar, egui::Rounding::ZERO, color);
+        }
+    }
+    let mut smin = egui::Slider::new(&mut win.min, lo..=hi).text("min");
+    let mut smax = egui::Slider::new(&mut win.max, lo..=hi).text("max");
+    if log {
+        smin = smin.logarithmic(true);
+        smax = smax.logarithmic(true);
+    }
+    ui.add(smin);
+    ui.add(smax);
     // Keep the range ordered AND non-degenerate: a zero-width window would collapse the
     // focus (zoom-to-window) remap onto a single line via the shader's 1e-6 halfspan clamp.
     let eps = (hi - lo) * 1e-3;

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -426,6 +426,16 @@ fn view_section(ui: &mut egui::Ui, state: &mut AppState, camera: &mut OrbitCamer
                     camera.reset();
                 }
                 // Orthographic projection is hidden until its bugs are sorted; keep perspective.
+                if ui
+                    .button(format!(
+                        "⟳ Roll up: {}",
+                        crate::camera::ROLL_UP_AXIS[(camera.roll % 3) as usize]
+                    ))
+                    .on_hover_text("Topple the cube so the next data axis points up")
+                    .clicked()
+                {
+                    camera.roll_axis();
+                }
             });
             ui.horizontal(|ui| {
                 if ui.button("m/z view").clicked() {

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -62,13 +62,34 @@ pub fn build(
             }
             ui.separator();
 
-            egui::ScrollArea::vertical().show(ui, |ui| {
-                filters_section(ui, state);
-                selection_section(ui, state);
-                rendering_section(ui, state, vol_range);
-                clustering_section(ui, state);
-                projections_section(ui, state);
-                view_section(ui, state, camera);
+            // ---- Tab bar: group the sections so the panel isn't overloaded ----
+            const TABS: [&str; 3] = ["Filter", "Render", "Analyze"];
+            ui.horizontal(|ui| {
+                if ui.button("‹").on_hover_text("Previous tab").clicked() {
+                    state.ui_tab = (state.ui_tab + TABS.len() as u8 - 1) % TABS.len() as u8;
+                }
+                for (i, name) in TABS.iter().enumerate() {
+                    ui.selectable_value(&mut state.ui_tab, i as u8, *name);
+                }
+                if ui.button("›").on_hover_text("Next tab").clicked() {
+                    state.ui_tab = (state.ui_tab + 1) % TABS.len() as u8;
+                }
+            });
+            ui.separator();
+
+            egui::ScrollArea::vertical().show(ui, |ui| match state.ui_tab {
+                0 => {
+                    filters_section(ui, state);
+                    selection_section(ui, state);
+                }
+                1 => {
+                    rendering_section(ui, state, vol_range);
+                    view_section(ui, state, camera);
+                }
+                _ => {
+                    clustering_section(ui, state);
+                    projections_section(ui, state);
+                }
             });
         });
 

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -184,7 +184,7 @@ fn selection_section(ui: &mut egui::Ui, state: &mut AppState) {
                     for g in 1..=n.min(32) {
                         let bit = 1u32 << (g - 1);
                         let mut on = state.group_mask & bit != 0;
-                        let [r, gg, b] = crate::data::loader::group_color(g, n);
+                        let [r, gg, b] = crate::render::colormap::group_color(g, n);
                         let label = egui::RichText::new(format!("{g}")).color(
                             egui::Color32::from_rgb(
                                 (r * 255.0) as u8,
@@ -711,7 +711,7 @@ fn draw_group_legend(ctx: &egui::Context, state: &AppState) {
         let row = idx % ROWS_PER_COL;
         let x = panel.left() + PAD + col as f32 * COL_W;
         let y = panel.top() + PAD + title_h + row as f32 * ROW_H;
-        let [r, gg, b] = crate::data::loader::group_color(g, state.n_window_groups);
+        let [r, gg, b] = crate::render::colormap::group_color(g, state.n_window_groups);
         let sw = egui::Rect::from_min_size(egui::pos2(x, y), egui::vec2(SWATCH, SWATCH));
         painter.rect_filled(
             sw,

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -124,10 +124,13 @@ fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
             ui.separator();
             ui.label("Windows (distribution + range)");
             let (rb, mb, ib) = (state.bounds.rt, state.bounds.mz, state.bounds.im);
-            hist_filter(ui, "RT (s)", &mut state.rt_window, rb.min, rb.max, &state.hist_rt, false);
-            hist_filter(ui, "m/z (Th)", &mut state.mz_window, mb.min, mb.max, &state.hist_mz, false);
-            hist_filter(ui, "1/K0", &mut state.im_window, ib.min, ib.max, &state.hist_im, false);
+            hist_filter(ui, "RT (s)", &mut state.rt_window, rb.min, rb.max, &state.hist_rt, false, true);
+            hist_filter(ui, "m/z (Th)", &mut state.mz_window, mb.min, mb.max, &state.hist_mz, false, true);
+            hist_filter(ui, "1/K0", &mut state.im_window, ib.min, ib.max, &state.hist_im, false, true);
             let (idlo, idhi) = (state.i_data_lo as f64, state.i_data_hi as f64);
+            // Intensity range is a placeholder (i_data_hi = 1e6) until the loader's Stats land
+            // (i_p99 > 0) — only then are the window clamps safe to apply.
+            let intensity_known = state.i_p99 > 0.0;
             hist_filter(
                 ui,
                 "intensity (log)",
@@ -136,6 +139,7 @@ fn filters_section(ui: &mut egui::Ui, state: &mut AppState) {
                 idhi,
                 &state.hist_intensity,
                 true,
+                intensity_known,
             );
             ui.checkbox(&mut state.focus, "Focus to window (zoom in)");
             if ui.button("Reset windows").clicked() {
@@ -740,6 +744,7 @@ fn hist_filter(
     hi: f64,
     hist: &[u32],
     log: bool,
+    known: bool,
 ) {
     ui.label(label);
     if !hist.is_empty() && hi > lo {
@@ -778,6 +783,10 @@ fn hist_filter(
             painter.rect_filled(bar, egui::Rounding::ZERO, color);
         }
     }
+    // Snapshot before the sliders so we can undo the slider's range-clamp while the range is only a
+    // placeholder (stats not yet in): otherwise the pass-all sentinel window (max = ∞) gets pinned to
+    // the placeholder `hi` and transiently culls the brightest points until the real range lands.
+    let saved = (win.min, win.max);
     let mut smin = egui::Slider::new(&mut win.min, lo..=hi).text("min");
     let mut smax = egui::Slider::new(&mut win.max, lo..=hi).text("max");
     if log {
@@ -786,14 +795,19 @@ fn hist_filter(
     }
     ui.add(smin);
     ui.add(smax);
-    // Keep the range ordered AND non-degenerate: a zero-width window would collapse the
-    // focus (zoom-to-window) remap onto a single line via the shader's 1e-6 halfspan clamp.
-    let eps = (hi - lo) * 1e-3;
-    win.min = win.min.clamp(lo, hi - eps);
-    if win.max < win.min + eps {
-        win.max = win.min + eps;
+    if known {
+        // Keep the range ordered AND non-degenerate: a zero-width window would collapse the
+        // focus (zoom-to-window) remap onto a single line via the shader's 1e-6 halfspan clamp.
+        let eps = (hi - lo) * 1e-3;
+        win.min = win.min.clamp(lo, hi - eps);
+        if win.max < win.min + eps {
+            win.max = win.min + eps;
+        }
+        win.max = win.max.min(hi);
+    } else {
+        win.min = saved.0;
+        win.max = saved.1;
     }
-    win.max = win.max.min(hi);
 }
 
 fn fmt_count(n: u64) -> String {

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -27,6 +27,8 @@ console_log = "1"
 web-sys = { version = "0.3", features = [
     "Document", "Window", "Element", "HtmlCanvasElement", "Node", "EventTarget",
     "Event", "MouseEvent", "WheelEvent", "Response", "Location",
-    "HtmlInputElement", "HtmlSelectElement", "HtmlElement", "CssStyleDeclaration",
+    "HtmlInputElement", "HtmlSelectElement", "HtmlElement", "HtmlLinkElement", "CssStyleDeclaration",
     "CanvasRenderingContext2d", "ImageData", "DomRect", "DomTokenList",
+    # Off-main-thread DBSCAN: a module Web Worker built from a Blob that re-imports this same wasm.
+    "Worker", "WorkerOptions", "WorkerType", "MessageEvent", "Blob", "Url",
 ] }

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -27,7 +27,9 @@ console_log = "1"
 web-sys = { version = "0.3", features = [
     "Document", "Window", "Element", "HtmlCanvasElement", "Node", "EventTarget",
     "Event", "MouseEvent", "WheelEvent", "Response", "Location",
-    "HtmlInputElement", "HtmlSelectElement", "HtmlElement", "HtmlLinkElement", "CssStyleDeclaration",
+    "HtmlInputElement", "HtmlSelectElement", "HtmlTextAreaElement", "HtmlElement", "HtmlLinkElement", "CssStyleDeclaration",
+    # Error telemetry: forward uncaught JS errors to /telemetry.
+    "ErrorEvent",
     "CanvasRenderingContext2d", "ImageData", "DomRect", "DomTokenList",
     # Off-main-thread DBSCAN: a module Web Worker built from a Blob that re-imports this same wasm.
     "Worker", "WorkerOptions", "WorkerType", "MessageEvent", "Blob", "BlobPropertyBag", "Url",

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "tims-viewer-web"
+version = "0.1.0"
+edition = "2021"
+description = "Browser (WASM/WebGPU) shell embedding the tims-viewer GPU point-cloud renderer."
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# Everything is wasm-only: on a native `cargo build` (the workspace default) this crate compiles
+# to an empty lib and pulls no web deps. Build the real thing with Trunk or
+# `cargo build -p tims-viewer-web --target wasm32-unknown-unknown`.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# The render-safe half of tims-viewer (no Bruker loader / native deps).
+tims-viewer = { path = "..", default-features = false }
+# `webgl` adds the WebGL2 fallback alongside the default WebGPU backend.
+wgpu = { version = "=22.1.0", features = ["webgl"] }
+glam = { version = "0.29", features = ["bytemuck"] }
+bytemuck = { version = "1.21", features = ["derive"] }
+log = "0.4"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+console_error_panic_hook = "0.1"
+console_log = "1"
+web-sys = { version = "0.3", features = [
+    "Document", "Window", "Element", "HtmlCanvasElement", "Node", "EventTarget",
+    "Event", "MouseEvent", "WheelEvent", "Response", "Location",
+    "HtmlInputElement", "HtmlSelectElement", "HtmlElement", "CssStyleDeclaration",
+] }

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -32,5 +32,5 @@ web-sys = { version = "0.3", features = [
     # Off-main-thread DBSCAN: a module Web Worker built from a Blob that re-imports this same wasm.
     "Worker", "WorkerOptions", "WorkerType", "MessageEvent", "Blob", "BlobPropertyBag", "Url",
     # POST points to an optional Python (sklearn) clustering service.
-    "Request", "RequestInit",
+    "RequestInit",
 ] }

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -31,4 +31,6 @@ web-sys = { version = "0.3", features = [
     "CanvasRenderingContext2d", "ImageData", "DomRect", "DomTokenList",
     # Off-main-thread DBSCAN: a module Web Worker built from a Blob that re-imports this same wasm.
     "Worker", "WorkerOptions", "WorkerType", "MessageEvent", "Blob", "BlobPropertyBag", "Url",
+    # POST points to an optional Python (sklearn) clustering service.
+    "Request", "RequestInit",
 ] }

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -31,6 +31,6 @@ web-sys = { version = "0.3", features = [
     "CanvasRenderingContext2d", "ImageData", "DomRect", "DomTokenList",
     # Off-main-thread DBSCAN: a module Web Worker built from a Blob that re-imports this same wasm.
     "Worker", "WorkerOptions", "WorkerType", "MessageEvent", "Blob", "BlobPropertyBag", "Url",
-    # POST points to an optional Python (sklearn) clustering service.
-    "RequestInit",
+    # POST points to an optional Python (sklearn) clustering service (+ a timed-out health probe).
+    "RequestInit", "AbortController", "AbortSignal",
 ] }

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -28,4 +28,5 @@ web-sys = { version = "0.3", features = [
     "Document", "Window", "Element", "HtmlCanvasElement", "Node", "EventTarget",
     "Event", "MouseEvent", "WheelEvent", "Response", "Location",
     "HtmlInputElement", "HtmlSelectElement", "HtmlElement", "CssStyleDeclaration",
+    "CanvasRenderingContext2d", "ImageData", "DomRect", "DomTokenList",
 ] }

--- a/tims-viewer/web/Cargo.toml
+++ b/tims-viewer/web/Cargo.toml
@@ -30,5 +30,5 @@ web-sys = { version = "0.3", features = [
     "HtmlInputElement", "HtmlSelectElement", "HtmlElement", "HtmlLinkElement", "CssStyleDeclaration",
     "CanvasRenderingContext2d", "ImageData", "DomRect", "DomTokenList",
     # Off-main-thread DBSCAN: a module Web Worker built from a Blob that re-imports this same wasm.
-    "Worker", "WorkerOptions", "WorkerType", "MessageEvent", "Blob", "Url",
+    "Worker", "WorkerOptions", "WorkerType", "MessageEvent", "Blob", "BlobPropertyBag", "Url",
 ] }

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -393,9 +393,17 @@
           <div class="dsum-row"><span class="k">RT</span><span class="v" id="data-rt">—</span></div>
           <div class="dsum-row"><span class="k">Cycle</span><span class="v" id="data-cycle">—</span></div>
         </div>
-        <div class="row" id="acq-row" style="display:none; margin-top:10px">
+        <div class="row" id="acq-row" style="display:none; margin-top:10px; gap:6px; align-items:center">
           <button class="btn" id="acq-play" type="button" style="flex:1">▶ Live acquisition</button>
-          <span class="tip" tabindex="0" role="img" aria-label="help" title="Play a simulated acquisition over time at the device frame rate, colouring each peak by its precursor (a precursor + its fragments share a hue). Requires the acquisition sidecar (?acq=).">i</span>
+          <select id="acq-speed" title="Playback speed (1× = the device's real frame rate)" aria-label="playback speed">
+            <option value="0.25">0.25×</option>
+            <option value="0.5">0.5×</option>
+            <option value="1" selected>1× real-time</option>
+            <option value="2">2×</option>
+            <option value="4">4×</option>
+            <option value="1000">Max</option>
+          </select>
+          <span class="tip" tabindex="0" role="img" aria-label="help" title="Play a simulated acquisition over time at the device frame rate, colouring each peak by its precursor (a precursor + its fragments share a hue). 1× is the real device rate; Max runs as fast as frames can be fetched. Requires the acquisition sidecar (?acq=).">i</span>
         </div>
       </section>
       </div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -256,7 +256,7 @@
         <div class="row"><label class="lbl" for="disp">Display</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="disp" min="1" max="100" step="1" value="100" aria-label="fraction of points to display" />
-            <output class="val" id="disp-v" for="disp">—</output></span></div>
+            <input type="number" class="numin" id="disp-n" min="1" step="1000" value="0" style="width:78px" aria-label="number of points to display" /></span></div>
         <div class="row"><span class="lbl" id="l-mode">Mode</span>
           <span class="seg" role="radiogroup" aria-labelledby="l-mode">
             <input type="radio" name="mode" id="m-add" checked /><label for="m-add">Density</label>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -481,6 +481,8 @@
       <div class="tabpane" id="tab-cluster">
       <section class="sec">
         <div class="ey">Cluster · DBSCAN</div>
+        <div class="row"><label class="lbl" for="cl-python">Python (sklearn) <span class="dim" id="cl-python-status" style="font-weight:400">checking…</span></label>
+          <span><input type="checkbox" class="sw" id="cl-python" /><label for="cl-python" class="sw-l" aria-hidden="true"></label></span></div>
         <div class="row"><label class="lbl" for="cl-eps">ε radius <span class="dim" style="font-weight:400">(norm.)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-eps" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -389,8 +389,9 @@
           <div class="dsum-row"><span class="k">RT</span><span class="v" id="data-rt">—</span></div>
           <div class="dsum-row"><span class="k">Cycle</span><span class="v" id="data-cycle">—</span></div>
         </div>
-        <div class="row" id="acq-row" style="display:none; margin-top:10px; gap:6px; align-items:center">
-          <button class="btn" id="acq-play" type="button" style="flex:1">▶ Live acquisition</button>
+        <div class="row" id="acq-row" style="display:none; margin-top:10px; gap:6px; align-items:center; flex-wrap:wrap">
+          <button class="btn" id="acq-play" type="button" style="flex:1 1 auto">▶ Live acquisition</button>
+          <span title="Experimental — streams a SIMULATED acquisition from the sidecar; behavior and wire format may still change." style="flex:none; font-size:9px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:#f0b429; border:1px solid rgba(240,180,41,.5); border-radius:3px; padding:1px 5px; white-space:nowrap">experimental</span>
           <select id="acq-speed" class="sel" title="Playback speed (1× = the device's real frame rate)" aria-label="playback speed">
             <option value="0.25">0.25×</option>
             <option value="0.5">0.5×</option>
@@ -399,7 +400,7 @@
             <option value="4">4×</option>
             <option value="1000">Max</option>
           </select>
-          <span class="tip" tabindex="0" role="img" aria-label="help" title="Play a simulated acquisition over time at the device frame rate, colouring each peak by its precursor (a precursor + its fragments share a hue). 1× is the real device rate; Max runs as fast as frames can be fetched. Requires the acquisition sidecar (?acq=).">i</span>
+          <span class="tip" tabindex="0" role="img" aria-label="help" title="EXPERIMENTAL. Play a SIMULATED acquisition over time at the device frame rate, colouring each peak by its precursor (a precursor + its fragments share a hue). 1× is the real device rate; Max runs as fast as frames can be fetched. Requires the acquisition sidecar (?acq=).">i</span>
         </div>
       </section>
       </div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -73,6 +73,13 @@
     .lbl { font-size: 12.5px; color: var(--ink); font-weight: 500; }
     .val { font-family: var(--mono); font-size: 11.5px; color: var(--accent-2);
       font-variant-numeric: tabular-nums; min-width: 40px; text-align: right; }
+    /* editable numeric readout — type a value or use the slider */
+    .numin { font-family: var(--mono); font-size: 11.5px; color: var(--accent-2); width: 54px;
+      text-align: right; background: transparent; border: 1px solid transparent; border-radius: 5px;
+      padding: 2px 5px; font-variant-numeric: tabular-nums; -moz-appearance: textfield; appearance: textfield; }
+    .numin::-webkit-outer-spin-button, .numin::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+    .numin:hover { border-color: var(--line); }
+    .numin:focus { border-color: var(--accent); outline: none; color: var(--ink); background: rgba(0,0,0,0.25); }
 
     /* range */
     .rng { -webkit-appearance: none; appearance: none; width: 150px; height: 3px; border-radius: 3px;
@@ -253,11 +260,11 @@
         <div class="row"><label class="lbl" for="psize">Point size</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="psize" min="0.5" max="6" step="0.1" value="2.5" />
-            <output class="val" id="psize-v" for="psize">2.5</output></span></div>
+            <input type="number" class="numin" id="psize-n" min="0.5" max="6" step="0.1" value="2.5" aria-label="point size value" /></span></div>
         <div class="row"><label class="lbl" for="opac">Opacity</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="opac" min="0.05" max="1" step="0.05" value="0.6" />
-            <output class="val" id="opac-v" for="opac">0.60</output></span></div>
+            <input type="number" class="numin" id="opac-n" min="0.05" max="1" step="0.05" value="0.60" aria-label="opacity value" /></span></div>
       </section>
 
       <section class="sec">
@@ -271,11 +278,11 @@
         <div class="row"><label class="lbl" for="expo">Exposure</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="expo" min="0.02" max="4" step="0.02" value="1.00" />
-            <output class="val" id="expo-v" for="expo">1.00</output></span></div>
+            <input type="number" class="numin" id="expo-n" min="0.02" max="4" step="0.02" value="1.00" aria-label="exposure value" /></span></div>
         <div class="row"><label class="lbl" for="floor">Floor</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="floor" min="0" max="5000" step="25" value="0" />
-            <output class="val" id="floor-v" for="floor">0</output></span></div>
+            <input type="number" class="numin" id="floor-n" min="0" max="5000" step="25" value="0" aria-label="intensity floor value" /></span></div>
       </section>
 
       <section class="sec">

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -412,14 +412,6 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="expo" min="0.02" max="4" step="0.02" value="1.00" />
             <input type="number" class="numin" id="expo-n" min="0.02" max="4" step="0.02" value="1.00" aria-label="exposure value" /></span></div>
-        <div class="crop">
-          <div class="clab"><b>Floor</b><span>intensity ≥ (counts) <span id="floor-src" class="acc"></span></span></div>
-          <div class="crop-hist" id="floor-hist"></div>
-          <div class="frow">
-            <input type="range" class="rng wide" id="floor" min="0" max="1000" step="1" value="0" aria-label="intensity floor" />
-            <input type="number" class="numin" id="floor-n" min="0" max="5000" step="1" value="0" aria-label="intensity floor value in counts" />
-          </div>
-        </div>
       </section>
       </div>
       <div class="tabpane" id="tab-focus">
@@ -463,6 +455,14 @@
             <div class="dual-track"></div><div class="dual-fill" id="crt-fill"></div>
             <input type="range" id="crt-lo" min="0" max="1000" value="0" aria-label="retention time crop minimum" />
             <input type="range" id="crt-hi" min="0" max="1000" value="1000" aria-label="retention time crop maximum" />
+          </div>
+        </div>
+        <div class="crop">
+          <div class="clab"><b>Floor</b><span>intensity ≥ (counts) <span id="floor-src" class="acc"></span></span></div>
+          <div class="crop-hist" id="floor-hist"></div>
+          <div class="frow">
+            <input type="range" class="rng wide" id="floor" min="0" max="1000" step="1" value="0" aria-label="intensity floor" />
+            <input type="number" class="numin" id="floor-n" min="0" max="5000" step="1" value="0" aria-label="intensity floor value in counts" />
           </div>
         </div>
       </section>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -62,11 +62,38 @@
     .body { flex: 1; overflow-y: auto; overflow-x: hidden; padding: 4px 0 14px; }
     .body::-webkit-scrollbar { width: 8px; }
     .body::-webkit-scrollbar-thumb { background: var(--line); border-radius: 8px; }
+    /* tabs */
+    .tabs { display: flex; gap: 4px; padding: 8px 16px 0 18px; border-bottom: 1px solid var(--line); }
+    .tab { flex: 1; font-family: var(--sans); font-size: 12px; font-weight: 500; color: var(--dim);
+      background: transparent; border: none; border-bottom: 2px solid transparent; margin-bottom: -1px;
+      padding: 7px 4px 8px; cursor: pointer; transition: color .14s, border-color .14s; }
+    .tab:hover { color: var(--ink); }
+    .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+    .tabpane { display: none; }
+    .tabpane.active { display: block; }
+
     .sec { padding: 14px 18px 4px 20px; }
     .sec + .sec { border-top: 1px solid var(--line-2); }
     .ey { display: flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: .18em;
-      text-transform: uppercase; color: var(--dim); margin-bottom: 11px; }
+      text-transform: uppercase; color: var(--dim); margin-bottom: 11px;
+      cursor: pointer; user-select: none; transition: color .14s; }
+    .ey:hover { color: var(--ink); }
+    .ey::before { content: "▾"; font-size: 9px; letter-spacing: 0; color: var(--faint);
+      transition: transform .18s; }
     .ey::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+    .sec.collapsed .ey { margin-bottom: 4px; }
+    .sec.collapsed .ey::before { transform: rotate(-90deg); }
+    .sec.collapsed > *:not(.ey) { display: none; }
+
+    /* 2D projection minimaps (box-select to focus) */
+    .map { margin-bottom: 12px; }
+    .map-cap { font-size: 11px; color: var(--dim); font-family: var(--mono); margin-bottom: 4px; }
+    .map-cap b { color: var(--ink); font-weight: 500; }
+    .map-wrap { position: relative; width: 100%; aspect-ratio: 1 / 1; border: 1px solid var(--line);
+      border-radius: 6px; overflow: hidden; cursor: crosshair; background: #05070b; }
+    .map-wrap canvas { width: 100%; height: 100%; display: block; }
+    .map-sel { position: absolute; border: 1px solid var(--accent); background: var(--accent-dim);
+      pointer-events: none; display: none; }
 
     .row { display: flex; align-items: center; justify-content: space-between; gap: 12px;
       min-height: 30px; margin-bottom: 9px; }
@@ -243,6 +270,11 @@
     </div>
 
     <div class="body">
+      <div class="tabs">
+        <button class="tab active" id="tabbtn-view" data-tab="view" type="button">View</button>
+        <button class="tab" id="tabbtn-focus" data-tab="focus" type="button">Focus</button>
+      </div>
+      <div class="tabpane active" id="tab-view">
       <section class="sec">
         <div class="ey">View</div>
         <div class="row"><label class="lbl" for="ar">Auto-orbit</label>
@@ -304,7 +336,8 @@
           </div>
         </div>
       </section>
-
+      </div>
+      <div class="tabpane" id="tab-focus">
       <section class="sec">
         <div class="ey">Filters</div>
         <div class="row" style="gap:8px">
@@ -345,6 +378,16 @@
           </div>
         </div>
       </section>
+      <section class="sec">
+        <div class="ey">Maps · drag a box to focus</div>
+        <div class="map"><div class="map-cap"><b>m/z</b> × <b>1/K₀</b></div>
+          <div class="map-wrap" id="mw-0"><canvas id="map-0" width="96" height="96"></canvas><div class="map-sel" id="sel-0"></div></div></div>
+        <div class="map"><div class="map-cap"><b>m/z</b> × <b>RT</b></div>
+          <div class="map-wrap" id="mw-1"><canvas id="map-1" width="96" height="96"></canvas><div class="map-sel" id="sel-1"></div></div></div>
+        <div class="map"><div class="map-cap"><b>1/K₀</b> × <b>RT</b></div>
+          <div class="map-wrap" id="mw-2"><canvas id="map-2" width="96" height="96"></canvas><div class="map-sel" id="sel-2"></div></div></div>
+      </section>
+      </div>
     </div>
   </aside>
 

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -74,6 +74,9 @@
     /* volume-only controls, shown when View = Volume */
     .vol-only { display: none; }
     body.volmode .vol-only { display: flex; }
+    /* point-only controls (Transfer/Exposure don't affect the volume) — greyed in Volume mode */
+    .points-only { transition: opacity .15s; }
+    body.volmode .points-only { opacity: .35; pointer-events: none; }
 
     .sec { padding: 14px 18px 4px 20px; }
     .sec + .sec { border-top: 1px solid var(--line-2); }
@@ -335,13 +338,13 @@
 
       <section class="sec">
         <div class="ey">Intensity</div>
-        <div class="row"><span class="lbl" id="l-xf">Transfer</span>
+        <div class="row points-only"><span class="lbl" id="l-xf">Transfer</span>
           <span class="seg" role="radiogroup" aria-labelledby="l-xf">
             <input type="radio" name="xf" id="xf-lin" /><label for="xf-lin">Lin</label>
             <input type="radio" name="xf" id="xf-sqrt" checked /><label for="xf-sqrt">√</label>
             <input type="radio" name="xf" id="xf-log" /><label for="xf-log">Log</label>
           </span></div>
-        <div class="row"><label class="lbl" for="expo">Exposure</label>
+        <div class="row points-only"><label class="lbl" for="expo">Exposure</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="expo" min="0.02" max="4" step="0.02" value="1.00" />
             <input type="number" class="numin" id="expo-n" min="0.02" max="4" step="0.02" value="1.00" aria-label="exposure value" /></span></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -98,6 +98,10 @@
     .cs-hist .map-cap b { color: var(--ink); font-weight: 500; }
     .cs-axis { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 9.5px;
       color: var(--faint); margin-top: 2px; }
+    /* per-algorithm parameter rows: DBSCAN params by default; HDBSCAN params under body.algo-hdb */
+    .algo-hdb { display: none; }
+    body.algo-hdb .algo-hdb { display: flex; }
+    body.algo-hdb .algo-dbscan { display: none; }
     /* clickable cluster list (isolate on click) */
     .cs-export { float: right; font-family: var(--sans); font-size: 10px; letter-spacing: .04em;
       color: var(--accent); background: transparent; border: 1px solid var(--line); border-radius: 5px;
@@ -480,17 +484,33 @@
       </div>
       <div class="tabpane" id="tab-cluster">
       <section class="sec">
-        <div class="ey">Cluster · DBSCAN</div>
-        <div class="row"><label class="lbl" for="cl-python">Python (sklearn) <span class="dim" id="cl-python-status" style="font-weight:400">checking…</span></label>
-          <span><input type="checkbox" class="sw" id="cl-python" /><label for="cl-python" class="sw-l" aria-hidden="true"></label></span></div>
-        <div class="row"><label class="lbl" for="cl-eps">ε radius <span class="dim" style="font-weight:400">(norm.)</span></label>
+        <div class="ey">Cluster</div>
+        <div class="row"><label class="lbl" for="cl-algo">Algorithm <span class="dim" id="cl-algo-status" style="font-weight:400">checking…</span></label>
+          <select class="sel" id="cl-algo" aria-label="clustering algorithm">
+            <option value="wasm">DBSCAN (built-in)</option>
+            <option value="sklearn" id="opt-sklearn" disabled>DBSCAN (sklearn)</option>
+            <option value="hdbscan" id="opt-hdbscan" disabled>HDBSCAN (sklearn)</option>
+          </select></div>
+        <div class="row algo-dbscan"><label class="lbl" for="cl-eps">ε radius <span class="dim" style="font-weight:400">(norm.)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-eps" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius" />
             <input type="number" class="numin" id="cl-eps-n" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius value" /></span></div>
-        <div class="row"><label class="lbl" for="cl-min">Min points</label>
+        <div class="row algo-dbscan"><label class="lbl" for="cl-min">Min points</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-min" min="2" max="50" step="1" value="8" aria-label="cluster min points" />
             <input type="number" class="numin" id="cl-min-n" min="2" max="50" step="1" value="8" aria-label="cluster min points value" /></span></div>
+        <div class="row algo-hdb"><label class="lbl" for="cl-mcs">Min cluster size</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="cl-mcs" min="2" max="100" step="1" value="7" aria-label="HDBSCAN min cluster size" />
+            <input type="number" class="numin" id="cl-mcs-n" min="2" max="500" step="1" value="7" aria-label="HDBSCAN min cluster size value" /></span></div>
+        <div class="row algo-hdb"><label class="lbl" for="cl-hms">Min samples <span class="dim" style="font-weight:400">(0=auto)</span></label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="cl-hms" min="0" max="50" step="1" value="0" aria-label="HDBSCAN min samples" />
+            <input type="number" class="numin" id="cl-hms-n" min="0" max="200" step="1" value="0" aria-label="HDBSCAN min samples value" /></span></div>
+        <div class="row algo-hdb"><label class="lbl" for="cl-cse">Selection ε</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="cl-cse" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon" />
+            <input type="number" class="numin" id="cl-cse-n" min="0" max="0.5" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon value" /></span></div>
         <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-rtc" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -555,6 +555,10 @@
             <span style="display:flex;align-items:center;gap:10px">
               <input type="range" class="rng" id="cl-rtc" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles" />
               <input type="number" class="numin" id="cl-rtc-n" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles value" /></span></div>
+          <div class="row"><label class="lbl" for="cl-ims">1/K₀ width <span class="dim" style="font-weight:400">(scans)</span></label>
+            <span style="display:flex;align-items:center;gap:10px">
+              <input type="range" class="rng" id="cl-ims" min="1" max="20" step="0.5" value="2" aria-label="cluster 1/K0 reach in scans" />
+              <input type="number" class="numin" id="cl-ims-n" min="1" max="20" step="0.5" value="2" aria-label="cluster 1/K0 reach in scans value" /></span></div>
           <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span></label>
             <span style="display:flex;align-items:center;gap:10px">
               <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="1.5" aria-label="cluster m/z peak-width reach" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>tims·view — GPU ion-cloud viewer</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --bg: #090c12; --bg2: #0c1018;
+      --ink: #cdd7e6; --dim: #7b8799; --faint: #515c70;
+      --line: rgba(150,172,205,0.11); --line-2: rgba(150,172,205,0.06);
+      --panel: rgba(13,18,27,0.66);
+      --accent: #35e0c4;       /* viridis teal — primary */
+      --accent-2: #ffb23e;     /* inferno amber — data highlight */
+      --accent-dim: rgba(53,224,196,0.16);
+      --sans: 'Inter', system-ui, -apple-system, sans-serif;
+      --disp: 'Space Grotesk', var(--sans);
+      --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+      --r: 9px;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; background: var(--bg); color: var(--ink);
+      font-family: var(--sans); overflow: hidden; }
+    body::before { /* faint instrument vignette + grid wash behind the canvas */
+      content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+      background:
+        radial-gradient(120% 90% at 70% 0%, rgba(53,224,196,0.05), transparent 55%),
+        radial-gradient(80% 70% at 0% 100%, rgba(255,178,62,0.04), transparent 60%); }
+
+    #tims-canvas { position: fixed; inset: 0; width: 100vw; height: 100vh; display: block;
+      z-index: 1; background: radial-gradient(120% 100% at 50% 40%, #0b0f17 0%, #05070b 100%); }
+
+    /* ---- control rail (glass) ---- */
+    .rail { position: fixed; z-index: 3; top: 16px; left: 16px; bottom: 16px; width: 320px;
+      display: flex; flex-direction: column; border-radius: var(--r);
+      background: var(--panel); border: 1px solid var(--line);
+      backdrop-filter: blur(18px) saturate(1.3); -webkit-backdrop-filter: blur(18px) saturate(1.3);
+      box-shadow: 0 24px 60px -24px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.04);
+      transition: transform .35s cubic-bezier(.4,.1,.2,1), opacity .3s; }
+    .rail::before { content: ""; position: absolute; left: 0; top: 14px; bottom: 14px; width: 2px;
+      border-radius: 2px; background: linear-gradient(var(--accent), var(--accent-2)); opacity: .85; }
+
+    .head { padding: 18px 18px 14px 20px; border-bottom: 1px solid var(--line); }
+    .mark { font-family: var(--disp); font-weight: 700; font-size: 18px; letter-spacing: .02em;
+      display: flex; align-items: baseline; gap: 7px; }
+    .mark b { color: var(--accent); font-weight: 700; }
+    .mark span { color: var(--faint); font-weight: 500; }
+    .sub { margin-top: 3px; font-size: 11px; color: var(--dim); letter-spacing: .04em; }
+
+    /* ---- telemetry HUD ---- */
+    .hud { padding: 12px 18px 12px 20px; border-bottom: 1px solid var(--line);
+      display: grid; grid-template-columns: 1fr 1fr; gap: 9px 14px; font-family: var(--mono); }
+    .stat { display: flex; flex-direction: column; gap: 2px; }
+    .stat .k { font-size: 9.5px; letter-spacing: .14em; text-transform: uppercase; color: var(--faint); }
+    .stat .v { font-size: 14px; font-weight: 500; color: var(--ink); font-variant-numeric: tabular-nums; }
+    .stat .v.accent { color: var(--accent); }
+
+    /* ---- scrolling sections ---- */
+    .body { flex: 1; overflow-y: auto; overflow-x: hidden; padding: 4px 0 14px; }
+    .body::-webkit-scrollbar { width: 8px; }
+    .body::-webkit-scrollbar-thumb { background: var(--line); border-radius: 8px; }
+    .sec { padding: 14px 18px 4px 20px; }
+    .sec + .sec { border-top: 1px solid var(--line-2); }
+    .ey { display: flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: .18em;
+      text-transform: uppercase; color: var(--dim); margin-bottom: 11px; }
+    .ey::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+
+    .row { display: flex; align-items: center; justify-content: space-between; gap: 12px;
+      min-height: 30px; margin-bottom: 9px; }
+    .lbl { font-size: 12.5px; color: var(--ink); font-weight: 500; }
+    .val { font-family: var(--mono); font-size: 11.5px; color: var(--accent-2);
+      font-variant-numeric: tabular-nums; min-width: 40px; text-align: right; }
+
+    /* range */
+    .rng { -webkit-appearance: none; appearance: none; width: 150px; height: 3px; border-radius: 3px;
+      background: var(--line); outline: none; }
+    .rng::-webkit-slider-thumb { -webkit-appearance: none; width: 13px; height: 13px; border-radius: 50%;
+      margin-top: -5px; /* center the thumb on the 3px track */
+      background: var(--ink); border: 2px solid var(--accent); cursor: pointer;
+      box-shadow: 0 0 0 3px transparent; transition: box-shadow .15s; }
+    .rng::-webkit-slider-thumb:hover { box-shadow: 0 0 0 4px var(--accent-dim); }
+    .rng::-moz-range-thumb { width: 12px; height: 12px; border-radius: 50%; background: var(--ink);
+      border: 2px solid var(--accent); cursor: pointer; }
+    .rng.wide { width: 100%; }
+
+    /* segmented (radios) */
+    .seg { display: inline-flex; background: rgba(0,0,0,0.25); border: 1px solid var(--line);
+      border-radius: 7px; padding: 2px; gap: 2px; }
+    .seg input { position: absolute; opacity: 0; pointer-events: none; }
+    .seg label { font-size: 11.5px; font-weight: 500; color: var(--dim); padding: 4px 10px;
+      border-radius: 5px; cursor: pointer; transition: all .14s; line-height: 1.2; }
+    .seg label:hover { color: var(--ink); }
+    .seg input:checked + label { background: var(--accent-dim); color: var(--accent); }
+    .seg.full { display: flex; } .seg.full label { flex: 1; text-align: center; }
+
+    /* select */
+    .sel { font-family: var(--sans); font-size: 12.5px; color: var(--ink); background: rgba(0,0,0,0.25);
+      border: 1px solid var(--line); border-radius: 7px; padding: 6px 28px 6px 10px; cursor: pointer;
+      appearance: none; -webkit-appearance: none; width: 150px;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%237b8799' stroke-width='1.5'/%3E%3C/svg%3E");
+      background-repeat: no-repeat; background-position: right 10px center; }
+    .sel:focus { border-color: var(--accent); outline: none; }
+
+    /* switch */
+    .sw { position: absolute; opacity: 0; }
+    .sw-l { width: 38px; height: 21px; border-radius: 21px; background: rgba(0,0,0,0.35);
+      border: 1px solid var(--line); position: relative; cursor: pointer; transition: all .18s; display: block; }
+    .sw-l::after { content: ""; position: absolute; top: 2px; left: 2px; width: 15px; height: 15px;
+      border-radius: 50%; background: var(--dim); transition: all .18s; }
+    .sw:checked + .sw-l { background: var(--accent-dim); border-color: var(--accent); }
+    .sw:checked + .sw-l::after { left: 19px; background: var(--accent); }
+
+    /* button */
+    .btn { font-family: var(--sans); font-size: 12px; font-weight: 500; color: var(--ink);
+      background: rgba(255,255,255,0.03); border: 1px solid var(--line); border-radius: 7px;
+      padding: 7px 12px; cursor: pointer; transition: all .14s; }
+    .btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-dim); }
+    .btn.mono { font-family: var(--mono); font-size: 11px; }
+    .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+
+    /* axis crop dual-mini-sliders */
+    .crop { margin-bottom: 11px; }
+    .crop .clab { display: flex; justify-content: space-between; font-size: 11px; color: var(--dim);
+      margin-bottom: 5px; font-family: var(--mono); }
+    .crop .clab b { color: var(--ink); font-weight: 500; }
+    /* dual-thumb range: two inputs overlaid on one track, fill between the thumbs */
+    .dual { position: relative; height: 20px; }
+    .dual-track, .dual-fill { position: absolute; top: 50%; transform: translateY(-50%);
+      height: 3px; border-radius: 3px; pointer-events: none; }
+    .dual-track { left: 0; right: 0; background: var(--line); }
+    .dual-fill { left: 0; width: 100%; background: var(--accent); opacity: .85; }
+    .dual input[type=range] { position: absolute; left: 0; top: 0; width: 100%; height: 20px; margin: 0;
+      -webkit-appearance: none; appearance: none; background: transparent; pointer-events: none; }
+    .dual input[type=range]::-webkit-slider-runnable-track { background: transparent; border: none; }
+    .dual input[type=range]::-moz-range-track { background: transparent; border: none; }
+    .dual input[type=range]::-webkit-slider-thumb { -webkit-appearance: none; pointer-events: auto;
+      width: 13px; height: 13px; margin-top: -5px; border-radius: 50%; background: var(--ink);
+      border: 2px solid var(--accent); cursor: grab; box-shadow: 0 1px 3px rgba(0,0,0,.5); }
+    .dual input[type=range]::-webkit-slider-thumb:active { cursor: grabbing; box-shadow: 0 0 0 4px var(--accent-dim); }
+    .dual input[type=range]::-moz-range-thumb { pointer-events: auto; width: 12px; height: 12px;
+      border-radius: 50%; background: var(--ink); border: 2px solid var(--accent); cursor: grab; }
+    .dual input[type=range]:focus-visible::-webkit-slider-thumb { box-shadow: 0 0 0 4px var(--accent-dim); }
+
+    /* colorbar */
+    .cbar { position: fixed; z-index: 3; right: 18px; bottom: 18px; width: 16px; height: 168px;
+      border-radius: 4px; border: 1px solid var(--line); display: flex; flex-direction: column;
+      box-shadow: 0 8px 24px -8px rgba(0,0,0,0.6); }
+    .cbar-track { flex: 1; border-radius: 3px; }
+    .cbar.v0 .cbar-track { background: linear-gradient(to top, #440154, #3b528b, #21918c, #5ec962, #fde725); }
+    .cbar.v1 .cbar-track { background: linear-gradient(to top, #000004, #57106e, #bc3754, #f98e09, #fcffa4); }
+    .cbar.v2 .cbar-track { background: linear-gradient(to top, #30123b, #4669db, #1ae4b6, #a4fc3c, #fb7e21, #7a0403); }
+    .cbar.v3 .cbar-track { background: linear-gradient(to top, #000, #fff); }
+    .cbar .caps { position: absolute; right: 22px; top: -2px; bottom: -2px; display: flex;
+      flex-direction: column; justify-content: space-between; font-family: var(--mono); font-size: 9px;
+      color: var(--faint); letter-spacing: .04em; white-space: nowrap; }
+
+    /* projected 3D axis tick labels (positioned by the wasm each frame) */
+    #axis-labels { position: fixed; inset: 0; z-index: 2; pointer-events: none; }
+    .axlabel { position: absolute; left: 0; top: 0; font-family: var(--mono); font-size: 10.5px;
+      font-variant-numeric: tabular-nums; letter-spacing: .01em; white-space: nowrap;
+      text-shadow: 0 1px 3px #000, 0 0 3px #000; will-change: transform; }
+
+    /* collapse (pure CSS checkbox) */
+    .railtgl { position: absolute; opacity: 0; pointer-events: none; }
+    .railtgl:checked ~ .rail { transform: translateX(calc(-100% - 18px)); opacity: 0; }
+    .railtgl:checked ~ .railbtn { left: 16px; }
+    .railbtn { position: fixed; z-index: 4; top: 16px; left: 348px; transition: left .35s cubic-bezier(.4,.1,.2,1);
+      width: 34px; height: 34px; display: grid; place-items: center; cursor: pointer; border-radius: 8px;
+      background: var(--panel); border: 1px solid var(--line); backdrop-filter: blur(18px);
+      color: var(--dim); }
+    .railbtn:hover { color: var(--accent); border-color: var(--accent); }
+    .railbtn svg { width: 15px; height: 15px; }
+
+    .err { position: fixed; z-index: 5; left: 50%; bottom: 22px; transform: translateX(-50%);
+      font-family: var(--mono); font-size: 12px; color: var(--accent-2); background: rgba(20,12,4,0.9);
+      border: 1px solid rgba(255,178,62,0.3); border-radius: 8px; padding: 8px 14px; max-width: 80vw; }
+    .err:empty { display: none; }
+
+    /* keyboard focus — inputs hide native outlines, so proxy focus onto the visible control */
+    .rng:focus-visible { box-shadow: 0 0 0 4px var(--accent-dim); }
+    .seg input:focus-visible + label,
+    .sw:focus-visible + .sw-l,
+    .railtgl:focus-visible + .railbtn,
+    .btn:focus-visible, .sel:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    /* HUD: keep long device names from breaking the 2-column grid */
+    .stat { min-width: 0; }
+    .stat .v { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+    /* opaque fallback where backdrop-filter is unsupported (panel stays legible over data) */
+    @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+      .rail, .railbtn, .cbar { background: #0d1119f2; }
+    }
+
+    @media (prefers-reduced-motion: reduce) { *, *::before { transition: none !important; } }
+
+    @media (max-width: 720px) {
+      .rail { width: calc(100vw - 32px); }
+      /* open: toggle parks at the rail's top-right (acts as close); collapsed: top-left to reopen */
+      .railbtn { left: auto; right: 16px; }
+      .railtgl:checked ~ .railbtn { left: 16px; right: auto; }
+    }
+  </style>
+</head>
+<body>
+  <canvas id="tims-canvas"></canvas>
+  <div id="axis-labels" aria-hidden="true"></div>
+
+  <input type="checkbox" id="railtgl" class="railtgl" />
+  <label for="railtgl" class="railbtn" title="Toggle panel" aria-label="Toggle panel">
+    <svg viewBox="0 0 16 16" fill="none"><path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>
+  </label>
+
+  <aside class="rail">
+    <div class="head">
+      <div class="mark">tims<b>·</b>view <span>/ ion cloud</span></div>
+      <div class="sub">m/z × 1/K₀ × retention time — GPU point field</div>
+    </div>
+
+    <div class="hud">
+      <div class="stat"><span class="k">Source</span><span class="v accent" id="hud-backend">—</span></div>
+      <div class="stat"><span class="k">Device</span><span class="v" id="hud-adapter">—</span></div>
+      <div class="stat"><span class="k">Points</span><span class="v" id="hud-points">—</span></div>
+      <div class="stat"><span class="k">Frame</span><span class="v" id="hud-fps">— fps</span></div>
+    </div>
+
+    <div class="body">
+      <section class="sec">
+        <div class="ey">View</div>
+        <div class="row"><label class="lbl" for="ar">Auto-orbit</label>
+          <span><input type="checkbox" class="sw" id="ar" checked /><label for="ar" class="sw-l" aria-hidden="true"></label></span></div>
+        <div class="grid2">
+          <button class="btn" id="reset">Reset view</button>
+          <button class="btn mono" id="roll" title="Cycle which axis points up">up: 1/K₀</button>
+        </div>
+      </section>
+
+      <section class="sec">
+        <div class="ey">Render</div>
+        <div class="row"><span class="lbl" id="l-mode">Mode</span>
+          <span class="seg" role="radiogroup" aria-labelledby="l-mode">
+            <input type="radio" name="mode" id="m-add" checked /><label for="m-add">Density</label>
+            <input type="radio" name="mode" id="m-opq" /><label for="m-opq">Solid</label>
+          </span></div>
+        <div class="row"><label class="lbl" for="cmap">Colormap</label>
+          <select class="sel" id="cmap" aria-label="Colormap">
+            <option value="0">Viridis</option><option value="1" selected>Inferno</option>
+            <option value="2">Turbo</option><option value="3">Grayscale</option>
+          </select></div>
+        <div class="row"><label class="lbl" for="psize">Point size</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="psize" min="0.5" max="6" step="0.1" value="2.5" />
+            <output class="val" id="psize-v" for="psize">2.5</output></span></div>
+        <div class="row"><label class="lbl" for="opac">Opacity</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="opac" min="0.05" max="1" step="0.05" value="0.6" />
+            <output class="val" id="opac-v" for="opac">0.60</output></span></div>
+      </section>
+
+      <section class="sec">
+        <div class="ey">Intensity</div>
+        <div class="row"><span class="lbl" id="l-xf">Transfer</span>
+          <span class="seg" role="radiogroup" aria-labelledby="l-xf">
+            <input type="radio" name="xf" id="xf-lin" /><label for="xf-lin">Lin</label>
+            <input type="radio" name="xf" id="xf-sqrt" checked /><label for="xf-sqrt">√</label>
+            <input type="radio" name="xf" id="xf-log" /><label for="xf-log">Log</label>
+          </span></div>
+        <div class="row"><label class="lbl" for="expo">Exposure</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="expo" min="0.02" max="4" step="0.02" value="1.00" />
+            <output class="val" id="expo-v" for="expo">1.00</output></span></div>
+        <div class="row"><label class="lbl" for="floor">Floor</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="floor" min="0" max="5000" step="25" value="0" />
+            <output class="val" id="floor-v" for="floor">0</output></span></div>
+      </section>
+
+      <section class="sec">
+        <div class="ey">Filters</div>
+        <div class="row"><span class="lbl" id="l-ms">Show</span>
+          <span class="seg" role="radiogroup" aria-labelledby="l-ms">
+            <input type="radio" name="ms" id="ms-1" checked /><label for="ms-1">MS1</label>
+            <input type="radio" name="ms" id="ms-2" /><label for="ms-2">MS2</label>
+            <input type="radio" name="ms" id="ms-b" /><label for="ms-b">Both</label>
+          </span></div>
+        <div class="crop">
+          <div class="clab"><b>m/z</b><span id="cmz-v">full</span></div>
+          <div class="dual">
+            <div class="dual-track"></div><div class="dual-fill" id="cmz-fill"></div>
+            <input type="range" id="cmz-lo" min="0" max="1000" value="0" aria-label="m/z crop minimum" />
+            <input type="range" id="cmz-hi" min="0" max="1000" value="1000" aria-label="m/z crop maximum" />
+          </div>
+        </div>
+        <div class="crop">
+          <div class="clab"><b>1/K₀</b><span id="cim-v">full</span></div>
+          <div class="dual">
+            <div class="dual-track"></div><div class="dual-fill" id="cim-fill"></div>
+            <input type="range" id="cim-lo" min="0" max="1000" value="0" aria-label="ion mobility crop minimum" />
+            <input type="range" id="cim-hi" min="0" max="1000" value="1000" aria-label="ion mobility crop maximum" />
+          </div>
+        </div>
+        <div class="crop">
+          <div class="clab"><b>RT</b><span id="crt-v">full</span></div>
+          <div class="dual">
+            <div class="dual-track"></div><div class="dual-fill" id="crt-fill"></div>
+            <input type="range" id="crt-lo" min="0" max="1000" value="0" aria-label="retention time crop minimum" />
+            <input type="range" id="crt-hi" min="0" max="1000" value="1000" aria-label="retention time crop maximum" />
+          </div>
+        </div>
+      </section>
+    </div>
+  </aside>
+
+  <div class="cbar v1" id="cbar"><div class="cbar-track"></div>
+    <div class="caps"><span>hi</span><span>lo</span></div></div>
+
+  <div class="err" id="status"></div>
+</body>
+</html>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -125,6 +125,8 @@
       background: rgba(255,255,255,0.03); border: 1px solid var(--line); border-radius: 7px;
       padding: 7px 12px; cursor: pointer; transition: all .14s; }
     .btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-dim); }
+    .btn:disabled, .btn:disabled:hover { opacity: .4; cursor: default; color: var(--dim);
+      border-color: var(--line); background: rgba(255,255,255,0.03); }
     .btn.mono { font-family: var(--mono); font-size: 11px; }
     .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 
@@ -305,6 +307,10 @@
 
       <section class="sec">
         <div class="ey">Filters</div>
+        <div class="row" style="gap:8px">
+          <button class="btn" id="focus-go" type="button" style="flex:1">⊕ Focus selection</button>
+          <button class="btn mono" id="focus-back" type="button" disabled>← Back <span id="focus-depth" class="dim"></span></button>
+        </div>
         <div class="row"><span class="lbl" id="l-ms">Show</span>
           <span class="seg" role="radiogroup" aria-labelledby="l-ms">
             <input type="radio" name="ms" id="ms-1" checked /><label for="ms-1">MS1</label>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -480,7 +480,7 @@
         <div class="row"><button class="btn" id="cl-run" type="button" style="flex:1">⬡ Run clustering</button></div>
         <div class="cl-prog" id="cl-prog"><div class="cl-bar" id="cl-bar"></div></div>
         <div class="row"><label class="lbl" for="cl-color">Color by cluster</label>
-          <span><input type="checkbox" class="sw" id="cl-color" /><label for="cl-color" class="sw-l" aria-hidden="true"></label></span></div>
+          <span><input type="checkbox" class="sw" id="cl-color" checked /><label for="cl-color" class="sw-l" aria-hidden="true"></label></span></div>
         <div class="row"><span class="lbl">Result</span><span class="val" id="cl-readout" style="min-width:auto">—</span></div>
         <div class="sub" style="padding:0 0 4px; color:var(--faint)">DBSCAN on the filtered points (Focus a region for big runs).</div>
       </section>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -286,7 +286,7 @@
             <input type="range" class="rng" id="expo" min="0.02" max="4" step="0.02" value="1.00" />
             <input type="number" class="numin" id="expo-n" min="0.02" max="4" step="0.02" value="1.00" aria-label="exposure value" /></span></div>
         <div class="crop">
-          <div class="clab"><b>Floor</b><span>intensity ≥ (cbrt)</span></div>
+          <div class="clab"><b>Floor</b><span>intensity ≥ (counts)</span></div>
           <div class="crop-hist" id="floor-hist"></div>
           <div class="frow">
             <input type="range" class="rng wide" id="floor" min="0" max="1000" step="1" value="0" aria-label="intensity floor" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -395,7 +395,7 @@
         </div>
         <div class="row" id="acq-row" style="display:none; margin-top:10px; gap:6px; align-items:center">
           <button class="btn" id="acq-play" type="button" style="flex:1">▶ Live acquisition</button>
-          <select id="acq-speed" title="Playback speed (1× = the device's real frame rate)" aria-label="playback speed">
+          <select id="acq-speed" class="sel" title="Playback speed (1× = the device's real frame rate)" aria-label="playback speed">
             <option value="0.25">0.25×</option>
             <option value="0.5">0.5×</option>
             <option value="1" selected>1× real-time</option>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -253,6 +253,10 @@
 
       <section class="sec">
         <div class="ey">Render</div>
+        <div class="row"><label class="lbl" for="disp">Display</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="disp" min="1" max="100" step="1" value="100" aria-label="fraction of points to display" />
+            <output class="val" id="disp-v" for="disp">—</output></span></div>
         <div class="row"><span class="lbl" id="l-mode">Mode</span>
           <span class="seg" role="radiogroup" aria-labelledby="l-mode">
             <input type="radio" name="mode" id="m-add" checked /><label for="m-add">Density</label>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -487,6 +487,10 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-min" min="2" max="50" step="1" value="8" aria-label="cluster min points" />
             <input type="number" class="numin" id="cl-min-n" min="2" max="50" step="1" value="8" aria-label="cluster min points value" /></span></div>
+        <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span></label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="cl-rtc" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles" />
+            <input type="number" class="numin" id="cl-rtc-n" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles value" /></span></div>
         <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -135,6 +135,7 @@
       border-radius: 5px; cursor: pointer; transition: all .14s; line-height: 1.2; }
     .seg label:hover { color: var(--ink); }
     .seg input:checked + label { background: var(--accent-dim); color: var(--accent); }
+    .seg input:disabled + label { opacity: .4; cursor: default; pointer-events: none; }
     .seg.full { display: flex; } .seg.full label { flex: 1; text-align: center; }
 
     /* select */

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -96,6 +96,22 @@
     .cs-hist { margin-bottom: 10px; }
     .cs-hist .map-cap { font-size: 10.5px; color: var(--dim); font-family: var(--mono); margin-bottom: 3px; }
     .cs-hist .map-cap b { color: var(--ink); font-weight: 500; }
+    /* clickable cluster list (isolate on click) */
+    .cs-export { float: right; font-family: var(--sans); font-size: 10px; letter-spacing: .04em;
+      color: var(--accent); background: transparent; border: 1px solid var(--line); border-radius: 5px;
+      padding: 2px 8px; cursor: pointer; text-transform: none; transition: border-color .14s, color .14s; }
+    .cs-export:hover { border-color: var(--accent); }
+    .cs-list { display: flex; flex-direction: column; gap: 2px; max-height: 260px; overflow-y: auto; }
+    .cs-row { display: flex; align-items: center; gap: 8px; width: 100%; text-align: left;
+      font-family: var(--mono); font-size: 11.5px; color: var(--ink); background: transparent;
+      border: 1px solid transparent; border-radius: 6px; padding: 4px 8px; cursor: pointer;
+      transition: background .12s, border-color .12s; }
+    .cs-row:hover { background: rgba(150,172,205,0.06); }
+    .cs-row.active { border-color: var(--accent); background: var(--accent-dim); }
+    .cs-row.show-all { color: var(--accent); justify-content: center; font-family: var(--sans); }
+    .cs-dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+    .cs-meta { margin-left: auto; color: var(--dim); font-variant-numeric: tabular-nums; }
+    .cs-more { font-family: var(--mono); font-size: 10.5px; color: var(--faint); padding: 5px 8px; }
 
     .sec { padding: 14px 18px 4px 20px; }
     .sec + .sec { border-top: 1px solid var(--line-2); }
@@ -477,6 +493,10 @@
         <div class="cs-hist"><div class="map-cap"><b>m/z</b> extent</div><div class="crop-hist" id="csh-mz"></div></div>
         <div class="cs-hist"><div class="map-cap"><b>1/K₀</b> extent</div><div class="crop-hist" id="csh-im"></div></div>
         <div class="cs-hist"><div class="map-cap"><b>RT</b> extent</div><div class="crop-hist" id="csh-rt"></div></div>
+      </section>
+      <section class="sec">
+        <div class="ey">Clusters <button class="cs-export" id="cl-export" type="button">Export CSV</button></div>
+        <div class="cs-list" id="cs-list"></div>
       </section>
     </div>
   </aside>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -557,8 +557,8 @@
               <input type="number" class="numin" id="cl-rtc-n" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles value" /></span></div>
           <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span></label>
             <span style="display:flex;align-items:center;gap:10px">
-              <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach" />
-              <input type="number" class="numin" id="cl-mzw-n" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach value" /></span></div>
+              <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="1.5" aria-label="cluster m/z peak-width reach" />
+              <input type="number" class="numin" id="cl-mzw-n" min="1" max="40" step="0.5" value="1.5" aria-label="cluster m/z peak-width reach value" /></span></div>
         </details>
         <div class="row"><button class="btn" id="cl-run" type="button" style="flex:1">⬡ Run clustering</button></div>
         <div class="cl-prog" id="cl-prog"><div class="cl-bar" id="cl-bar"></div></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -502,15 +502,15 @@
         <div class="row algo-hdb"><label class="lbl" for="cl-mcs">Min cluster size</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-mcs" min="2" max="100" step="1" value="7" aria-label="HDBSCAN min cluster size" />
-            <input type="number" class="numin" id="cl-mcs-n" min="2" max="500" step="1" value="7" aria-label="HDBSCAN min cluster size value" /></span></div>
+            <input type="number" class="numin" id="cl-mcs-n" min="2" max="100" step="1" value="7" aria-label="HDBSCAN min cluster size value" /></span></div>
         <div class="row algo-hdb"><label class="lbl" for="cl-hms">Min samples <span class="dim" style="font-weight:400">(0=auto)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-hms" min="0" max="50" step="1" value="0" aria-label="HDBSCAN min samples" />
-            <input type="number" class="numin" id="cl-hms-n" min="0" max="200" step="1" value="0" aria-label="HDBSCAN min samples value" /></span></div>
-        <div class="row algo-hdb"><label class="lbl" for="cl-cse">Selection ε</label>
+            <input type="number" class="numin" id="cl-hms-n" min="0" max="50" step="1" value="0" aria-label="HDBSCAN min samples value" /></span></div>
+        <div class="row algo-hdb"><label class="lbl" for="cl-cse">Selection ε <span class="dim" style="font-weight:400">(scaled)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-cse" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon" />
-            <input type="number" class="numin" id="cl-cse-n" min="0" max="0.5" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon value" /></span></div>
+            <input type="number" class="numin" id="cl-cse-n" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon value" /></span></div>
         <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-rtc" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -308,7 +308,7 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="vsteps" min="32" max="512" step="16" value="256" aria-label="raymarch steps" />
             <input type="number" class="numin" id="vsteps-n" min="32" max="512" step="16" value="256" aria-label="raymarch steps value" /></span></div>
-        <div class="row"><label class="lbl" for="disp">Display</label>
+        <div class="row points-only"><label class="lbl" for="disp">Display</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="disp" min="1" max="100" step="1" value="100" aria-label="fraction of points to display" />
             <input type="number" class="numin" id="disp-n" min="1" step="1000" value="0" style="width:78px" aria-label="number of points to display" /></span></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -98,6 +98,9 @@
     .cs-hist .map-cap b { color: var(--ink); font-weight: 500; }
     .cs-axis { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 9.5px;
       color: var(--faint); margin-top: 2px; }
+    .dspick { display: flex; align-items: center; gap: 8px; margin-top: 9px; }
+    .dspick .lbl { white-space: nowrap; }
+    .dspick .sel { flex: 1; min-width: 0; }
     /* per-algorithm parameter rows: DBSCAN params by default; HDBSCAN params under body.algo-hdb */
     .algo-hdb { display: none; }
     body.algo-hdb .algo-hdb { display: flex; }
@@ -336,6 +339,10 @@
     <div class="head">
       <div class="mark">tims<b>·</b>view <span>/ ion cloud</span></div>
       <div class="sub">m/z × 1/K₀ × retention time — GPU point field</div>
+      <div class="dspick" id="dspick" style="display:none">
+        <label class="lbl" for="dataset-sel">Dataset</label>
+        <select class="sel" id="dataset-sel" aria-label="dataset"></select>
+      </div>
     </div>
 
     <div class="hud">

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -414,7 +414,7 @@
       <div class="tabpane" id="tab-cluster">
       <section class="sec">
         <div class="ey">Cluster · DBSCAN</div>
-        <div class="row"><label class="lbl" for="cl-eps">ε radius</label>
+        <div class="row"><label class="lbl" for="cl-eps">ε radius <span class="dim" style="font-weight:400">(norm.)</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-eps" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius" />
             <input type="number" class="numin" id="cl-eps-n" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius value" /></span></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -213,6 +213,8 @@
     .btn:disabled, .btn:disabled:hover { opacity: .4; cursor: default; color: var(--dim);
       border-color: var(--line); background: rgba(255,255,255,0.03); }
     .btn.mono { font-family: var(--mono); font-size: 11px; }
+    .btn.stop { color: #ff6b6b; border-color: rgba(255,107,107,0.5); background: rgba(255,107,107,0.08); }
+    .btn.stop:hover { color: #ff8585; border-color: #ff6b6b; background: rgba(255,107,107,0.14); }
     .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 
     /* axis crop dual-mini-sliders */
@@ -267,11 +269,13 @@
     .railtgl, .railtgl-r { position: absolute; opacity: 0; pointer-events: none; }
     .railtgl:checked ~ .rail:not(.right) { transform: translateX(calc(-100% - 18px)); opacity: 0; }
     .railtgl:checked ~ .railbtn:not(.railbtn-r) { left: 16px; }
-    /* right rail (cluster panel) collapse — its own toggle, slides off to the right */
-    .railbtn-r { left: auto; right: 348px; display: none; transition: right .35s cubic-bezier(.4,.1,.2,1); }
-    body.has-clusters .railbtn-r { display: flex; } /* only exists when the panel does */
+    /* right rail (cluster panel) collapse — its own toggle, slides off to the right. Two-class
+       selectors (.railbtn.railbtn-r) beat the generic .railbtn rule below regardless of order. */
+    .railbtn.railbtn-r { left: auto; right: 348px; display: none;
+      transition: right .35s cubic-bezier(.4,.1,.2,1); }
+    body.has-clusters .railbtn.railbtn-r { display: grid; } /* only exists when the panel does */
     .railtgl-r:checked ~ .rail.right { transform: translateX(calc(100% + 18px)); opacity: 0; }
-    .railtgl-r:checked ~ .railbtn-r { right: 16px; }
+    .railtgl-r:checked ~ .railbtn.railbtn-r { right: 16px; }
     .railbtn { position: fixed; z-index: 4; top: 16px; left: 348px; transition: left .35s cubic-bezier(.4,.1,.2,1);
       width: 34px; height: 34px; display: grid; place-items: center; cursor: pointer; border-radius: 8px;
       background: var(--panel); border: 1px solid var(--line); backdrop-filter: blur(18px);
@@ -304,11 +308,12 @@
 
     @media (max-width: 720px) {
       .rail { width: calc(100vw - 32px); }
-      /* the stats rail would cover the controls full-width — hide it on narrow viewports */
+      /* the stats rail (and its toggle) would cover the controls full-width — hide on narrow */
       body.has-clusters .rail.right { display: none; }
+      body.has-clusters .railbtn.railbtn-r { display: none; }
       /* open: toggle parks at the rail's top-right (acts as close); collapsed: top-left to reopen */
-      .railbtn { left: auto; right: 16px; }
-      .railtgl:checked ~ .railbtn { left: 16px; right: auto; }
+      .railbtn:not(.railbtn-r) { left: auto; right: 16px; }
+      .railtgl:checked ~ .railbtn:not(.railbtn-r) { left: 16px; right: auto; }
     }
   </style>
 </head>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -78,6 +78,23 @@
     .points-only { transition: opacity .15s; }
     body.volmode .points-only { opacity: .35; pointer-events: none; }
 
+    /* cluster stats rail (right edge, shown when a clustering result exists) */
+    .rail.right { left: auto; right: 16px; display: none; }
+    body.has-clusters .rail.right { display: flex; }
+    body.has-clusters .cbar { display: none; } /* the stats rail takes the right edge */
+    .cs-table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 11.5px;
+      margin-bottom: 10px; }
+    .cs-table th, .cs-table td { text-align: right; padding: 3px 5px; }
+    .cs-table th:first-child, .cs-table td:first-child { text-align: left; color: var(--dim); }
+    .cs-table th { color: var(--faint); font-weight: 500; font-size: 10px; letter-spacing: .06em;
+      text-transform: uppercase; }
+    .cs-table td { color: var(--ink); font-variant-numeric: tabular-nums; }
+    .cs-table td:nth-child(3) { color: var(--accent); }
+    .cs-table td:nth-child(4) { color: var(--faint); }
+    .cs-hist { margin-bottom: 10px; }
+    .cs-hist .map-cap { font-size: 10.5px; color: var(--dim); font-family: var(--mono); margin-bottom: 3px; }
+    .cs-hist .map-cap b { color: var(--ink); font-weight: 500; }
+
     .sec { padding: 14px 18px 4px 20px; }
     .sec + .sec { border-top: 1px solid var(--line-2); }
     .ey { display: flex; align-items: center; gap: 8px; font-size: 10px; letter-spacing: .18em;
@@ -429,6 +446,33 @@
         <div class="sub" style="padding:0 0 4px; color:var(--faint)">DBSCAN on the filtered points (Focus a region for big runs).</div>
       </section>
       </div>
+    </div>
+  </aside>
+
+  <!-- cluster stats (right rail, shown when a clustering result exists) -->
+  <aside class="rail right" id="cluster-panel" aria-label="cluster statistics">
+    <div class="head">
+      <div class="mark"><b>clusters</b> <span>stats</span></div>
+      <div class="sub" id="cs-sub">—</div>
+    </div>
+    <div class="body">
+      <section class="sec">
+        <div class="ey">Summary</div>
+        <table class="cs-table">
+          <tr><th></th><th>Total</th><th>Signal</th><th>Noise</th></tr>
+          <tr><td>Points</td><td id="cs-pts-t">—</td><td id="cs-pts-c">—</td><td id="cs-pts-n">—</td></tr>
+          <tr><td>Intensity</td><td id="cs-int-t">—</td><td id="cs-int-c">—</td><td id="cs-int-n">—</td></tr>
+        </table>
+        <div class="row"><span class="lbl">Clusters</span><span class="val" id="cs-k" style="min-width:auto">—</span></div>
+        <div class="row"><span class="lbl">Signal / noise</span><span class="val" id="cs-ratio" style="min-width:auto">—</span></div>
+      </section>
+      <section class="sec">
+        <div class="ey">Per-cluster</div>
+        <div class="cs-hist"><div class="map-cap">Size (points)</div><div class="crop-hist" id="csh-size"></div></div>
+        <div class="cs-hist"><div class="map-cap"><b>m/z</b> extent</div><div class="crop-hist" id="csh-mz"></div></div>
+        <div class="cs-hist"><div class="map-cap"><b>1/K₀</b> extent</div><div class="crop-hist" id="csh-im"></div></div>
+        <div class="cs-hist"><div class="map-cap"><b>RT</b> extent</div><div class="crop-hist" id="csh-rt"></div></div>
+      </section>
     </div>
   </aside>
 

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -114,6 +114,12 @@
     .cs-hist .map-cap b { color: var(--ink); font-weight: 500; }
     .cs-axis { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 9.5px;
       color: var(--faint); margin-top: 2px; }
+    /* inline help affordance: a small ⓘ whose native tooltip (title) escapes the rail overflow clip */
+    .tip { display: inline-flex; align-items: center; justify-content: center; width: 13px; height: 13px;
+      border-radius: 50%; border: 1px solid var(--line); color: var(--faint); font-size: 9px;
+      font-weight: 700; font-style: normal; font-family: var(--sans); cursor: help; margin-left: 5px;
+      vertical-align: middle; }
+    .tip:hover, .tip:focus-visible { color: var(--accent); border-color: var(--accent-dim); outline: none; }
     .dspick { display: flex; align-items: center; gap: 8px; margin-top: 9px; }
     .dspick .lbl { white-space: nowrap; }
     .dspick .sel { flex: 1; min-width: 0; }
@@ -462,7 +468,7 @@
       <section class="sec">
         <div class="ey">Filters</div>
         <div class="row" style="gap:8px">
-          <button class="btn" id="focus-go" type="button" style="flex:1">⊕ Focus selection</button>
+          <button class="btn" id="focus-go" type="button" style="flex:1" title="Re-load just the boxed region from the full dataset at higher detail — densifies the sampling so isotopes and fine structure resolve. Back returns to the previous view.">⊕ Focus selection</button>
           <button class="btn mono" id="focus-back" type="button" disabled>← Back <span id="focus-depth" class="dim"></span></button>
         </div>
         <div class="row"><span class="lbl" id="l-ms">Show</span>
@@ -502,7 +508,7 @@
           </div>
         </div>
         <div class="crop">
-          <div class="clab"><b>Floor</b><span>intensity ≥ (counts) <span id="floor-src" class="acc"></span></span></div>
+          <div class="clab"><b>Floor</b><span class="tip" tabindex="0" role="img" aria-label="help" title="Drop points below this intensity (raw counts) before clustering and rendering — removes background noise so clusters stand out.">i</span><span>intensity ≥ (counts) <span id="floor-src" class="acc"></span></span></div>
           <div class="crop-hist" id="floor-hist"></div>
           <div class="frow">
             <input type="range" class="rng wide" id="floor" min="0" max="1000" step="1" value="0" aria-label="intensity floor" />
@@ -523,43 +529,43 @@
       <div class="tabpane" id="tab-cluster">
       <section class="sec">
         <div class="ey">Cluster</div>
-        <div class="row"><label class="lbl" for="cl-algo">Algorithm <span class="dim" id="cl-algo-status" style="font-weight:400">checking…</span></label>
+        <div class="row"><label class="lbl" for="cl-algo">Algorithm <span class="dim" id="cl-algo-status" style="font-weight:400">checking…</span><span class="tip" tabindex="0" role="img" aria-label="help" title="DBSCAN groups points denser than a fixed radius (ε); HDBSCAN finds clusters of varying density with no ε. ‘built-in’ runs in your browser; the others use the local Python service.">i</span></label>
           <select class="sel" id="cl-algo" aria-label="clustering algorithm">
             <option value="wasm">DBSCAN (built-in)</option>
             <option value="sklearn" id="opt-sklearn" disabled>DBSCAN (sklearn)</option>
             <option value="hdbscan" id="opt-hdbscan" disabled>HDBSCAN (sklearn)</option>
           </select></div>
-        <div class="row algo-dbscan"><label class="lbl" for="cl-eps">ε radius <span class="dim" style="font-weight:400">(norm.)</span></label>
+        <div class="row algo-dbscan"><label class="lbl" for="cl-eps">ε radius <span class="dim" style="font-weight:400">(norm.)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="DBSCAN neighbourhood radius in the calibrated metric. Larger ε → looser, bigger clusters. It scales all three axis reaches (RT / 1/K₀ / m/z) together.">i</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-eps" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius" />
             <input type="number" class="numin" id="cl-eps-n" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius value" /></span></div>
-        <div class="row algo-dbscan"><label class="lbl" for="cl-min">Min points</label>
+        <div class="row algo-dbscan"><label class="lbl" for="cl-min">Min points<span class="tip" tabindex="0" role="img" aria-label="help" title="Fewest neighbours (including itself) a point needs within ε to anchor a cluster. Higher → more points left as noise.">i</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-min" min="2" max="50" step="1" value="8" aria-label="cluster min points" />
             <input type="number" class="numin" id="cl-min-n" min="2" max="50" step="1" value="8" aria-label="cluster min points value" /></span></div>
-        <div class="row algo-hdb"><label class="lbl" for="cl-mcs">Min cluster size</label>
+        <div class="row algo-hdb"><label class="lbl" for="cl-mcs">Min cluster size<span class="tip" tabindex="0" role="img" aria-label="help" title="Smallest group HDBSCAN will report as a cluster. Smaller → more, finer clusters; larger → fewer, broader ones.">i</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-mcs" min="2" max="100" step="1" value="7" aria-label="HDBSCAN min cluster size" />
             <input type="number" class="numin" id="cl-mcs-n" min="2" max="100" step="1" value="7" aria-label="HDBSCAN min cluster size value" /></span></div>
-        <div class="row algo-hdb"><label class="lbl" for="cl-hms">Min samples <span class="dim" style="font-weight:400">(0=auto)</span></label>
+        <div class="row algo-hdb"><label class="lbl" for="cl-hms">Min samples <span class="dim" style="font-weight:400">(0=auto)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="How conservative HDBSCAN is: higher → denser cores and more points called noise. 0 = auto (uses min cluster size).">i</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-hms" min="0" max="50" step="1" value="0" aria-label="HDBSCAN min samples" />
             <input type="number" class="numin" id="cl-hms-n" min="0" max="50" step="1" value="0" aria-label="HDBSCAN min samples value" /></span></div>
-        <div class="row algo-hdb"><label class="lbl" for="cl-cse">Selection ε <span class="dim" style="font-weight:400">(scaled)</span></label>
+        <div class="row algo-hdb"><label class="lbl" for="cl-cse">Selection ε <span class="dim" style="font-weight:400">(scaled)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="Optional: merge HDBSCAN clusters closer than this in the scaled metric (0 = off). Coarsens an over-split result.">i</span></label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-cse" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon" />
             <input type="number" class="numin" id="cl-cse-n" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon value" /></span></div>
         <details class="adv">
           <summary>Advanced · metric</summary>
-          <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span></label>
+          <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="How many MS1 cycles ε spans along retention time. A precursor elutes over several cycles — raise to keep an elution together, lower to split co-eluting species. Independent of how you crop the view.">i</span></label>
             <span style="display:flex;align-items:center;gap:10px">
               <input type="range" class="rng" id="cl-rtc" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles" />
               <input type="number" class="numin" id="cl-rtc-n" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles value" /></span></div>
-          <div class="row"><label class="lbl" for="cl-ims">1/K₀ width <span class="dim" style="font-weight:400">(scans)</span></label>
+          <div class="row"><label class="lbl" for="cl-ims">1/K₀ width <span class="dim" style="font-weight:400">(scans)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="How many TIMS mobility scans ε spans along 1/K₀. Anchored to the run’s scans-per-1/K₀, so it stays fixed no matter how you crop the view. ~2 ≈ the classic default.">i</span></label>
             <span style="display:flex;align-items:center;gap:10px">
               <input type="range" class="rng" id="cl-ims" min="1" max="20" step="0.5" value="2" aria-label="cluster 1/K0 reach in scans" />
               <input type="number" class="numin" id="cl-ims-n" min="1" max="20" step="0.5" value="2" aria-label="cluster 1/K0 reach in scans value" /></span></div>
-          <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span></label>
+          <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="How many TOF peak-widths ε spans along m/z. Keep it small (≈1–2) so neighbouring isotopes — tens of peak-widths apart — don’t merge into one cluster.">i</span></label>
             <span style="display:flex;align-items:center;gap:10px">
               <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="1.5" aria-label="cluster m/z peak-width reach" />
               <input type="number" class="numin" id="cl-mzw-n" min="1" max="40" step="0.5" value="1.5" aria-label="cluster m/z peak-width reach value" /></span></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -281,6 +281,7 @@
       <div class="tabs">
         <button class="tab active" id="tabbtn-view" data-tab="view" type="button">View</button>
         <button class="tab" id="tabbtn-focus" data-tab="focus" type="button">Focus</button>
+        <button class="tab" id="tabbtn-cluster" data-tab="cluster" type="button">Cluster</button>
       </div>
       <div class="tabpane active" id="tab-view">
       <section class="sec">
@@ -408,6 +409,24 @@
           <div class="map-wrap" id="mw-1"><canvas id="map-1" width="96" height="96"></canvas><div class="map-sel" id="sel-1"></div></div></div>
         <div class="map"><div class="map-cap"><b>1/K₀</b> × <b>RT</b></div>
           <div class="map-wrap" id="mw-2"><canvas id="map-2" width="96" height="96"></canvas><div class="map-sel" id="sel-2"></div></div></div>
+      </section>
+      </div>
+      <div class="tabpane" id="tab-cluster">
+      <section class="sec">
+        <div class="ey">Cluster · DBSCAN</div>
+        <div class="row"><label class="lbl" for="cl-eps">ε radius</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="cl-eps" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius" />
+            <input type="number" class="numin" id="cl-eps-n" min="0.002" max="0.1" step="0.001" value="0.012" aria-label="cluster radius value" /></span></div>
+        <div class="row"><label class="lbl" for="cl-min">Min points</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="cl-min" min="2" max="50" step="1" value="8" aria-label="cluster min points" />
+            <input type="number" class="numin" id="cl-min-n" min="2" max="50" step="1" value="8" aria-label="cluster min points value" /></span></div>
+        <div class="row"><button class="btn" id="cl-run" type="button" style="flex:1">⬡ Run clustering</button></div>
+        <div class="row"><label class="lbl" for="cl-color">Color by cluster</label>
+          <span><input type="checkbox" class="sw" id="cl-color" /><label for="cl-color" class="sw-l" aria-hidden="true"></label></span></div>
+        <div class="row"><span class="lbl">Result</span><span class="val" id="cl-readout" style="min-width:auto">—</span></div>
+        <div class="sub" style="padding:0 0 4px; color:var(--faint)">DBSCAN on the filtered points (Focus a region for big runs).</div>
       </section>
       </div>
     </div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -96,6 +96,8 @@
     .cs-hist { margin-bottom: 10px; }
     .cs-hist .map-cap { font-size: 10.5px; color: var(--dim); font-family: var(--mono); margin-bottom: 3px; }
     .cs-hist .map-cap b { color: var(--ink); font-weight: 500; }
+    .cs-axis { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 9.5px;
+      color: var(--faint); margin-top: 2px; }
     /* clickable cluster list (isolate on click) */
     .cs-export { float: right; font-family: var(--sans); font-size: 10px; letter-spacing: .04em;
       color: var(--accent); background: transparent; border: 1px solid var(--line); border-radius: 5px;
@@ -532,10 +534,14 @@
       </section>
       <section class="sec">
         <div class="ey">Per-cluster</div>
-        <div class="cs-hist"><div class="map-cap">Size (points)</div><div class="crop-hist" id="csh-size"></div></div>
-        <div class="cs-hist"><div class="map-cap"><b>m/z</b> extent</div><div class="crop-hist" id="csh-mz"></div></div>
-        <div class="cs-hist"><div class="map-cap"><b>1/K₀</b> extent</div><div class="crop-hist" id="csh-im"></div></div>
-        <div class="cs-hist"><div class="map-cap"><b>RT</b> extent</div><div class="crop-hist" id="csh-rt"></div></div>
+        <div class="cs-hist"><div class="map-cap">Size (points)</div><div class="crop-hist" id="csh-size"></div>
+          <div class="cs-axis"><span>0</span><span id="csx-size"></span></div></div>
+        <div class="cs-hist"><div class="map-cap"><b>m/z</b> extent</div><div class="crop-hist" id="csh-mz"></div>
+          <div class="cs-axis"><span>0</span><span id="csx-mz"></span></div></div>
+        <div class="cs-hist"><div class="map-cap"><b>1/K₀</b> extent</div><div class="crop-hist" id="csh-im"></div>
+          <div class="cs-axis"><span>0</span><span id="csx-im"></span></div></div>
+        <div class="cs-hist"><div class="map-cap"><b>RT</b> extent</div><div class="crop-hist" id="csh-rt"></div>
+          <div class="cs-axis"><span>0</span><span id="csx-rt"></span></div></div>
       </section>
       <section class="sec">
         <div class="ey">Clusters <button class="cs-export" id="cl-export" type="button">Export CSV</button></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -314,6 +314,30 @@
       font-family: var(--mono); font-size: 12px; color: var(--accent-2); background: rgba(20,12,4,0.9);
       border: 1px solid rgba(255,178,62,0.3); border-radius: 8px; padding: 8px 14px; max-width: 80vw; }
     .err:empty { display: none; }
+    /* Feedback widget (PROD only — hidden until /clientconfig reports feedback:true) */
+    .feedback-btn { position: fixed; z-index: 6; right: 16px; bottom: 16px; display: none;
+      font-family: var(--mono); font-size: 12px; color: var(--accent); cursor: pointer;
+      background: rgba(20,28,40,0.92); border: 1px solid rgba(95,170,240,0.4); border-radius: 18px;
+      padding: 8px 14px; user-select: none; }
+    body.feedback-on .feedback-btn { display: block; }
+    .feedback-btn:hover { border-color: var(--accent); }
+    .feedback-modal { position: fixed; z-index: 7; inset: 0; display: none; align-items: center;
+      justify-content: center; background: rgba(0,0,0,0.45); }
+    body.feedback-open .feedback-modal { display: flex; }
+    .feedback-card { width: min(460px, 92vw); background: #0f1622; border: 1px solid rgba(95,170,240,0.35);
+      border-radius: 10px; padding: 16px 18px; font-family: var(--mono); color: #cfe0f5; }
+    .feedback-card h3 { margin: 0 0 4px; font-size: 14px; color: var(--accent); }
+    .feedback-card .sub { font-size: 11px; color: #8aa; margin-bottom: 12px; }
+    .feedback-card label { display: block; font-size: 11px; margin: 8px 0 3px; color: #9ab; }
+    .feedback-card select, .feedback-card input, .feedback-card textarea { width: 100%; box-sizing: border-box;
+      background: #0a0f18; color: #cfe0f5; border: 1px solid rgba(120,150,190,0.3); border-radius: 5px;
+      padding: 6px 8px; font: inherit; }
+    .feedback-card textarea { resize: vertical; min-height: 84px; }
+    .feedback-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 14px; align-items: center; }
+    .feedback-actions .fb-status { margin-right: auto; font-size: 11px; color: var(--accent-2); }
+    .feedback-actions button { font: inherit; cursor: pointer; border-radius: 6px; padding: 7px 14px;
+      border: 1px solid rgba(120,150,190,0.3); background: #12202f; color: #cfe0f5; }
+    .feedback-actions button.primary { background: var(--accent); color: #06121f; border-color: var(--accent); font-weight: 700; }
 
     /* keyboard focus — inputs hide native outlines, so proxy focus onto the visible control */
     .rng:focus-visible { box-shadow: 0 0 0 4px var(--accent-dim); }
@@ -632,5 +656,28 @@
     <div class="caps"><span>hi</span><span>lo</span></div></div>
 
   <div class="err" id="status"></div>
+  <!-- Feedback widget (revealed by body.feedback-on when the server enables it; wired in lib.rs) -->
+  <div class="feedback-btn" id="feedback-open" title="Report a bug, request a feature, or ask a question">💬 Feedback</div>
+  <div class="feedback-modal" id="feedback-modal">
+    <div class="feedback-card">
+      <h3>Send feedback</h3>
+      <div class="sub">Goes straight to the tims·view maintainers. Bugs, feature requests, questions — all welcome.</div>
+      <label for="feedback-type">Type</label>
+      <select id="feedback-type">
+        <option value="bug">Bug / something broke</option>
+        <option value="feature">Feature request</option>
+        <option value="question">Question</option>
+      </select>
+      <label for="feedback-text">Message</label>
+      <textarea id="feedback-text" placeholder="What happened, or what would help?"></textarea>
+      <label for="feedback-email">Email (optional — if you'd like a reply)</label>
+      <input id="feedback-email" type="email" placeholder="you@lab.org" />
+      <div class="feedback-actions">
+        <span class="fb-status" id="feedback-status"></span>
+        <button id="feedback-cancel" type="button">Cancel</button>
+        <button id="feedback-send" type="button" class="primary">Send</button>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -264,9 +264,14 @@
       text-shadow: 0 1px 3px #000, 0 0 3px #000; will-change: transform; }
 
     /* collapse (pure CSS checkbox) */
-    .railtgl { position: absolute; opacity: 0; pointer-events: none; }
-    .railtgl:checked ~ .rail { transform: translateX(calc(-100% - 18px)); opacity: 0; }
-    .railtgl:checked ~ .railbtn { left: 16px; }
+    .railtgl, .railtgl-r { position: absolute; opacity: 0; pointer-events: none; }
+    .railtgl:checked ~ .rail:not(.right) { transform: translateX(calc(-100% - 18px)); opacity: 0; }
+    .railtgl:checked ~ .railbtn:not(.railbtn-r) { left: 16px; }
+    /* right rail (cluster panel) collapse — its own toggle, slides off to the right */
+    .railbtn-r { left: auto; right: 348px; display: none; transition: right .35s cubic-bezier(.4,.1,.2,1); }
+    body.has-clusters .railbtn-r { display: flex; } /* only exists when the panel does */
+    .railtgl-r:checked ~ .rail.right { transform: translateX(calc(100% + 18px)); opacity: 0; }
+    .railtgl-r:checked ~ .railbtn-r { right: 16px; }
     .railbtn { position: fixed; z-index: 4; top: 16px; left: 348px; transition: left .35s cubic-bezier(.4,.1,.2,1);
       width: 34px; height: 34px; display: grid; place-items: center; cursor: pointer; border-radius: 8px;
       background: var(--panel); border: 1px solid var(--line); backdrop-filter: blur(18px);
@@ -481,6 +486,8 @@
         <div class="cl-prog" id="cl-prog"><div class="cl-bar" id="cl-bar"></div></div>
         <div class="row"><label class="lbl" for="cl-color">Color by cluster</label>
           <span><input type="checkbox" class="sw" id="cl-color" checked /><label for="cl-color" class="sw-l" aria-hidden="true"></label></span></div>
+        <div class="row"><label class="lbl" for="hide-noise">Hide noise</label>
+          <span><input type="checkbox" class="sw" id="hide-noise" /><label for="hide-noise" class="sw-l" aria-hidden="true"></label></span></div>
         <div class="row"><span class="lbl">Result</span><span class="val" id="cl-readout" style="min-width:auto">—</span></div>
         <div class="sub" style="padding:0 0 4px; color:var(--faint)">DBSCAN on the filtered points (Focus a region for big runs).</div>
       </section>
@@ -489,6 +496,10 @@
   </aside>
 
   <!-- cluster stats (right rail, shown when a clustering result exists) -->
+  <input type="checkbox" id="railtgl-r" class="railtgl-r" />
+  <label for="railtgl-r" class="railbtn railbtn-r" title="Toggle cluster panel" aria-label="Toggle cluster panel">
+    <svg viewBox="0 0 16 16" fill="none"><path d="M2 4h12M2 8h12M2 12h12" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>
+  </label>
   <aside class="rail right" id="cluster-panel" aria-label="cluster statistics">
     <div class="head">
       <div class="mark"><b>clusters</b> <span>stats</span></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -112,6 +112,15 @@
     .cs-dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
     .cs-meta { margin-left: auto; color: var(--dim); font-variant-numeric: tabular-nums; }
     .cs-more { font-family: var(--mono); font-size: 10.5px; color: var(--faint); padding: 5px 8px; }
+    /* DIA window per-group legend (toggle a group's windows); shown only when DIA windows are on */
+    .win-legend { display: none; flex-wrap: wrap; gap: 5px; margin: 2px 0 10px; }
+    body.show-windows .win-legend { display: flex; }
+    .wg { display: inline-flex; align-items: center; gap: 5px; font-family: var(--mono); font-size: 11px;
+      color: var(--dim); background: transparent; border: 1px solid var(--line); border-radius: 6px;
+      padding: 2px 7px; cursor: pointer; opacity: .45; transition: opacity .12s, border-color .12s; }
+    .wg.on { opacity: 1; color: var(--ink); border-color: var(--line-2); }
+    .wg:hover { border-color: var(--accent); }
+    .wg-dot { width: 9px; height: 9px; border-radius: 2px; flex: none; }
 
     .sec { padding: 14px 18px 4px 20px; }
     .sec + .sec { border-top: 1px solid var(--line-2); }
@@ -412,6 +421,7 @@
           </span></div>
         <div class="row"><label class="lbl" for="show-windows">DIA windows</label>
           <span><input type="checkbox" class="sw" id="show-windows" /><label for="show-windows" class="sw-l" aria-hidden="true"></label></span></div>
+        <div class="win-legend" id="win-groups"></div>
         <div class="crop">
           <div class="clab"><b>m/z</b><span id="cmz-v">full</span></div>
           <div class="crop-hist" id="cmz-hist"></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -63,14 +63,30 @@
     .body::-webkit-scrollbar { width: 8px; }
     .body::-webkit-scrollbar-thumb { background: var(--line); border-radius: 8px; }
     /* tabs */
-    .tabs { display: flex; gap: 4px; padding: 8px 16px 0 18px; border-bottom: 1px solid var(--line); }
-    .tab { flex: 1; font-family: var(--sans); font-size: 12px; font-weight: 500; color: var(--dim);
+    .tabs { display: flex; gap: 2px; padding: 8px 14px 0 16px; border-bottom: 1px solid var(--line); }
+    .tab { flex: 1; font-family: var(--sans); font-size: 11.5px; font-weight: 500; color: var(--dim);
       background: transparent; border: none; border-bottom: 2px solid transparent; margin-bottom: -1px;
-      padding: 7px 4px 8px; cursor: pointer; transition: color .14s, border-color .14s; }
+      padding: 7px 3px 8px; cursor: pointer; transition: color .14s, border-color .14s; white-space: nowrap; }
     .tab:hover { color: var(--ink); }
     .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+    .tab .tn { font-size: .92em; opacity: .55; margin-right: 3px; }
+    .tab.active .tn { opacity: .85; }
+    .tab-gear { flex: 0 0 auto; margin-left: auto; font-size: 13px; padding-left: 8px; padding-right: 6px; }
     .tabpane { display: none; }
     .tabpane.active { display: block; }
+    /* Advanced disclosure inside a flow tab (collapsed by default) */
+    .adv { margin: 2px 0 6px; }
+    .adv > summary { font-size: 11px; color: var(--dim); cursor: pointer; padding: 4px 0; list-style: none;
+      user-select: none; }
+    .adv > summary::-webkit-details-marker { display: none; }
+    .adv > summary::before { content: "▸"; color: var(--faint); margin-right: 5px; }
+    .adv[open] > summary::before { content: "▾"; }
+    /* ① Data meta summary */
+    .dsum { margin-top: 8px; }
+    .dsum-row { display: flex; justify-content: space-between; gap: 10px; padding: 4px 0; font-size: 12px;
+      border-bottom: 1px solid var(--line); }
+    .dsum-row .k { color: var(--dim); }
+    .dsum-row .v { color: var(--ink); font-family: var(--mono); text-align: right; }
     /* volume-only controls, shown when View = Volume */
     .vol-only { display: none; }
     body.volmode .vol-only { display: flex; }
@@ -339,10 +355,6 @@
     <div class="head">
       <div class="mark">tims<b>·</b>view <span>/ ion cloud</span></div>
       <div class="sub">m/z × 1/K₀ × retention time — GPU point field</div>
-      <div class="dspick" id="dspick" style="display:none">
-        <label class="lbl" for="dataset-sel">Dataset</label>
-        <select class="sel" id="dataset-sel" aria-label="dataset"></select>
-      </div>
     </div>
 
     <div class="hud">
@@ -354,11 +366,30 @@
 
     <div class="body">
       <div class="tabs">
-        <button class="tab active" id="tabbtn-view" data-tab="view" type="button">View</button>
-        <button class="tab" id="tabbtn-focus" data-tab="focus" type="button">Focus</button>
-        <button class="tab" id="tabbtn-cluster" data-tab="cluster" type="button">Cluster</button>
+        <button class="tab" id="tabbtn-data" data-tab="data" type="button"><span class="tn">①</span>Data</button>
+        <button class="tab active" id="tabbtn-region" data-tab="region" type="button"><span class="tn">②</span>Region</button>
+        <button class="tab" id="tabbtn-cluster" data-tab="cluster" type="button"><span class="tn">③</span>Cluster</button>
+        <button class="tab" id="tabbtn-save" data-tab="save" type="button"><span class="tn">④</span>Save</button>
+        <button class="tab tab-gear" id="tabbtn-display" data-tab="display" type="button" title="Display & exploration" aria-label="Display">⚙</button>
       </div>
-      <div class="tabpane active" id="tab-view">
+      <div class="tabpane" id="tab-data">
+      <section class="sec">
+        <div class="ey">Dataset</div>
+        <div class="dspick" id="dspick" style="display:none">
+          <label class="lbl" for="dataset-sel">Dataset</label>
+          <select class="sel" id="dataset-sel" aria-label="dataset"></select>
+        </div>
+        <div class="dsum">
+          <div class="dsum-row"><span class="k">Name</span><span class="v" id="data-name">—</span></div>
+          <div class="dsum-row"><span class="k">Points</span><span class="v" id="data-points">—</span></div>
+          <div class="dsum-row"><span class="k">m/z</span><span class="v" id="data-mz">—</span></div>
+          <div class="dsum-row"><span class="k">1/K₀</span><span class="v" id="data-im">—</span></div>
+          <div class="dsum-row"><span class="k">RT</span><span class="v" id="data-rt">—</span></div>
+          <div class="dsum-row"><span class="k">Cycle</span><span class="v" id="data-cycle">—</span></div>
+        </div>
+      </section>
+      </div>
+      <div class="tabpane" id="tab-display">
       <section class="sec">
         <div class="ey">View</div>
         <div class="row"><label class="lbl" for="ar">Auto-orbit</label>
@@ -427,7 +458,7 @@
             <input type="number" class="numin" id="expo-n" min="0.02" max="4" step="0.02" value="1.00" aria-label="exposure value" /></span></div>
       </section>
       </div>
-      <div class="tabpane" id="tab-focus">
+      <div class="tabpane active" id="tab-region">
       <section class="sec">
         <div class="ey">Filters</div>
         <div class="row" style="gap:8px">
@@ -518,14 +549,17 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-cse" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon" />
             <input type="number" class="numin" id="cl-cse-n" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon value" /></span></div>
-        <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span></label>
-          <span style="display:flex;align-items:center;gap:10px">
-            <input type="range" class="rng" id="cl-rtc" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles" />
-            <input type="number" class="numin" id="cl-rtc-n" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles value" /></span></div>
-        <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span></label>
-          <span style="display:flex;align-items:center;gap:10px">
-            <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach" />
-            <input type="number" class="numin" id="cl-mzw-n" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach value" /></span></div>
+        <details class="adv">
+          <summary>Advanced · metric</summary>
+          <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span></label>
+            <span style="display:flex;align-items:center;gap:10px">
+              <input type="range" class="rng" id="cl-rtc" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles" />
+              <input type="number" class="numin" id="cl-rtc-n" min="1" max="12" step="1" value="2" aria-label="cluster RT reach in cycles value" /></span></div>
+          <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span></label>
+            <span style="display:flex;align-items:center;gap:10px">
+              <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach" />
+              <input type="number" class="numin" id="cl-mzw-n" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach value" /></span></div>
+        </details>
         <div class="row"><button class="btn" id="cl-run" type="button" style="flex:1">⬡ Run clustering</button></div>
         <div class="cl-prog" id="cl-prog"><div class="cl-bar" id="cl-bar"></div></div>
         <div class="row"><label class="lbl" for="cl-color">Color by cluster</label>
@@ -533,7 +567,16 @@
         <div class="row"><label class="lbl" for="hide-noise">Hide noise</label>
           <span><input type="checkbox" class="sw" id="hide-noise" /><label for="hide-noise" class="sw-l" aria-hidden="true"></label></span></div>
         <div class="row"><span class="lbl">Result</span><span class="val" id="cl-readout" style="min-width:auto">—</span></div>
-        <div class="sub" style="padding:0 0 4px; color:var(--faint)">DBSCAN on the filtered points (Focus a region for big runs).</div>
+        <div class="sub" style="padding:0 0 4px; color:var(--faint)">Clusters the filtered points in the focused region.</div>
+      </section>
+      </div>
+      <div class="tabpane" id="tab-save">
+      <section class="sec">
+        <div class="ey">Save</div>
+        <div class="sub" style="padding:0 0 8px; color:var(--faint)">Export the reproducible setup anytime; export results once a clustering exists.</div>
+        <div class="row"><button class="btn" id="cfg-export" type="button" style="flex:1">⬡ Export config (JSON)</button></div>
+        <div class="row"><button class="btn" id="cl-export" type="button" style="flex:1" disabled>⬡ Export results (CSV + JSON)</button></div>
+        <div class="row"><span class="lbl">Status</span><span class="val" id="save-status" style="min-width:auto">no clustering yet</span></div>
       </section>
       </div>
     </div>
@@ -573,7 +616,7 @@
           <div class="cs-axis"><span>0</span><span id="csx-rt"></span></div></div>
       </section>
       <section class="sec">
-        <div class="ey">Clusters <button class="cs-export" id="cl-export" type="button">Export CSV</button></div>
+        <div class="ey">Clusters</div>
         <div class="cs-list" id="cs-list"></div>
       </section>
     </div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -136,6 +136,9 @@
     /* distribution strip above the crop slider (SVG injected by the wasm), aligned to its range */
     .crop-hist { height: 26px; margin: 1px 0 3px; opacity: .9; }
     .crop-hist svg { display: block; width: 100%; height: 100%; }
+    /* floor row: full-width slider + number field */
+    .frow { display: flex; align-items: center; gap: 10px; }
+    .frow .rng { flex: 1; }
     /* dual-thumb range: two inputs overlaid on one track, fill between the thumbs */
     .dual { position: relative; height: 20px; }
     .dual-track, .dual-fill { position: absolute; top: 50%; transform: translateY(-50%);
@@ -282,10 +285,14 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="expo" min="0.02" max="4" step="0.02" value="1.00" />
             <input type="number" class="numin" id="expo-n" min="0.02" max="4" step="0.02" value="1.00" aria-label="exposure value" /></span></div>
-        <div class="row"><label class="lbl" for="floor">Floor</label>
-          <span style="display:flex;align-items:center;gap:10px">
-            <input type="range" class="rng" id="floor" min="0" max="5000" step="25" value="0" />
-            <input type="number" class="numin" id="floor-n" min="0" max="5000" step="25" value="0" aria-label="intensity floor value" /></span></div>
+        <div class="crop">
+          <div class="clab"><b>Floor</b><span>intensity ≥ (cbrt)</span></div>
+          <div class="crop-hist" id="floor-hist"></div>
+          <div class="frow">
+            <input type="range" class="rng wide" id="floor" min="0" max="1000" step="1" value="0" aria-label="intensity floor" />
+            <input type="number" class="numin" id="floor-n" min="0" max="5000" step="1" value="0" aria-label="intensity floor value in counts" />
+          </div>
+        </div>
       </section>
 
       <section class="sec">

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -100,6 +100,7 @@
     .lbl { font-size: 12.5px; color: var(--ink); font-weight: 500; }
     .val { font-family: var(--mono); font-size: 11.5px; color: var(--accent-2);
       font-variant-numeric: tabular-nums; min-width: 40px; text-align: right; }
+    .acc { color: var(--accent-2); font-weight: 500; }
     /* editable numeric readout — type a value or use the slider */
     .numin { font-family: var(--mono); font-size: 11.5px; color: var(--accent-2); width: 54px;
       text-align: right; background: transparent; border: 1px solid transparent; border-radius: 5px;
@@ -328,7 +329,7 @@
             <input type="range" class="rng" id="expo" min="0.02" max="4" step="0.02" value="1.00" />
             <input type="number" class="numin" id="expo-n" min="0.02" max="4" step="0.02" value="1.00" aria-label="exposure value" /></span></div>
         <div class="crop">
-          <div class="clab"><b>Floor</b><span>intensity ≥ (counts)</span></div>
+          <div class="clab"><b>Floor</b><span>intensity ≥ (counts) <span id="floor-src" class="acc"></span></span></div>
           <div class="crop-hist" id="floor-hist"></div>
           <div class="frow">
             <input type="range" class="rng wide" id="floor" min="0" max="1000" step="1" value="0" aria-label="intensity floor" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -316,7 +316,7 @@
           <span style="display:flex;align-items:center;gap:8px">
             <input type="number" class="numin" id="load-n" min="1" step="100000" value="0" style="width:84px" aria-label="points to load from the server" />
             <button class="btn mono" id="load-go" type="button">load</button></span></div>
-        <div class="row"><span class="lbl" id="l-mode">Mode</span>
+        <div class="row points-only"><span class="lbl" id="l-mode">Mode</span>
           <span class="seg" role="radiogroup" aria-labelledby="l-mode">
             <input type="radio" name="mode" id="m-add" checked /><label for="m-add">Density</label>
             <input type="radio" name="mode" id="m-opq" /><label for="m-opq">Solid</label>
@@ -326,11 +326,11 @@
             <option value="0">Viridis</option><option value="1" selected>Inferno</option>
             <option value="2">Turbo</option><option value="3">Grayscale</option>
           </select></div>
-        <div class="row"><label class="lbl" for="psize">Point size</label>
+        <div class="row points-only"><label class="lbl" for="psize">Point size</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="psize" min="0.5" max="6" step="0.1" value="2.5" />
             <input type="number" class="numin" id="psize-n" min="0.5" max="6" step="0.1" value="2.5" aria-label="point size value" /></span></div>
-        <div class="row"><label class="lbl" for="opac">Opacity</label>
+        <div class="row points-only"><label class="lbl" for="opac">Opacity</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="opac" min="0.05" max="1" step="0.05" value="0.6" />
             <input type="number" class="numin" id="opac-n" min="0.05" max="1" step="0.05" value="0.60" aria-label="opacity value" /></span></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -198,6 +198,7 @@
       border-radius: 50%; background: var(--dim); transition: all .18s; }
     .sw:checked + .sw-l { background: var(--accent-dim); border-color: var(--accent); }
     .sw:checked + .sw-l::after { left: 19px; background: var(--accent); }
+    .sw:disabled + .sw-l { opacity: .35; cursor: default; pointer-events: none; }
 
     /* button */
     .btn { font-family: var(--sans); font-size: 12px; font-weight: 500; color: var(--ink);

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -487,6 +487,10 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-min" min="2" max="50" step="1" value="8" aria-label="cluster min points" />
             <input type="number" class="numin" id="cl-min-n" min="2" max="50" step="1" value="8" aria-label="cluster min points value" /></span></div>
+        <div class="row"><label class="lbl" for="cl-mzw">m/z width <span class="dim" style="font-weight:400">(peak-widths)</span></label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="cl-mzw" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach" />
+            <input type="number" class="numin" id="cl-mzw-n" min="1" max="40" step="0.5" value="6" aria-label="cluster m/z peak-width reach value" /></span></div>
         <div class="row"><button class="btn" id="cl-run" type="button" style="flex:1">⬡ Run clustering</button></div>
         <div class="cl-prog" id="cl-prog"><div class="cl-bar" id="cl-bar"></div></div>
         <div class="row"><label class="lbl" for="cl-color">Color by cluster</label>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -121,6 +121,11 @@
     .wg.on { opacity: 1; color: var(--ink); border-color: var(--line-2); }
     .wg:hover { border-color: var(--accent); }
     .wg-dot { width: 9px; height: 9px; border-radius: 2px; flex: none; }
+    /* clustering progress bar (worker reports visited-point ticks) */
+    .cl-prog { display: none; height: 4px; border-radius: 4px; margin: 0 0 9px; overflow: hidden;
+      background: var(--line); }
+    .cl-bar { height: 100%; width: 0; border-radius: 4px;
+      background: linear-gradient(90deg, var(--accent), var(--accent-2)); transition: width .2s ease-out; }
 
     .sec { padding: 14px 18px 4px 20px; }
     .sec + .sec { border-top: 1px solid var(--line-2); }
@@ -473,6 +478,7 @@
             <input type="range" class="rng" id="cl-min" min="2" max="50" step="1" value="8" aria-label="cluster min points" />
             <input type="number" class="numin" id="cl-min-n" min="2" max="50" step="1" value="8" aria-label="cluster min points value" /></span></div>
         <div class="row"><button class="btn" id="cl-run" type="button" style="flex:1">⬡ Run clustering</button></div>
+        <div class="cl-prog" id="cl-prog"><div class="cl-bar" id="cl-bar"></div></div>
         <div class="row"><label class="lbl" for="cl-color">Color by cluster</label>
           <span><input type="checkbox" class="sw" id="cl-color" /><label for="cl-color" class="sw-l" aria-hidden="true"></label></span></div>
         <div class="row"><span class="lbl">Result</span><span class="val" id="cl-readout" style="min-width:auto">—</span></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -71,6 +71,9 @@
     .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
     .tabpane { display: none; }
     .tabpane.active { display: block; }
+    /* volume-only controls, shown when View = Volume */
+    .vol-only { display: none; }
+    body.volmode .vol-only { display: flex; }
 
     .sec { padding: 14px 18px 4px 20px; }
     .sec + .sec { border-top: 1px solid var(--line-2); }
@@ -288,6 +291,20 @@
 
       <section class="sec">
         <div class="ey">Render</div>
+        <div class="row"><span class="lbl" id="l-view">View</span>
+          <span class="seg" role="radiogroup" aria-labelledby="l-view">
+            <input type="radio" name="viewm" id="v-pts" checked /><label for="v-pts">Points</label>
+            <input type="radio" name="viewm" id="v-vol" /><label for="v-vol">Volume</label>
+          </span></div>
+        <div class="row vol-only"><span class="lbl" id="l-vstyle">Volume</span>
+          <span class="seg" role="radiogroup" aria-labelledby="l-vstyle">
+            <input type="radio" name="vstyle" id="vs-comp" checked /><label for="vs-comp">Composite</label>
+            <input type="radio" name="vstyle" id="vs-mip" /><label for="vs-mip">MIP</label>
+          </span></div>
+        <div class="row vol-only"><label class="lbl" for="vsteps">Steps</label>
+          <span style="display:flex;align-items:center;gap:10px">
+            <input type="range" class="rng" id="vsteps" min="32" max="512" step="16" value="256" aria-label="raymarch steps" />
+            <input type="number" class="numin" id="vsteps-n" min="32" max="512" step="16" value="256" aria-label="raymarch steps value" /></span></div>
         <div class="row"><label class="lbl" for="disp">Display</label>
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="disp" min="1" max="100" step="1" value="100" aria-label="fraction of points to display" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -81,7 +81,9 @@
     /* cluster stats rail (right edge, shown when a clustering result exists) */
     .rail.right { left: auto; right: 16px; display: none; }
     body.has-clusters .rail.right { display: flex; }
-    body.has-clusters .cbar { display: none; } /* the stats rail takes the right edge */
+    /* hide the intensity colorbar when the stats rail takes the right edge, or when the cloud is
+       cluster-colored (the intensity legend is meaningless then) */
+    body.has-clusters .cbar, body.cluster-color .cbar { display: none; }
     .cs-table { width: 100%; border-collapse: collapse; font-family: var(--mono); font-size: 11.5px;
       margin-bottom: 10px; }
     .cs-table th, .cs-table td { text-align: right; padding: 3px 5px; }
@@ -266,6 +268,8 @@
 
     @media (max-width: 720px) {
       .rail { width: calc(100vw - 32px); }
+      /* the stats rail would cover the controls full-width — hide it on narrow viewports */
+      body.has-clusters .rail.right { display: none; }
       /* open: toggle parks at the rail's top-right (acts as close); collapsed: top-left to reopen */
       .railbtn { left: auto; right: 16px; }
       .railtgl:checked ~ .railbtn { left: 16px; right: auto; }
@@ -464,7 +468,8 @@
           <tr><td>Intensity</td><td id="cs-int-t">—</td><td id="cs-int-c">—</td><td id="cs-int-n">—</td></tr>
         </table>
         <div class="row"><span class="lbl">Clusters</span><span class="val" id="cs-k" style="min-width:auto">—</span></div>
-        <div class="row"><span class="lbl">Signal / noise</span><span class="val" id="cs-ratio" style="min-width:auto">—</span></div>
+        <div class="row"><span class="lbl">S/N · points</span><span class="val" id="cs-ratio" style="min-width:auto">—</span></div>
+        <div class="row"><span class="lbl">S/N · intensity</span><span class="val" id="cs-iratio" style="min-width:auto">—</span></div>
       </section>
       <section class="sec">
         <div class="ey">Per-cluster</div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -393,6 +393,10 @@
           <div class="dsum-row"><span class="k">RT</span><span class="v" id="data-rt">—</span></div>
           <div class="dsum-row"><span class="k">Cycle</span><span class="v" id="data-cycle">—</span></div>
         </div>
+        <div class="row" id="acq-row" style="display:none; margin-top:10px">
+          <button class="btn" id="acq-play" type="button" style="flex:1">▶ Live acquisition</button>
+          <span class="tip" tabindex="0" role="img" aria-label="help" title="Play a simulated acquisition over time at the device frame rate, colouring each peak by its precursor (a precursor + its fragments share a hue). Requires the acquisition sidecar (?acq=).">i</span>
+        </div>
       </section>
       </div>
       <div class="tabpane" id="tab-display">

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -257,6 +257,10 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="disp" min="1" max="100" step="1" value="100" aria-label="fraction of points to display" />
             <input type="number" class="numin" id="disp-n" min="1" step="1000" value="0" style="width:78px" aria-label="number of points to display" /></span></div>
+        <div class="row"><label class="lbl" for="load-n">Load <span class="dim" id="load-cap"></span></label>
+          <span style="display:flex;align-items:center;gap:8px">
+            <input type="number" class="numin" id="load-n" min="1" step="100000" value="0" style="width:84px" aria-label="points to load from the server" />
+            <button class="btn mono" id="load-go" type="button">load</button></span></div>
         <div class="row"><span class="lbl" id="l-mode">Mode</span>
           <span class="seg" role="radiogroup" aria-labelledby="l-mode">
             <input type="radio" name="mode" id="m-add" checked /><label for="m-add">Density</label>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -410,6 +410,8 @@
             <input type="radio" name="ms" id="ms-2" /><label for="ms-2">MS2</label>
             <input type="radio" name="ms" id="ms-b" /><label for="ms-b">Both</label>
           </span></div>
+        <div class="row"><label class="lbl" for="show-windows">DIA windows</label>
+          <span><input type="checkbox" class="sw" id="show-windows" /><label for="show-windows" class="sw-l" aria-hidden="true"></label></span></div>
         <div class="crop">
           <div class="clab"><b>m/z</b><span id="cmz-v">full</span></div>
           <div class="crop-hist" id="cmz-hist"></div>

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -133,6 +133,9 @@
     .crop .clab { display: flex; justify-content: space-between; font-size: 11px; color: var(--dim);
       margin-bottom: 5px; font-family: var(--mono); }
     .crop .clab b { color: var(--ink); font-weight: 500; }
+    /* distribution strip above the crop slider (SVG injected by the wasm), aligned to its range */
+    .crop-hist { height: 26px; margin: 1px 0 3px; opacity: .9; }
+    .crop-hist svg { display: block; width: 100%; height: 100%; }
     /* dual-thumb range: two inputs overlaid on one track, fill between the thumbs */
     .dual { position: relative; height: 20px; }
     .dual-track, .dual-fill { position: absolute; top: 50%; transform: translateY(-50%);
@@ -295,6 +298,7 @@
           </span></div>
         <div class="crop">
           <div class="clab"><b>m/z</b><span id="cmz-v">full</span></div>
+          <div class="crop-hist" id="cmz-hist"></div>
           <div class="dual">
             <div class="dual-track"></div><div class="dual-fill" id="cmz-fill"></div>
             <input type="range" id="cmz-lo" min="0" max="1000" value="0" aria-label="m/z crop minimum" />
@@ -303,6 +307,7 @@
         </div>
         <div class="crop">
           <div class="clab"><b>1/K₀</b><span id="cim-v">full</span></div>
+          <div class="crop-hist" id="cim-hist"></div>
           <div class="dual">
             <div class="dual-track"></div><div class="dual-fill" id="cim-fill"></div>
             <input type="range" id="cim-lo" min="0" max="1000" value="0" aria-label="ion mobility crop minimum" />
@@ -311,6 +316,7 @@
         </div>
         <div class="crop">
           <div class="clab"><b>RT</b><span id="crt-v">full</span></div>
+          <div class="crop-hist" id="crt-hist"></div>
           <div class="dual">
             <div class="dual-track"></div><div class="dual-fill" id="crt-fill"></div>
             <input type="range" id="crt-lo" min="0" max="1000" value="0" aria-label="retention time crop minimum" />

--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -123,10 +123,6 @@
     .dspick { display: flex; align-items: center; gap: 8px; margin-top: 9px; }
     .dspick .lbl { white-space: nowrap; }
     .dspick .sel { flex: 1; min-width: 0; }
-    /* per-algorithm parameter rows: DBSCAN params by default; HDBSCAN params under body.algo-hdb */
-    .algo-hdb { display: none; }
-    body.algo-hdb .algo-hdb { display: flex; }
-    body.algo-hdb .algo-dbscan { display: none; }
     /* clickable cluster list (isolate on click) */
     .cs-export { float: right; font-family: var(--sans); font-size: 10px; letter-spacing: .04em;
       color: var(--accent); background: transparent; border: 1px solid var(--line); border-radius: 5px;
@@ -545,7 +541,6 @@
           <select class="sel" id="cl-algo" aria-label="clustering algorithm">
             <option value="wasm">DBSCAN (built-in)</option>
             <option value="sklearn" id="opt-sklearn" disabled>DBSCAN (sklearn)</option>
-            <option value="hdbscan" id="opt-hdbscan" disabled>HDBSCAN (sklearn)</option>
           </select></div>
         <div class="row algo-dbscan"><label class="lbl" for="cl-eps">ε radius <span class="dim" style="font-weight:400">(norm.)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="DBSCAN neighbourhood radius in the calibrated metric. Larger ε → looser, bigger clusters. It scales all three axis reaches (RT / 1/K₀ / m/z) together.">i</span></label>
           <span style="display:flex;align-items:center;gap:10px">
@@ -555,18 +550,6 @@
           <span style="display:flex;align-items:center;gap:10px">
             <input type="range" class="rng" id="cl-min" min="2" max="50" step="1" value="8" aria-label="cluster min points" />
             <input type="number" class="numin" id="cl-min-n" min="2" max="50" step="1" value="8" aria-label="cluster min points value" /></span></div>
-        <div class="row algo-hdb"><label class="lbl" for="cl-mcs">Min cluster size<span class="tip" tabindex="0" role="img" aria-label="help" title="Smallest group HDBSCAN will report as a cluster. Smaller → more, finer clusters; larger → fewer, broader ones.">i</span></label>
-          <span style="display:flex;align-items:center;gap:10px">
-            <input type="range" class="rng" id="cl-mcs" min="2" max="100" step="1" value="7" aria-label="HDBSCAN min cluster size" />
-            <input type="number" class="numin" id="cl-mcs-n" min="2" max="100" step="1" value="7" aria-label="HDBSCAN min cluster size value" /></span></div>
-        <div class="row algo-hdb"><label class="lbl" for="cl-hms">Min samples <span class="dim" style="font-weight:400">(0=auto)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="How conservative HDBSCAN is: higher → denser cores and more points called noise. 0 = auto (uses min cluster size).">i</span></label>
-          <span style="display:flex;align-items:center;gap:10px">
-            <input type="range" class="rng" id="cl-hms" min="0" max="50" step="1" value="0" aria-label="HDBSCAN min samples" />
-            <input type="number" class="numin" id="cl-hms-n" min="0" max="50" step="1" value="0" aria-label="HDBSCAN min samples value" /></span></div>
-        <div class="row algo-hdb"><label class="lbl" for="cl-cse">Selection ε <span class="dim" style="font-weight:400">(scaled)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="Optional: merge HDBSCAN clusters closer than this in the scaled metric (0 = off). Coarsens an over-split result.">i</span></label>
-          <span style="display:flex;align-items:center;gap:10px">
-            <input type="range" class="rng" id="cl-cse" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon" />
-            <input type="number" class="numin" id="cl-cse-n" min="0" max="0.1" step="0.001" value="0" aria-label="HDBSCAN cluster selection epsilon value" /></span></div>
         <details class="adv">
           <summary>Advanced · metric</summary>
           <div class="row"><label class="lbl" for="cl-rtc">RT width <span class="dim" style="font-weight:400">(cycles)</span><span class="tip" tabindex="0" role="img" aria-label="help" title="How many MS1 cycles ε spans along retention time. A precursor elutes over several cycles — raise to keep an elution together, lower to split co-eluting species. Independent of how you crop the view.">i</span></label>

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -186,6 +186,15 @@ struct Region {
     imin: f32,
 }
 
+/// Static-view snapshot captured when acquisition starts, so Stop (and natural completion) can
+/// restore the dataset cloud in place — no page reload, no server round-trip. Holds the
+/// pre-acquisition CPU points plus the display params + view that entry overwrites.
+struct AcqStash {
+    points: Vec<GpuPoint>,
+    params: ParamsUniform,
+    view: ViewMode,
+}
+
 /// Live GPU + scene state, shared (single-threaded) between the render loop and resize handler.
 struct Gfx {
     canvas: web_sys::HtmlCanvasElement,
@@ -313,6 +322,9 @@ struct Gfx {
     /// Bumped each time playback (re)starts, so an in-flight prefetch from a previous session can tell
     /// it's stale and drop its result instead of contaminating the new run's buffer.
     acq_gen: u32,
+    /// Pre-acquisition static view, stashed at playback start and consumed by `restore_static_view`
+    /// on Stop / natural completion. `None` when not in (or after a clean exit from) acquisition.
+    acq_saved: Option<AcqStash>,
     /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
     /// the startup probe when the service is reachable; toggleable in the Cluster tab.
     use_python_cluster: bool,
@@ -769,6 +781,7 @@ async fn run() -> Result<(), String> {
         acq_fetch_next: 0,
         acq_fetching: false,
         acq_gen: 0,
+        acq_saved: None,
         dataset_name: String::new(),
         dataset_id: dataset_id(), // raw URL value; clamped to the registry by populate_datasets
         use_python_cluster: false,
@@ -1268,7 +1281,14 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
                 PointCloudRenderer::new(&g.device, &g.queue, g.config.format, DEPTH_FORMAT, cap, g.supports_compaction);
             g.renderer.enable_ring(); // append wraps + overwrites oldest -> bounded resident
             g.renderer.set_draw_count(u32::MAX);
-            g.cpu_points.clear(); // acquisition drives the GPU buffer directly
+            // Stash the static view so Stop / completion can restore it in place (chunk 2d). The
+            // mem::take also empties cpu_points (acquisition drives the GPU buffer directly); snapshot
+            // the display params + view that the lines below are about to overwrite.
+            g.acq_saved = Some(AcqStash {
+                points: std::mem::take(&mut g.cpu_points),
+                params: g.params,
+                view: g.view_mode,
+            });
             g.view_mode = ViewMode::Points; // acquisition is a point cloud; never the volume path
             // Acquisition replaces cpu_points/_pad[0], so any clustering is now invalid: a stale
             // cluster Run or a clicked cluster row would index the emptied cpu_points and panic.
@@ -1304,10 +1324,38 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
     if start {
         wasm_bindgen_futures::spawn_local(play_loop(gfx.clone()));
     } else {
-        // Stop leaves the acquisition cloud frozen; a full in-place return to the static dataset is a
-        // chunk-2d transition — for now, reload/switch dataset to get it back.
-        show_status("playback stopped — switch dataset or reload to return to the static view");
+        // In-place return to the static dataset cloud (chunk 2d): rebuild from the stash, no reload.
+        restore_static_view(gfx);
+        refresh_controls(gfx); // re-enable focus/back/load now that playback is stopped
+        show_status("playback stopped — returned to the dataset view");
     }
+}
+
+/// Stop's in-place return to the static dataset cloud (chunk 2d): rebuild a normal (non-ring)
+/// renderer from the points stashed at playback start, restore the display params + view that
+/// acquisition overwrote, and drop any in-flight prefetch. No page reload, no server round-trip.
+/// Coloring is forced back to intensity (entry destroyed the clustering, so the restored points
+/// have no cluster ids to color by — mirrors `apply_load`). A no-op if nothing was stashed.
+fn restore_static_view(gfx: &Rc<RefCell<Gfx>>) {
+    let mut g = gfx.borrow_mut();
+    let g = &mut *g;
+    let Some(stash) = g.acq_saved.take() else { return };
+    // Rebuild the GPU buffer at the stashed cloud's size (not the trailing-ring cap) and re-upload.
+    let cap = stash.points.len().min(g.n_cap).max(1) as u32;
+    let mut renderer =
+        PointCloudRenderer::new(&g.device, &g.queue, g.config.format, DEPTH_FORMAT, cap, g.supports_compaction);
+    let _ = renderer.append(&g.queue, &stash.points);
+    g.renderer = renderer;
+    g.cpu_points = stash.points;
+    g.params = stash.params; // restores transfer/exposure, MS mask, and the spatial crops
+    g.params.color_mode = 0; // intensity (no clusters survive acquisition entry)
+    g.view_mode = stash.view;
+    g.vol_needs_grid = true; // the volume density grid is rebuilt from the restored points if shown
+    g.data_gen = g.data_gen.wrapping_add(1);
+    g.acq_gen = g.acq_gen.wrapping_add(1); // a still-in-flight prefetch sees a stale gen and drops
+    g.acq_buffer.clear();
+    g.acq_fetching = false;
+    g.filter_dirty = true;
 }
 
 /// Detached prefetch: fetch one parallel batch and push its decoded frames into `acq_buffer`, then
@@ -1398,9 +1446,13 @@ async fn play_loop(gfx: Rc<RefCell<Gfx>>) {
             Next::Wait => sleep_ms(8).await,
             Next::Done(n) => {
                 gfx.borrow_mut().acq_playing = false;
+                // Same in-place return as a manual Stop, so completion never strands the user on a
+                // frozen trailing-window cloud with no way back but a reload.
+                restore_static_view(&gfx);
+                refresh_controls(&gfx);
                 set_body_class("cluster-color", false); // restore the intensity colorbar (manual stop does too)
                 set_text("acq-play", "▶ Live acquisition");
-                show_status(&format!("acquisition complete — {n} frames"));
+                show_status(&format!("acquisition complete — {n} frames; returned to the dataset view"));
                 return;
             }
         }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -337,22 +337,22 @@ async fn run() -> Result<(), String> {
 
     wire_input(&gfx, &window, &canvas_for_input);
     wire_controls(&gfx);
-    // Scale the intensity-floor controls (slider + number) to the data before syncing values.
-    if let Some(m) = &server_meta {
-        if m.i_p99 > 1.0 {
-            for id in ["floor", "floor-n"] {
-                if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
-                    let _ = inp.set_attribute("max", &format!("{:.0}", m.i_p99));
-                    let _ = inp.set_attribute("step", &format!("{:.0}", (m.i_p99 / 200.0).max(1.0)));
-                }
-            }
-        }
+    // Bind the cbrt-mapped intensity floor to the data range (number field is in real counts).
+    let floor_hi = server_meta.as_ref().map(|m| m.i_p99).filter(|x| *x > 1.0).unwrap_or(1000.0);
+    bind_floor(&gfx, floor_hi);
+    if let Some(n) = by_id::<web_sys::HtmlInputElement>("floor-n") {
+        let _ = n.set_attribute("max", &format!("{floor_hi:.0}"));
     }
     // Push code state onto every DOM control (defeats the browser's cross-reload form restore).
     sync_controls(&gfx);
-    // Draw the per-axis distribution strips above the crop sliders.
-    if let Some(h) = server_meta.as_ref().and_then(|m| m.hist.as_ref()) {
-        draw_hist_backdrops(h);
+    // Distribution strips: per-axis crops + the cbrt intensity floor.
+    if let Some(m) = &server_meta {
+        if let Some(h) = &m.hist {
+            draw_hist_backdrops(h);
+        }
+        if let Some(ih) = &m.i_hist {
+            set_hist_svg("floor-hist", ih);
+        }
     }
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
@@ -545,6 +545,8 @@ struct MetaInfo {
     /// Per-axis density histograms `[mz, im, rt]` (each over the full axis range), for the crop
     /// distribution strips. `None` if the server didn't provide them.
     hist: Option<[Vec<u32>; 3]>,
+    /// cbrt-binned intensity distribution over `[0, p99]`, for the floor control's strip.
+    i_hist: Option<Vec<u32>>,
 }
 
 /// Derive the `/meta` URL from the `/points` URL: replace only the trailing path endpoint and keep
@@ -622,27 +624,13 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
         .filter(|x| x.is_finite() && *x >= 1.0)
         .unwrap_or(1.0);
 
-    // Optional per-axis density histograms.
+    // Optional per-axis density histograms + the intensity (floor) histogram.
     let h = jget(&v, "hist");
-    let read_u32_array = |key: &str| -> Option<Vec<u32>> {
-        let a = jget(&h, key);
-        if !a.is_object() {
-            return None;
-        }
-        let arr = js_sys::Array::from(&a);
-        if arr.length() == 0 {
-            return None;
-        }
-        Some((0..arr.length()).map(|i| arr.get(i).as_f64().unwrap_or(0.0).max(0.0) as u32).collect())
+    let hist = match (js_u32_array(&h, "mz"), js_u32_array(&h, "im"), js_u32_array(&h, "rt")) {
+        (Some(mz), Some(im), Some(rt)) => Some([mz, im, rt]),
+        _ => None,
     };
-    let hist = if h.is_object() {
-        match (read_u32_array("mz"), read_u32_array("im"), read_u32_array("rt")) {
-            (Some(mz), Some(im), Some(rt)) => Some([mz, im, rt]),
-            _ => None,
-        }
-    } else {
-        None
-    };
+    let i_hist = js_u32_array(&it, "hist");
 
     Ok(MetaInfo {
         bounds,
@@ -651,7 +639,21 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
         i_p99: pos("p99").unwrap_or(0.0),
         stride,
         hist,
+        i_hist,
     })
+}
+
+/// Read a JSON `u32` array field (`obj[key]`); `None` if absent or not a non-empty array.
+fn js_u32_array(obj: &JsValue, key: &str) -> Option<Vec<u32>> {
+    let a = jget(obj, key);
+    if !a.is_object() {
+        return None;
+    }
+    let arr = js_sys::Array::from(&a);
+    if arr.length() == 0 {
+        return None;
+    }
+    Some((0..arr.length()).map(|i| arr.get(i).as_f64().unwrap_or(0.0).max(0.0) as u32).collect())
 }
 
 /// Label for a per-axis crop: real units when `/meta` bounds are known, else a percentage.
@@ -862,6 +864,43 @@ fn bind_value(
     }
 }
 
+/// Bind the intensity-floor control with a cbrt mapping: the slider's 0..1000 position is uniform
+/// in `cbrt(intensity)` over `[0, hi]` (so the low-intensity region gets fine control), while the
+/// number field stays in real counts. Both drive `filter_min[3]`.
+fn bind_floor(gfx: &Rc<RefCell<Gfx>>, hi: f64) {
+    let (Some(slider), Some(num)) = (
+        by_id::<web_sys::HtmlInputElement>("floor"),
+        by_id::<web_sys::HtmlInputElement>("floor-n"),
+    ) else {
+        return;
+    };
+    let hi = hi.max(1.0);
+    // slider position (0..1000) -> intensity = hi * (pos/1000)^3
+    {
+        let (gfx_c, s, n) = (gfx.clone(), slider.clone(), num.clone());
+        add_listener(slider.as_ref(), "input", move |_e: web_sys::Event| {
+            let pos = (s.value_as_number() / 1000.0).clamp(0.0, 1.0);
+            let intensity = hi * pos.powi(3);
+            gfx_c.borrow_mut().params.filter_min[3] = intensity as f32;
+            n.set_value(&format!("{intensity:.0}"));
+        });
+    }
+    // typed intensity -> pos = 1000 * cbrt(intensity/hi)
+    {
+        let (gfx_c, s, n) = (gfx.clone(), slider.clone(), num.clone());
+        add_listener(num.as_ref(), "change", move |_e: web_sys::Event| {
+            let raw = n.value_as_number();
+            if raw.is_nan() {
+                return;
+            }
+            let intensity = raw.clamp(0.0, hi);
+            s.set_value(&format!("{:.0}", 1000.0 * (intensity / hi).cbrt()));
+            n.set_value(&format!("{intensity:.0}"));
+            gfx_c.borrow_mut().params.filter_min[3] = intensity as f32;
+        });
+    }
+}
+
 /// Set a slider + its number field to `v` without firing handlers (for startup sync).
 fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
     if let Some(s) = by_id::<web_sys::HtmlInputElement>(slider_id) {
@@ -984,7 +1023,7 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
     on_toggle("xf-sqrt", gfx, |g, on| if on { g.params.transfer[0] = 1.0; });
     on_toggle("xf-log", gfx, |g, on| if on { g.params.transfer[0] = 2.0; });
     bind_value(gfx, "expo", "expo-n", 2, |g, v| g.params.transfer[3] = v as f32);
-    bind_value(gfx, "floor", "floor-n", 0, |g, v| g.params.filter_min[3] = v as f32);
+    // `floor` is bound separately (cbrt-mapped) once the intensity range is known — see bind_floor.
 
     // Filters
     on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; });

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -21,7 +21,15 @@ use tims_viewer::render::annotation::{AnnotationRenderer, LineVertex};
 use tims_viewer::ticks::{fmt_tick, ticks_for, Axis, RT_MINUTES_SPAN};
 use tims_viewer::render::colormap::{sample as colormap_sample, COLORMAP_NAMES};
 use tims_viewer::render::point_cloud::{PointCloudRenderer, PointMode};
-use tims_viewer::render::uniforms::ParamsUniform;
+use tims_viewer::render::uniforms::{ParamsUniform, VolumeUniform};
+use tims_viewer::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
+
+/// Points (the splat cloud) vs Volume (raymarched density grid).
+#[derive(Clone, Copy, PartialEq)]
+enum ViewMode {
+    Points,
+    Volume,
+}
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 const CANVAS_ID: &str = "tims-canvas";
@@ -101,6 +109,17 @@ struct Gfx {
     /// Whether the projection maps reflect the current view (valid grids drawn); box-select is gated
     /// on it so a drag never focuses against stale/blank maps.
     maps_ok: bool,
+    // ---- volume rendering (VOLUME_WEB_IDEA.md) ----
+    view_mode: ViewMode,
+    /// The raymarcher; `None` when the GPU can't host a 256³-ish 3D R16Float texture.
+    volume: Option<VolumeRenderer>,
+    /// CPU density grid, allocated on first volume use; rebuilt from `cpu_points` when stale.
+    vol_grid: Option<VolumeGrid>,
+    /// Rebuild the grid from `cpu_points` (set on load and MS-mask change).
+    vol_needs_grid: bool,
+    /// Raymarch samples; composite (0) vs max-intensity-projection (1).
+    vol_steps: u32,
+    vol_style: u32,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -146,6 +165,51 @@ impl Gfx {
         }
     }
 
+    /// Rebuild the density grid from `cpu_points` if stale, upload it, and refresh the volume
+    /// uniform for this frame. No-op when volume is unsupported.
+    fn ensure_volume(&mut self, aspect: f32) {
+        if self.volume.is_none() {
+            return;
+        }
+        if self.vol_grid.is_none() {
+            self.vol_grid = Some(VolumeGrid::new(VOLUME_DIMS));
+            self.vol_needs_grid = true;
+        }
+        let grid = self.vol_grid.as_mut().unwrap();
+        if self.vol_needs_grid {
+            // Density of all resident points, filtered by the current MS mask (the spatial crop is
+            // applied in the shader via box_min/max). Deposit intensity*weight so the density is
+            // independent of the downsample ratio.
+            grid.clear();
+            let ms = self.params.ms_mask;
+            for pt in &self.cpu_points {
+                let is_ms2 = pt.flags & GpuPoint::MS2_FLAG != 0;
+                if if is_ms2 { ms & 0b10 != 0 } else { ms & 0b01 != 0 } {
+                    grid.deposit(pt.pos, pt.intensity * pt.weight);
+                }
+            }
+            self.volume.as_ref().unwrap().upload(&self.queue, grid.to_f16_scaled());
+            self.vol_needs_grid = false;
+            show_status(""); // clear the "building volume…" notice
+        }
+        let p = &self.params;
+        let inv = self.camera.view_proj(aspect).inverse().to_cols_array_2d();
+        let vu = VolumeUniform {
+            inv_view_proj: inv,
+            box_min: [p.filter_min[0], p.filter_min[1], p.filter_min[2], 0.0],
+            box_max: [p.filter_max[0], p.filter_max[1], p.filter_max[2], 0.0],
+            transfer: p.transfer,
+            steps: self.vol_steps.max(1),
+            style: self.vol_style,
+            colormap_id: p.colormap_id,
+            n_colormaps: p.n_colormaps.max(1),
+            density_scale: grid.density_scale(),
+            focus: 0.0,
+            _pad: [0.0; 2],
+        };
+        self.volume.as_ref().unwrap().update_uniform(&self.queue, &vu);
+    }
+
     /// Render one frame. `now` is the RAF timestamp (ms). Returns `false` if the loop should stop.
     fn frame(&mut self, now: f64) -> bool {
         // Smoothed FPS, pushed to the HUD a few times a second.
@@ -184,7 +248,12 @@ impl Gfx {
         self.renderer.update_camera(&self.queue, &cam);
         self.axes.update_camera(&self.queue, &cam);
         self.update_labels(w / h);
-        self.renderer.update_params(&self.queue, &self.params);
+        let volume_view = self.view_mode == ViewMode::Volume && self.volume.is_some();
+        if volume_view {
+            self.ensure_volume(w / h);
+        } else {
+            self.renderer.update_params(&self.queue, &self.params);
+        }
 
         let surface_tex = match self.surface.get_current_texture() {
             Ok(t) => t,
@@ -203,7 +272,9 @@ impl Gfx {
         };
         let view = surface_tex.texture.create_view(&Default::default());
         let mut enc = self.device.create_command_encoder(&Default::default());
-        self.renderer.prepare(&self.queue, &mut enc);
+        if !volume_view {
+            self.renderer.prepare(&self.queue, &mut enc);
+        }
         {
             let mut rpass = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("scene"),
@@ -231,7 +302,11 @@ impl Gfx {
                 timestamp_writes: None,
                 occlusion_query_set: None,
             });
-            self.renderer.render(&mut rpass, self.point_mode);
+            if volume_view {
+                self.volume.as_ref().unwrap().render(&mut rpass);
+            } else {
+                self.renderer.render(&mut rpass, self.point_mode);
+            }
             self.axes.render(&mut rpass);
         }
         self.queue.submit(std::iter::once(enc.finish()));
@@ -345,6 +420,18 @@ async fn run() -> Result<(), String> {
     // true, so the first frame fills it).
     log::info!("uploaded {n} points (compaction: {supports_compaction})");
 
+    // Volume raymarcher, if the GPU can host the 3D R16Float density texture.
+    let vol_max = *VOLUME_DIMS.iter().max().unwrap();
+    let volume = if device.limits().max_texture_dimension_3d >= vol_max {
+        Some(VolumeRenderer::new(&device, &queue, format, DEPTH_FORMAT, VOLUME_DIMS))
+    } else {
+        log::warn!(
+            "volume disabled: max_texture_dimension_3d {} < {vol_max}",
+            device.limits().max_texture_dimension_3d
+        );
+        None
+    };
+
     // Native-matching defaults: MS1-only, sqrt transfer, additive density. When the server gave
     // intensity percentiles, auto-expose so the cloud isn't blown out (mirrors the native viewer).
     let mut params = ParamsUniform::default();
@@ -397,6 +484,12 @@ async fn run() -> Result<(), String> {
             .map(|b| vec![(Region { mz: b[0], im: b[1], rt: b[2], imin: 0.0 }, None)])
             .unwrap_or_default(),
         maps_ok: false, // set by the initial render_maps below
+        view_mode: ViewMode::Points,
+        volume,
+        vol_grid: None,
+        vol_needs_grid: true,
+        vol_steps: 256,
+        vol_style: 0,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -430,6 +523,8 @@ async fn run() -> Result<(), String> {
     bind_focus(&gfx);
     // 2D projection minimaps: drag a box to focus a region.
     bind_maps(&gfx);
+    // Points/Volume view mode + volume controls.
+    bind_volume(&gfx);
     // Collapsible section headers + tab switching.
     bind_panel_chrome();
 
@@ -954,6 +1049,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         let mut cpu = pts;
         cpu.truncate(cap as usize);
         g.cpu_points = cpu;
+        g.vol_needs_grid = true; // the volume density grid is rebuilt from the new points
         // Re-apply auto-transfer (exposure + floor range) and bounds from the new meta; keep the
         // user's colormap / point size / opacity / MS mask.
         if let Some(m) = &meta {
@@ -1196,6 +1292,39 @@ fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
             String::new()
         },
     );
+}
+
+/// Toggle the `volmode` body class (reveals the volume-only controls).
+fn set_volmode(on: bool) {
+    if let Some(body) = document().and_then(|d| d.body()) {
+        let _ = body.class_list().toggle_with_force("volmode", on);
+    }
+}
+
+/// Wire the Points/Volume view-mode toggle + volume controls (style, steps). Disables Volume when
+/// the GPU can't host the 3D density texture.
+fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
+    if gfx.borrow().volume.is_none() {
+        set_disabled("v-vol", true);
+        return; // leave Points selected; volume unsupported on this GPU
+    }
+    on_toggle("v-pts", gfx, |g, on| {
+        if on {
+            g.view_mode = ViewMode::Points;
+            set_volmode(false);
+        }
+    });
+    on_toggle("v-vol", gfx, |g, on| {
+        if on {
+            g.view_mode = ViewMode::Volume;
+            g.vol_needs_grid = true;
+            set_volmode(true);
+            show_status("building volume…");
+        }
+    });
+    on_toggle("vs-comp", gfx, |g, on| if on { g.vol_style = 0 });
+    on_toggle("vs-mip", gfx, |g, on| if on { g.vol_style = 1 });
+    bind_value(gfx, "vsteps", "vsteps-n", 0, |g, v| g.vol_steps = (v as u32).max(1));
 }
 
 /// Wire the Focus / Back buttons; control enable/disable is driven by `refresh_controls`.
@@ -1814,9 +1943,9 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
     });
 
     // Filters
-    on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; g.filter_dirty = true; });
-    on_toggle("ms-2", gfx, |g, on| if on { g.params.ms_mask = 0b10; g.filter_dirty = true; });
-    on_toggle("ms-b", gfx, |g, on| if on { g.params.ms_mask = 0b11; g.filter_dirty = true; });
+    on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; g.filter_dirty = true; g.vol_needs_grid = true; });
+    on_toggle("ms-2", gfx, |g, on| if on { g.params.ms_mask = 0b10; g.filter_dirty = true; g.vol_needs_grid = true; });
+    on_toggle("ms-b", gfx, |g, on| if on { g.params.ms_mask = 0b11; g.filter_dirty = true; g.vol_needs_grid = true; });
     bind_crop(gfx, "cmz", 0);
     bind_crop(gfx, "cim", 1);
     bind_crop(gfx, "crt", 2);

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -25,9 +25,9 @@ use tims_viewer::render::point_cloud::{PointCloudRenderer, PointMode};
 use tims_viewer::render::uniforms::{ParamsUniform, VolumeUniform};
 use tims_viewer::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
 
-/// Max points DBSCAN runs on in the browser (it blocks the main thread). Beyond this, Focus a region
-/// first. Mirrors the native CLUSTER_CAP.
-const CLUSTER_CAP: usize = 2_000_000;
+/// Max points DBSCAN runs on (the in-wasm worker, or the Python service). Beyond this, Focus a region
+/// first. Large runs go to the off-main-thread worker with a progress bar.
+const CLUSTER_CAP: usize = 6_000_000;
 
 /// Below this many filtered points, DBSCAN runs on the main thread (instant, no worker spin-up);
 /// at/above it, the off-main-thread worker is used so the tab doesn't freeze.

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -185,7 +185,11 @@ impl Gfx {
             // independent of the downsample ratio.
             grid.clear();
             let ms = self.params.ms_mask;
+            let floor = self.params.filter_min[3]; // intensity floor: dim points don't deposit
             for pt in &self.cpu_points {
+                if pt.intensity < floor {
+                    continue;
+                }
                 let is_ms2 = pt.flags & GpuPoint::MS2_FLAG != 0;
                 if if is_ms2 { ms & 0b10 != 0 } else { ms & 0b01 != 0 } {
                     grid.deposit(pt.pos, pt.intensity * pt.weight);
@@ -1336,6 +1340,16 @@ fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
     on_toggle("vs-comp", gfx, |g, on| if on { g.vol_style = 0 });
     on_toggle("vs-mip", gfx, |g, on| if on { g.vol_style = 1 });
     bind_value(gfx, "vsteps", "vsteps-n", 0, |g, v| g.vol_steps = (v as u32).max(1));
+    // The intensity floor feeds the volume deposit; rebuild when it SETTLES (slider release /
+    // number commit), not on every drag tick — a rebuild is O(resident) and would lag a drag.
+    for id in ["floor", "floor-n"] {
+        if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+            let gfx = gfx.clone();
+            add_listener(inp.as_ref(), "change", move |_e: web_sys::Event| {
+                gfx.borrow_mut().vol_needs_grid = true;
+            });
+        }
+    }
 }
 
 /// Wire the Focus / Back buttons; control enable/disable is driven by `refresh_controls`.

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -130,7 +130,14 @@ const ACQ_LOOKAHEAD: usize = 128;
 /// wasm entry point — Trunk/wasm-bindgen call this on load.
 #[wasm_bindgen(start)]
 pub fn start() {
-    console_error_panic_hook::set_once();
+    // Custom panic hook: keep the console output AND forward the panic to the server's /telemetry
+    // (PROD only, gated on TELEMETRY_ON once /clientconfig confirms it's enabled — no-op in dev).
+    std::panic::set_hook(Box::new(|info| {
+        console_error_panic_hook::hook(info);
+        if TELEMETRY_ON.load(std::sync::atomic::Ordering::Relaxed) {
+            fire_event("/telemetry", telemetry_json("wasm-panic", &info.to_string()));
+        }
+    }));
     // Off the main thread (the clustering Web Worker re-inits this same wasm) there is no DOM —
     // `window()` is None. Skip the renderer; the worker only calls `cluster_dbscan_flat`.
     if web_sys::window().is_none() {
@@ -143,6 +150,138 @@ pub fn start() {
             show_status(&format!("tims-viewer could not start: {e}"));
         }
     });
+    // Probe /clientconfig; wire error forwarding + the feedback widget only if the server enabled them.
+    wasm_bindgen_futures::spawn_local(init_telemetry_and_feedback());
+}
+
+static TELEMETRY_ON: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Server origin for the /clientconfig, /telemetry and /feedback endpoints — the /points base
+/// with the trailing `/points` stripped (they live on the same point server).
+fn server_base() -> String {
+    let b = points_base_url();
+    b.strip_suffix("/points").map(str::to_string).unwrap_or(b)
+}
+
+/// Minimal JSON string encoder (escape quotes/backslashes/controls), so we can hand-build event
+/// bodies without pulling in serde on the wasm side.
+fn json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// A telemetry event body: kind + message + light context (dataset, page URL, user agent).
+fn telemetry_json(kind: &str, message: &str) -> String {
+    let ds = dataset_id();
+    let win = web_sys::window();
+    let ua = win.as_ref().map(|w| w.navigator().user_agent().unwrap_or_default()).unwrap_or_default();
+    let href = win.and_then(|w| w.location().href().ok()).unwrap_or_default();
+    format!(
+        "{{\"kind\":{},\"message\":{},\"dataset\":{ds},\"url\":{},\"ua\":{}}}",
+        json_str(kind), json_str(message), json_str(&href), json_str(&ua)
+    )
+}
+
+/// Fire-and-forget POST of a JSON body to a same-server endpoint. A plain-string body stays a CORS
+/// "simple request" (no preflight); failures (e.g. telemetry disabled -> 404) are ignored on purpose.
+fn fire_event(path: &str, body: String) {
+    let Some(window) = web_sys::window() else { return };
+    let url = format!("{}{path}", server_base());
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_body(&wasm_bindgen::JsValue::from_str(&body));
+    let _ = window.fetch_with_str_and_init(&url, &opts);
+}
+
+/// Ask the server (GET /clientconfig) whether error telemetry + the feedback widget are enabled
+/// (PROD only), and wire them if so. In dev the endpoint 404s / returns false and this is a no-op.
+async fn init_telemetry_and_feedback() {
+    let Some(window) = web_sys::window() else { return };
+    let url = format!("{}/clientconfig", server_base());
+    let Ok(resp_val) = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&url)).await else { return };
+    let Ok(resp) = resp_val.dyn_into::<web_sys::Response>() else { return };
+    if !resp.ok() { return; }
+    let Ok(text_promise) = resp.text() else { return };
+    let Ok(text_val) = wasm_bindgen_futures::JsFuture::from(text_promise).await else { return };
+    let Some(text) = text_val.as_string() else { return };
+    let Ok(v) = js_sys::JSON::parse(&text) else { return };
+    if jget(&v, "telemetry").as_bool().unwrap_or(false) {
+        TELEMETRY_ON.store(true, std::sync::atomic::Ordering::Relaxed);
+        install_error_listeners();
+        log::info!("error telemetry enabled -> {}/telemetry", server_base());
+    }
+    if jget(&v, "feedback").as_bool().unwrap_or(false) {
+        set_body_class("feedback-on", true); // reveals the 💬 button (hidden by default)
+        wire_feedback_ui();
+    }
+}
+
+/// Forward uncaught JS errors + unhandled promise rejections to /telemetry (wasm panics go via the
+/// panic hook). Only installed when telemetry is enabled.
+fn install_error_listeners() {
+    let Some(window) = web_sys::window() else { return };
+    let on_err = Closure::wrap(Box::new(move |e: web_sys::Event| {
+        let msg = e
+            .dyn_ref::<web_sys::ErrorEvent>()
+            .map(|ee| ee.message())
+            .unwrap_or_else(|| "js error".to_string());
+        fire_event("/telemetry", telemetry_json("js-error", &msg));
+    }) as Box<dyn FnMut(web_sys::Event)>);
+    let _ = window.add_event_listener_with_callback("error", on_err.as_ref().unchecked_ref());
+    on_err.forget();
+    let on_rej = Closure::wrap(Box::new(move |_e: web_sys::Event| {
+        fire_event("/telemetry", telemetry_json("unhandledrejection", "unhandled promise rejection"));
+    }) as Box<dyn FnMut(web_sys::Event)>);
+    let _ = window.add_event_listener_with_callback("unhandledrejection", on_rej.as_ref().unchecked_ref());
+    on_rej.forget();
+}
+
+/// Wire the feedback widget: open/close the panel and POST the form to /feedback with light context.
+fn wire_feedback_ui() {
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("feedback-open") {
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| set_body_class("feedback-open", true));
+    }
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("feedback-cancel") {
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| set_body_class("feedback-open", false));
+    }
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("feedback-send") {
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| submit_feedback());
+    }
+}
+
+fn submit_feedback() {
+    let kind = by_id::<web_sys::HtmlSelectElement>("feedback-type").map(|s| s.value()).unwrap_or_default();
+    let text = by_id::<web_sys::HtmlTextAreaElement>("feedback-text").map(|t| t.value()).unwrap_or_default();
+    let email = by_id::<web_sys::HtmlInputElement>("feedback-email").map(|i| i.value()).unwrap_or_default();
+    if text.trim().is_empty() {
+        set_text("feedback-status", "please enter a message");
+        return;
+    }
+    let ds = dataset_id();
+    let backend = by_id::<web_sys::HtmlElement>("hud-backend").map(|e| e.inner_text()).unwrap_or_default();
+    let body = format!(
+        "{{\"type\":{},\"text\":{},\"email\":{},\"dataset\":{ds},\"backend\":{}}}",
+        json_str(&kind), json_str(&text), json_str(&email), json_str(&backend)
+    );
+    fire_event("/feedback", body);
+    if let Some(t) = by_id::<web_sys::HtmlTextAreaElement>("feedback-text") {
+        t.set_value("");
+    }
+    set_body_class("feedback-open", false);
+    show_status("thanks — your feedback was sent");
 }
 
 /// DBSCAN over a flat `[x,y,z, x,y,z, …]` buffer, returning per-point labels (`-1` = noise). The

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -287,9 +287,14 @@ struct Gfx {
     cluster_sel: Option<i32>,
     /// When clustered + colouring, hide the un-clustered (noise) points (color_mode 2 vs 1).
     hide_noise: bool,
-    /// Acquisition-playback metadata from the sidecar's `/acq/meta` (None = no sidecar). Drives the
-    /// (next-slice) live playback engine; populated by the startup probe.
+    /// Acquisition-playback metadata from the sidecar's `/acq/meta` (None = no sidecar). Populated by
+    /// the startup probe; drives the live playback engine.
     acq_meta: Option<AcqMeta>,
+    /// Live-acquisition playback state. `acq_playing` gates the async play-loop; `acq_cursor` is the
+    /// next frame index to fetch; `acq_speed` multiplies the real device cadence.
+    acq_playing: bool,
+    acq_cursor: u32,
+    acq_speed: f64,
     /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
     /// the startup probe when the service is reachable; toggleable in the Cluster tab.
     use_python_cluster: bool,
@@ -739,6 +744,9 @@ async fn run() -> Result<(), String> {
         cluster_sel: None,
         hide_noise: false,
         acq_meta: None,
+        acq_playing: false,
+        acq_cursor: 0,
+        acq_speed: 20.0, // chunk-1 default: lively build-up (no speed slider yet; ~fetch-limited)
         dataset_name: String::new(),
         dataset_id: dataset_id(), // raw URL value; clamped to the registry by populate_datasets
         use_python_cluster: false,
@@ -792,8 +800,12 @@ async fn run() -> Result<(), String> {
     bind_windows(&gfx);
     // Probe the Python clustering service; auto-enable the backend toggle if it's up.
     wasm_bindgen_futures::spawn_local(probe_cluster_service(gfx.clone()));
-    // Probe the acquisition sidecar; stash /acq/meta for the (next-slice) live playback engine.
+    // Probe the acquisition sidecar; reveals the Live-acquisition control if it's up.
     wasm_bindgen_futures::spawn_local(probe_acq_service(gfx.clone()));
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("acq-play") {
+        let gfx = gfx.clone();
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| toggle_acquisition(&gfx));
+    }
     // ① Data: fill the meta summary now (points/ranges/cycle); the dataset name arrives via /datasets.
     fill_data_summary(server_meta.as_ref());
     wasm_bindgen_futures::spawn_local(populate_datasets(gfx.clone()));
@@ -1098,8 +1110,7 @@ async fn fetch_acq_meta(base: &str) -> Option<AcqMeta> {
 
 /// Fetch `<base>/acq/frame?id=N` (24-byte/peak records) and build normalized `GpuPoint`s:
 /// `_pad[0]` = peptide_id (color key), `flags` bit0 = fragment. `id` is a 0-based frame INDEX
-/// (`0..n_frames`). Wired by the playback engine (next slice).
-#[allow(dead_code)]
+/// (`0..n_frames`). Used by the playback loop.
 async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoint>, String> {
     let window = web_sys::window().ok_or("no window")?;
     let resp_val = wasm_bindgen_futures::JsFuture::from(
@@ -1139,6 +1150,124 @@ async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoin
     Ok(pts)
 }
 
+/// Await `ms` milliseconds (wasm has no blocking sleep): a `setTimeout`-backed Promise.
+async fn sleep_ms(ms: i32) {
+    let Some(window) = web_sys::window() else { return };
+    let p = js_sys::Promise::new(&mut |resolve, _reject| {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms.max(0));
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+}
+
+/// Enter live-acquisition playback: clear the cloud, colour by peptide id (`_pad[0]`), and start the
+/// async play-loop. Toggling again stops it. (Re-uses the cluster-colour shader path; the cube bounds
+/// stay as-is for now — points are already normalized to the acq ranges by `fetch_acq_frame`.)
+fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
+    let start = {
+        let g = &mut *gfx.borrow_mut();
+        if g.acq_meta.is_none() {
+            return;
+        }
+        g.acq_playing = !g.acq_playing;
+        if g.acq_playing {
+            // Re-create the buffer at the full GPU capacity: the initial buffer was sized to the
+            // loaded (or demo) cloud, which would fill in a few frames as acquisition accumulates.
+            let cap = g.n_cap.max(1) as u32;
+            g.renderer =
+                PointCloudRenderer::new(&g.device, &g.queue, g.config.format, DEPTH_FORMAT, cap, g.supports_compaction);
+            g.renderer.set_draw_count(u32::MAX);
+            g.cpu_points.clear(); // acquisition drives the GPU buffer directly
+            g.params.color_mode = 3; // colour by _pad[0] = peptide_id + size-by-intensity (acq shader path)
+            g.params.ms_mask = 0b11; // show BOTH MS1 (precursors) and MS2 (fragments) — the whole point
+            // Intensity transfer so faint peaks shrink/recede: sqrt over [1, i_p99].
+            let i_p99 = g.acq_meta.as_ref().map(|m| m.i_p99.max(2.0)).unwrap_or(1000.0);
+            g.params.transfer = [1.0, 1.0, i_p99, 1.0];
+            g.acq_cursor = 0;
+            g.filter_dirty = true;
+        }
+        g.acq_playing
+    };
+    set_body_class("cluster-color", start); // the intensity colorbar is meaningless while peptide-coloured
+    set_text("acq-play", if start { "⏸ Stop playback" } else { "▶ Live acquisition" });
+    if start {
+        wasm_bindgen_futures::spawn_local(play_loop(gfx.clone()));
+    }
+}
+
+/// The async playback loop: fetch the cursor's frame, append it, advance, sleep one (speed-scaled)
+/// device cadence, repeat — until stopped or the run ends. No prefetch ring yet, so dense frames play
+/// "build-limited" (slower than real time); that's the accepted v1 behaviour.
+async fn play_loop(gfx: Rc<RefCell<Gfx>>) {
+    let base = acq_service_url();
+    let mut errors = 0u32;
+    loop {
+        // Snapshot the run state without holding the borrow across the await.
+        let snap = {
+            let g = gfx.borrow();
+            match g.acq_meta.clone() {
+                Some(m) if g.acq_playing && g.acq_cursor < m.n_frames => {
+                    Some((m, g.acq_cursor, g.acq_speed.max(0.05)))
+                }
+                _ => None,
+            }
+        };
+        let Some((meta, cursor, speed)) = snap else {
+            // Stopped, or ran off the end — settle the UI and exit.
+            let done = {
+                let g = gfx.borrow();
+                g.acq_meta.as_ref().is_some_and(|m| g.acq_cursor >= m.n_frames)
+            };
+            if done {
+                gfx.borrow_mut().acq_playing = false;
+                set_text("acq-play", "▶ Live acquisition");
+                show_status("acquisition complete");
+            }
+            return;
+        };
+        match fetch_acq_frame(&base, cursor, &meta).await {
+            Ok(pts) => {
+                errors = 0;
+                let resident = {
+                    let g = &mut *gfx.borrow_mut();
+                    if !g.acq_playing {
+                        return; // stopped while the fetch was in flight
+                    }
+                    if !pts.is_empty() {
+                        g.renderer.append(&g.queue, &pts);
+                        g.renderer.set_draw_count(u32::MAX);
+                        g.filter_dirty = true;
+                    }
+                    g.acq_cursor = cursor + 1;
+                    g.renderer.resident()
+                };
+                // Live readout (doubles as a timeline until chunk 2's scrubber); also overwrites the
+                // stale "demo cloud" status.
+                show_status(&format!(
+                    "▶ frame {} / {} · RT {:.0}s · {} pts",
+                    cursor + 1,
+                    meta.n_frames,
+                    (cursor as f64 + 1.0) * meta.rt_cycle_length,
+                    group_short(resident as usize),
+                ));
+            }
+            Err(e) => {
+                // Skip a bad/transient frame rather than killing the whole run; bail only if it's
+                // clearly broken (many in a row).
+                errors += 1;
+                log::warn!("acq frame {cursor} failed ({e}); skipping");
+                if errors > 8 {
+                    show_status("acquisition stopped (repeated frame errors)");
+                    gfx.borrow_mut().acq_playing = false;
+                    set_text("acq-play", "▶ Live acquisition");
+                    return;
+                }
+                gfx.borrow_mut().acq_cursor = cursor + 1;
+            }
+        }
+        sleep_ms((meta.rt_cycle_length * 1000.0 / speed) as i32).await;
+    }
+}
+
 /// Probe the acquisition sidecar (GET its health route); on success stash `/acq/meta` on `Gfx` so the
 /// playback engine (next slice) can offer "Live acquisition" mode.
 async fn probe_acq_service(gfx: Rc<RefCell<Gfx>>) {
@@ -1175,6 +1304,10 @@ async fn probe_acq_service(gfx: Rc<RefCell<Gfx>>) {
             meta.n_frames, meta.rt_cycle_length, meta.mz.min, meta.mz.max, meta.im.min, meta.im.max
         );
         gfx.borrow_mut().acq_meta = Some(meta);
+        // Reveal the Live-acquisition control now that the sidecar is confirmed.
+        if let Some(row) = by_id::<web_sys::HtmlElement>("acq-row") {
+            let _ = row.style().set_property("display", "flex");
+        }
     }
 }
 

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -37,6 +37,10 @@ const WORKER_THRESHOLD: usize = 300_000;
 /// RT is scaled so a cluster's elution stays connected across cycles regardless of the RT zoom.
 const CLUSTER_RT_CYCLES: f64 = 2.0;
 
+/// Hard ceiling on points loaded into the (32-bit) wasm heap, regardless of the server `--budget` or
+/// the GPU buffer limit: ~32M × 32 B ≈ 1 GB resident, well clear of the ~4 GB wasm address space.
+const MAX_WEB_POINTS: usize = 32_000_000;
+
 /// RT slices each DIA window footprint is drawn at (mirrors the native loader's `DIA_WINDOW_RT_SLICES`,
 /// which lives in the native-only loader module).
 const DIA_WINDOW_RT_SLICES: usize = 6;
@@ -502,12 +506,17 @@ async fn run() -> Result<(), String> {
     // Phase 2: stream real (or server-side DEMO) points from the tims-viewer point server; fall
     // back to a synthetic cloud so the page still works standalone.
     let url = points_url();
+    // Cap the request to what the GPU buffer can hold AND a wasm-memory-safe ceiling: the initial
+    // load must request `n=n_cap`, or a large server `--budget` (e.g. 90M pts ≈ 2.9 GB) is fetched
+    // whole into the 32-bit wasm heap and OOMs before the later GPU-cap clamp — a black screen.
+    let n_cap = gpu_point_cap(&device, supports_compaction).min(MAX_WEB_POINTS);
+    let initial = with_query(&url, &format!("n={n_cap}"));
     // Fetch /meta first to validate the wire contract and pick up real-unit axis/intensity ranges,
     // then the binary points; fall back to a synthetic cloud if the server is absent/incompatible.
     let mut axis_bounds: Option<[(f64, f64); 3]> = None;
     let mut server_meta: Option<MetaInfo> = None;
-    let (pts, is_demo_fallback) = match fetch_meta(&meta_url(&url)).await {
-        Ok(m) => match fetch_points(&url).await {
+    let (pts, is_demo_fallback) = match fetch_meta(&meta_url(&initial)).await {
+        Ok(m) => match fetch_points(&initial).await {
             Ok(p) if !p.is_empty() => {
                 axis_bounds = m.bounds;
                 server_meta = Some(m);
@@ -529,9 +538,7 @@ async fn run() -> Result<(), String> {
             (demo_cloud(), true)
         }
     };
-    // Cap to what the GPU buffer can hold (master is a vertex+storage buffer): on a 12M budget
-    // = 384 MB, clamp to the device's max so the allocation can't fail.
-    let n_cap = gpu_point_cap(&device, supports_compaction);
+    // `n_cap` (computed above, before the fetch) already bounds the request; clamp the buffer too.
     let capacity = pts.len().min(n_cap).max(1) as u32;
     if (capacity as usize) < pts.len() {
         log::warn!("capping {} -> {capacity} points (GPU buffer limit {} MB)",

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1446,12 +1446,21 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         return;
     }
     show_status("clustering…");
-    let (labels, k) = dbscan(&positions, eps, min_pts);
+    // Defer the (synchronous, blocking) DBSCAN one macrotask so the "clustering…" status paints
+    // first — otherwise the tab freezes with no feedback.
+    let gfx = gfx.clone();
+    defer(move || {
+        let (labels, k) = dbscan(&positions, eps, min_pts);
+        finish_clustering(&gfx, &idx, &labels, k);
+    });
+}
+
+/// Write DBSCAN labels into the GPU buffer + recolor by cluster, then update the UI.
+fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: usize) {
     let noise = labels.iter().filter(|&&l| l < 0).count();
     {
         let mut gb = gfx.borrow_mut();
         let g: &mut Gfx = &mut gb; // &mut Gfx so renderer/queue/cpu_points field-split
-        // Clear all ids, then write the survivors' labels (noise stays NO_CLUSTER).
         for pt in g.cpu_points.iter_mut() {
             pt._pad[0] = GpuPoint::NO_CLUSTER;
         }
@@ -1460,7 +1469,6 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
                 g.cpu_points[i]._pad[0] = labels[j] as u32;
             }
         }
-        // Take the points out so renderer (mut) and the points (shared) don't overlap.
         let pts = std::mem::take(&mut g.cpu_points);
         g.renderer.reset();
         g.renderer.append(&g.queue, &pts);
@@ -1470,7 +1478,6 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         g.view_mode = ViewMode::Points; // cluster colour is a point concept
         g.filter_dirty = true; // refresh the displayed-count HUD
     }
-
     set_checked("v-pts", true);
     set_checked("v-vol", false);
     set_volmode(false);
@@ -1482,10 +1489,18 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     show_status("");
 }
 
+/// Run a closure on the next macrotask (after a browser paint) via `setTimeout(0)`.
+fn defer<F: FnOnce() + 'static>(f: F) {
+    let cb = wasm_bindgen::closure::Closure::once_into_js(f);
+    if let Some(w) = web_sys::window() {
+        let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 0);
+    }
+}
+
 /// Wire the Cluster tab: eps / min-pts, Run, and the Color-by-cluster toggle.
 fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-eps", "cl-eps-n", 3, |g, v| g.cluster_eps = v as f32);
-    bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(1));
+    bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(2));
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-run") {
         let gfx = gfx.clone();
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| run_clustering(&gfx));
@@ -2007,7 +2022,7 @@ fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
 /// actual params (a checked-but-stale radio won't emit `change` when clicked); calling this after
 /// wiring re-asserts the truth so the panel always reflects what's rendering.
 fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
-    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor) = {
+    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min) = {
         let g = gfx.borrow();
         (
             g.auto_rotate,
@@ -2019,6 +2034,8 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
             g.params.opacity as f64,
             g.params.transfer[3] as f64,
             g.params.filter_min[3] as f64,
+            g.cluster_eps as f64,
+            g.cluster_min_pts as f64,
         )
     };
     set_checked("ar", auto);
@@ -2038,6 +2055,10 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_value_pair("opac", "opac-n", opac, 2);
     set_value_pair("expo", "expo-n", expo, 2);
     set_value_pair("floor", "floor-n", floor, 0);
+    // Cluster controls (defeat browser form-restore; no result yet, so colour off).
+    set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
+    set_value_pair("cl-min", "cl-min-n", cl_min, 0);
+    set_checked("cl-color", false);
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);
 }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -765,6 +765,8 @@ async fn run() -> Result<(), String> {
     bind_windows(&gfx);
     // Probe the Python clustering service; auto-enable the backend toggle if it's up.
     wasm_bindgen_futures::spawn_local(probe_cluster_service(gfx.clone()));
+    // Populate the dataset picker (reveals it only when the server offers more than one).
+    wasm_bindgen_futures::spawn_local(populate_datasets());
     // Collapsible section headers + tab switching.
     bind_panel_chrome(&gfx);
 
@@ -927,9 +929,27 @@ fn show_status(msg: &str) {
     }
 }
 
-/// The point-server URL. `?points=<url>` overrides it outright (for proxied/same-origin
-/// deploys); else `?port=N` selects `http://localhost:N/points`; else [`DEFAULT_SERVER_PORT`].
+/// Selected dataset id from `?dataset=N` (default 0). The frontend switches datasets by reloading
+/// the page with this param, so a fresh `run()` re-inits cleanly for the new dataset.
+fn dataset_id() -> usize {
+    web_sys::window()
+        .and_then(|w| w.location().search().ok())
+        .unwrap_or_default()
+        .trim_start_matches('?')
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("dataset=").and_then(|v| v.parse::<usize>().ok()))
+        .unwrap_or(0)
+}
+
+/// The point-server `/points` URL for the selected dataset (base + `?dataset=N`). `/meta` inherits
+/// the query via `meta_url`; `/windows` re-appends it.
 fn points_url() -> String {
+    with_query(&points_base_url(), &format!("dataset={}", dataset_id()))
+}
+
+/// The point-server base URL. `?points=<url>` overrides it outright (for proxied/same-origin
+/// deploys); else `?port=N` selects `http://localhost:N/points`; else [`DEFAULT_SERVER_PORT`].
+fn points_base_url() -> String {
     let search = web_sys::window()
         .and_then(|w| w.location().search().ok())
         .unwrap_or_default();
@@ -1131,12 +1151,93 @@ fn meta_url(points: &str) -> String {
     }
 }
 
-/// The run-level `/windows` URL (strip the `/points` query — windows are region-independent).
+/// The run-level `/windows` URL (region-independent, but per-dataset: re-append `?dataset=N`).
 fn windows_url(points: &str) -> String {
     let path = points.split('?').next().unwrap_or(points);
-    path.strip_suffix("/points")
+    let base = path
+        .strip_suffix("/points")
         .map(|base| format!("{base}/windows"))
+        .unwrap_or_else(|| path.to_string());
+    with_query(&base, &format!("dataset={}", dataset_id()))
+}
+
+/// The `/datasets` registry URL (derived from the points base; dataset-independent).
+fn datasets_url() -> String {
+    let base = points_base_url();
+    let path = base.split('?').next().unwrap_or(&base);
+    path.strip_suffix("/points")
+        .map(|b| format!("{b}/datasets"))
         .unwrap_or_else(|| path.to_string())
+}
+
+/// Switch the active dataset by reloading the page with `?dataset=N` — a fresh `run()` re-inits the
+/// scene (camera, focus, clusters, bounds) cleanly for the new dataset.
+fn switch_dataset(id: usize) {
+    let Some(w) = web_sys::window() else { return };
+    let loc = w.location();
+    let search = loc.search().unwrap_or_default();
+    let mut parts: Vec<String> = search
+        .trim_start_matches('?')
+        .split('&')
+        .filter(|kv| !kv.is_empty() && !kv.starts_with("dataset="))
+        .map(|s| s.to_string())
+        .collect();
+    parts.push(format!("dataset={id}"));
+    let _ = loc.set_search(&parts.join("&")); // navigates -> fresh load for the new dataset
+}
+
+/// Fetch the dataset registry; if more than one, reveal + populate the header picker (selecting one
+/// reloads with `?dataset=N`). Silent no-op when the server is absent or offers a single dataset.
+async fn populate_datasets() {
+    let Some(window) = web_sys::window() else { return };
+    let Some(doc) = window.document() else { return };
+    let resp_val = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&datasets_url())).await
+    {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let Ok(resp) = resp_val.dyn_into::<web_sys::Response>() else { return };
+    if !resp.ok() {
+        return;
+    }
+    let text = match resp.text() {
+        Ok(p) => match wasm_bindgen_futures::JsFuture::from(p).await {
+            Ok(t) => t.as_string().unwrap_or_default(),
+            Err(_) => return,
+        },
+        Err(_) => return,
+    };
+    let Ok(v) = js_sys::JSON::parse(&text) else { return };
+    let arr = js_sys::Array::from(&v);
+    if arr.length() <= 1 {
+        return; // nothing to choose between
+    }
+    let Some(sel) = by_id::<web_sys::HtmlSelectElement>("dataset-sel") else { return };
+    sel.set_inner_html("");
+    let cur = dataset_id();
+    for i in 0..arr.length() {
+        let item = arr.get(i);
+        let id = jnum(&item, "id").unwrap_or(i as f64) as usize;
+        let name = jget(&item, "name").as_string().unwrap_or_else(|| format!("dataset {id}"));
+        if let Ok(opt) = doc.create_element("option") {
+            opt.set_attribute("value", &id.to_string()).ok();
+            opt.set_text_content(Some(&name));
+            if id == cur {
+                opt.set_attribute("selected", "selected").ok();
+            }
+            let _ = sel.append_child(&opt);
+        }
+    }
+    // Reveal the picker (hidden by default for the single-dataset case).
+    if let Some(pick) = by_id::<web_sys::HtmlElement>("dspick") {
+        let _ = pick.style().set_property("display", "flex");
+    }
+    let s2 = sel.clone();
+    add_listener(sel.as_ref(), "change", move |_e: web_sys::Event| {
+        if let Ok(id) = s2.value().parse::<usize>() {
+            switch_dataset(id);
+        }
+    });
 }
 
 /// Fetch the run's DIA isolation-window footprints (real units) + the max group id.

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -279,6 +279,9 @@ struct Gfx {
     use_python_cluster: bool,
     /// Selected dataset's display name (from `/datasets`), for the Data summary + exported config.
     dataset_name: String,
+    /// Resolved (registry-clamped) dataset id — what the server actually loaded. Seeded from the URL,
+    /// corrected by `populate_datasets`; exports use this, not the raw `?dataset=` value.
+    dataset_id: usize,
     /// Set once the user picks an algorithm from the dropdown, so the async service probe won't
     /// stomp their choice with its auto-select.
     cluster_algo_user_set: bool,
@@ -718,6 +721,7 @@ async fn run() -> Result<(), String> {
         cluster_sel: None,
         hide_noise: false,
         dataset_name: String::new(),
+        dataset_id: dataset_id(), // raw URL value; clamped to the registry by populate_datasets
         use_python_cluster: false,
         cluster_algo_user_set: false,
         cluster_method: ClusterMethod::Dbscan,
@@ -1229,9 +1233,13 @@ async fn populate_datasets(gfx: Rc<RefCell<Gfx>>) {
     // Stash + show the active dataset's name BEFORE the single-dataset early return, so even a
     // one-entry registry fills the Data summary.
     let cur_name = jget(&arr.get(cur as u32), "name").as_string().unwrap_or_default();
-    if !cur_name.is_empty() {
-        set_text("data-name", &cur_name);
-        gfx.borrow_mut().dataset_name = cur_name;
+    {
+        let mut g = gfx.borrow_mut();
+        g.dataset_id = cur; // the registry-clamped id the server actually loaded
+        if !cur_name.is_empty() {
+            set_text("data-name", &cur_name);
+            g.dataset_name = cur_name;
+        }
     }
     if arr.length() <= 1 {
         return; // only one — name is set, but no picker to show
@@ -2193,7 +2201,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         }
         // Snapshot the parameters used (for the export JSON), so a slider edit mid-run can't skew it.
         let run_params = ClusterRunParams {
-            dataset_id: dataset_id(),
+            dataset_id: g.dataset_id, // resolved/clamped id, not the raw URL value
             method: g.cluster_method,
             python: g.use_python_cluster,
             eps,
@@ -3006,8 +3014,13 @@ fn cluster_config_json(g: &Gfx) -> String {
         let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(key), v);
     };
     let dataset = js_sys::Object::new();
-    let _ = js_sys::Reflect::set(&dataset, &"id".into(), &JsValue::from_f64(dataset_id() as f64));
-    let _ = js_sys::Reflect::set(&dataset, &"name".into(), &JsValue::from_str(&g.dataset_name));
+    let name = if g.dataset_name.is_empty() {
+        format!("dataset {}", g.dataset_id) // /datasets not resolved yet / demo — never emit ""
+    } else {
+        g.dataset_name.clone()
+    };
+    let _ = js_sys::Reflect::set(&dataset, &"id".into(), &JsValue::from_f64(g.dataset_id as f64));
+    let _ = js_sys::Reflect::set(&dataset, &"name".into(), &JsValue::from_str(&name));
     set("dataset", &dataset);
     let ms_level = match g.params.ms_mask {
         0b10 => "MS2",

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -62,6 +62,7 @@ const DIA_WINDOW_RT_SLICES: usize = 6;
 /// was actually used, not later slider edits while the worker runs).
 #[derive(Clone, Copy)]
 struct ClusterRunParams {
+    dataset_id: usize, // name (a String) is resolved at serialize time — keeps this struct Copy
     method: ClusterMethod,
     python: bool,
     eps: f32,
@@ -276,6 +277,8 @@ struct Gfx {
     /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
     /// the startup probe when the service is reachable; toggleable in the Cluster tab.
     use_python_cluster: bool,
+    /// Selected dataset's display name (from `/datasets`), for the Data summary + exported config.
+    dataset_name: String,
     /// Set once the user picks an algorithm from the dropdown, so the async service probe won't
     /// stomp their choice with its auto-select.
     cluster_algo_user_set: bool,
@@ -714,6 +717,7 @@ async fn run() -> Result<(), String> {
         cluster_labels: Vec::new(),
         cluster_sel: None,
         hide_noise: false,
+        dataset_name: String::new(),
         use_python_cluster: false,
         cluster_algo_user_set: false,
         cluster_method: ClusterMethod::Dbscan,
@@ -765,8 +769,9 @@ async fn run() -> Result<(), String> {
     bind_windows(&gfx);
     // Probe the Python clustering service; auto-enable the backend toggle if it's up.
     wasm_bindgen_futures::spawn_local(probe_cluster_service(gfx.clone()));
-    // Populate the dataset picker (reveals it only when the server offers more than one).
-    wasm_bindgen_futures::spawn_local(populate_datasets());
+    // ① Data: fill the meta summary now (points/ranges/cycle); the dataset name arrives via /datasets.
+    fill_data_summary(server_meta.as_ref());
+    wasm_bindgen_futures::spawn_local(populate_datasets(gfx.clone()));
     // Collapsible section headers + tab switching.
     bind_panel_chrome(&gfx);
 
@@ -1135,6 +1140,8 @@ struct MetaInfo {
     /// Mean RT gap (seconds) between consecutive MS1 frames; 0 if unknown. Used to cluster RT in
     /// cycle units so precursors stay connected across cycles regardless of focus.
     cycle_duration: f64,
+    /// Total resident points the server holds for this region/run (for the Data summary).
+    n_points: f64,
 }
 
 /// Derive the `/meta` URL from the `/points` URL: replace only the trailing path endpoint and keep
@@ -1189,9 +1196,10 @@ fn switch_dataset(id: usize) {
     let _ = loc.set_search(&parts.join("&")); // navigates -> fresh load for the new dataset
 }
 
-/// Fetch the dataset registry; if more than one, reveal + populate the header picker (selecting one
-/// reloads with `?dataset=N`). Silent no-op when the server is absent or offers a single dataset.
-async fn populate_datasets() {
+/// Fetch the dataset registry: always stash the active dataset's name (for the Data summary +
+/// config export), and — if more than one — reveal + populate the picker (selecting one reloads
+/// with `?dataset=N`). Silent no-op when the server is absent.
+async fn populate_datasets(gfx: Rc<RefCell<Gfx>>) {
     let Some(window) = web_sys::window() else { return };
     let Some(doc) = window.document() else { return };
     let resp_val = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&datasets_url())).await
@@ -1212,14 +1220,24 @@ async fn populate_datasets() {
     };
     let Ok(v) = js_sys::JSON::parse(&text) else { return };
     let arr = js_sys::Array::from(&v);
-    if arr.length() <= 1 {
-        return; // nothing to choose between
+    if arr.length() == 0 {
+        return;
     }
-    let Some(sel) = by_id::<web_sys::HtmlSelectElement>("dataset-sel") else { return };
-    sel.set_inner_html("");
     // The server clamps an out-of-range ?dataset to the last id, so clamp here too — else the picker
     // would highlight the wrong (first) option while a different dataset is actually loaded.
     let cur = dataset_id().min(arr.length() as usize - 1);
+    // Stash + show the active dataset's name BEFORE the single-dataset early return, so even a
+    // one-entry registry fills the Data summary.
+    let cur_name = jget(&arr.get(cur as u32), "name").as_string().unwrap_or_default();
+    if !cur_name.is_empty() {
+        set_text("data-name", &cur_name);
+        gfx.borrow_mut().dataset_name = cur_name;
+    }
+    if arr.length() <= 1 {
+        return; // only one — name is set, but no picker to show
+    }
+    let Some(sel) = by_id::<web_sys::HtmlSelectElement>("dataset-sel") else { return };
+    sel.set_inner_html("");
     for i in 0..arr.length() {
         let item = arr.get(i);
         let id = jnum(&item, "id").unwrap_or(i as f64) as usize;
@@ -1243,6 +1261,26 @@ async fn populate_datasets() {
             switch_dataset(id);
         }
     });
+}
+
+/// Fill the ① Data summary (points / ranges / cycle) from the loaded meta. The dataset NAME is set
+/// separately by `populate_datasets` (it comes from `/datasets`).
+fn fill_data_summary(meta: Option<&MetaInfo>) {
+    let Some(m) = meta else {
+        for id in ["data-points", "data-mz", "data-im", "data-rt", "data-cycle"] {
+            set_text(id, "—");
+        }
+        return;
+    };
+    set_text("data-points", &group(m.n_points as usize));
+    if let Some(b) = m.bounds {
+        set_text("data-mz", &format!("{:.1} – {:.1}", b[0].0, b[0].1));
+        set_text("data-im", &format!("{:.3} – {:.3}", b[1].0, b[1].1));
+        set_text("data-rt", &format!("{:.1} – {:.1} s", b[2].0, b[2].1));
+    }
+    if m.cycle_duration > 0.0 {
+        set_text("data-cycle", &format!("{:.3} s", m.cycle_duration));
+    }
 }
 
 /// Fetch the run's DIA isolation-window footprints (real units) + the max group id.
@@ -1464,6 +1502,7 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
         proj,
         proj_bins,
         cycle_duration: jnum(&v, "cycle_duration").filter(|x| x.is_finite() && *x > 0.0).unwrap_or(0.0),
+        n_points: jnum(&v, "n_points").filter(|x| x.is_finite() && *x >= 0.0).unwrap_or(0.0),
     })
 }
 
@@ -1668,6 +1707,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         g.cluster_stats = None;
         g.cluster_params_json = None;
         g.cluster_run_params = None;
+        set_save_ready(false); // ④ Save: results gone with the clustering
         g.cluster_idx = Vec::new();
         g.cluster_labels = Vec::new();
         g.cluster_sel = None;
@@ -2058,6 +2098,7 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
         g.cluster_stats = None;
         g.cluster_params_json = None;
         g.cluster_run_params = None;
+        set_save_ready(false); // ④ Save: results gone with the clustering
         g.cluster_idx = Vec::new();
         g.cluster_labels = Vec::new();
         g.cluster_sel = None;
@@ -2152,6 +2193,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         }
         // Snapshot the parameters used (for the export JSON), so a slider edit mid-run can't skew it.
         let run_params = ClusterRunParams {
+            dataset_id: dataset_id(),
             method: g.cluster_method,
             python: g.use_python_cluster,
             eps,
@@ -2442,6 +2484,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, 
     set_body_class("cluster-color", true); // cluster coloring active -> hide the intensity colorbar
     set_cluster_progress(None); // done — hide the progress bar
     set_cluster_running(false); // restore the Run button
+    set_save_ready(true); // ④ Save: results are now exportable
     update_cluster_panel(gfx); // we ran from the Cluster tab, so this shows + renders the panel
     show_status("");
 }
@@ -2684,9 +2727,14 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     }
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-export") {
         let gfx = gfx.clone();
-        add_listener(btn.as_ref(), "click", move |e: web_sys::Event| {
-            e.stop_propagation(); // the button sits in an .ey header — don't toggle collapse
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| {
             export_clusters(&gfx);
+        });
+    }
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("cfg-export") {
+        let gfx = gfx.clone();
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| {
+            export_config(&gfx);
         });
     }
 }
@@ -2796,9 +2844,9 @@ fn set_class(id: &str, class: &str, on: bool) {
     }
 }
 
-/// Show one tab pane (`view`/`focus`) and highlight its button; hide the others.
+/// Show one flow tab pane + highlight its button; hide the others.
 fn switch_tab(name: &str) {
-    for t in ["view", "focus", "cluster"] {
+    for t in ["data", "region", "cluster", "save", "display"] {
         set_class(&format!("tabbtn-{t}"), "active", t == name);
         set_class(&format!("tab-{t}"), "active", t == name);
     }
@@ -2878,6 +2926,7 @@ fn cluster_params_json(p: &ClusterRunParams, k: usize, noise: usize, n_in: usize
     let set = |key: &str, v: &JsValue| {
         let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(key), v);
     };
+    set("dataset_id", &JsValue::from_f64(p.dataset_id as f64));
     let ms_level = if p.ms_mask == 0b10 { "MS2" } else { "MS1" };
     set("ms_level", &JsValue::from_str(ms_level));
     let (algo, engine) = match (p.method, p.python) {
@@ -2940,6 +2989,74 @@ fn export_clusters(gfx: &Rc<RefCell<Gfx>>) {
     if let Some(pj) = g.cluster_params_json.as_ref() {
         download_text("cluster_params.json", "application/json", pj);
     }
+}
+
+/// Enable the results export + reflect Save status. Results need a finished clustering; the config
+/// export is always available.
+fn set_save_ready(ready: bool) {
+    set_disabled("cl-export", !ready);
+    set_text("save-status", if ready { "results ready" } else { "no clustering yet" });
+}
+
+/// The reproducible *recipe* as JSON — dataset + region + algorithm + params — built live from the
+/// current state, so it works before any clustering (unlike the post-run `cluster_params.json`).
+fn cluster_config_json(g: &Gfx) -> String {
+    let obj = js_sys::Object::new();
+    let set = |key: &str, v: &JsValue| {
+        let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(key), v);
+    };
+    let dataset = js_sys::Object::new();
+    let _ = js_sys::Reflect::set(&dataset, &"id".into(), &JsValue::from_f64(dataset_id() as f64));
+    let _ = js_sys::Reflect::set(&dataset, &"name".into(), &JsValue::from_str(&g.dataset_name));
+    set("dataset", &dataset);
+    let ms_level = match g.params.ms_mask {
+        0b10 => "MS2",
+        0b01 => "MS1",
+        _ => "both",
+    };
+    set("ms_level", &JsValue::from_str(ms_level));
+    set("intensity_floor", &JsValue::from_f64(g.params.filter_min[3] as f64));
+    let (algo, engine) = match (g.cluster_method, g.use_python_cluster) {
+        (ClusterMethod::Hdbscan, _) => ("hdbscan", "python-sklearn"),
+        (ClusterMethod::Dbscan, true) => ("dbscan", "python-sklearn"),
+        (ClusterMethod::Dbscan, false) => ("dbscan", "wasm"),
+    };
+    set("algorithm", &JsValue::from_str(algo));
+    set("engine", &JsValue::from_str(engine));
+    if g.cluster_method == ClusterMethod::Hdbscan {
+        set("min_cluster_size", &JsValue::from_f64(g.cluster_min_cluster_size as f64));
+        set("min_samples", &JsValue::from_f64(g.cluster_hdb_min_samples as f64));
+        set("cluster_selection_epsilon", &JsValue::from_f64(g.cluster_selection_eps));
+    } else {
+        set("eps", &JsValue::from_f64(g.cluster_eps as f64));
+        set("min_points", &JsValue::from_f64(g.cluster_min_pts as f64));
+    }
+    set("rt_cycles", &JsValue::from_f64(g.cluster_rt_cycles));
+    set("mz_peak_widths", &JsValue::from_f64(g.cluster_mz_peak_widths));
+    set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
+    if let Some(b) = g.axis_bounds {
+        let region = js_sys::Object::new();
+        let pair = |lo: f64, hi: f64| {
+            let a = js_sys::Array::new();
+            a.push(&JsValue::from_f64(lo));
+            a.push(&JsValue::from_f64(hi));
+            a
+        };
+        let _ = js_sys::Reflect::set(&region, &"mz".into(), &pair(b[0].0, b[0].1));
+        let _ = js_sys::Reflect::set(&region, &"im".into(), &pair(b[1].0, b[1].1));
+        let _ = js_sys::Reflect::set(&region, &"rt".into(), &pair(b[2].0, b[2].1));
+        set("region", &region);
+    }
+    js_sys::JSON::stringify_with_replacer_and_space(&obj, &JsValue::NULL, &JsValue::from_f64(2.0))
+        .ok()
+        .and_then(|s| s.as_string())
+        .unwrap_or_default()
+}
+
+/// Download the live config recipe (`config.json`).
+fn export_config(gfx: &Rc<RefCell<Gfx>>) {
+    let json = cluster_config_json(&gfx.borrow());
+    download_text("config.json", "application/json", &json);
 }
 
 /// Trigger a file download of `content` via a `data:` URL anchor (attached to the DOM for the click

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -82,6 +82,9 @@ struct Gfx {
     floor_hi: f64,
     /// True while a reload is in flight (debounces overlapping Load/Focus requests).
     reloading: bool,
+    /// Set when the active filter or draw count changes; the next frame recomputes the displayed
+    /// count (CPU-side over `cpu_points`) — camera-independent, so it need not run every frame.
+    filter_dirty: bool,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -141,6 +144,20 @@ impl Gfx {
         self.hud_tick = self.hud_tick.wrapping_add(1);
         if self.hud_tick % 12 == 0 {
             set_text("hud-fps", &format!("{:.0} fps", self.fps_ema));
+        }
+        // Recompute the displayed (filter-surviving) count when the filter/draw-count changed.
+        if self.filter_dirty {
+            let shown = recount_displayed(self);
+            let resident = self.renderer.resident() as usize;
+            let txt = if self.points_base.is_empty() {
+                format!("{} · demo", group_short(shown))
+            } else if shown >= resident {
+                group_short(resident) // nothing hidden — show the loaded pool
+            } else {
+                format!("{} / {}", group_short(shown), group_short(resident))
+            };
+            set_text("hud-points", &txt);
+            self.filter_dirty = false;
         }
 
         if self.auto_rotate {
@@ -308,10 +325,8 @@ async fn run() -> Result<(), String> {
         supports_compaction,
     );
     let n = renderer.append(&queue, &pts);
-    set_text(
-        "hud-points",
-        &if is_demo_fallback { format!("{} · demo", group(n)) } else { group(n) },
-    );
+    // The HUD point count is owned by the per-frame displayed-count recount (filter_dirty starts
+    // true, so the first frame fills it).
     log::info!("uploaded {n} points (compaction: {supports_compaction})");
 
     // Native-matching defaults: MS1-only, sqrt transfer, additive density. When the server gave
@@ -361,6 +376,7 @@ async fn run() -> Result<(), String> {
         cpu_points,
         floor_hi,
         reloading: false,
+        filter_dirty: true,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -852,7 +868,11 @@ fn reset_crops(gfx: &Rc<RefCell<Gfx>>) {
 
 /// Reset the Display control to 100% of the (new) resident pool.
 fn reset_display(gfx: &Rc<RefCell<Gfx>>, n: usize) {
-    gfx.borrow_mut().renderer.set_draw_count(u32::MAX);
+    {
+        let mut g = gfx.borrow_mut();
+        g.renderer.set_draw_count(u32::MAX);
+        g.filter_dirty = true; // HUD displayed-count recomputed next frame
+    }
     if let Some(s) = by_id::<web_sys::HtmlInputElement>("disp") {
         s.set_value("100");
     }
@@ -860,7 +880,6 @@ fn reset_display(gfx: &Rc<RefCell<Gfx>>, n: usize) {
         num.set_value(&n.to_string());
         let _ = num.set_attribute("max", &n.to_string());
     }
-    set_text("hud-points", &group(n));
 }
 
 /// Apply a freshly fetched load in place: rebuild the GPU buffer at the new capacity, retain the
@@ -1036,6 +1055,18 @@ fn set_checked(id: &str, v: bool) {
 }
 
 /// Group an integer with thin spaces for the HUD readout, e.g. 300000 -> "300 000".
+/// Compact count for the HUD: `3.7M`, `379k`, or grouped digits under 10k. Keeps the
+/// `displayed / resident` readout from overflowing the stat cell.
+fn group_short(n: usize) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1e6)
+    } else if n >= 10_000 {
+        format!("{:.0}k", n as f64 / 1e3)
+    } else {
+        group(n)
+    }
+}
+
 fn group(n: usize) -> String {
     let s = n.to_string();
     let b = s.as_bytes();
@@ -1047,6 +1078,37 @@ fn group(n: usize) -> String {
         out.push(*c as char);
     }
     out
+}
+
+/// Count points surviving the active 4D filter (spatial window + intensity floor + MS mask) among
+/// the drawn prefix of the resident pool. Camera-independent (frustum culling excluded), so it is
+/// recomputed only when the filter or draw count changes — not every frame.
+fn recount_displayed(g: &Gfx) -> usize {
+    let p = &g.params;
+    let limit = (g.renderer.drawn() as usize).min(g.cpu_points.len());
+    let (fmin, fmax, ms) = (p.filter_min, p.filter_max, p.ms_mask);
+    let mut shown = 0usize;
+    for pt in &g.cpu_points[..limit] {
+        let pos = pt.pos;
+        if pos[0] < fmin[0]
+            || pos[0] > fmax[0]
+            || pos[1] < fmin[1]
+            || pos[1] > fmax[1]
+            || pos[2] < fmin[2]
+            || pos[2] > fmax[2]
+        {
+            continue;
+        }
+        if pt.intensity < fmin[3] {
+            continue;
+        }
+        let is_ms2 = (pt.flags & GpuPoint::MS2_FLAG) != 0;
+        let pass = if is_ms2 { ms & 0b10 != 0 } else { ms & 0b01 != 0 };
+        if pass {
+            shown += 1;
+        }
+    }
+    shown
 }
 
 /// Bind the Display slider (1..100 %) to the renderer's runtime draw count — trade detail for
@@ -1097,8 +1159,7 @@ fn display_apply(gfx: &Rc<RefCell<Gfx>>, k: u32) -> (u32, u32) {
     let total = g.renderer.resident().max(1);
     let kk = k.clamp(1, total);
     g.renderer.set_draw_count(kk);
-    drop(g);
-    set_text("hud-points", &group(kk as usize));
+    g.filter_dirty = true; // the displayed count is recomputed next frame
     (kk, total)
 }
 
@@ -1259,12 +1320,15 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
     on_toggle("xf-log", gfx, |g, on| if on { g.params.transfer[0] = 2.0; });
     bind_value(gfx, "expo", "expo-n", 2, |g, v| g.params.transfer[3] = v as f32);
     // Floor is linear in real counts; its slider/number range is scaled to the data in run().
-    bind_value(gfx, "floor", "floor-n", 0, |g, v| g.params.filter_min[3] = v as f32);
+    bind_value(gfx, "floor", "floor-n", 0, |g, v| {
+        g.params.filter_min[3] = v as f32;
+        g.filter_dirty = true;
+    });
 
     // Filters
-    on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; });
-    on_toggle("ms-2", gfx, |g, on| if on { g.params.ms_mask = 0b10; });
-    on_toggle("ms-b", gfx, |g, on| if on { g.params.ms_mask = 0b11; });
+    on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; g.filter_dirty = true; });
+    on_toggle("ms-2", gfx, |g, on| if on { g.params.ms_mask = 0b10; g.filter_dirty = true; });
+    on_toggle("ms-b", gfx, |g, on| if on { g.params.ms_mask = 0b11; g.filter_dirty = true; });
     bind_crop(gfx, "cmz", 0);
     bind_crop(gfx, "cim", 1);
     bind_crop(gfx, "crt", 2);
@@ -1316,6 +1380,7 @@ fn crop_apply(gfx: &Rc<RefCell<Gfx>>, axis: usize, prefix: &str, lo_val: f64, hi
         let mut g = gfx.borrow_mut();
         g.params.filter_min[axis] = a;
         g.params.filter_max[axis] = b;
+        g.filter_dirty = true;
         g.axis_bounds
     };
     set_text(&format!("{prefix}-v"), &crop_label(bounds, axis, a, b));

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 use tims_viewer::camera::{OrbitCamera, ROLL_UP_AXIS};
-use tims_viewer::data::point::{AxisTransform, GpuPoint};
+use tims_viewer::data::point::{AxisTransform, GpuPoint, WindowRect, DIA_WINDOW_RT_SLICES};
 use tims_viewer::render::annotation::{AnnotationRenderer, LineVertex};
 use tims_viewer::ticks::{fmt_tick, ticks_for, Axis, RT_MINUTES_SPAN};
 use tims_viewer::render::colormap::{sample as colormap_sample, COLORMAP_NAMES};
@@ -58,10 +58,6 @@ const CLUSTER_MZ_PEAK_WIDTHS: f64 = 1.5;
 /// the GPU buffer limit: ~32M × 32 B ≈ 1 GB resident, well clear of the ~4 GB wasm address space.
 const MAX_WEB_POINTS: usize = 32_000_000;
 
-/// RT slices each DIA window footprint is drawn at (mirrors the native loader's `DIA_WINDOW_RT_SLICES`,
-/// which lives in the native-only loader module).
-const DIA_WINDOW_RT_SLICES: usize = 6;
-
 /// Parameters of a clustering Run, snapshotted at gather time (so the exported JSON reflects what
 /// was actually used, not later slider edits while the worker runs).
 #[derive(Clone, Copy)]
@@ -84,16 +80,6 @@ struct ClusterRunParams {
     im_per_scan: f64,
 }
 
-/// A DIA isolation-window footprint in real units (from `/windows`); re-normalized to the focused
-/// region each load to draw the precursor-selection overlay in the m/z × 1/K0 (scan) plane.
-#[derive(Clone, Copy)]
-struct WinRect {
-    g: u32,
-    mz0: f64,
-    mz1: f64,
-    im0: f64,
-    im1: f64,
-}
 
 /// Points (the splat cloud) vs Volume (raymarched density grid).
 #[derive(Clone, Copy, PartialEq)]
@@ -348,7 +334,7 @@ struct Gfx {
     /// DIA isolation-window overlay (separate line buffer from the axes), with the run's footprints
     /// in real units re-normalized to the focused region.
     windows: AnnotationRenderer,
-    window_rects: Vec<WinRect>,
+    window_rects: Vec<WindowRect>,
     max_window_group: u32,
     show_windows: bool,
     /// Per-group visibility bitmask (bit g-1 = group g, for g in 1..=32); groups >32 and ungrouped
@@ -1948,7 +1934,7 @@ fn fill_data_summary(meta: Option<&MetaInfo>) {
 }
 
 /// Fetch the run's DIA isolation-window footprints (real units) + the max group id.
-async fn fetch_windows(url: &str) -> Result<(Vec<WinRect>, u32), String> {
+async fn fetch_windows(url: &str) -> Result<(Vec<WindowRect>, u32), String> {
     let window = web_sys::window().ok_or("no window")?;
     let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(url))
         .await
@@ -1972,7 +1958,7 @@ async fn fetch_windows(url: &str) -> Result<(Vec<WinRect>, u32), String> {
             continue;
         }
         let f = |k: u32| row.get(k).as_f64().unwrap_or(0.0);
-        rects.push(WinRect { g: f(0) as u32, mz0: f(1), mz1: f(2), im0: f(3), im1: f(4) });
+        rects.push(WindowRect { group: f(0) as u32, mz0: f(1), mz1: f(2), im0: f(3), im1: f(4) });
     }
     Ok((rects, max_group))
 }
@@ -1980,7 +1966,7 @@ async fn fetch_windows(url: &str) -> Result<(Vec<WinRect>, u32), String> {
 /// Build the window-overlay line vertices: each footprint as an `(m/z × 1/K0)` rectangle at
 /// `DIA_WINDOW_RT_SLICES` RT slices, normalized to the focused region's `bounds` and colored by group.
 fn build_window_verts(
-    rects: &[WinRect],
+    rects: &[WindowRect],
     bounds: [(f64, f64); 3],
     max_group: u32,
     mask: u32,
@@ -1993,7 +1979,7 @@ fn build_window_verts(
     let denom = max_group.max(1);
     for r in rects {
         // Per-group visibility: groups 1..=32 gate on their mask bit; >32 and group 0 always show.
-        if r.g >= 1 && r.g <= 32 && (mask & (1u32 << (r.g - 1))) == 0 {
+        if r.group >= 1 && r.group <= 32 && (mask & (1u32 << (r.group - 1))) == 0 {
             continue;
         }
         // Order each axis first: a footprint can arrive descending (1/K0 falls as scan rises, so
@@ -2009,7 +1995,7 @@ fn build_window_verts(
         if mz1r <= mz0r || im1r <= im0r {
             continue;
         }
-        let color = tims_viewer::render::colormap::group_color(r.g, denom);
+        let color = tims_viewer::render::colormap::group_color(r.group, denom);
         let (mz0, mz1) = (norm(mz0r, 0), norm(mz1r, 0));
         let (im0, im1) = (norm(im0r, 1), norm(im1r, 1));
         for i in 0..DIA_WINDOW_RT_SLICES {

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -123,6 +123,9 @@ struct Gfx {
     window_rects: Vec<WinRect>,
     max_window_group: u32,
     show_windows: bool,
+    /// Per-group visibility bitmask (bit g-1 = group g, for g in 1..=32); groups >32 and ungrouped
+    /// are always shown. Mirrors the native `group_mask`.
+    window_group_mask: u32,
     /// DOM tick/axis labels (element + its world position in the `[-1,1]` cube), projected each
     /// frame onto the canvas. Empty when real-unit bounds are unknown (demo fallback).
     labels: Vec<(web_sys::HtmlElement, [f32; 3])>,
@@ -576,6 +579,7 @@ async fn run() -> Result<(), String> {
         window_rects: Vec::new(),
         max_window_group: 0,
         show_windows: false,
+        window_group_mask: u32::MAX,
         labels,
         camera: OrbitCamera::default(),
         params,
@@ -671,6 +675,7 @@ async fn run() -> Result<(), String> {
                     g.max_window_group = max_group;
                 }
                 rebuild_window_overlay(&gfx);
+                render_window_legend(&gfx);
                 set_disabled("show-windows", gfx.borrow().max_window_group == 0);
             }
         });
@@ -945,7 +950,12 @@ async fn fetch_windows(url: &str) -> Result<(Vec<WinRect>, u32), String> {
 
 /// Build the window-overlay line vertices: each footprint as an `(m/z × 1/K0)` rectangle at
 /// `DIA_WINDOW_RT_SLICES` RT slices, normalized to the focused region's `bounds` and colored by group.
-fn build_window_verts(rects: &[WinRect], bounds: [(f64, f64); 3], max_group: u32) -> Vec<LineVertex> {
+fn build_window_verts(
+    rects: &[WinRect],
+    bounds: [(f64, f64); 3],
+    max_group: u32,
+    mask: u32,
+) -> Vec<LineVertex> {
     let norm = |val: f64, axis: usize| -> f32 {
         let (lo, hi) = bounds[axis];
         (((val - lo) / (hi - lo).max(1e-12)) * 2.0 - 1.0) as f32
@@ -953,6 +963,10 @@ fn build_window_verts(rects: &[WinRect], bounds: [(f64, f64); 3], max_group: u32
     let mut v: Vec<LineVertex> = Vec::new();
     let denom = max_group.max(1);
     for r in rects {
+        // Per-group visibility: groups 1..=32 gate on their mask bit; >32 and group 0 always show.
+        if r.g >= 1 && r.g <= 32 && (mask & (1u32 << (r.g - 1))) == 0 {
+            continue;
+        }
         // Clamp the axis-aligned footprint to the region so a partly-off-region window clips cleanly
         // (the per-vertex shader cull would otherwise leave stubs); drop windows fully outside.
         let (mz0r, mz1r) = (r.mz0.max(bounds[0].0), r.mz1.min(bounds[0].1));
@@ -984,7 +998,7 @@ fn rebuild_window_overlay(gfx: &Rc<RefCell<Gfx>>) {
         let g = gfx.borrow();
         match g.axis_bounds {
             Some(b) if !g.window_rects.is_empty() => {
-                build_window_verts(&g.window_rects, b, g.max_window_group)
+                build_window_verts(&g.window_rects, b, g.max_window_group, g.window_group_mask)
             }
             _ => Vec::new(),
         }
@@ -992,6 +1006,39 @@ fn rebuild_window_overlay(gfx: &Rc<RefCell<Gfx>>) {
     let mut g = gfx.borrow_mut();
     let g = &mut *g;
     g.windows.upload(&g.device, &verts);
+}
+
+/// CSS color matching the rendered window's `group_color` (so the legend swatch is exact).
+fn group_css(g: u32, n: u32) -> String {
+    let [r, gg, b] = tims_viewer::render::colormap::group_color(g, n.max(1));
+    format!("rgb({},{},{})", (r * 255.0) as u8, (gg * 255.0) as u8, (b * 255.0) as u8)
+}
+
+/// (Re)render the per-group window legend: a toggleable colored chip per group (capped at 32, like
+/// the native mask). Groups beyond 32 are always shown.
+fn render_window_legend(gfx: &Rc<RefCell<Gfx>>) {
+    let (max_g, mask) = {
+        let g = gfx.borrow();
+        (g.max_window_group, g.window_group_mask)
+    };
+    if max_g == 0 {
+        set_html("win-groups", "");
+        return;
+    }
+    let n = max_g.min(32);
+    let mut html = String::new();
+    for g in 1..=n {
+        let on = (mask & (1u32 << (g - 1))) != 0;
+        let cls = if on { "wg on" } else { "wg" };
+        html.push_str(&format!(
+            "<button class=\"{cls}\" data-g=\"{g}\"><span class=\"wg-dot\" style=\"background:{}\"></span>{g}</button>",
+            group_css(g, max_g)
+        ));
+    }
+    if max_g > 32 {
+        html.push_str(&format!("<span class=\"cs-more\">+{} more (shown)</span>", max_g - 32));
+    }
+    set_html("win-groups", &html);
 }
 
 fn jget(obj: &JsValue, key: &str) -> JsValue {
@@ -2073,9 +2120,37 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     }
 }
 
-/// Wire the "Show DIA windows" toggle (enabled only once `/windows` returns groups).
+/// Wire the "Show DIA windows" toggle + the per-group legend (enabled once `/windows` returns groups).
 fn bind_windows(gfx: &Rc<RefCell<Gfx>>) {
-    on_toggle("show-windows", gfx, |g, on| g.show_windows = on);
+    if let Some(inp) = by_id::<web_sys::HtmlInputElement>("show-windows") {
+        let (gfx, el) = (gfx.clone(), inp.clone());
+        add_listener(inp.as_ref(), "change", move |_e: web_sys::Event| {
+            let on = el.checked();
+            gfx.borrow_mut().show_windows = on;
+            set_body_class("show-windows", on); // reveals the group legend
+            if on {
+                render_window_legend(&gfx);
+            }
+        });
+    }
+    // Click a group chip to toggle that group's windows.
+    if let Some(list) = by_id::<web_sys::HtmlElement>("win-groups") {
+        let gfx = gfx.clone();
+        add_listener(list.as_ref(), "click", move |e: web_sys::Event| {
+            let Some(t) = e.target().and_then(|t| t.dyn_into::<web_sys::Element>().ok()) else {
+                return;
+            };
+            if let Ok(Some(chip)) = t.closest(".wg") {
+                if let Some(g) = chip.get_attribute("data-g").and_then(|s| s.parse::<u32>().ok()) {
+                    if (1..=32).contains(&g) {
+                        gfx.borrow_mut().window_group_mask ^= 1u32 << (g - 1);
+                    }
+                    rebuild_window_overlay(&gfx);
+                    render_window_legend(&gfx);
+                }
+            }
+        });
+    }
 }
 
 /// Wire the Focus / Back buttons; control enable/disable is driven by `refresh_controls`.

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -954,8 +954,9 @@ fn points_base_url() -> String {
         .and_then(|w| w.location().search().ok())
         .unwrap_or_default();
     let params = search.trim_start_matches('?');
-    // Explicit full-URL override (percent-decoded). Strip any baked-in `n=` so our budget caps stay
-    // authoritative (with_query appends `n=n_cap`; a leftover n would double up).
+    // Explicit full-URL override (percent-decoded). Strip any baked-in `n=` (so our budget caps stay
+    // authoritative) and `dataset=` (so `points_url` is the sole source of the dataset param — else
+    // /points and /windows could disagree, and picker switches wouldn't take).
     if let Some(v) = params.split('&').find_map(|kv| kv.strip_prefix("points=")) {
         if !v.is_empty() {
             let decoded = js_sys::decode_uri_component(v)
@@ -964,8 +965,10 @@ fn points_base_url() -> String {
                 .unwrap_or_else(|| v.to_string());
             return match decoded.split_once('?') {
                 Some((path, query)) => {
-                    let kept: Vec<&str> =
-                        query.split('&').filter(|kv| !kv.starts_with("n=")).collect();
+                    let kept: Vec<&str> = query
+                        .split('&')
+                        .filter(|kv| !kv.starts_with("n=") && !kv.starts_with("dataset="))
+                        .collect();
                     if kept.is_empty() {
                         path.to_string()
                     } else {
@@ -1214,7 +1217,9 @@ async fn populate_datasets() {
     }
     let Some(sel) = by_id::<web_sys::HtmlSelectElement>("dataset-sel") else { return };
     sel.set_inner_html("");
-    let cur = dataset_id();
+    // The server clamps an out-of-range ?dataset to the last id, so clamp here too — else the picker
+    // would highlight the wrong (first) option while a different dataset is actually loaded.
+    let cur = dataset_id().min(arr.length() as usize - 1);
     for i in 0..arr.length() {
         let item = arr.get(i);
         let id = jnum(&item, "id").unwrap_or(i as f64) as usize;

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -20,7 +20,7 @@ use tims_viewer::data::point::{AxisTransform, GpuPoint};
 use tims_viewer::render::annotation::{AnnotationRenderer, LineVertex};
 use tims_viewer::ticks::{fmt_tick, ticks_for, Axis, RT_MINUTES_SPAN};
 use tims_viewer::render::colormap::{sample as colormap_sample, COLORMAP_NAMES};
-use tims_viewer::cluster::dbscan;
+use tims_viewer::cluster::{dbscan, dbscan_with_progress};
 use tims_viewer::render::point_cloud::{PointCloudRenderer, PointMode};
 use tims_viewer::render::uniforms::{ParamsUniform, VolumeUniform};
 use tims_viewer::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
@@ -75,11 +75,20 @@ pub fn start() {
 }
 
 /// DBSCAN over a flat `[x,y,z, x,y,z, …]` buffer, returning per-point labels (`-1` = noise). The
-/// Web Worker calls this; exported so its wasm instance has it too.
+/// Web Worker calls this; exported so its wasm instance has it too. `progress` (if a JS function) is
+/// called `(visited, total)` ~every 1% so the worker can post progress back to the main thread.
 #[wasm_bindgen]
-pub fn cluster_dbscan_flat(flat: &[f32], min_pts: usize, eps: f32) -> Vec<i32> {
+pub fn cluster_dbscan_flat(flat: &[f32], min_pts: usize, eps: f32, progress: &JsValue) -> Vec<i32> {
     let pts: Vec<[f32; 3]> = flat.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect();
-    dbscan(&pts, eps, min_pts).0
+    let total = pts.len() as f64;
+    let cb = progress.dyn_ref::<js_sys::Function>();
+    dbscan_with_progress(&pts, eps, min_pts, |visited| {
+        if let Some(f) = cb {
+            let _ =
+                f.call2(&JsValue::NULL, &JsValue::from_f64(visited as f64), &JsValue::from_f64(total));
+        }
+    })
+    .0
 }
 
 /// Summary of a clustering result, for the MIDIA-style stats panel.
@@ -1594,6 +1603,18 @@ fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
     );
 }
 
+/// Show the clustering progress bar at `frac` (0..1), or hide it with `None`.
+fn set_cluster_progress(frac: Option<f32>) {
+    if let Some(el) = by_id::<web_sys::HtmlElement>("cl-prog") {
+        let _ = el.style().set_property("display", if frac.is_some() { "block" } else { "none" });
+    }
+    if let Some(f) = frac {
+        if let Some(bar) = by_id::<web_sys::HtmlElement>("cl-bar") {
+            let _ = bar.style().set_property("width", &format!("{:.0}%", f.clamp(0.0, 1.0) * 100.0));
+        }
+    }
+}
+
 /// Toggle the `volmode` body class (reveals the volume-only controls).
 fn set_volmode(on: bool) {
     if let Some(body) = document().and_then(|d| d.body()) {
@@ -1654,6 +1675,7 @@ fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
 /// flips `color_mode` back to intensity; the stale `_pad[0]` ids stay unused until the next Run.
 fn invalidate_clusters_mut(g: &mut Gfx) {
     g.cluster_pending = None; // abandon any in-flight worker job (its reply will be ignored)
+    set_cluster_progress(None);
     if g.clustered {
         g.params.color_mode = 0;
         g.clustered = false;
@@ -1731,6 +1753,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         };
         if post_cluster_job(&worker, &flat, eps, min_pts, job) {
             gfx.borrow_mut().cluster_pending = Some((idx, gen, job));
+            set_cluster_progress(Some(0.0)); // worker reports ticks back; bar advances live
             return;
         }
     }
@@ -1749,7 +1772,8 @@ import init, { cluster_dbscan_flat } from '__GLUE__';
 await init({ module_or_path: '__WASM__' });
 self.onmessage = (e) => {
   const { flat, eps, min_pts, job } = e.data;
-  const labels = cluster_dbscan_flat(new Float32Array(flat), min_pts, eps);
+  const onProgress = (visited, total) => self.postMessage({ progress: visited / total, job });
+  const labels = cluster_dbscan_flat(new Float32Array(flat), min_pts, eps, onProgress);
   self.postMessage({ labels, job }, [labels.buffer]);
 };
 "#;
@@ -1804,22 +1828,25 @@ fn create_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
         move |e: web_sys::MessageEvent| {
             let data = e.data();
             let get = |k: &str| js_sys::Reflect::get(&data, &JsValue::from_str(k)).ok();
+            let reply_job = get("job").and_then(|v| v.as_f64()).map(|f| f as u64);
+            let job_matches = |g: &Gfx| {
+                matches!((&g.cluster_pending, reply_job), (Some((_, _, pj)), Some(rj)) if *pj == rj)
+            };
+            // Progress tick (no labels): advance the bar if it's for the current job.
+            if let Some(p) = get("progress").and_then(|v| v.as_f64()) {
+                if job_matches(&gfx_msg.borrow()) {
+                    set_cluster_progress(Some(p as f32));
+                }
+                return;
+            }
             let Some(labels) = get("labels")
                 .and_then(|v| v.dyn_into::<js_sys::Int32Array>().ok())
                 .map(|a| a.to_vec())
             else {
                 return;
             };
-            let reply_job = get("job").and_then(|v| v.as_f64()).map(|f| f as u64);
-            let job = {
-                let g = gfx_msg.borrow();
-                match (&g.cluster_pending, reply_job) {
-                    (Some((_, _, pj)), Some(rj)) if *pj == rj => Some(rj),
-                    _ => None, // no pending / superseded job — drop this reply
-                }
-            };
-            if job.is_none() {
-                return;
+            if !job_matches(&gfx_msg.borrow()) {
+                return; // no pending / superseded job — drop this reply
             }
             if let Some((idx, gen, _)) = gfx_msg.borrow_mut().cluster_pending.take() {
                 if labels.len() != idx.len() {
@@ -1844,6 +1871,7 @@ fn create_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
             g.cluster_worker = None;
             g.cluster_worker_failed = true;
             drop(g);
+            set_cluster_progress(None);
             show_status("clustering worker unavailable — runs on the main thread");
         });
     }
@@ -1913,6 +1941,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, 
     set_checked("cl-color", true);
     set_text("cl-readout", &format!("{k} clusters · {} noise · {} pts", group(noise), group(n_in)));
     set_body_class("cluster-color", true); // cluster coloring active -> hide the intensity colorbar
+    set_cluster_progress(None); // done — hide the progress bar
     update_cluster_panel(gfx); // we ran from the Cluster tab, so this shows + renders the panel
     show_status("");
 }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -81,6 +81,7 @@ struct ClusterRunParams {
     floor: f32,
     region: Option<[(f64, f64); 3]>,
     cycle_duration: f64,
+    im_per_scan: f64,
 }
 
 /// A DIA isolation-window footprint in real units (from `/windows`); re-normalized to the focused
@@ -1748,6 +1749,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
             g.floor_hi = m.i_p99.max(1.0);
             g.axis_bounds = m.bounds;
             g.cycle_duration = m.cycle_duration;
+            g.im_per_scan = m.im_per_scan;
         }
         // The new load defines the view: reset spatial crops + the intensity floor to "show all".
         for a in 0..3 {
@@ -2215,6 +2217,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             floor: g.params.filter_min[3],
             region: g.axis_bounds,
             cycle_duration: g.cycle_duration,
+            im_per_scan: g.im_per_scan,
         };
         (idx, positions, eps, g.cluster_min_pts, g.data_gen, run_params)
     };
@@ -2959,6 +2962,7 @@ fn cluster_params_json(p: &ClusterRunParams, k: usize, noise: usize, n_in: usize
     set("mz_peak_widths", &JsValue::from_f64(p.mz_peak_widths));
     set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
     set("cycle_duration_s", &JsValue::from_f64(p.cycle_duration));
+    set("im_per_scan_1k0", &JsValue::from_f64(p.im_per_scan));
     set("intensity_floor", &JsValue::from_f64(p.floor as f64));
     set("clusters", &JsValue::from_f64(k as f64));
     set("noise_points", &JsValue::from_f64(noise as f64));
@@ -3050,6 +3054,9 @@ fn cluster_config_json(g: &Gfx) -> String {
     set("im_scans", &JsValue::from_f64(g.cluster_im_scans));
     set("mz_peak_widths", &JsValue::from_f64(g.cluster_mz_peak_widths));
     set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
+    // The run-level metric anchors, so the config reproduces the exact scaling on its own.
+    set("cycle_duration_s", &JsValue::from_f64(g.cycle_duration));
+    set("im_per_scan_1k0", &JsValue::from_f64(g.im_per_scan));
     if let Some(b) = g.axis_bounds {
         let region = js_sys::Object::new();
         let pair = |lo: f64, hi: f64| {

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -33,8 +33,9 @@ const CLUSTER_CAP: usize = 2_000_000;
 /// at/above it, the off-main-thread worker is used so the tab doesn't freeze.
 const WORKER_THRESHOLD: usize = 300_000;
 
-/// How many MS1 cycles `eps` should bridge along RT (precursor RT is quantized at the cycle period).
-/// RT is scaled so a cluster's elution stays connected across cycles regardless of the RT zoom.
+/// Default for the RT-cycles lever (`Gfx::cluster_rt_cycles`): how many MS1 cycles `eps` bridges
+/// along RT. Precursor RT is quantized at the cycle period, so RT is scaled to span this many cycles
+/// regardless of the RT zoom.
 const CLUSTER_RT_CYCLES: f64 = 2.0;
 
 /// Reference eps the RT/m/z axis scalings are calibrated to (the slider default). The scalings use
@@ -221,6 +222,8 @@ struct Gfx {
     // ---- clustering (CLUSTERING_WEB_PLAN.md) ----
     cluster_eps: f32,
     cluster_min_pts: usize,
+    /// User lever: how many MS1 cycles `eps` bridges along RT (integer; higher = looser RT).
+    cluster_rt_cycles: f64,
     /// User lever: max m/z peak-widths `eps` may span (lower = isotopes separate harder).
     cluster_mz_peak_widths: f64,
     /// True while a DBSCAN result is colouring the cloud (`params.color_mode == 1`). Invalidated on
@@ -655,6 +658,7 @@ async fn run() -> Result<(), String> {
         vol_i_max: 2.0,
         cluster_eps: 0.012,
         cluster_min_pts: 8,
+        cluster_rt_cycles: CLUSTER_RT_CYCLES,
         cluster_mz_peak_widths: CLUSTER_MZ_PEAK_WIDTHS,
         clustered: false,
         cluster_stats: None,
@@ -1830,7 +1834,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         let rt_scale = match g.axis_bounds {
             Some(b) if g.cycle_duration > 0.0 && (b[2].1 - b[2].0).abs() > 0.0 => {
                 let cycle_gap_norm = 2.0 * g.cycle_duration / (b[2].1 - b[2].0).abs();
-                let desired = (CLUSTER_RT_CYCLES * cycle_gap_norm).max(CLUSTER_EPS_REF);
+                let desired = (g.cluster_rt_cycles.max(1.0) * cycle_gap_norm).max(CLUSTER_EPS_REF);
                 (CLUSTER_EPS_REF / desired) as f32
             }
             _ => 1.0,
@@ -2261,6 +2265,7 @@ fn defer<F: FnOnce() + 'static>(f: F) {
 fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-eps", "cl-eps-n", 3, |g, v| g.cluster_eps = v as f32);
     bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(2));
+    bind_value(gfx, "cl-rtc", "cl-rtc-n", 0, |g, v| g.cluster_rt_cycles = v.round().max(1.0));
     bind_value(gfx, "cl-mzw", "cl-mzw-n", 1, |g, v| g.cluster_mz_peak_widths = v.max(0.1));
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-run") {
         let gfx = gfx.clone();
@@ -2954,7 +2959,7 @@ fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
 /// actual params (a checked-but-stale radio won't emit `change` when clicked); calling this after
 /// wiring re-asserts the truth so the panel always reflects what's rendering.
 fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
-    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min, cl_mzw) = {
+    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min, cl_rtc, cl_mzw) = {
         let g = gfx.borrow();
         (
             g.auto_rotate,
@@ -2968,6 +2973,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
             g.params.filter_min[3] as f64,
             g.cluster_eps as f64,
             g.cluster_min_pts as f64,
+            g.cluster_rt_cycles,
             g.cluster_mz_peak_widths,
         )
     };
@@ -2991,6 +2997,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     // Cluster controls (defeat browser form-restore; no result yet, so colour off).
     set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
+    set_value_pair("cl-rtc", "cl-rtc-n", cl_rtc, 0);
     set_value_pair("cl-mzw", "cl-mzw-n", cl_mzw, 1);
     set_checked("cl-color", true); // colour by cluster is on by default (applies after a Run)
     set_checked("hide-noise", false);

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1077,11 +1077,46 @@ async fn load_region(gfx: Rc<RefCell<Gfx>>, region: Region, budget: Option<usize
 fn compute_focus_region(g: &Gfx) -> Option<Region> {
     let b = g.axis_bounds?;
     let p = &g.params;
+    let (fmin, fmax, ms) = (p.filter_min, p.filter_max, p.ms_mask);
+    let limit = (g.renderer.drawn() as usize).min(g.cpu_points.len());
+    // Fit the box to the points that actually survive the active 4D filter (window + intensity
+    // floor + MS) — NOT to the crop sliders. Otherwise points removed by the intensity floor still
+    // "hold the box open" to the full extent. Survivors already lie inside any active spatial crop.
+    let mut lo = [f32::INFINITY; 3];
+    let mut hi = [f32::NEG_INFINITY; 3];
+    let mut n = 0u64;
+    for pt in &g.cpu_points[..limit] {
+        let pos = pt.pos;
+        if pos[0] < fmin[0]
+            || pos[0] > fmax[0]
+            || pos[1] < fmin[1]
+            || pos[1] > fmax[1]
+            || pos[2] < fmin[2]
+            || pos[2] > fmax[2]
+            || pt.intensity < fmin[3]
+        {
+            continue;
+        }
+        let is_ms2 = (pt.flags & GpuPoint::MS2_FLAG) != 0;
+        if !(if is_ms2 { ms & 0b10 != 0 } else { ms & 0b01 != 0 }) {
+            continue;
+        }
+        for a in 0..3 {
+            lo[a] = lo[a].min(pos[a]);
+            hi[a] = hi[a].max(pos[a]);
+        }
+        n += 1;
+    }
+    if n == 0 {
+        return None; // nothing visible to focus on
+    }
+    // Normalized survivor bbox -> real units, with a small margin (and a floor so a thin axis can't
+    // collapse to zero width).
     let lerp = |rng: (f64, f64), norm: f32| rng.0 + ((norm as f64 + 1.0) * 0.5) * (rng.1 - rng.0);
     let mk = |axis: usize| {
-        let a = lerp(b[axis], p.filter_min[axis]);
-        let c = lerp(b[axis], p.filter_max[axis]);
-        (a.min(c), a.max(c))
+        let m = ((hi[axis] - lo[axis]) * 0.02).max(0.01);
+        let (a, c) = ((lo[axis] - m).max(-1.0), (hi[axis] + m).min(1.0));
+        (lerp(b[axis], a), lerp(b[axis], c))
     };
     let (mz, im, rt) = (mk(0), mk(1), mk(2));
     let ok = |r: (f64, f64)| r.0.is_finite() && r.1.is_finite() && r.1 > r.0;

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -231,6 +231,9 @@ struct Gfx {
     clustered: bool,
     /// The last clustering result's stats (for the right-hand panel); cleared on invalidate.
     cluster_stats: Option<ClusterStats>,
+    /// JSON of the parameters used for the last clustering (snapshotted at Run); exported alongside
+    /// the per-cluster CSV. Cleared on invalidate.
+    cluster_params_json: Option<String>,
     /// Retained DBSCAN result for isolation: the survivor `cpu_points` indices + their labels, and
     /// which cluster is currently isolated (`None` = show all). Cleared on invalidate.
     cluster_idx: Vec<usize>,
@@ -662,6 +665,7 @@ async fn run() -> Result<(), String> {
         cluster_mz_peak_widths: CLUSTER_MZ_PEAK_WIDTHS,
         clustered: false,
         cluster_stats: None,
+        cluster_params_json: None,
         cluster_idx: Vec::new(),
         cluster_labels: Vec::new(),
         cluster_sel: None,
@@ -1407,6 +1411,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         g.params.color_mode = 0; // the fresh buffer has no cluster ids
         g.clustered = false;
         g.cluster_stats = None;
+        g.cluster_params_json = None;
         g.cluster_idx = Vec::new();
         g.cluster_labels = Vec::new();
         g.cluster_sel = None;
@@ -1772,6 +1777,7 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
         g.params.color_mode = 0;
         g.clustered = false;
         g.cluster_stats = None;
+        g.cluster_params_json = None;
         g.cluster_idx = Vec::new();
         g.cluster_labels = Vec::new();
         g.cluster_sel = None;
@@ -2073,6 +2079,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, 
         reupload_points(g);
         g.params.color_mode = if g.hide_noise { 2 } else { 1 };
         g.clustered = true;
+        g.cluster_params_json = Some(cluster_params_json(g, k, noise, n_in));
         g.cluster_stats = Some(stats);
         g.cluster_idx = idx;
         g.cluster_labels = labels;
@@ -2499,7 +2506,44 @@ fn isolate_cluster(gfx: &Rc<RefCell<Gfx>>, sel: Option<i32>) {
     update_cluster_panel(gfx); // re-render the list with the active row marked
 }
 
-/// Download the per-cluster summary as CSV (a data-URL anchor — no Blob/Url features needed).
+/// JSON snapshot of the parameters used for a clustering run, so the export is reproducible.
+fn cluster_params_json(g: &Gfx, k: usize, noise: usize, n_in: usize) -> String {
+    let obj = js_sys::Object::new();
+    let set = |key: &str, v: &JsValue| {
+        let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(key), v);
+    };
+    let ms_level = if g.params.ms_mask == 0b10 { "MS2" } else { "MS1" };
+    set("ms_level", &JsValue::from_str(ms_level));
+    set("eps", &JsValue::from_f64(g.cluster_eps as f64));
+    set("min_points", &JsValue::from_f64(g.cluster_min_pts as f64));
+    set("rt_cycles", &JsValue::from_f64(g.cluster_rt_cycles));
+    set("mz_peak_widths", &JsValue::from_f64(g.cluster_mz_peak_widths));
+    set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
+    set("cycle_duration_s", &JsValue::from_f64(g.cycle_duration));
+    set("intensity_floor", &JsValue::from_f64(g.params.filter_min[3] as f64));
+    set("clusters", &JsValue::from_f64(k as f64));
+    set("noise_points", &JsValue::from_f64(noise as f64));
+    set("input_points", &JsValue::from_f64(n_in as f64));
+    if let Some(b) = g.axis_bounds {
+        let region = js_sys::Object::new();
+        let pair = |lo: f64, hi: f64| {
+            let a = js_sys::Array::new();
+            a.push(&JsValue::from_f64(lo));
+            a.push(&JsValue::from_f64(hi));
+            a
+        };
+        let _ = js_sys::Reflect::set(&region, &JsValue::from_str("mz"), &pair(b[0].0, b[0].1));
+        let _ = js_sys::Reflect::set(&region, &JsValue::from_str("im"), &pair(b[1].0, b[1].1));
+        let _ = js_sys::Reflect::set(&region, &JsValue::from_str("rt"), &pair(b[2].0, b[2].1));
+        set("region", &region);
+    }
+    js_sys::JSON::stringify_with_replacer_and_space(&obj, &JsValue::NULL, &JsValue::from_f64(2.0))
+        .ok()
+        .and_then(|s| s.as_string())
+        .unwrap_or_default()
+}
+
+/// Download the per-cluster summary as CSV plus the run's parameters as JSON (two data-URL anchors).
 fn export_clusters(gfx: &Rc<RefCell<Gfx>>) {
     let g = gfx.borrow();
     let Some(s) = g.cluster_stats.as_ref() else {
@@ -2513,6 +2557,9 @@ fn export_clusters(gfx: &Rc<RefCell<Gfx>>) {
         ));
     }
     download_text("clusters.csv", "text/csv", &csv);
+    if let Some(pj) = g.cluster_params_json.as_ref() {
+        download_text("cluster_params.json", "application/json", pj);
+    }
 }
 
 /// Trigger a file download of `content` via a `data:` URL anchor (attached to the DOM for the click

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -19,7 +19,7 @@ use tims_viewer::camera::{OrbitCamera, ROLL_UP_AXIS};
 use tims_viewer::data::point::{AxisTransform, GpuPoint};
 use tims_viewer::render::annotation::{AnnotationRenderer, LineVertex};
 use tims_viewer::ticks::{fmt_tick, ticks_for, Axis, RT_MINUTES_SPAN};
-use tims_viewer::render::colormap::COLORMAP_NAMES;
+use tims_viewer::render::colormap::{sample as colormap_sample, COLORMAP_NAMES};
 use tims_viewer::render::point_cloud::{PointCloudRenderer, PointMode};
 use tims_viewer::render::uniforms::ParamsUniform;
 
@@ -407,7 +407,7 @@ async fn run() -> Result<(), String> {
     }
     // Push code state onto every DOM control (defeats the browser's cross-reload form restore).
     sync_controls(&gfx);
-    // Distribution strips: per-axis crops + the linear intensity floor.
+    // Distribution strips: per-axis crops + the linear intensity floor + the projection maps.
     if let Some(m) = &server_meta {
         if let Some(h) = &m.hist {
             draw_hist_backdrops(h);
@@ -415,6 +415,7 @@ async fn run() -> Result<(), String> {
         if let Some(ih) = &m.i_hist {
             set_hist_svg("floor-hist", ih);
         }
+        render_maps(m);
     }
     // Runtime detail/performance control over how many of the loaded points are drawn.
     bind_display(&gfx);
@@ -422,6 +423,10 @@ async fn run() -> Result<(), String> {
     bind_load(&gfx);
     // Focus / Back: drill into the crop+floor region at full budget, and pop back out.
     bind_focus(&gfx);
+    // 2D projection minimaps: drag a box to focus a region.
+    bind_maps(&gfx);
+    // Collapsible section headers + tab switching.
+    bind_panel_chrome();
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -630,6 +635,9 @@ struct MetaInfo {
     hist: Option<[Vec<u32>; 3]>,
     /// Linear intensity distribution over `[0, p99]` (real counts), for the floor strip.
     i_hist: Option<Vec<u32>>,
+    /// 2D density projections `[mz×im, mz×rt, im×rt]` (each `proj_bins²`) for the box-select maps.
+    proj: Option<[Vec<u32>; 3]>,
+    proj_bins: usize,
 }
 
 /// Derive the `/meta` URL from the `/points` URL: replace only the trailing path endpoint and keep
@@ -715,6 +723,21 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
     };
     let i_hist = js_u32_array(&it, "hist");
 
+    // 2D projections for the box-select maps.
+    let pj = jget(&v, "proj");
+    let proj = match (
+        js_u32_array(&pj, "mz_im"),
+        js_u32_array(&pj, "mz_rt"),
+        js_u32_array(&pj, "im_rt"),
+    ) {
+        (Some(a), Some(b), Some(c)) => Some([a, b, c]),
+        _ => None,
+    };
+    let proj_bins = proj
+        .as_ref()
+        .map(|p| (p[0].len() as f64).sqrt().round() as usize)
+        .unwrap_or(0);
+
     Ok(MetaInfo {
         bounds,
         i_p1: pos("p1").unwrap_or(0.0),
@@ -723,6 +746,8 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
         stride,
         hist,
         i_hist,
+        proj,
+        proj_bins,
     })
 }
 
@@ -946,6 +971,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         if let Some(ih) = &m.i_hist {
             set_hist_svg("floor-hist", ih);
         }
+        render_maps(m);
     }
     for id in ["floor", "floor-n"] {
         if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
@@ -1171,6 +1197,201 @@ fn bind_load(gfx: &Rc<RefCell<Gfx>>) {
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| trigger());
     }
     add_listener(num.as_ref(), "change", move |_e: web_sys::Event| trigger());
+}
+
+/// Toggle a class on an element by id.
+fn set_class(id: &str, class: &str, on: bool) {
+    if let Some(el) = by_id::<web_sys::HtmlElement>(id) {
+        let _ = el.class_list().toggle_with_force(class, on);
+    }
+}
+
+/// Show one tab pane (`view`/`focus`) and highlight its button; hide the others.
+fn switch_tab(name: &str) {
+    for t in ["view", "focus"] {
+        set_class(&format!("tabbtn-{t}"), "active", t == name);
+        set_class(&format!("tab-{t}"), "active", t == name);
+    }
+}
+
+/// Wire tab switching + collapsible section headers via one delegated click listener.
+fn bind_panel_chrome() {
+    let Some(doc) = document() else {
+        return;
+    };
+    add_listener(doc.as_ref(), "click", move |e: web_sys::Event| {
+        let Some(t) = e.target().and_then(|t| t.dyn_into::<web_sys::Element>().ok()) else {
+            return;
+        };
+        if let Ok(Some(tab)) = t.closest(".tab") {
+            if let Some(name) = tab.get_attribute("data-tab") {
+                switch_tab(&name);
+            }
+        } else if let Ok(Some(ey)) = t.closest(".ey") {
+            if let Some(sec) = ey.parent_element() {
+                let _ = sec.class_list().toggle("collapsed");
+            }
+        }
+    });
+}
+
+/// Render a 2D density projection to its `<canvas>` with the inferno colormap (sqrt-scaled). The
+/// projection is row-major `x + bins*y`; y is flipped so the low bin sits at the bottom.
+fn render_heatmap(canvas_id: &str, data: &[u32], bins: usize) {
+    if bins == 0 || data.len() < bins * bins {
+        return;
+    }
+    let Some(canvas) = by_id::<web_sys::HtmlCanvasElement>(canvas_id) else {
+        return;
+    };
+    canvas.set_width(bins as u32);
+    canvas.set_height(bins as u32);
+    let Some(ctx) = canvas
+        .get_context("2d")
+        .ok()
+        .flatten()
+        .and_then(|c| c.dyn_into::<web_sys::CanvasRenderingContext2d>().ok())
+    else {
+        return;
+    };
+    let max = data.iter().copied().max().unwrap_or(1).max(1) as f32;
+    let mut buf = vec![0u8; bins * bins * 4];
+    for y in 0..bins {
+        let row = bins - 1 - y; // flip: low bin at the bottom
+        for x in 0..bins {
+            let t = (data[x + bins * y] as f32 / max).sqrt();
+            let rgb = colormap_sample(1, t); // inferno
+            let i = (row * bins + x) * 4;
+            buf[i] = rgb[0];
+            buf[i + 1] = rgb[1];
+            buf[i + 2] = rgb[2];
+            buf[i + 3] = 255;
+        }
+    }
+    if let Ok(img) = web_sys::ImageData::new_with_u8_clamped_array_and_sh(
+        wasm_bindgen::Clamped(&buf),
+        bins as u32,
+        bins as u32,
+    ) {
+        let _ = ctx.put_image_data(&img, 0.0, 0.0);
+    }
+}
+
+/// Render all three projection minimaps from a load's meta.
+fn render_maps(meta: &MetaInfo) {
+    if let Some(proj) = &meta.proj {
+        for (i, id) in ["map-0", "map-1", "map-2"].iter().enumerate() {
+            render_heatmap(id, &proj[i], meta.proj_bins);
+        }
+    }
+}
+
+/// Map a box on projection `proj` (x,y fractions of the map) to a 4D region of the current view.
+/// The map renders low-at-bottom, so the y fractions flip; the unselected axis keeps the full view
+/// range, and the current intensity floor carries through.
+fn region_from_box(g: &Gfx, proj: usize, x: (f64, f64), y: (f64, f64)) -> Option<Region> {
+    let b = g.axis_bounds?;
+    let lerp = |rng: (f64, f64), f: f64| rng.0 + f * (rng.1 - rng.0);
+    let (yl, yh) = (1.0 - y.1, 1.0 - y.0); // top->bottom px, but low-at-bottom display
+    let imin = g.params.filter_min[3].max(0.0);
+    let (mz, im, rt) = match proj {
+        0 => ((lerp(b[0], x.0), lerp(b[0], x.1)), (lerp(b[1], yl), lerp(b[1], yh)), b[2]),
+        1 => ((lerp(b[0], x.0), lerp(b[0], x.1)), b[1], (lerp(b[2], yl), lerp(b[2], yh))),
+        2 => (b[0], (lerp(b[1], x.0), lerp(b[1], x.1)), (lerp(b[2], yl), lerp(b[2], yh))),
+        _ => return None,
+    };
+    Some(Region { mz, im, rt, imin })
+}
+
+/// Mouse position within a map-wrap as fractions `[0,1]` (x left→right, y top→bottom).
+fn map_frac(mw: &web_sys::HtmlElement, e: &web_sys::MouseEvent) -> (f64, f64) {
+    let rect = mw.get_bounding_client_rect();
+    let nx = ((e.client_x() as f64 - rect.left()) / rect.width().max(1.0)).clamp(0.0, 1.0);
+    let ny = ((e.client_y() as f64 - rect.top()) / rect.height().max(1.0)).clamp(0.0, 1.0);
+    (nx, ny)
+}
+
+/// Position (or, with `show=false`, hide) the selection-box overlay on map `proj`.
+fn set_sel_box(proj: usize, x0: f64, y0: f64, x1: f64, y1: f64, show: bool) {
+    let Some(sel) = by_id::<web_sys::HtmlElement>(&format!("sel-{proj}")) else {
+        return;
+    };
+    let st = sel.style();
+    if !show {
+        let _ = st.set_property("display", "none");
+        return;
+    }
+    let (l, r) = (x0.min(x1), x0.max(x1));
+    let (t, b) = (y0.min(y1), y0.max(y1));
+    let _ = st.set_property("display", "block");
+    let _ = st.set_property("left", &format!("{:.2}%", l * 100.0));
+    let _ = st.set_property("top", &format!("{:.2}%", t * 100.0));
+    let _ = st.set_property("width", &format!("{:.2}%", (r - l) * 100.0));
+    let _ = st.set_property("height", &format!("{:.2}%", (b - t) * 100.0));
+}
+
+/// Wire box-select on the three projection maps: drag a rectangle → Focus that 4D region.
+fn bind_maps(gfx: &Rc<RefCell<Gfx>>) {
+    if gfx.borrow().points_base.is_empty() {
+        return; // demo fallback: maps render but can't drive a server focus
+    }
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    // Shared drag state: (proj index, start-x frac, start-y frac).
+    let drag: Rc<RefCell<Option<(usize, f64, f64)>>> = Rc::new(RefCell::new(None));
+
+    for proj in 0..3usize {
+        let Some(mw) = by_id::<web_sys::HtmlElement>(&format!("mw-{proj}")) else {
+            continue;
+        };
+        let (drag, mw2) = (drag.clone(), mw.clone());
+        add_listener(mw.as_ref(), "mousedown", move |e: web_sys::MouseEvent| {
+            e.prevent_default();
+            let (nx, ny) = map_frac(&mw2, &e);
+            *drag.borrow_mut() = Some((proj, nx, ny));
+            set_sel_box(proj, nx, ny, nx, ny, true);
+        });
+    }
+    {
+        let drag = drag.clone();
+        add_listener(window.as_ref(), "mousemove", move |e: web_sys::MouseEvent| {
+            let Some((proj, x0, y0)) = *drag.borrow() else {
+                return;
+            };
+            if let Some(mw) = by_id::<web_sys::HtmlElement>(&format!("mw-{proj}")) {
+                let (nx, ny) = map_frac(&mw, &e);
+                set_sel_box(proj, x0, y0, nx, ny, true);
+            }
+        });
+    }
+    {
+        let (drag, gfx) = (drag.clone(), gfx.clone());
+        add_listener(window.as_ref(), "mouseup", move |e: web_sys::MouseEvent| {
+            let Some((proj, x0, y0)) = drag.borrow_mut().take() else {
+                return;
+            };
+            set_sel_box(proj, 0.0, 0.0, 0.0, 0.0, false);
+            let Some(mw) = by_id::<web_sys::HtmlElement>(&format!("mw-{proj}")) else {
+                return;
+            };
+            let (nx, ny) = map_frac(&mw, &e);
+            let (xa, xb) = (x0.min(nx), x0.max(nx));
+            let (ya, yb) = (y0.min(ny), y0.max(ny));
+            if (xb - xa) < 0.02 || (yb - ya) < 0.02 || gfx.borrow().reloading {
+                return; // ignore clicks / tiny drags / mid-load
+            }
+            if let Some(r) = region_from_box(&gfx.borrow(), proj, (xa, xb), (ya, yb)) {
+                let budget = gfx.borrow().n_cap;
+                wasm_bindgen_futures::spawn_local(load_region(
+                    gfx.clone(),
+                    r,
+                    Some(budget),
+                    StackOp::Push,
+                ));
+            }
+        });
+    }
 }
 
 /// Create the DOM label elements inside `#axis-labels`; returns `(element, cube-position)` pairs

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1541,7 +1541,6 @@ async fn probe_cluster_service(gfx: Rc<RefCell<Gfx>>) {
     };
     if ok {
         set_disabled("opt-sklearn", false);
-        set_disabled("opt-hdbscan", false);
         // Prefer sklearn DBSCAN when the service is up — unless the user already picked an algorithm.
         if !gfx.borrow().cluster_algo_user_set {
             if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
@@ -2492,20 +2491,17 @@ fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
     );
 }
 
-/// Apply a clustering-algorithm dropdown value: set the engine (wasm vs Python) + method, and reveal
-/// that algorithm's parameter rows.
+/// Apply a clustering-algorithm dropdown value: set the engine (wasm DBSCAN vs Python sklearn DBSCAN).
+/// HDBSCAN was removed from the UI (it blacked the canvas on selection via a compositor-layer drop on
+/// the param-row reflow, and added nothing for the demo); the backend plumbing stays dormant.
 fn apply_cluster_algo(gfx: &Rc<RefCell<Gfx>>, value: &str) {
     let (python, method) = match value {
         "sklearn" => (true, ClusterMethod::Dbscan),
-        "hdbscan" => (true, ClusterMethod::Hdbscan),
         _ => (false, ClusterMethod::Dbscan), // "wasm"
     };
-    {
-        let mut g = gfx.borrow_mut();
-        g.use_python_cluster = python;
-        g.cluster_method = method;
-    }
-    set_body_class("algo-hdb", method == ClusterMethod::Hdbscan);
+    let mut g = gfx.borrow_mut();
+    g.use_python_cluster = python;
+    g.cluster_method = method;
 }
 
 /// Flip the Run/Stop button: while a (worker) clustering is in flight it becomes a red "Stop".
@@ -3179,11 +3175,8 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-rtc", "cl-rtc-n", 0, |g, v| g.cluster_rt_cycles = v.round().max(1.0));
     bind_value(gfx, "cl-ims", "cl-ims-n", 1, |g, v| g.cluster_im_scans = v.max(0.1));
     bind_value(gfx, "cl-mzw", "cl-mzw-n", 1, |g, v| g.cluster_mz_peak_widths = v.max(0.1));
-    // HDBSCAN parameters (Python only).
-    bind_value(gfx, "cl-mcs", "cl-mcs-n", 0, |g, v| g.cluster_min_cluster_size = (v as usize).max(2));
-    bind_value(gfx, "cl-hms", "cl-hms-n", 0, |g, v| g.cluster_hdb_min_samples = v.max(0.0) as usize);
-    bind_value(gfx, "cl-cse", "cl-cse-n", 3, |g, v| g.cluster_selection_eps = v.max(0.0));
-    // Algorithm dropdown: maps to (engine, method) + reveals that algorithm's params.
+    // (HDBSCAN params removed from the UI; the cl-mcs/cl-hms/cl-cse rows no longer exist.)
+    // Algorithm dropdown: maps to (engine, method).
     if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
         let (gfx, el) = (gfx.clone(), sel.clone());
         add_listener(sel.as_ref(), "change", move |_e: web_sys::Event| {
@@ -4078,8 +4071,6 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
         sel.set_value("wasm");
     }
     set_disabled("opt-sklearn", true);
-    set_disabled("opt-hdbscan", true);
-    set_body_class("algo-hdb", false);
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);
 }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1097,7 +1097,8 @@ async fn fetch_acq_meta(base: &str) -> Option<AcqMeta> {
 }
 
 /// Fetch `<base>/acq/frame?id=N` (24-byte/peak records) and build normalized `GpuPoint`s:
-/// `_pad[0]` = peptide_id (color key), `flags` bit0 = fragment. Wired by the playback engine (next).
+/// `_pad[0]` = peptide_id (color key), `flags` bit0 = fragment. `id` is a 0-based frame INDEX
+/// (`0..n_frames`). Wired by the playback engine (next slice).
 #[allow(dead_code)]
 async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoint>, String> {
     let window = web_sys::window().ok_or("no window")?;
@@ -1116,6 +1117,9 @@ async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoin
     .await
     .map_err(|e| format!("body read failed: {e:?}"))?;
     let bytes = js_sys::Uint8Array::new(&buf).to_vec();
+    if bytes.len() % 24 != 0 {
+        return Err(format!("acq frame body not 24-byte aligned ({} bytes)", bytes.len()));
+    }
     let mut pts = Vec::with_capacity(bytes.len() / 24);
     for c in bytes.chunks_exact(24) {
         let f = |o: usize| f32::from_le_bytes([c[o], c[o + 1], c[o + 2], c[o + 3]]);
@@ -1140,7 +1144,15 @@ async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoin
 async fn probe_acq_service(gfx: Rc<RefCell<Gfx>>) {
     let base = acq_service_url();
     let Some(window) = web_sys::window() else { return };
-    let healthy = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&base)).await {
+    // Abort after 3s — the sidecar is single-threaded, so a probe issued while it's mid-build (or a
+    // half-open service) must not pin detection forever.
+    let opts = web_sys::RequestInit::new();
+    if let Ok(controller) = web_sys::AbortController::new() {
+        opts.set_signal(Some(&controller.signal()));
+        let cb = wasm_bindgen::closure::Closure::once_into_js(move || controller.abort());
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 3000);
+    }
+    let healthy = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str_and_init(&base, &opts)).await {
         Ok(v) => match v.dyn_into::<web_sys::Response>() {
             Ok(r) if r.ok() => match r.text() {
                 Ok(p) => wasm_bindgen_futures::JsFuture::from(p)

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -2819,8 +2819,11 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         let g = gfx.borrow();
         let p = &g.params;
         let (fmin, fmax, ms) = (p.filter_min, p.filter_max, p.ms_mask);
-        let mut idx: Vec<usize> = Vec::with_capacity(g.cpu_points.len());
-        let mut positions: Vec<[f32; 3]> = Vec::with_capacity(g.cpu_points.len());
+        // Grow on demand — do NOT reserve cpu_points.len(): a cropped/focused cluster keeps only a
+        // small subset, so reserving the whole (up to 32M-point) cloud would waste hundreds of MB of
+        // wasm heap and raise OOM risk (codex review). The reallocs are bounded by the survivor count.
+        let mut idx: Vec<usize> = Vec::new();
+        let mut positions: Vec<[f32; 3]> = Vec::new();
         for (i, pt) in g.cpu_points.iter().enumerate() {
             let pos = pt.pos;
             if pos[0] < fmin[0]

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1319,6 +1319,14 @@ fn set_volmode(on: bool) {
 /// Wire the Points/Volume view-mode toggle + volume controls (style, steps). Disables Volume when
 /// the GPU can't host the 3D density texture.
 fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
+    // Force the View toggle + style to the code defaults (Points / Composite), so a browser-restored
+    // radio can't desync from view_mode (starts Points) / vol_style (starts Composite) — otherwise
+    // the toggle shows Volume/MIP while the code renders Points/Composite.
+    set_checked("v-pts", true);
+    set_checked("v-vol", false);
+    set_checked("vs-comp", true);
+    set_checked("vs-mip", false);
+    set_volmode(false);
     if gfx.borrow().volume.is_none() {
         set_disabled("v-vol", true);
         return; // leave Points selected; volume unsupported on this GPU
@@ -1346,7 +1354,12 @@ fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
         if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
             let gfx = gfx.clone();
             add_listener(inp.as_ref(), "change", move |_e: web_sys::Event| {
-                gfx.borrow_mut().vol_needs_grid = true;
+                let mut g = gfx.borrow_mut();
+                // Only flag in Volume mode; entering Volume already rebuilds, so a Points-mode
+                // floor change needs no flag.
+                if g.view_mode == ViewMode::Volume {
+                    g.vol_needs_grid = true;
+                }
             });
         }
     }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -279,7 +279,18 @@ async fn run() -> Result<(), String> {
             (demo_cloud(), true)
         }
     };
-    let capacity = pts.len() as u32;
+    // Cap to what the GPU buffer can hold (master is a vertex+storage buffer): on a 12M budget
+    // = 384 MB, clamp to the device's max so the allocation can't fail.
+    let stride = std::mem::size_of::<GpuPoint>() as u64;
+    let mut max_pts = (device.limits().max_buffer_size / stride) as usize;
+    if supports_compaction {
+        max_pts = max_pts.min((device.limits().max_storage_buffer_binding_size as u64 / stride) as usize);
+    }
+    let capacity = pts.len().min(max_pts).max(1) as u32;
+    if (capacity as usize) < pts.len() {
+        log::warn!("capping {} -> {capacity} points (GPU buffer limit {} MB)",
+            pts.len(), device.limits().max_buffer_size / (1 << 20));
+    }
     let mut renderer = PointCloudRenderer::new(
         &device,
         &queue,
@@ -337,15 +348,17 @@ async fn run() -> Result<(), String> {
 
     wire_input(&gfx, &window, &canvas_for_input);
     wire_controls(&gfx);
-    // Bind the cbrt-mapped intensity floor to the data range (number field is in real counts).
+    // Scale the linear intensity-floor controls (slider + number, both real counts) to the data.
     let floor_hi = server_meta.as_ref().map(|m| m.i_p99).filter(|x| *x > 1.0).unwrap_or(1000.0);
-    bind_floor(&gfx, floor_hi);
-    if let Some(n) = by_id::<web_sys::HtmlInputElement>("floor-n") {
-        let _ = n.set_attribute("max", &format!("{floor_hi:.0}"));
+    for id in ["floor", "floor-n"] {
+        if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+            let _ = inp.set_attribute("max", &format!("{floor_hi:.0}"));
+            let _ = inp.set_attribute("step", &format!("{:.0}", (floor_hi / 200.0).max(1.0)));
+        }
     }
     // Push code state onto every DOM control (defeats the browser's cross-reload form restore).
     sync_controls(&gfx);
-    // Distribution strips: per-axis crops + the cbrt intensity floor.
+    // Distribution strips: per-axis crops + the linear intensity floor.
     if let Some(m) = &server_meta {
         if let Some(h) = &m.hist {
             draw_hist_backdrops(h);
@@ -388,6 +401,21 @@ fn device_desc(limits: wgpu::Limits) -> wgpu::DeviceDescriptor<'static> {
     }
 }
 
+/// Downlevel limits for the backend, but with the buffer-size limits raised to the adapter's real
+/// maximum so large point budgets (e.g. 12M points = 384 MB) can allocate where the GPU allows.
+fn web_limits(adapter: &wgpu::Adapter, is_webgl: bool) -> wgpu::Limits {
+    let base = if is_webgl {
+        wgpu::Limits::downlevel_webgl2_defaults()
+    } else {
+        wgpu::Limits::downlevel_defaults()
+    };
+    let a = adapter.limits();
+    let mut l = base.using_resolution(a.clone());
+    l.max_buffer_size = a.max_buffer_size;
+    l.max_storage_buffer_binding_size = a.max_storage_buffer_binding_size;
+    l
+}
+
 /// Create a wgpu surface + device, preferring WebGPU and falling back to WebGL2 if its
 /// `requestDevice` fails (see the `maxInterStageShaderComponents` note in `run`). WebGPU enumerates
 /// its adapter globally (no canvas context yet), so we only create the WebGPU surface once the
@@ -407,7 +435,7 @@ async fn init_gpu(canvas: &web_sys::HtmlCanvasElement) -> Result<Gpu, String> {
         .await
     {
         Some(adapter) => {
-            let limits = wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits());
+            let limits = web_limits(&adapter, false);
             match adapter.request_device(&device_desc(limits), None).await {
                 // Surface creation can also fail here — treat that like any WebGPU failure and
                 // fall through to WebGL2 rather than giving up (the canvas has no context yet).
@@ -442,7 +470,7 @@ async fn init_gpu(canvas: &web_sys::HtmlCanvasElement) -> Result<Gpu, String> {
         })
         .await
         .ok_or_else(|| format!("no WebGL2 adapter (after {webgpu_err:?})"))?;
-    let limits = wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits());
+    let limits = web_limits(&adapter, true);
     let (device, queue) = adapter
         .request_device(&device_desc(limits), None)
         .await
@@ -545,7 +573,7 @@ struct MetaInfo {
     /// Per-axis density histograms `[mz, im, rt]` (each over the full axis range), for the crop
     /// distribution strips. `None` if the server didn't provide them.
     hist: Option<[Vec<u32>; 3]>,
-    /// cbrt-binned intensity distribution over `[0, p99]`, for the floor control's strip.
+    /// Linear intensity distribution over `[0, p99]` (real counts), for the floor strip.
     i_hist: Option<Vec<u32>>,
 }
 
@@ -864,43 +892,6 @@ fn bind_value(
     }
 }
 
-/// Bind the intensity-floor control with a cbrt mapping: the slider's 0..1000 position is uniform
-/// in `cbrt(intensity)` over `[0, hi]` (so the low-intensity region gets fine control), while the
-/// number field stays in real counts. Both drive `filter_min[3]`.
-fn bind_floor(gfx: &Rc<RefCell<Gfx>>, hi: f64) {
-    let (Some(slider), Some(num)) = (
-        by_id::<web_sys::HtmlInputElement>("floor"),
-        by_id::<web_sys::HtmlInputElement>("floor-n"),
-    ) else {
-        return;
-    };
-    let hi = hi.max(1.0);
-    // slider position (0..1000) -> intensity = hi * (pos/1000)^3
-    {
-        let (gfx_c, s, n) = (gfx.clone(), slider.clone(), num.clone());
-        add_listener(slider.as_ref(), "input", move |_e: web_sys::Event| {
-            let pos = (s.value_as_number() / 1000.0).clamp(0.0, 1.0);
-            let intensity = hi * pos.powi(3);
-            gfx_c.borrow_mut().params.filter_min[3] = intensity as f32;
-            n.set_value(&format!("{intensity:.0}"));
-        });
-    }
-    // typed intensity -> pos = 1000 * cbrt(intensity/hi)
-    {
-        let (gfx_c, s, n) = (gfx.clone(), slider.clone(), num.clone());
-        add_listener(num.as_ref(), "change", move |_e: web_sys::Event| {
-            let raw = n.value_as_number();
-            if raw.is_nan() {
-                return;
-            }
-            let intensity = raw.clamp(0.0, hi);
-            s.set_value(&format!("{:.0}", 1000.0 * (intensity / hi).cbrt()));
-            n.set_value(&format!("{intensity:.0}"));
-            gfx_c.borrow_mut().params.filter_min[3] = intensity as f32;
-        });
-    }
-}
-
 /// Set a slider + its number field to `v` without firing handlers (for startup sync).
 fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
     if let Some(s) = by_id::<web_sys::HtmlInputElement>(slider_id) {
@@ -1023,7 +1014,8 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
     on_toggle("xf-sqrt", gfx, |g, on| if on { g.params.transfer[0] = 1.0; });
     on_toggle("xf-log", gfx, |g, on| if on { g.params.transfer[0] = 2.0; });
     bind_value(gfx, "expo", "expo-n", 2, |g, v| g.params.transfer[3] = v as f32);
-    // `floor` is bound separately (cbrt-mapped) once the intensity range is known — see bind_floor.
+    // Floor is linear in real counts; its slider/number range is scaled to the data in run().
+    bind_value(gfx, "floor", "floor-n", 0, |g, v| g.params.filter_min[3] = v as f32);
 
     // Filters
     on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; });

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -37,6 +37,12 @@ const WORKER_THRESHOLD: usize = 300_000;
 /// RT is scaled so a cluster's elution stays connected across cycles regardless of the RT zoom.
 const CLUSTER_RT_CYCLES: f64 = 2.0;
 
+/// Nominal TOF resolution for the m/z peak-width transform (peak width ≈ m/z / resolution).
+const MZ_RESOLUTION: f64 = 50_000.0;
+/// Cap on how many m/z peak-widths `eps` may span: the m/z axis is expanded so `eps` never bridges
+/// more than this, keeping adjacent isotopes (tens of peak-widths apart) as separate clusters.
+const CLUSTER_MZ_PEAK_WIDTHS: f64 = 6.0;
+
 /// Hard ceiling on points loaded into the (32-bit) wasm heap, regardless of the server `--budget` or
 /// the GPU buffer limit: ~32M × 32 B ≈ 1 GB resident, well clear of the ~4 GB wasm address space.
 const MAX_WEB_POINTS: usize = 32_000_000;
@@ -1751,6 +1757,12 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         show_status("clustering already running…");
         return;
     }
+    // MS1 (precursors) and MS2 (fragments) live in different m/z spaces — clustering them together is
+    // meaningless. Require a single MS level.
+    if gfx.borrow().params.ms_mask == 0b11 {
+        show_status("pick MS1 or MS2 to cluster — clustering both levels together isn't meaningful");
+        return;
+    }
     // Gather the filtered survivors (spatial crop + intensity floor + MS) and their cube positions.
     let (idx, positions, eps, min_pts, gen) = {
         let g = gfx.borrow();
@@ -1791,9 +1803,28 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             }
             _ => 1.0,
         };
-        if rt_scale != 1.0 {
-            for p in positions.iter_mut() {
+        // Expand the m/z axis into ~peak-width units so eps spans only a few peak-widths and can't
+        // bridge across isotopes (tens of peak-widths apart). Linear over the region (peak width at
+        // the m/z center); max(1) so a narrow focus only ever sharpens m/z, never loosens it.
+        let mz_scale = match g.axis_bounds {
+            Some(b) => {
+                let mz_center = ((b[0].0 + b[0].1) * 0.5).abs();
+                let mz_range = (b[0].1 - b[0].0).abs();
+                let peak_width = mz_center / MZ_RESOLUTION;
+                if mz_center > 0.0 && mz_range > 0.0 && peak_width > 0.0 {
+                    (eps as f64 * mz_range / (2.0 * CLUSTER_MZ_PEAK_WIDTHS * peak_width)).max(1.0) as f32
+                } else {
+                    1.0
+                }
+            }
+            _ => 1.0,
+        };
+        for p in positions.iter_mut() {
+            if rt_scale != 1.0 {
                 p[2] *= rt_scale;
+            }
+            if mz_scale != 1.0 {
+                p[0] *= mz_scale;
             }
         }
         (idx, positions, eps, g.cluster_min_pts, g.data_gen)

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -45,6 +45,11 @@ const DEFAULT_SERVER_PORT: u16 = 8090;
 #[wasm_bindgen(start)]
 pub fn start() {
     console_error_panic_hook::set_once();
+    // Off the main thread (the clustering Web Worker re-inits this same wasm) there is no DOM —
+    // `window()` is None. Skip the renderer; the worker only calls `cluster_dbscan_flat`.
+    if web_sys::window().is_none() {
+        return;
+    }
     let _ = console_log::init_with_level(log::Level::Info);
     wasm_bindgen_futures::spawn_local(async {
         if let Err(e) = run().await {
@@ -52,6 +57,14 @@ pub fn start() {
             show_status(&format!("tims-viewer could not start: {e}"));
         }
     });
+}
+
+/// DBSCAN over a flat `[x,y,z, x,y,z, …]` buffer, returning per-point labels (`-1` = noise). The
+/// Web Worker calls this; exported so its wasm instance has it too.
+#[wasm_bindgen]
+pub fn cluster_dbscan_flat(flat: &[f32], min_pts: usize, eps: f32) -> Vec<i32> {
+    let pts: Vec<[f32; 3]> = flat.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect();
+    dbscan(&pts, eps, min_pts).0
 }
 
 /// Summary of a clustering result, for the MIDIA-style stats panel.
@@ -159,6 +172,10 @@ struct Gfx {
     cluster_idx: Vec<usize>,
     cluster_labels: Vec<i32>,
     cluster_sel: Option<i32>,
+    /// Persistent DBSCAN worker (lazily created; `None` if workers are unavailable → main-thread
+    /// fallback), and the in-flight job's (survivor idx, data generation) awaiting its reply.
+    cluster_worker: Option<web_sys::Worker>,
+    cluster_pending: Option<(Vec<usize>, u64)>,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -555,6 +572,8 @@ async fn run() -> Result<(), String> {
         cluster_idx: Vec::new(),
         cluster_labels: Vec::new(),
         cluster_sel: None,
+        cluster_worker: None,
+        cluster_pending: None,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -1124,6 +1143,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         g.cluster_idx = Vec::new();
         g.cluster_labels = Vec::new();
         g.cluster_sel = None;
+        g.cluster_pending = None;
         // Re-apply auto-transfer (exposure + floor range) and bounds from the new meta; keep the
         // user's colormap / point size / opacity / MS mask.
         if let Some(m) = &meta {
@@ -1431,6 +1451,7 @@ fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
 /// Revert cluster colouring (a filter/load changed the set, so the labels are stale). Cheap — just
 /// flips `color_mode` back to intensity; the stale `_pad[0]` ids stay unused until the next Run.
 fn invalidate_clusters_mut(g: &mut Gfx) {
+    g.cluster_pending = None; // abandon any in-flight worker job (its reply will be ignored)
     if g.clustered {
         g.params.color_mode = 0;
         g.clustered = false;
@@ -1450,6 +1471,10 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
 fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     if gfx.borrow().reloading {
         show_status("loading — try clustering again in a moment");
+        return;
+    }
+    if gfx.borrow().cluster_pending.is_some() {
+        show_status("clustering already running…");
         return;
     }
     // Gather the filtered survivors (spatial crop + intensity floor + MS) and their cube positions.
@@ -1493,13 +1518,116 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         return;
     }
     show_status("clustering…");
-    // Defer the (synchronous, blocking) DBSCAN one macrotask so the "clustering…" status paints
-    // first — otherwise the tab freezes with no feedback.
+    // Off-main-thread: post to the persistent DBSCAN worker so the tab stays responsive. The worker
+    // replies via its onmessage handler, which calls finish_clustering.
+    if let Some(worker) = ensure_cluster_worker(gfx) {
+        let flat: Vec<f32> = positions.iter().flatten().copied().collect();
+        if post_cluster_job(&worker, &flat, eps, min_pts) {
+            gfx.borrow_mut().cluster_pending = Some((idx, gen));
+            return;
+        }
+    }
+    // Fallback (no worker): defer the blocking DBSCAN one macrotask so the status paints first.
     let gfx = gfx.clone();
     defer(move || {
         let (labels, k) = dbscan(&positions, eps, min_pts);
         finish_clustering(&gfx, idx, labels, k, gen);
     });
+}
+
+/// JS module source for the DBSCAN worker — re-imports this same wasm (URLs injected) and runs
+/// `cluster_dbscan_flat` per posted job. Top-level await holds the message queue until wasm is ready.
+const CLUSTER_WORKER_SRC: &str = r#"
+import init, { cluster_dbscan_flat } from '__GLUE__';
+await init({ module_or_path: '__WASM__' });
+self.onmessage = (e) => {
+  const { flat, eps, min_pts } = e.data;
+  const labels = cluster_dbscan_flat(new Float32Array(flat), min_pts, eps);
+  self.postMessage({ labels }, [labels.buffer]);
+};
+"#;
+
+/// Return the persistent DBSCAN worker, creating it on first use. `None` (→ main-thread fallback) if
+/// workers are unavailable or the wasm/glue URLs can't be discovered.
+fn ensure_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
+    if let Some(w) = gfx.borrow().cluster_worker.clone() {
+        return Some(w);
+    }
+    let w = create_cluster_worker(gfx)?;
+    gfx.borrow_mut().cluster_worker = Some(w.clone());
+    Some(w)
+}
+
+/// Build the DBSCAN worker from a Blob module that re-imports the Trunk-built wasm (URLs read from
+/// the page's preload links, so Trunk's content hashing is handled).
+fn create_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
+    let doc = document()?;
+    // The glue JS + wasm URLs from Trunk's preload links (absolute via the element `href` property).
+    let link_href = |sel: &str| -> Option<String> {
+        doc.query_selector(sel)
+            .ok()
+            .flatten()
+            .and_then(|e| e.dyn_into::<web_sys::HtmlLinkElement>().ok())
+            .map(|l| l.href())
+    };
+    let glue = link_href("link[rel='modulepreload']")?;
+    let wasm = link_href("link[rel='preload'][as='fetch']")?;
+    let src = CLUSTER_WORKER_SRC.replace("__GLUE__", &glue).replace("__WASM__", &wasm);
+
+    let parts = js_sys::Array::of1(&JsValue::from_str(&src));
+    let blob = web_sys::Blob::new_with_str_sequence(&parts).ok()?;
+    let url = web_sys::Url::create_object_url_with_blob(&blob).ok()?;
+    let opts = web_sys::WorkerOptions::new();
+    opts.set_type(web_sys::WorkerType::Module);
+    let worker = web_sys::Worker::new_with_options(&url, &opts).ok()?;
+    let _ = web_sys::Url::revoke_object_url(&url); // the worker has captured the script
+
+    // Reply handler: pair the labels with the pending (idx, gen) and finish on the main thread.
+    let gfx_msg = gfx.clone();
+    let cb = wasm_bindgen::closure::Closure::<dyn FnMut(web_sys::MessageEvent)>::new(
+        move |e: web_sys::MessageEvent| {
+            let Some(labels) = js_sys::Reflect::get(&e.data(), &JsValue::from_str("labels"))
+                .ok()
+                .and_then(|v| v.dyn_into::<js_sys::Int32Array>().ok())
+                .map(|a| a.to_vec())
+            else {
+                return;
+            };
+            if let Some((idx, gen)) = gfx_msg.borrow_mut().cluster_pending.take() {
+                let k = labels.iter().copied().max().map_or(0, |m| (m + 1).max(0) as usize);
+                finish_clustering(&gfx_msg, idx, labels, k, gen);
+            }
+        },
+    );
+    worker.set_onmessage(Some(cb.as_ref().unchecked_ref()));
+    cb.forget(); // the worker lives for the app's lifetime
+
+    // If the worker fails (e.g. its wasm can't load), drop it so the next Run uses the main thread,
+    // and release any stuck pending job.
+    let gfx_err = gfx.clone();
+    add_listener(worker.as_ref(), "error", move |_e: web_sys::Event| {
+        let mut g = gfx_err.borrow_mut();
+        g.cluster_pending = None;
+        g.cluster_worker = None;
+        drop(g);
+        show_status("clustering worker unavailable — runs on the main thread");
+    });
+    Some(worker)
+}
+
+/// Post a clustering job (the flat positions buffer is transferred, not copied) to the worker.
+fn post_cluster_job(worker: &web_sys::Worker, flat: &[f32], eps: f32, min_pts: usize) -> bool {
+    let arr = js_sys::Float32Array::from(flat);
+    let msg = js_sys::Object::new();
+    let set = |k: &str, v: &JsValue| js_sys::Reflect::set(&msg, &JsValue::from_str(k), v).is_ok();
+    if !set("flat", &arr.buffer()) || !set("eps", &JsValue::from_f64(eps as f64)) {
+        return false;
+    }
+    if !set("min_pts", &JsValue::from_f64(min_pts as f64)) {
+        return false;
+    }
+    let transfer = js_sys::Array::of1(&arr.buffer());
+    worker.post_message_with_transfer(&msg, &transfer).is_ok()
 }
 
 /// Re-upload the resident `cpu_points` to the GPU (the only path to refresh the cluster ids).

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -988,8 +988,20 @@ async fn probe_cluster_service(gfx: Rc<RefCell<Gfx>>) {
     let Some(window) = web_sys::window() else {
         return;
     };
+    // Abort the probe after 3s so a half-open service (200 then a stalled body) can't pin the UI at
+    // "checking…" forever.
+    let opts = web_sys::RequestInit::new();
+    if let Ok(controller) = web_sys::AbortController::new() {
+        opts.set_signal(Some(&controller.signal()));
+        let cb = wasm_bindgen::closure::Closure::once_into_js(move || controller.abort());
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 3000);
+    }
     // Verify it's actually our service (a 200 from some other process on the port isn't enough).
-    let ok = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&cluster_service_url())).await {
+    let ok = match wasm_bindgen_futures::JsFuture::from(
+        window.fetch_with_str_and_init(&cluster_service_url(), &opts),
+    )
+    .await
+    {
         Ok(v) => match v.dyn_into::<web_sys::Response>() {
             Ok(r) if r.ok() => match r.text() {
                 Ok(p) => wasm_bindgen_futures::JsFuture::from(p)

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -929,9 +929,16 @@ fn web_limits(adapter: &wgpu::Adapter, is_webgl: bool) -> wgpu::Limits {
 }
 
 /// Create a wgpu surface + device, preferring WebGPU and falling back to WebGL2 if its
-/// `requestDevice` fails (see the `maxInterStageShaderComponents` note in `run`). WebGPU enumerates
-/// its adapter globally (no canvas context yet), so we only create the WebGPU surface once the
-/// device succeeds; WebGL2 instead needs the canvas surface to find its adapter at all.
+/// `requestDevice` fails. WebGPU enumerates its adapter globally (no canvas context yet), so we only
+/// create the WebGPU surface once the device succeeds; WebGL2 instead needs the canvas surface to
+/// find its adapter at all.
+///
+/// KNOWN ISSUE (deferred): on current Chrome/Firefox the WebGPU `requestDevice` always fails with
+/// `The limit "maxInterStageShaderComponents" ... is not recognized`, so we silently run on WebGL2.
+/// wgpu 22.1.0 sends that spec-removed limit and the value can't be suppressed via its API; the fix
+/// requires bumping to wgpu 23+ (latest 29), which forces a coordinated egui/egui-wgpu/egui-winit
+/// (0.29 -> matching) + winit upgrade across the whole render stack and the native GUI. WebGL2 is
+/// fully functional, so this is a post-demo upgrade, not a blocker.
 async fn init_gpu(canvas: &web_sys::HtmlCanvasElement) -> Result<Gpu, String> {
     // 1) WebGPU — global adapter; create the surface only if the device is actually obtained.
     let wgpu_inst = wgpu::Instance::new(wgpu::InstanceDescriptor {

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -339,6 +339,11 @@ impl Gfx {
         self.renderer.update_camera(&self.queue, &cam);
         self.axes.update_camera(&self.queue, &cam);
         self.windows.update_camera(&self.queue, &cam);
+        if self.show_windows {
+            // Cull the windows to the live crop box (mirror the point filter), like the native overlay.
+            self.windows
+                .update_filter(&self.queue, self.params.filter_min, self.params.filter_max, 0.0);
+        }
         self.update_labels(w / h);
         let volume_view = self.view_mode == ViewMode::Volume && self.volume.is_some();
         if volume_view {
@@ -948,9 +953,16 @@ fn build_window_verts(rects: &[WinRect], bounds: [(f64, f64); 3], max_group: u32
     let mut v: Vec<LineVertex> = Vec::new();
     let denom = max_group.max(1);
     for r in rects {
+        // Clamp the axis-aligned footprint to the region so a partly-off-region window clips cleanly
+        // (the per-vertex shader cull would otherwise leave stubs); drop windows fully outside.
+        let (mz0r, mz1r) = (r.mz0.max(bounds[0].0), r.mz1.min(bounds[0].1));
+        let (im0r, im1r) = (r.im0.max(bounds[1].0), r.im1.min(bounds[1].1));
+        if mz1r <= mz0r || im1r <= im0r {
+            continue;
+        }
         let color = tims_viewer::render::colormap::group_color(r.g, denom);
-        let (mz0, mz1) = (norm(r.mz0, 0), norm(r.mz1, 0));
-        let (im0, im1) = (norm(r.im0, 1), norm(r.im1, 1));
+        let (mz0, mz1) = (norm(mz0r, 0), norm(mz1r, 0));
+        let (im0, im1) = (norm(im0r, 1), norm(im1r, 1));
         for i in 0..DIA_WINDOW_RT_SLICES {
             let rt_real =
                 bounds[2].0 + (bounds[2].1 - bounds[2].0) * (i as f64 + 0.5) / DIA_WINDOW_RT_SLICES as f64;

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -367,6 +367,8 @@ async fn run() -> Result<(), String> {
             set_hist_svg("floor-hist", ih);
         }
     }
+    // Runtime detail/performance control over how many of the loaded points are drawn.
+    bind_display(&gfx);
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -848,6 +850,29 @@ fn group(n: usize) -> String {
         out.push(*c as char);
     }
     out
+}
+
+/// Bind the Display slider (1..100 %) to the renderer's runtime draw count — trade detail for
+/// performance live, with no re-upload. Points are shuffled server-side, so the drawn prefix is a
+/// representative subsample at any fraction. Also reflects the drawn count in the HUD.
+fn bind_display(gfx: &Rc<RefCell<Gfx>>) {
+    let Some(slider) = by_id::<web_sys::HtmlInputElement>("disp") else {
+        return;
+    };
+    let total = gfx.borrow().renderer.resident();
+    let apply: std::rc::Rc<dyn Fn()> = {
+        let (gfx, s) = (gfx.clone(), slider.clone());
+        std::rc::Rc::new(move || {
+            let pct = (s.value_as_number() / 100.0).clamp(0.0, 1.0);
+            let k = ((total as f64) * pct).round().max(1.0) as u32;
+            gfx.borrow_mut().renderer.set_draw_count(k);
+            set_text("disp-v", &group(k as usize));
+            set_text("hud-points", &group(k as usize));
+        })
+    };
+    apply(); // honor the slider's current (possibly browser-restored) value on startup
+    let apply_c = apply.clone();
+    add_listener(slider.as_ref(), "input", move |_e: web_sys::Event| apply_c());
 }
 
 /// Bind a slider + its editable number field bidirectionally to a render parameter: dragging the

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1783,10 +1783,16 @@ fn build_window_verts(
         if r.g >= 1 && r.g <= 32 && (mask & (1u32 << (r.g - 1))) == 0 {
             continue;
         }
+        // Order each axis first: a footprint can arrive descending (1/K0 falls as scan rises, so
+        // the scan_lo/scan_hi -> 1/K0 conversion yields im0 > im1). Without this the clamp below
+        // produces hi < lo and the next check drops EVERY window — the overlay vanishes while the
+        // legend (which only needs max_window_group) still shows.
+        let (rmz0, rmz1) = (r.mz0.min(r.mz1), r.mz0.max(r.mz1));
+        let (rim0, rim1) = (r.im0.min(r.im1), r.im0.max(r.im1));
         // Clamp the axis-aligned footprint to the region so a partly-off-region window clips cleanly
         // (the per-vertex shader cull would otherwise leave stubs); drop windows fully outside.
-        let (mz0r, mz1r) = (r.mz0.max(bounds[0].0), r.mz1.min(bounds[0].1));
-        let (im0r, im1r) = (r.im0.max(bounds[1].0), r.im1.min(bounds[1].1));
+        let (mz0r, mz1r) = (rmz0.max(bounds[0].0), rmz1.min(bounds[0].1));
+        let (im0r, im1r) = (rim0.max(bounds[1].0), rim1.min(bounds[1].1));
         if mz1r <= mz0r || im1r <= im0r {
             continue;
         }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -275,10 +275,14 @@ fn submit_feedback() {
 /// called `(visited, total)` ~every 1% so the worker can post progress back to the main thread.
 #[wasm_bindgen]
 pub fn cluster_dbscan_flat(flat: &[f32], min_pts: usize, eps: f32, progress: &JsValue) -> Vec<i32> {
-    let pts: Vec<[f32; 3]> = flat.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect();
+    // Reinterpret the flat xyz buffer as [f32;3] triples with no copy ([f32;3] and f32 share align 4).
+    // Truncate any trailing partial triple first — matches the old chunks_exact drop-remainder
+    // behavior and avoids a cast_slice length panic on malformed input.
+    let n = flat.len() - flat.len() % 3;
+    let pts: &[[f32; 3]] = bytemuck::cast_slice(&flat[..n]);
     let total = pts.len() as f64;
     let cb = progress.dyn_ref::<js_sys::Function>();
-    dbscan_with_progress(&pts, eps, min_pts, |visited| {
+    dbscan_with_progress(pts, eps, min_pts, |visited| {
         if let Some(f) = cb {
             let _ =
                 f.call2(&JsValue::NULL, &JsValue::from_f64(visited as f64), &JsValue::from_f64(total));
@@ -2796,8 +2800,8 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         let g = gfx.borrow();
         let p = &g.params;
         let (fmin, fmax, ms) = (p.filter_min, p.filter_max, p.ms_mask);
-        let mut idx: Vec<usize> = Vec::new();
-        let mut positions: Vec<[f32; 3]> = Vec::new();
+        let mut idx: Vec<usize> = Vec::with_capacity(g.cpu_points.len());
+        let mut positions: Vec<[f32; 3]> = Vec::with_capacity(g.cpu_points.len());
         for (i, pt) in g.cpu_points.iter().enumerate() {
             let pos = pt.pos;
             if pos[0] < fmin[0]
@@ -2879,7 +2883,6 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     // POST the scaled points to the service and colour by its labels. Else the wasm path below.
     if gfx.borrow().use_python_cluster {
         let svc = cluster_service_url();
-        let flat: Vec<f32> = positions.iter().flatten().copied().collect();
         let (job, query) = {
             let mut g = gfx.borrow_mut();
             g.next_cluster_job = g.next_cluster_job.wrapping_add(1);
@@ -2897,7 +2900,9 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         show_status("clustering (python)…");
         let gfx2 = gfx.clone();
         wasm_bindgen_futures::spawn_local(async move {
-            let result = fetch_cluster(&svc, &flat, &query).await;
+            // Reinterpret the [f32;3] positions as a flat f32 slice with no intermediate copy
+            // (fetch_cluster's Float32Array::from does the one unavoidable copy into JS).
+            let result = fetch_cluster(&svc, bytemuck::cast_slice(&positions), &query).await;
             // Only consume the reply if it's still THIS job — a Stop / invalidate / newer Run
             // supersedes it (the un-aborted fetch would otherwise steal the new pending job).
             let mut g = gfx2.borrow_mut();
@@ -2932,13 +2937,15 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     // move.
     if idx.len() > WORKER_THRESHOLD {
         if let Some(worker) = ensure_cluster_worker(gfx) {
-            let flat: Vec<f32> = positions.iter().flatten().copied().collect();
+            // Zero-copy view of the positions as a flat f32 slice (post_cluster_job's
+            // Float32Array::from does the one copy into JS).
+            let flat: &[f32] = bytemuck::cast_slice(&positions);
             let job = {
                 let mut g = gfx.borrow_mut();
                 g.next_cluster_job = g.next_cluster_job.wrapping_add(1);
                 g.next_cluster_job
             };
-            if post_cluster_job(&worker, &flat, eps, min_pts, job) {
+            if post_cluster_job(&worker, flat, eps, min_pts, job) {
                 gfx.borrow_mut().cluster_pending = Some((idx, gen, job));
                 set_cluster_progress(Some(0.0)); // worker reports ticks back; bar advances live
                 set_cluster_running(true); // button becomes "Stop clustering"

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -62,8 +62,13 @@ const DIA_WINDOW_RT_SLICES: usize = 6;
 /// was actually used, not later slider edits while the worker runs).
 #[derive(Clone, Copy)]
 struct ClusterRunParams {
+    method: ClusterMethod,
+    python: bool,
     eps: f32,
     min_pts: usize,
+    min_cluster_size: usize,
+    hdb_min_samples: usize,
+    selection_eps: f64,
     rt_cycles: f64,
     mz_peak_widths: f64,
     ms_mask: u32,
@@ -88,6 +93,13 @@ struct WinRect {
 enum ViewMode {
     Points,
     Volume,
+}
+
+/// Clustering algorithm. The in-wasm path is DBSCAN only; the Python service does both.
+#[derive(Clone, Copy, PartialEq)]
+enum ClusterMethod {
+    Dbscan,
+    Hdbscan,
 }
 
 const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
@@ -264,6 +276,11 @@ struct Gfx {
     /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
     /// the startup probe when the service is reachable; toggleable in the Cluster tab.
     use_python_cluster: bool,
+    /// Algorithm (Python service only; wasm is always DBSCAN) + its HDBSCAN parameters.
+    cluster_method: ClusterMethod,
+    cluster_min_cluster_size: usize,
+    cluster_hdb_min_samples: usize, // 0 = auto (defaults to min_cluster_size)
+    cluster_selection_eps: f64,
     /// Persistent DBSCAN worker (lazily created; `None` if workers are unavailable → main-thread
     /// fallback), and the in-flight job's (survivor idx, data generation, job id) awaiting its reply.
     /// `job_id` distinguishes a superseded job's late reply; `worker_failed` latches a runtime failure
@@ -695,6 +712,10 @@ async fn run() -> Result<(), String> {
         cluster_sel: None,
         hide_noise: false,
         use_python_cluster: false,
+        cluster_method: ClusterMethod::Dbscan,
+        cluster_min_cluster_size: 7,
+        cluster_hdb_min_samples: 0,
+        cluster_selection_eps: 0.0,
         cluster_worker: None,
         cluster_pending: None,
         next_cluster_job: 0,
@@ -968,25 +989,27 @@ async fn probe_cluster_service(gfx: Rc<RefCell<Gfx>>) {
         Err(_) => false,
     };
     if ok {
-        gfx.borrow_mut().use_python_cluster = true; // prefer sklearn when it's available
-        set_checked("cl-python", true);
-        set_disabled("cl-python", false);
-        set_text("cl-python-status", "sklearn ✓");
+        set_disabled("opt-sklearn", false);
+        set_disabled("opt-hdbscan", false);
+        if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
+            sel.set_value("sklearn"); // prefer sklearn DBSCAN when the service is up
+        }
+        apply_cluster_algo(&gfx, "sklearn");
+        set_text("cl-algo-status", "sklearn ✓");
     } else {
-        set_disabled("cl-python", true);
-        set_text("cl-python-status", "not running");
+        set_text("cl-algo-status", "offline · built-in");
     }
 }
 
 /// POST the (already axis-scaled) flat positions to the Python clustering service and read back the
 /// per-point labels. Same wire format as the wasm worker: float32 xyz triples in, int32 labels out.
-async fn fetch_cluster(svc: &str, flat: &[f32], eps: f32, min_pts: usize) -> Result<Vec<i32>, String> {
+async fn fetch_cluster(svc: &str, flat: &[f32], query: &str) -> Result<Vec<i32>, String> {
     let window = web_sys::window().ok_or("no window")?;
     let arr = js_sys::Float32Array::from(flat);
     let opts = web_sys::RequestInit::new();
     opts.set_method("POST");
     opts.set_body(&arr.buffer());
-    let url = with_query(svc, &format!("eps={eps}&min={min_pts}"));
+    let url = with_query(svc, query);
     let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str_and_init(&url, &opts))
         .await
         .map_err(|e| format!("fetch failed: {e:?}"))?;
@@ -1776,6 +1799,22 @@ fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
     );
 }
 
+/// Apply a clustering-algorithm dropdown value: set the engine (wasm vs Python) + method, and reveal
+/// that algorithm's parameter rows.
+fn apply_cluster_algo(gfx: &Rc<RefCell<Gfx>>, value: &str) {
+    let (python, method) = match value {
+        "sklearn" => (true, ClusterMethod::Dbscan),
+        "hdbscan" => (true, ClusterMethod::Hdbscan),
+        _ => (false, ClusterMethod::Dbscan), // "wasm"
+    };
+    {
+        let mut g = gfx.borrow_mut();
+        g.use_python_cluster = python;
+        g.cluster_method = method;
+    }
+    set_body_class("algo-hdb", method == ClusterMethod::Hdbscan);
+}
+
 /// Flip the Run/Stop button: while a (worker) clustering is in flight it becomes a red "Stop".
 fn set_cluster_running(running: bool) {
     set_text("cl-run", if running { "⬡ Stop clustering" } else { "⬡ Run clustering" });
@@ -1977,8 +2016,13 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         }
         // Snapshot the parameters used (for the export JSON), so a slider edit mid-run can't skew it.
         let run_params = ClusterRunParams {
+            method: g.cluster_method,
+            python: g.use_python_cluster,
             eps,
             min_pts: g.cluster_min_pts,
+            min_cluster_size: g.cluster_min_cluster_size,
+            hdb_min_samples: g.cluster_hdb_min_samples,
+            selection_eps: g.cluster_selection_eps,
             rt_cycles: g.cluster_rt_cycles,
             mz_peak_widths: g.cluster_mz_peak_widths,
             ms_mask: g.params.ms_mask,
@@ -2007,17 +2051,24 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     if gfx.borrow().use_python_cluster {
         let svc = cluster_service_url();
         let flat: Vec<f32> = positions.iter().flatten().copied().collect();
-        let job = {
+        let (job, query) = {
             let mut g = gfx.borrow_mut();
             g.next_cluster_job = g.next_cluster_job.wrapping_add(1);
+            let q = match g.cluster_method {
+                ClusterMethod::Hdbscan => format!(
+                    "method=hdbscan&mcs={}&ms={}&cse={}",
+                    g.cluster_min_cluster_size, g.cluster_hdb_min_samples, g.cluster_selection_eps
+                ),
+                ClusterMethod::Dbscan => format!("method=dbscan&eps={eps}&min={min_pts}"),
+            };
             g.cluster_pending = Some((idx, gen, g.next_cluster_job));
-            g.next_cluster_job
+            (g.next_cluster_job, q)
         };
         set_cluster_running(true);
         show_status("clustering (python)…");
         let gfx2 = gfx.clone();
         wasm_bindgen_futures::spawn_local(async move {
-            let result = fetch_cluster(&svc, &flat, eps, min_pts).await;
+            let result = fetch_cluster(&svc, &flat, &query).await;
             // Only consume the reply if it's still THIS job — a Stop / invalidate / newer Run
             // supersedes it (the un-aborted fetch would otherwise steal the new pending job).
             let mut g = gfx2.borrow_mut();
@@ -2441,7 +2492,17 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(2));
     bind_value(gfx, "cl-rtc", "cl-rtc-n", 0, |g, v| g.cluster_rt_cycles = v.round().max(1.0));
     bind_value(gfx, "cl-mzw", "cl-mzw-n", 1, |g, v| g.cluster_mz_peak_widths = v.max(0.1));
-    on_toggle("cl-python", gfx, |g, on| g.use_python_cluster = on);
+    // HDBSCAN parameters (Python only).
+    bind_value(gfx, "cl-mcs", "cl-mcs-n", 0, |g, v| g.cluster_min_cluster_size = (v as usize).max(2));
+    bind_value(gfx, "cl-hms", "cl-hms-n", 0, |g, v| g.cluster_hdb_min_samples = v.max(0.0) as usize);
+    bind_value(gfx, "cl-cse", "cl-cse-n", 3, |g, v| g.cluster_selection_eps = v.max(0.0));
+    // Algorithm dropdown: maps to (engine, method) + reveals that algorithm's params.
+    if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
+        let (gfx, el) = (gfx.clone(), sel.clone());
+        add_listener(sel.as_ref(), "change", move |_e: web_sys::Event| {
+            apply_cluster_algo(&gfx, &el.value());
+        });
+    }
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-run") {
         let gfx = gfx.clone();
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| {
@@ -2682,8 +2743,22 @@ fn cluster_params_json(p: &ClusterRunParams, k: usize, noise: usize, n_in: usize
     };
     let ms_level = if p.ms_mask == 0b10 { "MS2" } else { "MS1" };
     set("ms_level", &JsValue::from_str(ms_level));
-    set("eps", &JsValue::from_f64(p.eps as f64));
-    set("min_points", &JsValue::from_f64(p.min_pts as f64));
+    let (algo, engine) = match (p.method, p.python) {
+        (ClusterMethod::Hdbscan, _) => ("hdbscan", "python-sklearn"),
+        (ClusterMethod::Dbscan, true) => ("dbscan", "python-sklearn"),
+        (ClusterMethod::Dbscan, false) => ("dbscan", "wasm"),
+    };
+    set("algorithm", &JsValue::from_str(algo));
+    set("engine", &JsValue::from_str(engine));
+    // Each algorithm exports only its own parameters.
+    if p.method == ClusterMethod::Hdbscan {
+        set("min_cluster_size", &JsValue::from_f64(p.min_cluster_size as f64));
+        set("min_samples", &JsValue::from_f64(p.hdb_min_samples as f64)); // 0 = auto
+        set("cluster_selection_epsilon", &JsValue::from_f64(p.selection_eps));
+    } else {
+        set("eps", &JsValue::from_f64(p.eps as f64));
+        set("min_points", &JsValue::from_f64(p.min_pts as f64));
+    }
     set("rt_cycles", &JsValue::from_f64(p.rt_cycles));
     set("mz_peak_widths", &JsValue::from_f64(p.mz_peak_widths));
     set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
@@ -3174,7 +3249,7 @@ fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
 /// actual params (a checked-but-stale radio won't emit `change` when clicked); calling this after
 /// wiring re-asserts the truth so the panel always reflects what's rendering.
 fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
-    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min, cl_rtc, cl_mzw) = {
+    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min, cl_rtc, cl_mzw, cl_mcs, cl_hms, cl_cse) = {
         let g = gfx.borrow();
         (
             g.auto_rotate,
@@ -3190,6 +3265,9 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
             g.cluster_min_pts as f64,
             g.cluster_rt_cycles,
             g.cluster_mz_peak_widths,
+            g.cluster_min_cluster_size as f64,
+            g.cluster_hdb_min_samples as f64,
+            g.cluster_selection_eps,
         )
     };
     set_checked("ar", auto);
@@ -3214,11 +3292,19 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
     set_value_pair("cl-rtc", "cl-rtc-n", cl_rtc, 0);
     set_value_pair("cl-mzw", "cl-mzw-n", cl_mzw, 1);
+    set_value_pair("cl-mcs", "cl-mcs-n", cl_mcs, 0);
+    set_value_pair("cl-hms", "cl-hms-n", cl_hms, 0);
+    set_value_pair("cl-cse", "cl-cse-n", cl_cse, 3);
     set_checked("cl-color", true); // colour by cluster is on by default (applies after a Run)
     set_checked("hide-noise", false);
     set_checked("show-windows", false); // off by default (defeats browser form-restore)
-    set_checked("cl-python", false); // enabled + auto-checked by the startup service probe
-    set_disabled("cl-python", true);
+    // Clustering algorithm: default to built-in; the Python options are enabled by the startup probe.
+    if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
+        sel.set_value("wasm");
+    }
+    set_disabled("opt-sklearn", true);
+    set_disabled("opt-hdbscan", true);
+    set_body_class("algo-hdb", false);
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);
 }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -580,7 +580,7 @@ async fn run() -> Result<(), String> {
     // Clustering (DBSCAN on the focused set).
     bind_cluster(&gfx);
     // Collapsible section headers + tab switching.
-    bind_panel_chrome();
+    bind_panel_chrome(&gfx);
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -1146,6 +1146,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
     set_text("cl-readout", "—"); // clustering is invalidated by a new load
     set_checked("cl-color", false);
     set_body_class("has-clusters", false);
+    set_body_class("cluster-color", false);
 }
 
 /// Build the region + budget query string for `/points` and `/meta`.
@@ -1420,6 +1421,7 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
         set_text("cl-readout", "—");
         set_checked("cl-color", false);
         set_body_class("has-clusters", false);
+        set_body_class("cluster-color", false);
     }
 }
 
@@ -1509,10 +1511,8 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: u
         "cl-readout",
         &format!("{k} clusters · {} noise · {} pts", group(noise), group(idx.len())),
     );
-    if let Some(s) = gfx.borrow().cluster_stats.as_ref() {
-        render_cluster_panel(s);
-    }
-    set_body_class("has-clusters", true);
+    set_body_class("cluster-color", true); // cluster coloring active -> hide the intensity colorbar
+    update_cluster_panel(gfx); // we ran from the Cluster tab, so this shows + renders the panel
     show_status("");
 }
 
@@ -1532,7 +1532,7 @@ fn compute_cluster_stats(
     let (mut signal_int, mut noise_int) = (0f64, 0f64);
     for (j, &l) in labels.iter().enumerate() {
         let pt = &pts[idx[j]];
-        let contrib = (pt.intensity * pt.weight) as f64;
+        let contrib = pt.intensity as f64 * pt.weight as f64; // widen before multiply
         if l < 0 {
             noise_pts += 1;
             noise_int += contrib;
@@ -1582,18 +1582,19 @@ fn render_cluster_panel(s: &ClusterStats) {
     set_text("cs-pts-t", &group_short(total_pts as usize));
     set_text("cs-pts-c", &group_short(s.signal_pts as usize));
     set_text("cs-pts-n", &group_short(s.noise_pts as usize));
-    set_text("cs-int-t", &group_short(total_int as usize));
-    set_text("cs-int-c", &group_short(s.signal_int as usize));
-    set_text("cs-int-n", &group_short(s.noise_int as usize));
+    set_text("cs-int-t", &fmt_count(total_int));
+    set_text("cs-int-c", &fmt_count(s.signal_int));
+    set_text("cs-int-n", &fmt_count(s.noise_int));
     set_text("cs-k", &s.k.to_string());
-    set_text(
-        "cs-ratio",
-        &if s.noise_pts > 0 {
-            format!("{:.1}×", s.signal_pts as f64 / s.noise_pts as f64)
+    let ratio = |sig: f64, noise: f64| {
+        if noise > 0.0 {
+            format!("{:.1}×", sig / noise)
         } else {
             "∞".into()
-        },
-    );
+        }
+    };
+    set_text("cs-ratio", &ratio(s.signal_pts as f64, s.noise_pts as f64));
+    set_text("cs-iratio", &ratio(s.signal_int, s.noise_int));
     set_text("cs-sub", &format!("{} clusters · {} pts", s.k, group_short(total_pts as usize)));
     set_hist_svg("csh-size", &hist_bins(&s.sizes, 24));
     set_hist_svg("csh-mz", &hist_bins(&s.mz_extent, 24));
@@ -1601,18 +1602,41 @@ fn render_cluster_panel(s: &ClusterStats) {
     set_hist_svg("csh-rt", &hist_bins(&s.rt_extent, 24));
 }
 
-/// Bin non-negative values into `n` equal bins over `[0, max]` (counts per bin).
+/// Bin non-negative finite values into `n` equal-width bins over `[0, max]`. Everything collapses to
+/// bin 0 when every value is 0.
 fn hist_bins(values: &[f64], n: usize) -> Vec<u32> {
-    let mut h = vec![0u32; n.max(1)];
-    let max = values.iter().cloned().fold(0.0f64, f64::max);
+    let n = n.max(1);
+    let mut h = vec![0u32; n];
+    let finite: Vec<f64> = values.iter().copied().filter(|v| v.is_finite() && *v >= 0.0).collect();
+    let max = finite.iter().copied().fold(0.0f64, f64::max);
     if max <= 0.0 {
+        h[0] = finite.len() as u32;
         return h;
     }
-    for &v in values {
-        let b = ((v / max) * (n as f64 - 1.0)).clamp(0.0, n as f64 - 1.0) as usize;
+    for &v in &finite {
+        // equal-width: scale by n then clamp to n-1 (vs *(n-1), which leaves the last bin only for
+        // exact maxima).
+        let b = ((v / max * n as f64) as usize).min(n - 1);
         h[b] += 1;
     }
     h
+}
+
+/// Compact display of a (possibly huge / non-finite) f64 sum — avoids the silent `as usize`
+/// saturation when intensity totals are large.
+fn fmt_count(x: f64) -> String {
+    if !x.is_finite() {
+        return "—".into();
+    }
+    if x >= 1e9 {
+        format!("{:.1}G", x / 1e9)
+    } else if x >= 1e6 {
+        format!("{:.1}M", x / 1e6)
+    } else if x >= 1e4 {
+        format!("{:.0}k", x / 1e3)
+    } else {
+        format!("{:.0}", x)
+    }
 }
 
 /// Toggle a class on `<body>`.
@@ -1641,6 +1665,7 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     on_toggle("cl-color", gfx, |g, on| {
         if g.clustered {
             g.params.color_mode = if on { 1 } else { 0 };
+            set_body_class("cluster-color", on); // toggles the intensity colorbar back on when off
         }
     });
 }
@@ -1722,10 +1747,11 @@ fn switch_tab(name: &str) {
 }
 
 /// Wire tab switching + collapsible section headers via one delegated click listener.
-fn bind_panel_chrome() {
+fn bind_panel_chrome(gfx: &Rc<RefCell<Gfx>>) {
     let Some(doc) = document() else {
         return;
     };
+    let gfx = gfx.clone();
     add_listener(doc.as_ref(), "click", move |e: web_sys::Event| {
         let Some(t) = e.target().and_then(|t| t.dyn_into::<web_sys::Element>().ok()) else {
             return;
@@ -1733,6 +1759,7 @@ fn bind_panel_chrome() {
         if let Ok(Some(tab)) = t.closest(".tab") {
             if let Some(name) = tab.get_attribute("data-tab") {
                 switch_tab(&name);
+                update_cluster_panel(&gfx); // stats panel shows only on the Cluster tab
             }
         } else if let Ok(Some(ey)) = t.closest(".ey") {
             if let Some(sec) = ey.parent_element() {
@@ -1740,6 +1767,21 @@ fn bind_panel_chrome() {
             }
         }
     });
+}
+
+/// Show the cluster stats panel iff the Cluster tab is active and a result exists (so switching tabs
+/// is the natural dismiss, and the right edge is free for the colorbar elsewhere).
+fn update_cluster_panel(gfx: &Rc<RefCell<Gfx>>) {
+    let on_cluster_tab = by_id::<web_sys::HtmlElement>("tabbtn-cluster")
+        .map(|b| b.class_list().contains("active"))
+        .unwrap_or(false);
+    let show = on_cluster_tab && gfx.borrow().clustered;
+    set_body_class("has-clusters", show);
+    if show {
+        if let Some(s) = gfx.borrow().cluster_stats.as_ref() {
+            render_cluster_panel(s);
+        }
+    }
 }
 
 /// Render a 2D density projection to its `<canvas>` with the inferno colormap (sqrt-scaled). The

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -4150,9 +4150,20 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "floor", "floor-n", 0, |g, v| {
         g.params.filter_min[3] = v as f32;
         g.filter_dirty = true;
-        g.vol_needs_grid = true; // the volume bakes the floor at deposit time — re-voxel so it updates live
         invalidate_clusters_mut(g);
     });
+    // The volume bakes the floor in at deposit time, so it must re-voxel to reflect a floor change.
+    // Do that only on slider RELEASE / number commit (the "change" event), not on every continuous
+    // "input" tick — otherwise dragging the floor in Volume mode re-deposits the whole cloud per
+    // frame. The point cloud still tracks the floor live via the input handler above.
+    for id in ["floor", "floor-n"] {
+        if let Some(el) = by_id::<web_sys::HtmlInputElement>(id) {
+            let gfx = gfx.clone();
+            add_listener(el.as_ref(), "change", move |_e: web_sys::Event| {
+                gfx.borrow_mut().vol_needs_grid = true;
+            });
+        }
+    }
 
     // Filters
     on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; g.filter_dirty = true; g.vol_needs_grid = true; invalidate_clusters_mut(g); });

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1,0 +1,1060 @@
+//! Browser shell for the tims-viewer GPU point-cloud renderer (NATIVE_WEB.md Phase 1).
+//!
+//! Compiles the render-safe half of `tims-viewer` to WASM and drives it on a `<canvas>` via
+//! WebGPU (WebGL2 fallback). For now it renders a synthetic demo cloud with an auto-orbiting
+//! camera — the proof that the native renderer runs in a browser. Server-streamed `GpuPoint`s
+//! (Phase 2) will replace `demo_cloud()`.
+//!
+//! Everything is gated to `wasm32`: on a native workspace build this file is empty.
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use bytemuck::Zeroable;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+
+use tims_viewer::camera::{OrbitCamera, ROLL_UP_AXIS};
+use tims_viewer::data::point::{AxisTransform, GpuPoint};
+use tims_viewer::render::annotation::{AnnotationRenderer, LineVertex};
+use tims_viewer::ticks::{fmt_tick, ticks_for, Axis, RT_MINUTES_SPAN};
+use tims_viewer::render::colormap::COLORMAP_NAMES;
+use tims_viewer::render::point_cloud::{PointCloudRenderer, PointMode};
+use tims_viewer::render::uniforms::ParamsUniform;
+
+const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
+const CANVAS_ID: &str = "tims-canvas";
+/// Default point-server port (`tims-viewer DEMO --serve 8090`). Override with `?port=N` in the URL.
+const DEFAULT_SERVER_PORT: u16 = 8090;
+
+/// wasm entry point — Trunk/wasm-bindgen call this on load.
+#[wasm_bindgen(start)]
+pub fn start() {
+    console_error_panic_hook::set_once();
+    let _ = console_log::init_with_level(log::Level::Info);
+    wasm_bindgen_futures::spawn_local(async {
+        if let Err(e) = run().await {
+            log::error!("{e}");
+            show_status(&format!("tims-viewer could not start: {e}"));
+        }
+    });
+}
+
+/// Live GPU + scene state, shared (single-threaded) between the render loop and resize handler.
+struct Gfx {
+    /// Kept alive so it outlives the surface/device (wgpu requires the instance to live longest).
+    _instance: wgpu::Instance,
+    canvas: web_sys::HtmlCanvasElement,
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    depth_view: wgpu::TextureView,
+    renderer: PointCloudRenderer,
+    /// Wireframe cube + axis edges drawn around the cloud for spatial orientation.
+    axes: AnnotationRenderer,
+    /// DOM tick/axis labels (element + its world position in the `[-1,1]` cube), projected each
+    /// frame onto the canvas. Empty when real-unit bounds are unknown (demo fallback).
+    labels: Vec<(web_sys::HtmlElement, [f32; 3])>,
+    camera: OrbitCamera,
+    /// Live render parameters, mutated by the control panel and uploaded each frame.
+    params: ParamsUniform,
+    /// Draw mode (kept in sync with `params.render_mode`).
+    point_mode: PointMode,
+    /// Auto-orbit until the user first interacts, then hand control to the mouse.
+    auto_rotate: bool,
+    /// Mouse button currently held for dragging (0 = left/orbit, else pan); `None` = idle.
+    dragging: Option<i16>,
+    /// Smoothed FPS + last RAF timestamp + a tick counter to throttle the HUD update.
+    fps_ema: f32,
+    fps_t: f64,
+    hud_tick: u32,
+    /// Real-unit axis ranges `[mz, im, rt]` from `/meta`, for crop labels; `None` => show %.
+    axis_bounds: Option<[(f64, f64); 3]>,
+}
+
+impl Gfx {
+    /// Match the surface (and depth texture) to the canvas's CSS size × device-pixel-ratio, so
+    /// the cloud stays crisp on HiDPI displays and tracks window resizes.
+    fn resize_to_display(&mut self) {
+        let (w, h) = display_size(&self.canvas);
+        if w == 0 || h == 0 || (w == self.config.width && h == self.config.height) {
+            return;
+        }
+        self.canvas.set_width(w);
+        self.canvas.set_height(h);
+        self.config.width = w;
+        self.config.height = h;
+        self.surface.configure(&self.device, &self.config);
+        self.depth_view = create_depth(&self.device, w, h);
+    }
+
+    /// Project each axis label's cube position to the canvas and position its DOM element.
+    fn update_labels(&self, aspect: f32) {
+        if self.labels.is_empty() {
+            return;
+        }
+        let vp = self.camera.view_proj(aspect); // glam::Mat4, with the axis-roll baked in
+        let (cw, ch) = (self.canvas.client_width() as f32, self.canvas.client_height() as f32);
+        for (el, w) in &self.labels {
+            let clip = vp * glam::Vec4::new(w[0], w[1], w[2], 1.0);
+            let style = el.style();
+            if clip.w <= 0.0 {
+                let _ = style.set_property("display", "none"); // behind the camera
+                continue;
+            }
+            let x = (clip.x / clip.w * 0.5 + 0.5) * cw;
+            let y = (1.0 - (clip.y / clip.w * 0.5 + 0.5)) * ch;
+            let _ = style.set_property("display", "block");
+            let _ = style.set_property(
+                "transform",
+                &format!("translate({x:.1}px,{y:.1}px) translate(-50%,-50%)"),
+            );
+        }
+    }
+
+    /// Render one frame. `now` is the RAF timestamp (ms). Returns `false` if the loop should stop.
+    fn frame(&mut self, now: f64) -> bool {
+        // Smoothed FPS, pushed to the HUD a few times a second.
+        if self.fps_t > 0.0 {
+            let dt = (now - self.fps_t) as f32;
+            if dt > 0.0 {
+                let inst = 1000.0 / dt;
+                self.fps_ema = if self.fps_ema == 0.0 { inst } else { self.fps_ema * 0.9 + inst * 0.1 };
+            }
+        }
+        self.fps_t = now;
+        self.hud_tick = self.hud_tick.wrapping_add(1);
+        if self.hud_tick % 12 == 0 {
+            set_text("hud-fps", &format!("{:.0} fps", self.fps_ema));
+        }
+
+        if self.auto_rotate {
+            self.camera.yaw += 0.005;
+        }
+        let (w, h) = (self.config.width as f32, self.config.height as f32);
+        let cam = self.camera.to_uniform(w / h, [w, h]);
+        self.renderer.update_camera(&self.queue, &cam);
+        self.axes.update_camera(&self.queue, &cam);
+        self.update_labels(w / h);
+        self.renderer.update_params(&self.queue, &self.params);
+
+        let surface_tex = match self.surface.get_current_texture() {
+            Ok(t) => t,
+            // Transient: just skip this frame.
+            Err(wgpu::SurfaceError::Timeout) => return true,
+            // Stale/lost (e.g. resize, tab restore): reconfigure and retry once next frame.
+            Err(wgpu::SurfaceError::Outdated) | Err(wgpu::SurfaceError::Lost) => {
+                self.surface.configure(&self.device, &self.config);
+                return true;
+            }
+            Err(wgpu::SurfaceError::OutOfMemory) => {
+                log::error!("surface out of memory — stopping render loop");
+                show_status("GPU out of memory — render loop stopped.");
+                return false;
+            }
+        };
+        let view = surface_tex.texture.create_view(&Default::default());
+        let mut enc = self.device.create_command_encoder(&Default::default());
+        self.renderer.prepare(&self.queue, &mut enc);
+        {
+            let mut rpass = enc.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("scene"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.02,
+                            g: 0.02,
+                            b: 0.05,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &self.depth_view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            self.renderer.render(&mut rpass, self.point_mode);
+            self.axes.render(&mut rpass);
+        }
+        self.queue.submit(std::iter::once(enc.finish()));
+        surface_tex.present();
+        true
+    }
+}
+
+async fn run() -> Result<(), String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let canvas = window
+        .document()
+        .ok_or("no document")?
+        .get_element_by_id(CANVAS_ID)
+        .ok_or_else(|| format!("no #{CANVAS_ID} canvas"))?
+        .dyn_into::<web_sys::HtmlCanvasElement>()
+        .map_err(|_| "#tims-canvas is not a <canvas>".to_string())?;
+    let (width, height) = display_size(&canvas);
+    canvas.set_width(width);
+    canvas.set_height(height);
+
+    // Choose a backend by actually creating a device. wgpu 22 asks WebGPU for an obsolete limit
+    // (`maxInterStageShaderComponents`) that current Chrome rejects, so WebGPU `requestDevice`
+    // fails there; we then fall back to WebGL2, which the capability-split renderer fully supports.
+    // The surface is created only after a backend wins, so the canvas context matches it.
+    let (instance, surface, adapter, device, queue, is_webgl) = init_gpu(&canvas).await?;
+
+    let info = adapter.get_info();
+    log::info!("using {} ({:?})", info.name, info.backend);
+    set_text("hud-backend", if is_webgl { "WebGL2" } else { "WebGPU" });
+    set_text("hud-adapter", &info.name);
+
+    let downlevel = adapter.get_downlevel_capabilities().flags;
+    let supports_compaction = downlevel.contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
+        && downlevel.contains(wgpu::DownlevelFlags::INDIRECT_EXECUTION);
+
+    let caps = surface.get_capabilities(&adapter);
+    let format = caps
+        .formats
+        .iter()
+        .copied()
+        .find(|f| f.is_srgb())
+        .or_else(|| caps.formats.first().copied())
+        .ok_or("surface reported no supported formats")?;
+    let alpha_mode = caps
+        .alpha_modes
+        .first()
+        .copied()
+        .unwrap_or(wgpu::CompositeAlphaMode::Auto);
+    let config = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        format,
+        width,
+        height,
+        present_mode: wgpu::PresentMode::Fifo,
+        alpha_mode,
+        view_formats: vec![],
+        desired_maximum_frame_latency: 2,
+    };
+    surface.configure(&device, &config);
+    let depth_view = create_depth(&device, width, height);
+
+    // Phase 2: stream real (or server-side DEMO) points from the tims-viewer point server; fall
+    // back to a synthetic cloud so the page still works standalone.
+    let url = points_url();
+    // Fetch /meta first to validate the wire contract and pick up real-unit axis/intensity ranges,
+    // then the binary points; fall back to a synthetic cloud if the server is absent/incompatible.
+    let mut axis_bounds: Option<[(f64, f64); 3]> = None;
+    let mut server_meta: Option<MetaInfo> = None;
+    let (pts, is_demo_fallback) = match fetch_meta(&meta_url(&url)).await {
+        Ok(m) => match fetch_points(&url).await {
+            Ok(p) if !p.is_empty() => {
+                axis_bounds = m.bounds;
+                server_meta = Some(m);
+                (p, false)
+            }
+            Ok(_) => {
+                show_status("server returned no points — showing synthetic demo cloud");
+                (demo_cloud(), true)
+            }
+            Err(e) => {
+                log::warn!("point fetch failed ({e}); using synthetic demo");
+                show_status("point fetch failed — showing synthetic demo cloud");
+                (demo_cloud(), true)
+            }
+        },
+        Err(e) => {
+            log::warn!("no/incompatible point server ({e}); using synthetic demo");
+            show_status(&format!("no point server at {url} — showing synthetic demo cloud"));
+            (demo_cloud(), true)
+        }
+    };
+    let capacity = pts.len() as u32;
+    let mut renderer = PointCloudRenderer::new(
+        &device,
+        &queue,
+        format,
+        DEPTH_FORMAT,
+        capacity,
+        supports_compaction,
+    );
+    let n = renderer.append(&queue, &pts);
+    set_text(
+        "hud-points",
+        &if is_demo_fallback { format!("{} · demo", group(n)) } else { group(n) },
+    );
+    log::info!("uploaded {n} points (compaction: {supports_compaction})");
+
+    // Native-matching defaults: MS1-only, sqrt transfer, additive density. When the server gave
+    // intensity percentiles, auto-expose so the cloud isn't blown out (mirrors the native viewer).
+    let mut params = ParamsUniform::default();
+    params.ms_mask = 0b01; // MS1 only
+    params.transfer[0] = 1.0; // sqrt
+    params.colormap_id = 1; // Inferno
+    params.n_colormaps = COLORMAP_NAMES.len() as u32; // match the multi-row LUT so colormaps switch
+    if let Some(m) = &server_meta {
+        apply_auto_transfer(&mut params, m);
+    }
+    let applied_exposure = params.transfer[3];
+
+    // The orientation box (cube + axis edges) + projected DOM tick labels.
+    let mut axes = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
+    axes.upload(&device, &cube_box_verts());
+    axes.update_filter(&queue, [-2.0, -2.0, -2.0, 0.0], [2.0, 2.0, 2.0, 0.0], 0.0);
+    let labels = create_axis_labels(axis_bounds);
+
+    let canvas_for_input = canvas.clone();
+    let gfx = Rc::new(RefCell::new(Gfx {
+        _instance: instance,
+        canvas,
+        surface,
+        device,
+        queue,
+        config,
+        depth_view,
+        renderer,
+        axes,
+        labels,
+        camera: OrbitCamera::default(),
+        params,
+        point_mode: PointMode::AdditiveDensity,
+        auto_rotate: true,
+        dragging: None,
+        fps_ema: 0.0,
+        fps_t: 0.0,
+        hud_tick: 0,
+        axis_bounds,
+    }));
+
+    wire_input(&gfx, &window, &canvas_for_input);
+    wire_controls(&gfx);
+    // Browsers restore a control's previous state across reloads, which can leave the Auto-orbit
+    // switch out of sync with the code default — force it to match so the first click works.
+    set_checked("ar", gfx.borrow().auto_rotate);
+    // Reflect the auto-exposure on its slider, and scale the intensity-floor control to the data.
+    if let Some(m) = &server_meta {
+        if let Some(inp) = by_id::<web_sys::HtmlInputElement>("expo") {
+            inp.set_value(&format!("{applied_exposure:.2}"));
+        }
+        set_text("expo-v", &format!("{applied_exposure:.2}"));
+        if m.i_p99 > 1.0 {
+            if let Some(inp) = by_id::<web_sys::HtmlInputElement>("floor") {
+                let _ = inp.set_attribute("max", &format!("{:.0}", m.i_p99));
+                let _ = inp.set_attribute("step", &format!("{:.0}", (m.i_p99 / 200.0).max(1.0)));
+            }
+        }
+    }
+
+    // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
+    {
+        let gfx = gfx.clone();
+        let cb = Closure::wrap(Box::new(move || gfx.borrow_mut().resize_to_display()) as Box<dyn FnMut()>);
+        window
+            .add_event_listener_with_callback("resize", cb.as_ref().unchecked_ref())
+            .map_err(|_| "failed to add resize listener".to_string())?;
+        cb.forget(); // lives for the page; cancellation is a Phase-4 (embedding) concern
+    }
+
+    // requestAnimationFrame render loop (the callback receives the frame timestamp).
+    let f = Rc::new(RefCell::new(None));
+    let g = f.clone();
+    *g.borrow_mut() = Some(Closure::wrap(Box::new(move |now: f64| {
+        if gfx.borrow_mut().frame(now) {
+            request_animation_frame(f.borrow().as_ref().unwrap());
+        }
+    }) as Box<dyn FnMut(f64)>));
+    request_animation_frame(g.borrow().as_ref().unwrap());
+    Ok(())
+}
+
+type Gpu = (wgpu::Instance, wgpu::Surface<'static>, wgpu::Adapter, wgpu::Device, wgpu::Queue, bool);
+
+fn device_desc(limits: wgpu::Limits) -> wgpu::DeviceDescriptor<'static> {
+    wgpu::DeviceDescriptor {
+        label: Some("tims-web-device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: limits,
+        memory_hints: wgpu::MemoryHints::Performance,
+    }
+}
+
+/// Create a wgpu surface + device, preferring WebGPU and falling back to WebGL2 if its
+/// `requestDevice` fails (see the `maxInterStageShaderComponents` note in `run`). WebGPU enumerates
+/// its adapter globally (no canvas context yet), so we only create the WebGPU surface once the
+/// device succeeds; WebGL2 instead needs the canvas surface to find its adapter at all.
+async fn init_gpu(canvas: &web_sys::HtmlCanvasElement) -> Result<Gpu, String> {
+    // 1) WebGPU — global adapter; create the surface only if the device is actually obtained.
+    let wgpu_inst = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::BROWSER_WEBGPU,
+        ..Default::default()
+    });
+    let webgpu_err: Option<String> = match wgpu_inst
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        })
+        .await
+    {
+        Some(adapter) => {
+            let limits = wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits());
+            match adapter.request_device(&device_desc(limits), None).await {
+                Ok((device, queue)) => {
+                    let surface = wgpu_inst
+                        .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
+                        .map_err(|e| format!("create_surface (webgpu): {e}"))?;
+                    return Ok((wgpu_inst, surface, adapter, device, queue, false));
+                }
+                Err(e) => Some(format!("WebGPU requestDevice: {e:?}")),
+            }
+        }
+        None => Some("no WebGPU adapter".to_string()),
+    };
+    if let Some(e) = &webgpu_err {
+        log::warn!("{e}; falling back to WebGL2");
+    }
+
+    // 2) WebGL2 — needs the canvas surface to enumerate its adapter.
+    let gl_inst = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::GL,
+        ..Default::default()
+    });
+    let surface = gl_inst
+        .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
+        .map_err(|e| format!("create_surface (webgl2): {e}"))?;
+    let adapter = gl_inst
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+            compatible_surface: Some(&surface),
+        })
+        .await
+        .ok_or_else(|| format!("no WebGL2 adapter (after {webgpu_err:?})"))?;
+    let limits = wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits());
+    let (device, queue) = adapter
+        .request_device(&device_desc(limits), None)
+        .await
+        .map_err(|e| format!("WebGL2 requestDevice: {e:?} (after {webgpu_err:?})"))?;
+    Ok((gl_inst, surface, adapter, device, queue, true))
+}
+
+/// Backing-store size = canvas CSS size × device-pixel-ratio (min 1×1).
+fn display_size(canvas: &web_sys::HtmlCanvasElement) -> (u32, u32) {
+    let dpr = web_sys::window()
+        .map(|w| w.device_pixel_ratio())
+        .unwrap_or(1.0)
+        .max(1.0);
+    let w = ((canvas.client_width().max(1) as f64) * dpr).round() as u32;
+    let h = ((canvas.client_height().max(1) as f64) * dpr).round() as u32;
+    (w.max(1), h.max(1))
+}
+
+fn request_animation_frame(f: &Closure<dyn FnMut(f64)>) {
+    if let Some(w) = web_sys::window() {
+        let _ = w.request_animation_frame(f.as_ref().unchecked_ref());
+    }
+}
+
+/// Show a message in the page's `#status` element (if present) — used for fatal errors so the
+/// page reports instead of silently going blank.
+fn show_status(msg: &str) {
+    if let Some(el) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id("status"))
+    {
+        el.set_text_content(Some(msg));
+    }
+}
+
+/// The point-server URL. `?points=<url>` overrides it outright (for proxied/same-origin
+/// deploys); else `?port=N` selects `http://localhost:N/points`; else [`DEFAULT_SERVER_PORT`].
+fn points_url() -> String {
+    let search = web_sys::window()
+        .and_then(|w| w.location().search().ok())
+        .unwrap_or_default();
+    let params = search.trim_start_matches('?');
+    // Explicit full-URL override (percent-decoded).
+    if let Some(v) = params.split('&').find_map(|kv| kv.strip_prefix("points=")) {
+        if !v.is_empty() {
+            return js_sys::decode_uri_component(v)
+                .ok()
+                .and_then(|s| s.as_string())
+                .unwrap_or_else(|| v.to_string());
+        }
+    }
+    let port = params
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("port=").and_then(|v| v.parse::<u16>().ok()))
+        .unwrap_or(DEFAULT_SERVER_PORT);
+    format!("http://localhost:{port}/points")
+}
+
+/// Fetch packed `GpuPoint` bytes from the server and reinterpret them (the server already
+/// normalized positions to the `[-1, 1]` cube, so they upload as-is).
+async fn fetch_points(url: &str) -> Result<Vec<GpuPoint>, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(url))
+        .await
+        .map_err(|e| format!("fetch failed: {e:?}"))?;
+    let resp: web_sys::Response = resp_val.dyn_into().map_err(|_| "not a Response".to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let buf = wasm_bindgen_futures::JsFuture::from(
+        resp.array_buffer().map_err(|e| format!("array_buffer: {e:?}"))?,
+    )
+    .await
+    .map_err(|e| format!("body read failed: {e:?}"))?;
+
+    let bytes = js_sys::Uint8Array::new(&buf);
+    let len = bytes.length();
+    let stride = std::mem::size_of::<GpuPoint>() as u32;
+    if len == 0 {
+        return Err("empty body".into());
+    }
+    if len % stride != 0 {
+        return Err(format!("body {len} bytes is not a multiple of the {stride}-byte point stride"));
+    }
+    let mut pts = vec![GpuPoint::zeroed(); (len / stride) as usize];
+    // dst is exactly `len` bytes and 4-aligned (it's a Vec<GpuPoint>); copy_to requires equal len.
+    let dst: &mut [u8] = bytemuck::cast_slice_mut(&mut pts);
+    bytes.copy_to(dst);
+    Ok(pts)
+}
+
+/// Real-unit + exposure context from `/meta`: axis ranges `[mz, im, rt]` (None if absent/malformed),
+/// intensity percentiles, and the downsample stride (per-point weight) for auto-exposure.
+struct MetaInfo {
+    bounds: Option<[(f64, f64); 3]>,
+    i_p1: f64,
+    i_p50: f64,
+    i_p99: f64,
+    stride: f64,
+}
+
+/// Derive the `/meta` URL from the `/points` URL: replace only the trailing path endpoint and keep
+/// any query string. Non-`/points` overrides are left unchanged (the meta fetch then just fails).
+fn meta_url(points: &str) -> String {
+    let (path, query) = match points.split_once('?') {
+        Some((p, q)) => (p, Some(q)),
+        None => (points, None),
+    };
+    let meta_path = path
+        .strip_suffix("/points")
+        .map(|base| format!("{base}/meta"))
+        .unwrap_or_else(|| path.to_string());
+    match query {
+        Some(q) => format!("{meta_path}?{q}"),
+        None => meta_path,
+    }
+}
+
+fn jget(obj: &JsValue, key: &str) -> JsValue {
+    js_sys::Reflect::get(obj, &JsValue::from_str(key)).unwrap_or(JsValue::UNDEFINED)
+}
+fn jnum(obj: &JsValue, key: &str) -> Option<f64> {
+    jget(obj, key).as_f64()
+}
+
+/// Fetch `/meta` and validate the wire contract (version + point stride) before trusting `/points`.
+async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(url))
+        .await
+        .map_err(|e| format!("fetch failed: {e:?}"))?;
+    let resp: web_sys::Response = resp_val.dyn_into().map_err(|_| "not a Response".to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let text = wasm_bindgen_futures::JsFuture::from(resp.text().map_err(|e| format!("text: {e:?}"))?)
+        .await
+        .map_err(|e| format!("body read failed: {e:?}"))?
+        .as_string()
+        .ok_or("meta body is not text")?;
+    let v = js_sys::JSON::parse(&text).map_err(|_| "meta is not valid JSON".to_string())?;
+
+    if jnum(&v, "version") != Some(1.0) {
+        return Err("unsupported or missing meta version (expected 1)".to_string());
+    }
+    // Exact stride check — no `as usize` truncation (32.9 must NOT pass as 32).
+    let expect = std::mem::size_of::<GpuPoint>() as f64;
+    if jnum(&v, "point_stride") != Some(expect) {
+        return Err(format!("point stride mismatch (expected {expect})"));
+    }
+
+    // Bounds are best-effort: render points regardless, but only label in real units if every axis
+    // is a valid [lo, hi] with lo < hi; otherwise the crop labels fall back to percentages.
+    let b = jget(&v, "bounds");
+    let axis = |k: &str| -> Option<(f64, f64)> {
+        let a = jget(&b, k);
+        if !a.is_object() {
+            return None; // arrays are objects; this also rejects null/number/missing
+        }
+        let arr = js_sys::Array::from(&a);
+        if arr.length() < 2 {
+            return None;
+        }
+        let (lo, hi) = (arr.get(0).as_f64()?, arr.get(1).as_f64()?);
+        (lo.is_finite() && hi.is_finite() && hi > lo).then_some((lo, hi))
+    };
+    let bounds = match (axis("mz"), axis("im"), axis("rt")) {
+        (Some(mz), Some(im), Some(rt)) => Some([mz, im, rt]),
+        _ => None,
+    };
+    let it = jget(&v, "intensity");
+    let pos = |key: &str| jnum(&it, key).filter(|x| x.is_finite() && *x > 0.0);
+    let stride = jnum(&v, "downsample_stride")
+        .filter(|x| x.is_finite() && *x >= 1.0)
+        .unwrap_or(1.0);
+    Ok(MetaInfo {
+        bounds,
+        i_p1: pos("p1").unwrap_or(0.0),
+        i_p50: pos("p50").unwrap_or(0.0),
+        i_p99: pos("p99").unwrap_or(0.0),
+        stride,
+    })
+}
+
+/// Label for a per-axis crop: real units when `/meta` bounds are known, else a percentage.
+fn crop_label(bounds: Option<[(f64, f64); 3]>, axis: usize, a: f32, b: f32) -> String {
+    if a <= -0.999 && b >= 0.999 {
+        return "full".into();
+    }
+    let (fa, fb) = ((a * 0.5 + 0.5) as f64, (b * 0.5 + 0.5) as f64);
+    match bounds {
+        Some(bnd) => {
+            let (lo, hi) = bnd[axis];
+            let (ra, rb) = (lo + fa * (hi - lo), lo + fb * (hi - lo));
+            let p = if axis == 1 { 3 } else { 0 }; // 1/K0 needs decimals; m/z & RT are integer-ish
+            format!("{ra:.*}–{rb:.*}", p, p)
+        }
+        None => format!("{:.0}–{:.0}%", fa * 100.0, fb * 100.0),
+    }
+}
+
+/// Auto-set the transfer function + exposure from intensity percentiles, mirroring the native
+/// viewer's `auto_transfer_points`, so the additive cloud is legible (not blown out) on load.
+fn apply_auto_transfer(params: &mut ParamsUniform, m: &MetaInfo) {
+    if m.i_p50 <= 0.0 {
+        return;
+    }
+    let p1 = m.i_p1.max(1.0) as f32;
+    let p50 = m.i_p50.max(m.i_p1) as f32;
+    let p99 = m.i_p99.max(m.i_p50 * 1.0001) as f32;
+    params.transfer[0] = 1.0; // sqrt: lifts the mid-range without flattening bright peaks
+    params.transfer[1] = p1; // i_min
+    params.transfer[2] = (p99 * 4.0).max(p50 * 1.0001); // i_max — headroom above p99 for peaks
+    // Exposure solves a single median splat to ~0.35 alpha; weight = downsample stride.
+    let weight = (m.stride as f32).max(1.0);
+    params.transfer[3] = (0.35 / (params.opacity.max(0.05) * weight)).clamp(0.02, 4.0);
+}
+
+/// The 12 edges of the normalized `[-1, 1]` cube around the data, with the three principal edges
+/// (meeting at the `(-1,-1,-1)` corner) tinted by axis: m/z orange, 1/K₀ cyan, RT green.
+fn cube_box_verts() -> Vec<LineVertex> {
+    const DIM: [f32; 3] = [0.30, 0.36, 0.48];
+    const MZ: [f32; 3] = [1.0, 0.59, 0.35];
+    const IM: [f32; 3] = [0.47, 0.86, 1.0];
+    const RT: [f32; 3] = [0.59, 0.92, 0.59];
+    let c = [-1.0f32, 1.0f32];
+    let mut v = Vec::with_capacity(24);
+    let mut seg = |a: [f32; 3], b: [f32; 3], col: [f32; 3]| {
+        v.push(LineVertex::new(a, col));
+        v.push(LineVertex::new(b, col));
+    };
+    for &j in &[0usize, 1] {
+        for &k in &[0usize, 1] {
+            let col = if j == 0 && k == 0 { MZ } else { DIM };
+            seg([c[0], c[j], c[k]], [c[1], c[j], c[k]], col); // edges along x (m/z)
+        }
+    }
+    for &i in &[0usize, 1] {
+        for &k in &[0usize, 1] {
+            let col = if i == 0 && k == 0 { IM } else { DIM };
+            seg([c[i], c[0], c[k]], [c[i], c[1], c[k]], col); // edges along y (1/K0)
+        }
+    }
+    for &i in &[0usize, 1] {
+        for &j in &[0usize, 1] {
+            let col = if i == 0 && j == 0 { RT } else { DIM };
+            seg([c[i], c[j], c[0]], [c[i], c[j], c[1]], col); // edges along z (RT)
+        }
+    }
+    v
+}
+
+const MZ_CSS: &str = "#ff9659";
+const IM_CSS: &str = "#78dcff";
+const RT_CSS: &str = "#97eb97";
+
+/// Tick + axis-name labels in real units, as `(text, cube-position, css-color)`. Ticks ride the
+/// three principal cube edges (the colored ones); positions are pushed slightly outside the box.
+fn axis_label_specs(bounds: [(f64, f64); 3]) -> Vec<(String, [f32; 3], &'static str)> {
+    let (mz, im, rt) = (bounds[0], bounds[1], bounds[2]);
+    let (txm, txi, txr) = (
+        AxisTransform::new(mz.0, mz.1),
+        AxisTransform::new(im.0, im.1),
+        AxisTransform::new(rt.0, rt.1),
+    );
+    let mut out = Vec::new();
+    // m/z (x) ticks along the y=-1,z=-1 edge, label pushed down (-y).
+    for t in ticks_for(mz.0, mz.1, 5, |v| txm.normalize(v)) {
+        out.push((fmt_tick(Axis::Mz, t.value, (mz.1 - mz.0).abs()), [t.norm, -1.14, -1.0], MZ_CSS));
+    }
+    // 1/K0 (y) ticks along the x=-1,z=-1 edge, label pushed out (-x).
+    for t in ticks_for(im.0, im.1, 5, |v| txi.normalize(v)) {
+        out.push((fmt_tick(Axis::Im, t.value, (im.1 - im.0).abs()), [-1.14, t.norm, -1.0], IM_CSS));
+    }
+    // RT (z) ticks along the x=-1,y=-1 edge, label pushed down (-y).
+    for t in ticks_for(rt.0, rt.1, 5, |v| txr.normalize(v)) {
+        out.push((fmt_tick(Axis::Rt, t.value, (rt.1 - rt.0).abs()), [-1.0, -1.14, t.norm], RT_CSS));
+    }
+    // Axis names (with the RT unit) at the far ends of each colored edge.
+    let rt_name = if (rt.1 - rt.0).abs() > RT_MINUTES_SPAN { "RT (min)" } else { "RT (s)" };
+    out.push(("m/z".into(), [1.28, -1.14, -1.0], MZ_CSS));
+    out.push(("1/K₀".into(), [-1.14, 1.28, -1.0], IM_CSS));
+    out.push((rt_name.into(), [-1.0, -1.14, 1.28], RT_CSS));
+    out
+}
+
+/// Create the DOM label elements inside `#axis-labels`; returns `(element, cube-position)` pairs
+/// for per-frame projection. Empty when bounds are unknown (demo) or the container is missing.
+fn create_axis_labels(bounds: Option<[(f64, f64); 3]>) -> Vec<(web_sys::HtmlElement, [f32; 3])> {
+    let (Some(bounds), Some(doc)) = (bounds, document()) else {
+        return Vec::new();
+    };
+    let Some(container) = doc.get_element_by_id("axis-labels") else {
+        return Vec::new();
+    };
+    container.set_inner_html(""); // clear any stale labels
+    let mut out = Vec::new();
+    for (text, world, color) in axis_label_specs(bounds) {
+        if let Some(el) = doc
+            .create_element("div")
+            .ok()
+            .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
+        {
+            el.set_class_name("axlabel");
+            el.set_text_content(Some(&text));
+            let _ = el.style().set_property("color", color);
+            let _ = container.append_child(&el);
+            out.push((el, world));
+        }
+    }
+    out
+}
+
+// ---- control-panel wiring ----------------------------------------------------------------
+
+fn document() -> Option<web_sys::Document> {
+    web_sys::window().and_then(|w| w.document())
+}
+
+fn by_id<T: JsCast>(id: &str) -> Option<T> {
+    document()?.get_element_by_id(id)?.dyn_into::<T>().ok()
+}
+
+fn set_text(id: &str, s: &str) {
+    if let Some(el) = document().and_then(|d| d.get_element_by_id(id)) {
+        el.set_text_content(Some(s));
+    }
+}
+
+/// Reflect a state change back onto a checkbox (e.g. uncheck Auto-orbit when the mouse takes over).
+fn set_checked(id: &str, v: bool) {
+    if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+        inp.set_checked(v);
+    }
+}
+
+/// Group an integer with thin spaces for the HUD readout, e.g. 300000 -> "300 000".
+fn group(n: usize) -> String {
+    let s = n.to_string();
+    let b = s.as_bytes();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in b.iter().enumerate() {
+        if i > 0 && (b.len() - i) % 3 == 0 {
+            out.push('\u{2009}'); // thin space
+        }
+        out.push(*c as char);
+    }
+    out
+}
+
+/// Bind an `<input type=range>`: call `f` with the live numeric value on every input.
+fn on_range(id: &str, gfx: &Rc<RefCell<Gfx>>, mut f: impl FnMut(&mut Gfx, f64) + 'static) {
+    if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+        let (gfx, el) = (gfx.clone(), inp.clone());
+        add_listener(inp.as_ref(), "input", move |_e: web_sys::Event| {
+            f(&mut gfx.borrow_mut(), el.value_as_number());
+        });
+    }
+}
+
+/// Bind a radio/checkbox: call `f(g, checked)` on change.
+fn on_toggle(id: &str, gfx: &Rc<RefCell<Gfx>>, mut f: impl FnMut(&mut Gfx, bool) + 'static) {
+    if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+        let (gfx, el) = (gfx.clone(), inp.clone());
+        add_listener(inp.as_ref(), "change", move |_e: web_sys::Event| {
+            f(&mut gfx.borrow_mut(), el.checked());
+        });
+    }
+}
+
+/// Bind a `<button>` click.
+fn on_click(id: &str, gfx: &Rc<RefCell<Gfx>>, mut f: impl FnMut(&mut Gfx) + 'static) {
+    if let Some(el) = document().and_then(|d| d.get_element_by_id(id)) {
+        let gfx = gfx.clone();
+        add_listener(el.as_ref(), "click", move |_e: web_sys::Event| f(&mut gfx.borrow_mut()));
+    }
+}
+
+fn set_cbar(colormap_id: u32) {
+    if let Some(el) = document().and_then(|d| d.get_element_by_id("cbar")) {
+        el.set_class_name(&format!("cbar v{colormap_id}"));
+    }
+}
+
+/// Wire every panel control to a live render parameter.
+fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
+    // View
+    on_toggle("ar", gfx, |g, on| g.auto_rotate = on);
+    on_click("reset", gfx, |g| g.camera.reset());
+    on_click("roll", gfx, |g| {
+        g.camera.roll_axis();
+        set_text("roll", &format!("up: {}", ROLL_UP_AXIS[(g.camera.roll % 3) as usize]));
+    });
+
+    // Render
+    on_toggle("m-add", gfx, |g, on| {
+        if on {
+            g.point_mode = PointMode::AdditiveDensity;
+            g.params.render_mode = 0;
+        }
+    });
+    on_toggle("m-opq", gfx, |g, on| {
+        if on {
+            g.point_mode = PointMode::StructuralOpaque;
+            g.params.render_mode = 1;
+        }
+    });
+    if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cmap") {
+        let (gfx, el) = (gfx.clone(), sel.clone());
+        add_listener(sel.as_ref(), "change", move |_e: web_sys::Event| {
+            // Read the option's own value (don't rely on DOM order matching COLORMAP_NAMES).
+            let id = el.value().parse::<u32>().unwrap_or(0).min(COLORMAP_NAMES.len() as u32 - 1);
+            gfx.borrow_mut().params.colormap_id = id;
+            set_cbar(id);
+        });
+    }
+    on_range("psize", gfx, |g, v| {
+        g.params.point_size = v as f32;
+        set_text("psize-v", &format!("{v:.1}"));
+    });
+    on_range("opac", gfx, |g, v| {
+        g.params.opacity = v as f32;
+        set_text("opac-v", &format!("{v:.2}"));
+    });
+
+    // Intensity transfer
+    on_toggle("xf-lin", gfx, |g, on| if on { g.params.transfer[0] = 0.0; });
+    on_toggle("xf-sqrt", gfx, |g, on| if on { g.params.transfer[0] = 1.0; });
+    on_toggle("xf-log", gfx, |g, on| if on { g.params.transfer[0] = 2.0; });
+    on_range("expo", gfx, |g, v| {
+        g.params.transfer[3] = v as f32;
+        set_text("expo-v", &format!("{v:.2}"));
+    });
+    on_range("floor", gfx, |g, v| {
+        g.params.filter_min[3] = v as f32; // intensity floor (real units)
+        set_text("floor-v", &format!("{v:.0}"));
+    });
+
+    // Filters
+    on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; });
+    on_toggle("ms-2", gfx, |g, on| if on { g.params.ms_mask = 0b10; });
+    on_toggle("ms-b", gfx, |g, on| if on { g.params.ms_mask = 0b11; });
+    bind_crop(gfx, "cmz", 0);
+    bind_crop(gfx, "cim", 1);
+    bind_crop(gfx, "crt", 2);
+}
+
+/// Bind a lo/hi range-slider pair to `filter_min/max[axis]` (normalized cube `[-1, 1]`). The two
+/// thumbs push each other rather than crossing: dragging `lo` past `hi` bumps `hi` up (and vice
+/// versa), so the lower bound can never exceed the upper.
+fn bind_crop(gfx: &Rc<RefCell<Gfx>>, prefix: &str, axis: usize) {
+    let (lo, hi) = match (
+        by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-lo")),
+        by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-hi")),
+    ) {
+        (Some(lo), Some(hi)) => (lo, hi),
+        _ => return,
+    };
+    // Lower thumb: if it passes the upper, push the upper up to meet it.
+    {
+        let (gfx_c, lo_c, hi_c, p) = (gfx.clone(), lo.clone(), hi.clone(), prefix.to_string());
+        add_listener(lo.as_ref(), "input", move |_e: web_sys::Event| {
+            if lo_c.value_as_number() > hi_c.value_as_number() {
+                hi_c.set_value(&lo_c.value());
+            }
+            crop_apply(&gfx_c, axis, &p, lo_c.value_as_number(), hi_c.value_as_number());
+        });
+    }
+    // Upper thumb: if it drops below the lower, push the lower down to meet it.
+    {
+        let (gfx_c, lo_c, hi_c, p) = (gfx.clone(), lo.clone(), hi.clone(), prefix.to_string());
+        add_listener(hi.as_ref(), "input", move |_e: web_sys::Event| {
+            if hi_c.value_as_number() < lo_c.value_as_number() {
+                lo_c.set_value(&hi_c.value());
+            }
+            crop_apply(&gfx_c, axis, &p, lo_c.value_as_number(), hi_c.value_as_number());
+        });
+    }
+}
+
+/// Apply a crop pair (slider units 0..1000) to `filter_min/max[axis]`, refresh the real-unit
+/// readout, and move the highlighted fill bar to sit between the two thumbs.
+fn crop_apply(gfx: &Rc<RefCell<Gfx>>, axis: usize, prefix: &str, lo_val: f64, hi_val: f64) {
+    let a = (lo_val / 1000.0) as f32 * 2.0 - 1.0;
+    let b = (hi_val / 1000.0) as f32 * 2.0 - 1.0;
+    let bounds = {
+        let mut g = gfx.borrow_mut();
+        g.params.filter_min[axis] = a;
+        g.params.filter_max[axis] = b;
+        g.axis_bounds
+    };
+    set_text(&format!("{prefix}-v"), &crop_label(bounds, axis, a, b));
+    if let Some(fill) = document()
+        .and_then(|d| d.get_element_by_id(&format!("{prefix}-fill")))
+        .and_then(|e| e.dyn_into::<web_sys::HtmlElement>().ok())
+    {
+        let st = fill.style();
+        let _ = st.set_property("left", &format!("{:.2}%", lo_val / 10.0));
+        let _ = st.set_property("width", &format!("{:.2}%", (hi_val - lo_val).max(0.0) / 10.0));
+    }
+}
+
+/// Wire mouse controls into the camera: left-drag orbits, wheel zooms, shift/right-drag pans.
+/// First interaction stops the auto-orbit. `mousemove`/`mouseup` live on the window so a drag
+/// keeps working when the cursor leaves the canvas.
+fn wire_input(gfx: &Rc<RefCell<Gfx>>, window: &web_sys::Window, canvas: &web_sys::HtmlCanvasElement) {
+    {
+        let gfx = gfx.clone();
+        add_listener(canvas.as_ref(), "mousedown", move |e: web_sys::MouseEvent| {
+            let mut g = gfx.borrow_mut();
+            g.auto_rotate = false;
+            g.dragging = Some(e.button());
+            set_checked("ar", false); // keep the Auto-orbit switch in sync
+        });
+    }
+    {
+        let gfx = gfx.clone();
+        add_listener(window.as_ref(), "mousemove", move |e: web_sys::MouseEvent| {
+            let mut g = gfx.borrow_mut();
+            if let Some(btn) = g.dragging {
+                let (dx, dy) = (e.movement_x() as f32, e.movement_y() as f32);
+                if btn == 0 && !e.shift_key() {
+                    g.camera.orbit(dx, dy);
+                } else {
+                    g.camera.pan(dx, dy);
+                }
+            }
+        });
+    }
+    {
+        let gfx = gfx.clone();
+        add_listener(window.as_ref(), "mouseup", move |_e: web_sys::MouseEvent| {
+            gfx.borrow_mut().dragging = None;
+        });
+    }
+    {
+        let gfx = gfx.clone();
+        add_listener(canvas.as_ref(), "wheel", move |e: web_sys::WheelEvent| {
+            e.prevent_default(); // don't scroll the page
+            let mut g = gfx.borrow_mut();
+            g.auto_rotate = false; // zoom is an interaction too — hand control to the user
+            g.camera.zoom(-(e.delta_y() as f32) / 100.0);
+            set_checked("ar", false);
+        });
+    }
+    // Suppress the context menu so right-drag pan works.
+    add_listener(canvas.as_ref(), "contextmenu", |e: web_sys::MouseEvent| e.prevent_default());
+}
+
+/// Attach a typed event listener and leak the closure (it lives for the page; cancellation is a
+/// Phase-4 embedding concern).
+fn add_listener<E>(target: &web_sys::EventTarget, event: &str, handler: impl FnMut(E) + 'static)
+where
+    E: wasm_bindgen::convert::FromWasmAbi + 'static,
+{
+    let cb = Closure::wrap(Box::new(handler) as Box<dyn FnMut(E)>);
+    let _ = target.add_event_listener_with_callback(event, cb.as_ref().unchecked_ref());
+    cb.forget();
+}
+
+fn create_depth(device: &wgpu::Device, width: u32, height: u32) -> wgpu::TextureView {
+    device
+        .create_texture(&wgpu::TextureDescriptor {
+            label: Some("depth"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
+        .create_view(&Default::default())
+}
+
+/// A synthetic point cloud in the normalized cube `[-1, 1]^3`: a helix plus two gaussian blobs,
+/// intensities spanning the default log transfer range. Deterministic (seeded LCG, no `rand`).
+fn demo_cloud() -> Vec<GpuPoint> {
+    const N: usize = 250_000;
+    let mut seed: u32 = 0x9E37_79B9;
+    let mut rng = move || {
+        seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        (seed >> 8) as f32 / (1u32 << 24) as f32 // [0, 1)
+    };
+    let blob = |c: [f32; 3], s: f32, r: &mut dyn FnMut() -> f32| {
+        // crude gaussian via the central limit theorem (mean of 3 uniforms).
+        let g = |r: &mut dyn FnMut() -> f32| (r() + r() + r() - 1.5) * 2.0 * s;
+        [c[0] + g(r), c[1] + g(r), c[2] + g(r)]
+    };
+
+    let mut pts = Vec::with_capacity(N);
+    for i in 0..N {
+        let m = (rng() * 3.0) as u32;
+        let pos = match m {
+            0 => {
+                let t = i as f32 / N as f32;
+                let ang = t * 40.0;
+                [0.6 * ang.cos(), 0.6 * ang.sin(), t * 2.0 - 1.0]
+            }
+            1 => blob([-0.4, 0.3, -0.2], 0.16, &mut rng),
+            _ => blob([0.5, -0.4, 0.4], 0.20, &mut rng),
+        };
+        let u = rng();
+        let intensity = 50.0 + u * u * 50_000.0; // skew toward low, span ~[50, 5e4]
+        pts.push(GpuPoint {
+            pos,
+            intensity,
+            weight: 1.0,
+            flags: (m == 0) as u32, // helix tagged MS2 for variety; both shown via ms_mask
+            _pad: [GpuPoint::NO_CLUSTER, 0],
+        });
+    }
+    pts
+}

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1257,6 +1257,12 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
             g.renderer.enable_ring(); // append wraps + overwrites oldest -> bounded resident
             g.renderer.set_draw_count(u32::MAX);
             g.cpu_points.clear(); // acquisition drives the GPU buffer directly
+            g.view_mode = ViewMode::Points; // acquisition is a point cloud; never the volume path
+            // Acquisition replaces cpu_points/_pad[0], so any clustering is now invalid: a stale
+            // cluster Run or a clicked cluster row would index the emptied cpu_points and panic.
+            // Invalidate + clear it (and bump data_gen so an already-posted worker result is dropped).
+            g.data_gen = g.data_gen.wrapping_add(1);
+            invalidate_clusters_mut(g);
             g.params.color_mode = 3; // colour by _pad[0] = peptide_id + size-by-intensity (acq shader path)
             g.params.ms_mask = 0b11; // show BOTH MS1 (precursors) and MS2 (fragments) — the whole point
             // Intensity transfer so faint peaks shrink/recede: sqrt over [1, i_p99].
@@ -1271,10 +1277,19 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
         }
         g.acq_playing
     };
+    if start {
+        // Tear down the cluster panel/results UI and the save-ready state alongside the state reset.
+        set_body_class("has-clusters", false);
+        set_save_ready(false);
+    }
     set_body_class("cluster-color", start); // the intensity colorbar is meaningless while peptide-coloured
     set_text("acq-play", if start { "⏸ Stop playback" } else { "▶ Live acquisition" });
     if start {
         wasm_bindgen_futures::spawn_local(play_loop(gfx.clone()));
+    } else {
+        // Stop leaves the acquisition cloud frozen; a full in-place return to the static dataset is a
+        // chunk-2d transition — for now, reload/switch dataset to get it back.
+        show_status("playback stopped — switch dataset or reload to return to the static view");
     }
 }
 
@@ -1365,8 +1380,8 @@ async fn play_loop(gfx: Rc<RefCell<Gfx>>) {
             }
             Next::Wait => sleep_ms(8).await,
             Next::Done(n) => {
-                let g = &mut *gfx.borrow_mut();
-                g.acq_playing = false;
+                gfx.borrow_mut().acq_playing = false;
+                set_body_class("cluster-color", false); // restore the intensity colorbar (manual stop does too)
                 set_text("acq-play", "▶ Live acquisition");
                 show_status(&format!("acquisition complete — {n} frames"));
                 return;
@@ -1406,6 +1421,10 @@ async fn probe_acq_service(gfx: Rc<RefCell<Gfx>>) {
         return;
     }
     if let Some(meta) = fetch_acq_meta(&base).await {
+        if meta.n_frames == 0 {
+            log::warn!("acquisition sidecar reports 0 frames — not offering Live");
+            return;
+        }
         log::info!(
             "acquisition sidecar: {} frames, cadence {:.3}s/frame, mz [{:.0},{:.0}] 1/K0 [{:.3},{:.3}]",
             meta.n_frames, meta.rt_cycle_length, meta.mz.min, meta.mz.max, meta.im.min, meta.im.max
@@ -2529,6 +2548,10 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
 /// Run DBSCAN on the filtered resident points, write cluster ids into the GPU buffer, and colour by
 /// cluster. Synchronous (blocks the main thread) — Focus first if the filtered set is large.
 fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
+    if gfx.borrow().acq_playing {
+        show_status("stop live acquisition before clustering");
+        return;
+    }
     if gfx.borrow().reloading {
         show_status("loading — try clustering again in a moment");
         return;

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -20,7 +20,7 @@ use tims_viewer::data::point::{AxisTransform, GpuPoint};
 use tims_viewer::render::annotation::{AnnotationRenderer, LineVertex};
 use tims_viewer::ticks::{fmt_tick, ticks_for, Axis, RT_MINUTES_SPAN};
 use tims_viewer::render::colormap::{sample as colormap_sample, COLORMAP_NAMES};
-use tims_viewer::cluster::{dbscan, dbscan_with_progress};
+use tims_viewer::cluster::{cluster_axis_scales, dbscan, dbscan_with_progress, AxisScales, ScaleInputs};
 use tims_viewer::render::point_cloud::{PointCloudRenderer, PointMode};
 use tims_viewer::render::uniforms::{ParamsUniform, VolumeUniform};
 use tims_viewer::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
@@ -37,6 +37,10 @@ const WORKER_THRESHOLD: usize = 300_000;
 /// along RT. Precursor RT is quantized at the cycle period, so RT is scaled to span this many cycles
 /// regardless of the RT zoom.
 const CLUSTER_RT_CYCLES: f64 = 2.0;
+
+/// Default for the 1/K0-scans lever (`Gfx::cluster_im_scans`): how many TIMS scans `eps` bridges
+/// along mobility. ~2 scans matches the old MIDIA scan-index reach (`1.7·2^0.4 ≈ 2.2`).
+const CLUSTER_IM_SCANS: f64 = 2.0;
 
 /// Reference eps the RT/m/z axis scalings are calibrated to (the slider default). The scalings use
 /// this fixed value — not the live eps — so the live eps still scales the reach on every axis
@@ -71,6 +75,7 @@ struct ClusterRunParams {
     hdb_min_samples: usize,
     selection_eps: f64,
     rt_cycles: f64,
+    im_scans: f64,
     mz_peak_widths: f64,
     ms_mask: u32,
     floor: f32,
@@ -254,8 +259,12 @@ struct Gfx {
     cluster_min_pts: usize,
     /// User lever: how many MS1 cycles `eps` bridges along RT (integer; higher = looser RT).
     cluster_rt_cycles: f64,
+    /// User lever: how many TIMS scans `eps` bridges along 1/K0 (higher = looser mobility).
+    cluster_im_scans: f64,
     /// User lever: max m/z peak-widths `eps` may span (lower = isotopes separate harder).
     cluster_mz_peak_widths: f64,
+    /// Run-level 1/K0 per TIMS scan (from `/meta`); 0 if unknown. Anchors the 1/K0 cluster reach.
+    im_per_scan: f64,
     /// True while a DBSCAN result is colouring the cloud (`params.color_mode == 1`). Invalidated on
     /// reload / focus / filter change.
     clustered: bool,
@@ -711,7 +720,9 @@ async fn run() -> Result<(), String> {
         cluster_eps: 0.012,
         cluster_min_pts: 8,
         cluster_rt_cycles: CLUSTER_RT_CYCLES,
+        cluster_im_scans: CLUSTER_IM_SCANS,
         cluster_mz_peak_widths: CLUSTER_MZ_PEAK_WIDTHS,
+        im_per_scan: server_meta.as_ref().map(|m| m.im_per_scan).unwrap_or(0.0),
         clustered: false,
         cluster_stats: None,
         cluster_run_params: None,
@@ -1146,6 +1157,9 @@ struct MetaInfo {
     cycle_duration: f64,
     /// Total resident points the server holds for this region/run (for the Data summary).
     n_points: f64,
+    /// Run-level 1/K0 per TIMS scan (full mobility span / ramp length); 0 if unknown. Anchors the
+    /// clustering's 1/K0 reach to a fixed number of scans, focus-independent.
+    im_per_scan: f64,
 }
 
 /// Derive the `/meta` URL from the `/points` URL: replace only the trailing path endpoint and keep
@@ -1511,6 +1525,7 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
         proj_bins,
         cycle_duration: jnum(&v, "cycle_duration").filter(|x| x.is_finite() && *x > 0.0).unwrap_or(0.0),
         n_points: jnum(&v, "n_points").filter(|x| x.is_finite() && *x >= 0.0).unwrap_or(0.0),
+        im_per_scan: jnum(&v, "im_per_scan_1k0").filter(|x| x.is_finite() && *x > 0.0).unwrap_or(0.0),
     })
 }
 
@@ -2160,44 +2175,28 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             idx.push(i);
             positions.push(pos);
         }
-        // Per-axis equi-distancing, calibrated to CLUSTER_EPS_REF (not the live eps) so the live eps
-        // still scales the reach on every axis proportionally. (The metric only; labels/stats use the
-        // unscaled points.)
+        // Per-axis equi-distancing (the shared, unit-tested helper in tims_viewer::cluster): calibrated
+        // to CLUSTER_EPS_REF so the live eps scales the reach proportionally, and — crucially —
+        // region-INDEPENDENT, so eps spans a fixed physical reach on every axis (cycles / scans /
+        // peak-widths) regardless of focus crop. (The metric only; labels/stats use unscaled points.)
         let eps = g.cluster_eps;
-        // RT: compress into ~cycle units so eps bridges CLUSTER_RT_CYCLES cycles regardless of the RT
-        // zoom — precursor RT is quantized at the cycle period, so an un-scaled eps shatters elutions.
-        let rt_scale = match g.axis_bounds {
-            Some(b) if g.cycle_duration > 0.0 && (b[2].1 - b[2].0).abs() > 0.0 => {
-                let cycle_gap_norm = 2.0 * g.cycle_duration / (b[2].1 - b[2].0).abs();
-                let desired = (g.cluster_rt_cycles.max(1.0) * cycle_gap_norm).max(CLUSTER_EPS_REF);
-                (CLUSTER_EPS_REF / desired) as f32
-            }
-            _ => 1.0,
-        };
-        // m/z: expand into ~peak-width units so eps spans at most `cluster_mz_peak_widths` peak-widths
-        // (peak width ≈ m/z / resolution) and can't bridge across isotopes. The cap is a user lever,
-        // independent of eps; max(1) so a narrow focus only sharpens m/z, never loosens it.
-        let mz_scale = match g.axis_bounds {
-            Some(b) => {
-                let mz_center = ((b[0].0 + b[0].1) * 0.5).abs();
-                let mz_range = (b[0].1 - b[0].0).abs();
-                let peak_width = mz_center / MZ_RESOLUTION;
-                let pw = g.cluster_mz_peak_widths.max(0.1);
-                if mz_center > 0.0 && mz_range > 0.0 && peak_width > 0.0 {
-                    (CLUSTER_EPS_REF * mz_range / (2.0 * pw * peak_width)).max(1.0) as f32
-                } else {
-                    1.0
-                }
-            }
-            _ => 1.0,
+        let scales = match g.axis_bounds {
+            Some(bounds) => cluster_axis_scales(&ScaleInputs {
+                bounds,
+                eps_ref: CLUSTER_EPS_REF,
+                cycle_duration: g.cycle_duration,
+                im_per_scan: g.im_per_scan,
+                mz_resolution: MZ_RESOLUTION,
+                rt_cycles: g.cluster_rt_cycles,
+                im_scans: g.cluster_im_scans,
+                mz_peak_widths: g.cluster_mz_peak_widths,
+            }),
+            None => AxisScales { mz: 1.0, im: 1.0, rt: 1.0 },
         };
         for p in positions.iter_mut() {
-            if rt_scale != 1.0 {
-                p[2] *= rt_scale;
-            }
-            if mz_scale != 1.0 {
-                p[0] *= mz_scale;
-            }
+            p[0] *= scales.mz;
+            p[1] *= scales.im;
+            p[2] *= scales.rt;
         }
         // Snapshot the parameters used (for the export JSON), so a slider edit mid-run can't skew it.
         let run_params = ClusterRunParams {
@@ -2210,6 +2209,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             hdb_min_samples: g.cluster_hdb_min_samples,
             selection_eps: g.cluster_selection_eps,
             rt_cycles: g.cluster_rt_cycles,
+            im_scans: g.cluster_im_scans,
             mz_peak_widths: g.cluster_mz_peak_widths,
             ms_mask: g.params.ms_mask,
             floor: g.params.filter_min[3],
@@ -2678,6 +2678,7 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-eps", "cl-eps-n", 3, |g, v| g.cluster_eps = v as f32);
     bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(2));
     bind_value(gfx, "cl-rtc", "cl-rtc-n", 0, |g, v| g.cluster_rt_cycles = v.round().max(1.0));
+    bind_value(gfx, "cl-ims", "cl-ims-n", 1, |g, v| g.cluster_im_scans = v.max(0.1));
     bind_value(gfx, "cl-mzw", "cl-mzw-n", 1, |g, v| g.cluster_mz_peak_widths = v.max(0.1));
     // HDBSCAN parameters (Python only).
     bind_value(gfx, "cl-mcs", "cl-mcs-n", 0, |g, v| g.cluster_min_cluster_size = (v as usize).max(2));
@@ -2954,6 +2955,7 @@ fn cluster_params_json(p: &ClusterRunParams, k: usize, noise: usize, n_in: usize
         set("min_points", &JsValue::from_f64(p.min_pts as f64));
     }
     set("rt_cycles", &JsValue::from_f64(p.rt_cycles));
+    set("im_scans", &JsValue::from_f64(p.im_scans));
     set("mz_peak_widths", &JsValue::from_f64(p.mz_peak_widths));
     set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
     set("cycle_duration_s", &JsValue::from_f64(p.cycle_duration));
@@ -3045,6 +3047,7 @@ fn cluster_config_json(g: &Gfx) -> String {
         set("min_points", &JsValue::from_f64(g.cluster_min_pts as f64));
     }
     set("rt_cycles", &JsValue::from_f64(g.cluster_rt_cycles));
+    set("im_scans", &JsValue::from_f64(g.cluster_im_scans));
     set("mz_peak_widths", &JsValue::from_f64(g.cluster_mz_peak_widths));
     set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
     if let Some(b) = g.axis_bounds {
@@ -3516,7 +3519,7 @@ fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
 /// actual params (a checked-but-stale radio won't emit `change` when clicked); calling this after
 /// wiring re-asserts the truth so the panel always reflects what's rendering.
 fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
-    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min, cl_rtc, cl_mzw, cl_mcs, cl_hms, cl_cse) = {
+    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min, cl_rtc, cl_ims, cl_mzw, cl_mcs, cl_hms, cl_cse) = {
         let g = gfx.borrow();
         (
             g.auto_rotate,
@@ -3531,6 +3534,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
             g.cluster_eps as f64,
             g.cluster_min_pts as f64,
             g.cluster_rt_cycles,
+            g.cluster_im_scans,
             g.cluster_mz_peak_widths,
             g.cluster_min_cluster_size as f64,
             g.cluster_hdb_min_samples as f64,
@@ -3558,6 +3562,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
     set_value_pair("cl-rtc", "cl-rtc-n", cl_rtc, 0);
+    set_value_pair("cl-ims", "cl-ims-n", cl_ims, 1);
     set_value_pair("cl-mzw", "cl-mzw-n", cl_mzw, 1);
     set_value_pair("cl-mcs", "cl-mcs-n", cl_mcs, 0);
     set_value_pair("cl-hms", "cl-hms-n", cl_hms, 0);

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -48,7 +48,7 @@ const MZ_RESOLUTION: f64 = 50_000.0;
 /// Default for the m/z-peak-width lever (`Gfx::cluster_mz_peak_widths`): how many m/z peak-widths
 /// `eps` may span. The m/z axis is expanded so `eps` never bridges more than this, keeping adjacent
 /// isotopes (tens of peak-widths apart) as separate clusters.
-const CLUSTER_MZ_PEAK_WIDTHS: f64 = 6.0;
+const CLUSTER_MZ_PEAK_WIDTHS: f64 = 1.5;
 
 /// Hard ceiling on points loaded into the (32-bit) wasm heap, regardless of the server `--budget` or
 /// the GPU buffer limit: ~32M × 32 B ≈ 1 GB resident, well clear of the ~4 GB wasm address space.

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -58,6 +58,20 @@ const MAX_WEB_POINTS: usize = 32_000_000;
 /// which lives in the native-only loader module).
 const DIA_WINDOW_RT_SLICES: usize = 6;
 
+/// Parameters of a clustering Run, snapshotted at gather time (so the exported JSON reflects what
+/// was actually used, not later slider edits while the worker runs).
+#[derive(Clone, Copy)]
+struct ClusterRunParams {
+    eps: f32,
+    min_pts: usize,
+    rt_cycles: f64,
+    mz_peak_widths: f64,
+    ms_mask: u32,
+    floor: f32,
+    region: Option<[(f64, f64); 3]>,
+    cycle_duration: f64,
+}
+
 /// A DIA isolation-window footprint in real units (from `/windows`); re-normalized to the focused
 /// region each load to draw the precursor-selection overlay in the m/z × 1/K0 (scan) plane.
 #[derive(Clone, Copy)]
@@ -231,8 +245,11 @@ struct Gfx {
     clustered: bool,
     /// The last clustering result's stats (for the right-hand panel); cleared on invalidate.
     cluster_stats: Option<ClusterStats>,
-    /// JSON of the parameters used for the last clustering (snapshotted at Run); exported alongside
-    /// the per-cluster CSV. Cleared on invalidate.
+    /// Parameters captured at the last Run (gather time); the export JSON is built from this, not
+    /// live fields. Cleared on invalidate.
+    cluster_run_params: Option<ClusterRunParams>,
+    /// JSON of the parameters used for the last clustering (built at finish from cluster_run_params);
+    /// exported alongside the per-cluster CSV. Cleared on invalidate.
     cluster_params_json: Option<String>,
     /// Retained DBSCAN result for isolation: the survivor `cpu_points` indices + their labels, and
     /// which cluster is currently isolated (`None` = show all). Cleared on invalidate.
@@ -665,6 +682,7 @@ async fn run() -> Result<(), String> {
         cluster_mz_peak_widths: CLUSTER_MZ_PEAK_WIDTHS,
         clustered: false,
         cluster_stats: None,
+        cluster_run_params: None,
         cluster_params_json: None,
         cluster_idx: Vec::new(),
         cluster_labels: Vec::new(),
@@ -1412,10 +1430,17 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         g.clustered = false;
         g.cluster_stats = None;
         g.cluster_params_json = None;
+        g.cluster_run_params = None;
         g.cluster_idx = Vec::new();
         g.cluster_labels = Vec::new();
         g.cluster_sel = None;
-        g.cluster_pending = None;
+        // Terminate a worker job in flight (a reload abandons it) so it doesn't keep computing with
+        // the next Run queued behind it; the next Run rebuilds a fresh worker.
+        if g.cluster_pending.take().is_some() {
+            if let Some(w) = g.cluster_worker.take() {
+                w.terminate();
+            }
+        }
         // Re-apply auto-transfer (exposure + floor range) and bounds from the new meta; keep the
         // user's colormap / point size / opacity / MS mask.
         if let Some(m) = &meta {
@@ -1479,9 +1504,10 @@ enum StackOp {
 }
 
 /// The focus-lens load primitive: re-fetch a region and rebuild the GPU buffer. `budget == None`
-/// loads the pinned full run via no-query (cache hit for Back-to-root); `Some(b)` is an explicit
-/// region+budget query. The stack op is applied only after the load succeeds, so a debounced or
-/// failed load never desyncs the stack from the displayed view. Debounced via `reloading`.
+/// (the root stack entry) clamps to `n_cap` — the request is always a capped region query, never a
+/// bare `/points`, so Back-to-root can't pull the server's full `--budget` and OOM the wasm heap.
+/// The stack op is applied only after the load succeeds, so a debounced or failed load never desyncs
+/// the stack from the displayed view. Debounced via `reloading`.
 async fn load_region(gfx: Rc<RefCell<Gfx>>, region: Region, budget: Option<usize>, op: StackOp) {
     {
         let mut g = gfx.borrow_mut();
@@ -1778,6 +1804,7 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
         g.clustered = false;
         g.cluster_stats = None;
         g.cluster_params_json = None;
+        g.cluster_run_params = None;
         g.cluster_idx = Vec::new();
         g.cluster_labels = Vec::new();
         g.cluster_sel = None;
@@ -1806,7 +1833,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         return;
     }
     // Gather the filtered survivors (spatial crop + intensity floor + MS) and their cube positions.
-    let (idx, positions, eps, min_pts, gen) = {
+    let (idx, positions, eps, min_pts, gen, run_params) = {
         let g = gfx.borrow();
         let p = &g.params;
         let (fmin, fmax, ms) = (p.filter_min, p.filter_max, p.ms_mask);
@@ -1870,7 +1897,18 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
                 p[0] *= mz_scale;
             }
         }
-        (idx, positions, eps, g.cluster_min_pts, g.data_gen)
+        // Snapshot the parameters used (for the export JSON), so a slider edit mid-run can't skew it.
+        let run_params = ClusterRunParams {
+            eps,
+            min_pts: g.cluster_min_pts,
+            rt_cycles: g.cluster_rt_cycles,
+            mz_peak_widths: g.cluster_mz_peak_widths,
+            ms_mask: g.params.ms_mask,
+            floor: g.params.filter_min[3],
+            region: g.axis_bounds,
+            cycle_duration: g.cycle_duration,
+        };
+        (idx, positions, eps, g.cluster_min_pts, g.data_gen, run_params)
     };
     if idx.is_empty() {
         show_status("nothing to cluster — adjust the filter");
@@ -1884,6 +1922,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         ));
         return;
     }
+    gfx.borrow_mut().cluster_run_params = Some(run_params); // before dispatch, for the export JSON
     show_status("clustering…");
     // Small inputs cluster in well under a second, so run them on the main thread (deferred one
     // macrotask so the status paints): instant, with none of the worker's one-time wasm spin-up
@@ -2079,7 +2118,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, 
         reupload_points(g);
         g.params.color_mode = if g.hide_noise { 2 } else { 1 };
         g.clustered = true;
-        g.cluster_params_json = Some(cluster_params_json(g, k, noise, n_in));
+        g.cluster_params_json = g.cluster_run_params.map(|p| cluster_params_json(&p, k, noise, n_in));
         g.cluster_stats = Some(stats);
         g.cluster_idx = idx;
         g.cluster_labels = labels;
@@ -2507,24 +2546,24 @@ fn isolate_cluster(gfx: &Rc<RefCell<Gfx>>, sel: Option<i32>) {
 }
 
 /// JSON snapshot of the parameters used for a clustering run, so the export is reproducible.
-fn cluster_params_json(g: &Gfx, k: usize, noise: usize, n_in: usize) -> String {
+fn cluster_params_json(p: &ClusterRunParams, k: usize, noise: usize, n_in: usize) -> String {
     let obj = js_sys::Object::new();
     let set = |key: &str, v: &JsValue| {
         let _ = js_sys::Reflect::set(&obj, &JsValue::from_str(key), v);
     };
-    let ms_level = if g.params.ms_mask == 0b10 { "MS2" } else { "MS1" };
+    let ms_level = if p.ms_mask == 0b10 { "MS2" } else { "MS1" };
     set("ms_level", &JsValue::from_str(ms_level));
-    set("eps", &JsValue::from_f64(g.cluster_eps as f64));
-    set("min_points", &JsValue::from_f64(g.cluster_min_pts as f64));
-    set("rt_cycles", &JsValue::from_f64(g.cluster_rt_cycles));
-    set("mz_peak_widths", &JsValue::from_f64(g.cluster_mz_peak_widths));
+    set("eps", &JsValue::from_f64(p.eps as f64));
+    set("min_points", &JsValue::from_f64(p.min_pts as f64));
+    set("rt_cycles", &JsValue::from_f64(p.rt_cycles));
+    set("mz_peak_widths", &JsValue::from_f64(p.mz_peak_widths));
     set("mz_resolution", &JsValue::from_f64(MZ_RESOLUTION));
-    set("cycle_duration_s", &JsValue::from_f64(g.cycle_duration));
-    set("intensity_floor", &JsValue::from_f64(g.params.filter_min[3] as f64));
+    set("cycle_duration_s", &JsValue::from_f64(p.cycle_duration));
+    set("intensity_floor", &JsValue::from_f64(p.floor as f64));
     set("clusters", &JsValue::from_f64(k as f64));
     set("noise_points", &JsValue::from_f64(noise as f64));
     set("input_points", &JsValue::from_f64(n_in as f64));
-    if let Some(b) = g.axis_bounds {
+    if let Some(b) = p.region {
         let region = js_sys::Object::new();
         let pair = |lo: f64, hi: f64| {
             let a = js_sys::Array::new();

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1382,7 +1382,16 @@ async fn acq_prefetch(gfx: Rc<RefCell<Gfx>>, start: u32, count: u32, meta: AcqMe
                 g.acq_buffer.extend(frames);
             }
         }
-        Err(e) => log::warn!("acq batch [{start},{}) failed: {e}", start + count),
+        Err(e) => {
+            log::warn!("acq batch [{start},{}) failed: {e}", start + count);
+            // Roll the fetch frontier back so this batch is RETRIED next tick instead of leaving a
+            // permanent hole in the played stream. Only when we're still the current frontier (no
+            // newer advance/reset owns it). A transient sidecar hiccup self-heals; a dead sidecar
+            // stalls visibly rather than silently skipping frames.
+            if g.acq_fetch_next == start + count {
+                g.acq_fetch_next = start;
+            }
+        }
     }
 }
 
@@ -1569,6 +1578,13 @@ async fn fetch_cluster(svc: &str, flat: &[f32], query: &str) -> Result<Vec<i32>,
     let opts = web_sys::RequestInit::new();
     opts.set_method("POST");
     opts.set_body(&arr.buffer());
+    // Abort after 30s so a hung/half-open cluster service can't pin the Run button forever (the user
+    // can still Stop sooner). Generous enough for a legitimate sklearn run over the capped point set.
+    if let Ok(controller) = web_sys::AbortController::new() {
+        opts.set_signal(Some(&controller.signal()));
+        let cb = wasm_bindgen::closure::Closure::once_into_js(move || controller.abort());
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 30000);
+    }
     let url = with_query(svc, query);
     let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str_and_init(&url, &opts))
         .await
@@ -2897,7 +2913,13 @@ fn create_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
             if !job_matches(&gfx_msg.borrow()) {
                 return; // no pending / superseded job — drop this reply
             }
-            if let Some((idx, gen, _)) = gfx_msg.borrow_mut().cluster_pending.take() {
+            // Take the pending job in its OWN statement so the borrow_mut RefMut is dropped before
+            // finish_clustering (which re-borrows mutably). In edition 2021 an `if let` scrutinee
+            // temporary lives to the end of the body, so borrowing inline here would double-borrow
+            // and panic on every worker completion (the Python path drops its borrow for the same
+            // reason).
+            let pending = gfx_msg.borrow_mut().cluster_pending.take();
+            if let Some((idx, gen, _)) = pending {
                 if labels.len() != idx.len() {
                     return; // malformed reply — never index past the survivor set
                 }
@@ -4152,18 +4174,8 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
         g.filter_dirty = true;
         invalidate_clusters_mut(g);
     });
-    // The volume bakes the floor in at deposit time, so it must re-voxel to reflect a floor change.
-    // Do that only on slider RELEASE / number commit (the "change" event), not on every continuous
-    // "input" tick — otherwise dragging the floor in Volume mode re-deposits the whole cloud per
-    // frame. The point cloud still tracks the floor live via the input handler above.
-    for id in ["floor", "floor-n"] {
-        if let Some(el) = by_id::<web_sys::HtmlInputElement>(id) {
-            let gfx = gfx.clone();
-            add_listener(el.as_ref(), "change", move |_e: web_sys::Event| {
-                gfx.borrow_mut().vol_needs_grid = true;
-            });
-        }
-    }
+    // (The volume re-voxel on floor RELEASE is wired where the volume controls are bound — a "change"
+    // listener on floor/floor-n, gated on Volume mode. No duplicate handler here.)
 
     // Filters
     on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; g.filter_dirty = true; g.vol_needs_grid = true; invalidate_clusters_mut(g); });

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -116,6 +116,9 @@ const DEFAULT_SERVER_PORT: u16 = 8090;
 /// Default Python (sklearn) clustering-service port (`cluster_service.py --port 8091`). Override with
 /// `?clusterport=N`, or a full URL via `?cluster=<url>`.
 const DEFAULT_CLUSTER_PORT: u16 = 8091;
+/// Default acquisition-sidecar port (`acquisition_service.py --port 8092`). Override with
+/// `?acqport=N`, or a full base URL via `?acq=<url>`.
+const DEFAULT_ACQ_PORT: u16 = 8092;
 
 /// wasm entry point — Trunk/wasm-bindgen call this on load.
 #[wasm_bindgen(start)]
@@ -284,6 +287,9 @@ struct Gfx {
     cluster_sel: Option<i32>,
     /// When clustered + colouring, hide the un-clustered (noise) points (color_mode 2 vs 1).
     hide_noise: bool,
+    /// Acquisition-playback metadata from the sidecar's `/acq/meta` (None = no sidecar). Drives the
+    /// (next-slice) live playback engine; populated by the startup probe.
+    acq_meta: Option<AcqMeta>,
     /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
     /// the startup probe when the service is reachable; toggleable in the Cluster tab.
     use_python_cluster: bool,
@@ -732,6 +738,7 @@ async fn run() -> Result<(), String> {
         cluster_labels: Vec::new(),
         cluster_sel: None,
         hide_noise: false,
+        acq_meta: None,
         dataset_name: String::new(),
         dataset_id: dataset_id(), // raw URL value; clamped to the registry by populate_datasets
         use_python_cluster: false,
@@ -785,6 +792,8 @@ async fn run() -> Result<(), String> {
     bind_windows(&gfx);
     // Probe the Python clustering service; auto-enable the backend toggle if it's up.
     wasm_bindgen_futures::spawn_local(probe_cluster_service(gfx.clone()));
+    // Probe the acquisition sidecar; stash /acq/meta for the (next-slice) live playback engine.
+    wasm_bindgen_futures::spawn_local(probe_acq_service(gfx.clone()));
     // ① Data: fill the meta summary now (points/ranges/cycle); the dataset name arrives via /datasets.
     fill_data_summary(server_meta.as_ref());
     wasm_bindgen_futures::spawn_local(populate_datasets(gfx.clone()));
@@ -1024,6 +1033,137 @@ fn cluster_service_url() -> String {
         .find_map(|kv| kv.strip_prefix("clusterport=").and_then(|v| v.parse::<u16>().ok()))
         .unwrap_or(DEFAULT_CLUSTER_PORT);
     format!("http://localhost:{port}/cluster")
+}
+
+/// Acquisition-playback metadata from the sidecar's `/acq/meta` (real-unit axis ranges as
+/// `AxisTransform`s for normalizing streamed frame points, plus the run's frame count / cadence).
+#[derive(Clone)]
+struct AcqMeta {
+    n_frames: u32,
+    rt_cycle_length: f64,
+    mz: AxisTransform,
+    im: AxisTransform,
+    rt: AxisTransform,
+    // Used by the playback engine (next slice): auto-exposure reference + per-frame MS1/MS2 timeline.
+    #[allow(dead_code)]
+    i_p99: f32,
+    #[allow(dead_code)]
+    ms_types: Vec<i32>, // per-frame ms_type (0 = MS1, 9 = MS2)
+}
+
+/// Acquisition-sidecar base URL: `?acq=<url>` override, else `http://localhost:<DEFAULT_ACQ_PORT>`
+/// (or `?acqport=N`). Endpoints are `<base>/acq/meta` and `<base>/acq/frame?id=N`.
+fn acq_service_url() -> String {
+    let search = web_sys::window().and_then(|w| w.location().search().ok()).unwrap_or_default();
+    let params = search.trim_start_matches('?');
+    if let Some(v) = params.split('&').find_map(|kv| kv.strip_prefix("acq=")).filter(|v| !v.is_empty()) {
+        if let Some(decoded) = js_sys::decode_uri_component(v).ok().and_then(|s| s.as_string()) {
+            return decoded;
+        }
+    }
+    let port = params
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("acqport=").and_then(|v| v.parse::<u16>().ok()))
+        .unwrap_or(DEFAULT_ACQ_PORT);
+    format!("http://localhost:{port}")
+}
+
+/// Fetch `<base>/acq/meta` and parse it; `None` if the sidecar is absent/incompatible.
+async fn fetch_acq_meta(base: &str) -> Option<AcqMeta> {
+    let window = web_sys::window()?;
+    let resp_val = wasm_bindgen_futures::JsFuture::from(
+        window.fetch_with_str(&format!("{base}/acq/meta")),
+    )
+    .await
+    .ok()?;
+    let resp: web_sys::Response = resp_val.dyn_into().ok()?;
+    if !resp.ok() {
+        return None;
+    }
+    let text = wasm_bindgen_futures::JsFuture::from(resp.text().ok()?).await.ok()?.as_string()?;
+    let v = js_sys::JSON::parse(&text).ok()?;
+    let num = |k: &str| jnum(&v, k);
+    let arr = js_sys::Array::from(&jget(&v, "ms_types"));
+    let ms_types = (0..arr.length()).map(|i| arr.get(i).as_f64().unwrap_or(0.0) as i32).collect();
+    Some(AcqMeta {
+        n_frames: num("n_frames").unwrap_or(0.0).max(0.0) as u32,
+        rt_cycle_length: num("rt_cycle_length").filter(|x| x.is_finite() && *x > 0.0).unwrap_or(0.1),
+        i_p99: num("i_p99").filter(|x| x.is_finite() && *x > 0.0).unwrap_or(1000.0) as f32,
+        mz: AxisTransform::new(num("mz_min").unwrap_or(100.0), num("mz_max").unwrap_or(1700.0)),
+        im: AxisTransform::new(num("im_min").unwrap_or(0.6), num("im_max").unwrap_or(1.6)),
+        rt: AxisTransform::new(num("rt_min").unwrap_or(0.0), num("rt_max").unwrap_or(1.0)),
+        ms_types,
+    })
+}
+
+/// Fetch `<base>/acq/frame?id=N` (24-byte/peak records) and build normalized `GpuPoint`s:
+/// `_pad[0]` = peptide_id (color key), `flags` bit0 = fragment. Wired by the playback engine (next).
+#[allow(dead_code)]
+async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoint>, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let resp_val = wasm_bindgen_futures::JsFuture::from(
+        window.fetch_with_str(&format!("{base}/acq/frame?id={id}")),
+    )
+    .await
+    .map_err(|e| format!("fetch failed: {e:?}"))?;
+    let resp: web_sys::Response = resp_val.dyn_into().map_err(|_| "not a Response".to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let buf = wasm_bindgen_futures::JsFuture::from(
+        resp.array_buffer().map_err(|e| format!("array_buffer: {e:?}"))?,
+    )
+    .await
+    .map_err(|e| format!("body read failed: {e:?}"))?;
+    let bytes = js_sys::Uint8Array::new(&buf).to_vec();
+    let mut pts = Vec::with_capacity(bytes.len() / 24);
+    for c in bytes.chunks_exact(24) {
+        let f = |o: usize| f32::from_le_bytes([c[o], c[o + 1], c[o + 2], c[o + 3]]);
+        let u = |o: usize| u32::from_le_bytes([c[o], c[o + 1], c[o + 2], c[o + 3]]);
+        pts.push(GpuPoint {
+            pos: [
+                m.mz.normalize(f(0) as f64),
+                m.im.normalize(f(4) as f64),
+                m.rt.normalize(f(8) as f64),
+            ],
+            intensity: f(12),
+            weight: 1.0,
+            flags: u(20),
+            _pad: [u(16), 0],
+        });
+    }
+    Ok(pts)
+}
+
+/// Probe the acquisition sidecar (GET its health route); on success stash `/acq/meta` on `Gfx` so the
+/// playback engine (next slice) can offer "Live acquisition" mode.
+async fn probe_acq_service(gfx: Rc<RefCell<Gfx>>) {
+    let base = acq_service_url();
+    let Some(window) = web_sys::window() else { return };
+    let healthy = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&base)).await {
+        Ok(v) => match v.dyn_into::<web_sys::Response>() {
+            Ok(r) if r.ok() => match r.text() {
+                Ok(p) => wasm_bindgen_futures::JsFuture::from(p)
+                    .await
+                    .ok()
+                    .and_then(|t| t.as_string())
+                    .is_some_and(|s| s.contains("acquisition service")),
+                Err(_) => false,
+            },
+            _ => false,
+        },
+        Err(_) => false,
+    };
+    if !healthy {
+        return;
+    }
+    if let Some(meta) = fetch_acq_meta(&base).await {
+        log::info!(
+            "acquisition sidecar: {} frames, cadence {:.3}s/frame, mz [{:.0},{:.0}] 1/K0 [{:.3},{:.3}]",
+            meta.n_frames, meta.rt_cycle_length, meta.mz.min, meta.mz.max, meta.im.min, meta.im.max
+        );
+        gfx.borrow_mut().acq_meta = Some(meta);
+    }
 }
 
 /// Probe the cluster service (GET its health route); on success enable + auto-select the Python

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -33,6 +33,10 @@ const CLUSTER_CAP: usize = 2_000_000;
 /// at/above it, the off-main-thread worker is used so the tab doesn't freeze.
 const WORKER_THRESHOLD: usize = 300_000;
 
+/// How many MS1 cycles `eps` should bridge along RT (precursor RT is quantized at the cycle period).
+/// RT is scaled so a cluster's elution stays connected across cycles regardless of the RT zoom.
+const CLUSTER_RT_CYCLES: f64 = 2.0;
+
 /// RT slices each DIA window footprint is drawn at (mirrors the native loader's `DIA_WINDOW_RT_SLICES`,
 /// which lives in the native-only loader module).
 const DIA_WINDOW_RT_SLICES: usize = 6;
@@ -157,6 +161,8 @@ struct Gfx {
     hud_tick: u32,
     /// Real-unit axis ranges `[mz, im, rt]` from `/meta`, for crop labels; `None` => show %.
     axis_bounds: Option<[(f64, f64); 3]>,
+    /// Mean RT seconds per cycle (from `/meta`); 0 if unknown. Clusters RT in cycle units.
+    cycle_duration: f64,
     // ---- reload state (focus-lens A3): re-fetch a region/budget and rebuild the GPU buffer ----
     /// Base `/points` URL of the server (query appended per load); empty in the demo fallback.
     points_base: String,
@@ -605,6 +611,7 @@ async fn run() -> Result<(), String> {
         fps_t: 0.0,
         hud_tick: 0,
         axis_bounds,
+        cycle_duration: server_meta.as_ref().map(|m| m.cycle_duration).unwrap_or(0.0),
         points_base: if is_demo_fallback { String::new() } else { url.clone() },
         n_cap,
         supports_compaction,
@@ -910,6 +917,9 @@ struct MetaInfo {
     /// 2D density projections `[mz×im, mz×rt, im×rt]` (each `proj_bins²`) for the box-select maps.
     proj: Option<[Vec<u32>; 3]>,
     proj_bins: usize,
+    /// Mean RT gap (seconds) between consecutive MS1 frames; 0 if unknown. Used to cluster RT in
+    /// cycle units so precursors stay connected across cycles regardless of focus.
+    cycle_duration: f64,
 }
 
 /// Derive the `/meta` URL from the `/points` URL: replace only the trailing path endpoint and keep
@@ -1155,6 +1165,7 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
         i_hist,
         proj,
         proj_bins,
+        cycle_duration: jnum(&v, "cycle_duration").filter(|x| x.is_finite() && *x > 0.0).unwrap_or(0.0),
     })
 }
 
@@ -1367,6 +1378,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
             apply_auto_transfer(&mut g.params, m);
             g.floor_hi = m.i_p99.max(1.0);
             g.axis_bounds = m.bounds;
+            g.cycle_duration = m.cycle_duration;
         }
         // The new load defines the view: reset spatial crops + the intensity floor to "show all".
         for a in 0..3 {
@@ -1758,7 +1770,26 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             idx.push(i);
             positions.push(pos);
         }
-        (idx, positions, g.cluster_eps, g.cluster_min_pts, g.data_gen)
+        // Compress the RT axis into ~cycle units so eps bridges several cycles. Precursor RT is
+        // quantized at the cycle period (one MS1 per cycle); after a focus the per-cycle gap can
+        // exceed eps in normalized space and shatter every elution into one-cycle clusters. Scaling
+        // RT down (<=1) makes eps reach CLUSTER_RT_CYCLES cycles regardless of the RT zoom; m/z and
+        // 1/K0 keep the user's eps. (The metric only; labels/stats use the unscaled points.)
+        let eps = g.cluster_eps;
+        let rt_scale = match g.axis_bounds {
+            Some(b) if g.cycle_duration > 0.0 && (b[2].1 - b[2].0).abs() > 0.0 => {
+                let cycle_gap_norm = 2.0 * g.cycle_duration / (b[2].1 - b[2].0).abs();
+                let desired = (CLUSTER_RT_CYCLES * cycle_gap_norm).max(eps as f64);
+                (eps as f64 / desired) as f32
+            }
+            _ => 1.0,
+        };
+        if rt_scale != 1.0 {
+            for p in positions.iter_mut() {
+                p[2] *= rt_scale;
+            }
+        }
+        (idx, positions, eps, g.cluster_min_pts, g.data_gen)
     };
     if idx.is_empty() {
         show_status("nothing to cluster — adjust the filter");

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -70,6 +70,18 @@ struct Gfx {
     hud_tick: u32,
     /// Real-unit axis ranges `[mz, im, rt]` from `/meta`, for crop labels; `None` => show %.
     axis_bounds: Option<[(f64, f64); 3]>,
+    // ---- reload state (focus-lens A3): re-fetch a region/budget and rebuild the GPU buffer ----
+    /// Base `/points` URL of the server (query appended per load); empty in the demo fallback.
+    points_base: String,
+    /// Max points the GPU buffer can hold (`max_buffer_size / stride`); the load budget cap.
+    n_cap: usize,
+    supports_compaction: bool,
+    /// Resident CPU copy of the uploaded points (retained for the displayed-count recount, B).
+    cpu_points: Vec<GpuPoint>,
+    /// Current intensity p99 — the linear floor range; read live by the floor binding.
+    floor_hi: f64,
+    /// True while a reload is in flight (debounces overlapping Load/Focus requests).
+    reloading: bool,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -281,12 +293,8 @@ async fn run() -> Result<(), String> {
     };
     // Cap to what the GPU buffer can hold (master is a vertex+storage buffer): on a 12M budget
     // = 384 MB, clamp to the device's max so the allocation can't fail.
-    let stride = std::mem::size_of::<GpuPoint>() as u64;
-    let mut max_pts = (device.limits().max_buffer_size / stride) as usize;
-    if supports_compaction {
-        max_pts = max_pts.min((device.limits().max_storage_buffer_binding_size as u64 / stride) as usize);
-    }
-    let capacity = pts.len().min(max_pts).max(1) as u32;
+    let n_cap = gpu_point_cap(&device, supports_compaction);
+    let capacity = pts.len().min(n_cap).max(1) as u32;
     if (capacity as usize) < pts.len() {
         log::warn!("capping {} -> {capacity} points (GPU buffer limit {} MB)",
             pts.len(), device.limits().max_buffer_size / (1 << 20));
@@ -324,6 +332,9 @@ async fn run() -> Result<(), String> {
     let labels = create_axis_labels(axis_bounds);
 
     let canvas_for_input = canvas.clone();
+    let mut cpu_points = pts;
+    cpu_points.truncate(capacity as usize);
+    let floor_hi = server_meta.as_ref().map(|m| m.i_p99).filter(|x| *x > 1.0).unwrap_or(1000.0);
     let gfx = Rc::new(RefCell::new(Gfx {
         _instance: instance,
         canvas,
@@ -344,6 +355,12 @@ async fn run() -> Result<(), String> {
         fps_t: 0.0,
         hud_tick: 0,
         axis_bounds,
+        points_base: if is_demo_fallback { String::new() } else { url.clone() },
+        n_cap,
+        supports_compaction,
+        cpu_points,
+        floor_hi,
+        reloading: false,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -369,6 +386,8 @@ async fn run() -> Result<(), String> {
     }
     // Runtime detail/performance control over how many of the loaded points are drawn.
     bind_display(&gfx);
+    // Load-budget control: re-fetch a different number of points from the server.
+    bind_load(&gfx);
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -788,6 +807,184 @@ fn axis_label_specs(bounds: [(f64, f64); 3]) -> Vec<(String, [f32; 3], &'static 
     out
 }
 
+/// Max points the GPU buffer can hold = `max_buffer_size / stride` (also bounded by the storage-
+/// bind limit on the compaction path). The hard ceiling on a load budget.
+fn gpu_point_cap(device: &wgpu::Device, supports_compaction: bool) -> usize {
+    let stride = std::mem::size_of::<GpuPoint>() as u64;
+    let mut cap = (device.limits().max_buffer_size / stride) as usize;
+    if supports_compaction {
+        cap = cap.min((device.limits().max_storage_buffer_binding_size as u64 / stride) as usize);
+    }
+    cap.max(1)
+}
+
+/// Append a query string to a URL (`?q` or `&q`).
+fn with_query(base: &str, query: &str) -> String {
+    if base.contains('?') {
+        format!("{base}&{query}")
+    } else {
+        format!("{base}?{query}")
+    }
+}
+
+/// Scale the linear intensity-floor controls (slider + number) to a new data range.
+fn set_floor_range(floor_hi: f64) {
+    for id in ["floor", "floor-n"] {
+        if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+            let _ = inp.set_attribute("max", &format!("{floor_hi:.0}"));
+            let _ = inp.set_attribute("step", &format!("{:.0}", (floor_hi / 200.0).max(1.0)));
+        }
+    }
+}
+
+/// Reset the per-axis crop sliders to the full cube (thumbs, fills, readouts, and the filter).
+fn reset_crops(gfx: &Rc<RefCell<Gfx>>) {
+    for (axis, prefix) in [(0usize, "cmz"), (1, "cim"), (2, "crt")] {
+        if let Some(lo) = by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-lo")) {
+            lo.set_value("0");
+        }
+        if let Some(hi) = by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-hi")) {
+            hi.set_value("1000");
+        }
+        crop_apply(gfx, axis, prefix, 0.0, 1000.0);
+    }
+}
+
+/// Reset the Display control to 100% of the (new) resident pool.
+fn reset_display(gfx: &Rc<RefCell<Gfx>>, n: usize) {
+    gfx.borrow_mut().renderer.set_draw_count(u32::MAX);
+    if let Some(s) = by_id::<web_sys::HtmlInputElement>("disp") {
+        s.set_value("100");
+    }
+    if let Some(num) = by_id::<web_sys::HtmlInputElement>("disp-n") {
+        num.set_value(&n.to_string());
+        let _ = num.set_attribute("max", &n.to_string());
+    }
+    set_text("hud-points", &group(n));
+}
+
+/// Apply a freshly fetched load in place: rebuild the GPU buffer at the new capacity, retain the
+/// CPU copy, re-apply auto-transfer + bounds, reset crops/floor/Display, and rebind the DOM. Used
+/// by every reload (Load budget now; Focus/Back next). Returns the resident count.
+fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>) {
+    let n = {
+        let mut g = gfx.borrow_mut();
+        let cap = pts.len().min(g.n_cap).max(1) as u32;
+        let mut renderer = PointCloudRenderer::new(
+            &g.device,
+            &g.queue,
+            g.config.format,
+            DEPTH_FORMAT,
+            cap,
+            g.supports_compaction,
+        );
+        let n = renderer.append(&g.queue, &pts);
+        g.renderer = renderer;
+        let mut cpu = pts;
+        cpu.truncate(cap as usize);
+        g.cpu_points = cpu;
+        // Re-apply auto-transfer (exposure + floor range) and bounds from the new meta; keep the
+        // user's colormap / point size / opacity / MS mask.
+        if let Some(m) = &meta {
+            apply_auto_transfer(&mut g.params, m);
+            g.floor_hi = m.i_p99.max(1.0);
+            g.axis_bounds = m.bounds;
+        }
+        // The new load defines the view: reset spatial crops + the intensity floor to "show all".
+        for a in 0..3 {
+            g.params.filter_min[a] = -1.0;
+            g.params.filter_max[a] = 1.0;
+        }
+        g.params.filter_min[3] = 0.0;
+        let bounds = g.axis_bounds;
+        g.labels = create_axis_labels(bounds); // clears the container first, then rebuilds
+        n
+    };
+    // DOM rebind (outside the borrow).
+    if let Some(m) = &meta {
+        set_floor_range(m.i_p99.max(1.0));
+        if let Some(h) = &m.hist {
+            draw_hist_backdrops(h);
+        }
+        if let Some(ih) = &m.i_hist {
+            set_hist_svg("floor-hist", ih);
+        }
+    }
+    for id in ["floor", "floor-n"] {
+        if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+            inp.set_value("0");
+        }
+    }
+    reset_crops(gfx);
+    reset_display(gfx, n);
+}
+
+/// Re-fetch the run at a new budget (full bounds) and rebuild the GPU buffer. Debounced via
+/// `reloading`. Focus/Back will drive the same path with a region query.
+async fn reload(gfx: Rc<RefCell<Gfx>>, budget: usize) {
+    {
+        let mut g = gfx.borrow_mut();
+        if g.reloading || g.points_base.is_empty() {
+            return;
+        }
+        g.reloading = true;
+    }
+    let base = gfx.borrow().points_base.clone();
+    let q = format!("n={budget}");
+    let purl = with_query(&base, &q);
+    let murl = with_query(&meta_url(&base), &q);
+    show_status("loading…");
+    let meta = fetch_meta(&murl).await.ok();
+    let result = fetch_points(&purl).await;
+    gfx.borrow_mut().reloading = false;
+    match result {
+        Ok(pts) if !pts.is_empty() => {
+            apply_load(&gfx, meta, pts);
+            show_status("");
+        }
+        Ok(_) => show_status("load returned no points"),
+        Err(e) => show_status(&format!("load failed: {e}")),
+    }
+}
+
+/// Wire the Load control: show N_cap, initialize to the resident count, and re-fetch the run at the
+/// typed budget (clamped to N_cap) on click / Enter. Disabled in the demo fallback (no server).
+fn bind_load(gfx: &Rc<RefCell<Gfx>>) {
+    let (Some(num), Some(btn)) = (
+        by_id::<web_sys::HtmlInputElement>("load-n"),
+        by_id::<web_sys::HtmlElement>("load-go"),
+    ) else {
+        return;
+    };
+    let (n0, n_cap, has_server) = {
+        let g = gfx.borrow();
+        (g.renderer.resident(), g.n_cap, !g.points_base.is_empty())
+    };
+    num.set_value(&n0.to_string());
+    let _ = num.set_attribute("max", &n_cap.to_string());
+    set_text("load-cap", &format!("≤ {}", group(n_cap)));
+    if !has_server {
+        let _ = num.set_attribute("disabled", "true");
+        let _ = btn.set_attribute("disabled", "true");
+        return;
+    }
+    let trigger = {
+        let (gfx, num) = (gfx.clone(), num.clone());
+        move || {
+            let v = num.value_as_number();
+            if v.is_finite() && v >= 1.0 {
+                let budget = (v as usize).min(n_cap).max(1);
+                wasm_bindgen_futures::spawn_local(reload(gfx.clone(), budget));
+            }
+        }
+    };
+    {
+        let trigger = trigger.clone();
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| trigger());
+    }
+    add_listener(num.as_ref(), "change", move |_e: web_sys::Event| trigger());
+}
+
 /// Create the DOM label elements inside `#axis-labels`; returns `(element, cube-position)` pairs
 /// for per-frame projection. Empty when bounds are unknown (demo) or the container is missing.
 fn create_axis_labels(bounds: Option<[(f64, f64); 3]>) -> Vec<(web_sys::HtmlElement, [f32; 3])> {
@@ -993,16 +1190,8 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_value_pair("opac", "opac-n", opac, 2);
     set_value_pair("expo", "expo-n", expo, 2);
     set_value_pair("floor", "floor-n", floor, 0);
-    // Crops start at full range; crop_apply also resets the fill bars + real-unit readouts.
-    for (axis, prefix) in [(0usize, "cmz"), (1, "cim"), (2, "crt")] {
-        if let Some(lo) = by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-lo")) {
-            lo.set_value("0");
-        }
-        if let Some(hi) = by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-hi")) {
-            hi.set_value("1000");
-        }
-        crop_apply(gfx, axis, prefix, 0.0, 1000.0);
-    }
+    // Crops start at the full range (thumbs, fills, readouts).
+    reset_crops(gfx);
 }
 
 /// Bind a radio/checkbox: call `f(g, checked)` on change.

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -120,6 +120,9 @@ struct Gfx {
     /// Raymarch samples; composite (0) vs max-intensity-projection (1).
     vol_steps: u32,
     vol_style: u32,
+    /// Volume density transfer range (raw density percentiles), auto-ranged on grid build.
+    vol_i_min: f32,
+    vol_i_max: f32,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -188,6 +191,11 @@ impl Gfx {
                     grid.deposit(pt.pos, pt.intensity * pt.weight);
                 }
             }
+            // Auto-range the density transfer to the grid's own percentiles (median..p99.9) — the
+            // point intensity range is a different scale, which is why the volume looked flat.
+            let (lo, hi) = grid.density_percentiles();
+            self.vol_i_min = lo;
+            self.vol_i_max = hi;
             self.volume.as_ref().unwrap().upload(&self.queue, grid.to_f16_scaled());
             self.vol_needs_grid = false;
             show_status(""); // clear the "building volume…" notice
@@ -198,7 +206,8 @@ impl Gfx {
             inv_view_proj: inv,
             box_min: [p.filter_min[0], p.filter_min[1], p.filter_min[2], 0.0],
             box_max: [p.filter_max[0], p.filter_max[1], p.filter_max[2], 0.0],
-            transfer: p.transfer,
+            // Log over the density percentiles + exposure 1.0 (mirrors the native auto-range).
+            transfer: [2.0, self.vol_i_min, self.vol_i_max, 1.0],
             steps: self.vol_steps.max(1),
             style: self.vol_style,
             colormap_id: p.colormap_id,
@@ -490,6 +499,8 @@ async fn run() -> Result<(), String> {
         vol_needs_grid: true,
         vol_steps: 256,
         vol_style: 0,
+        vol_i_min: 1.0,
+        vol_i_max: 2.0,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -173,9 +173,13 @@ struct Gfx {
     cluster_labels: Vec<i32>,
     cluster_sel: Option<i32>,
     /// Persistent DBSCAN worker (lazily created; `None` if workers are unavailable → main-thread
-    /// fallback), and the in-flight job's (survivor idx, data generation) awaiting its reply.
+    /// fallback), and the in-flight job's (survivor idx, data generation, job id) awaiting its reply.
+    /// `job_id` distinguishes a superseded job's late reply; `worker_failed` latches a runtime failure
+    /// so we stop recreating a broken worker and use the main thread.
     cluster_worker: Option<web_sys::Worker>,
-    cluster_pending: Option<(Vec<usize>, u64)>,
+    cluster_pending: Option<(Vec<usize>, u64, u64)>,
+    next_cluster_job: u64,
+    cluster_worker_failed: bool,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -574,6 +578,8 @@ async fn run() -> Result<(), String> {
         cluster_sel: None,
         cluster_worker: None,
         cluster_pending: None,
+        next_cluster_job: 0,
+        cluster_worker_failed: false,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -1522,8 +1528,13 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     // replies via its onmessage handler, which calls finish_clustering.
     if let Some(worker) = ensure_cluster_worker(gfx) {
         let flat: Vec<f32> = positions.iter().flatten().copied().collect();
-        if post_cluster_job(&worker, &flat, eps, min_pts) {
-            gfx.borrow_mut().cluster_pending = Some((idx, gen));
+        let job = {
+            let mut g = gfx.borrow_mut();
+            g.next_cluster_job = g.next_cluster_job.wrapping_add(1);
+            g.next_cluster_job
+        };
+        if post_cluster_job(&worker, &flat, eps, min_pts, job) {
+            gfx.borrow_mut().cluster_pending = Some((idx, gen, job));
             return;
         }
     }
@@ -1541,17 +1552,23 @@ const CLUSTER_WORKER_SRC: &str = r#"
 import init, { cluster_dbscan_flat } from '__GLUE__';
 await init({ module_or_path: '__WASM__' });
 self.onmessage = (e) => {
-  const { flat, eps, min_pts } = e.data;
+  const { flat, eps, min_pts, job } = e.data;
   const labels = cluster_dbscan_flat(new Float32Array(flat), min_pts, eps);
-  self.postMessage({ labels }, [labels.buffer]);
+  self.postMessage({ labels, job }, [labels.buffer]);
 };
 "#;
 
 /// Return the persistent DBSCAN worker, creating it on first use. `None` (→ main-thread fallback) if
 /// workers are unavailable or the wasm/glue URLs can't be discovered.
 fn ensure_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
-    if let Some(w) = gfx.borrow().cluster_worker.clone() {
-        return Some(w);
+    {
+        let g = gfx.borrow();
+        if g.cluster_worker_failed {
+            return None; // a prior runtime failure latched — stay on the main thread
+        }
+        if let Some(w) = g.cluster_worker.clone() {
+            return Some(w);
+        }
     }
     let w = create_cluster_worker(gfx)?;
     gfx.borrow_mut().cluster_worker = Some(w.clone());
@@ -1575,25 +1592,43 @@ fn create_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
     let src = CLUSTER_WORKER_SRC.replace("__GLUE__", &glue).replace("__WASM__", &wasm);
 
     let parts = js_sys::Array::of1(&JsValue::from_str(&src));
-    let blob = web_sys::Blob::new_with_str_sequence(&parts).ok()?;
+    let bag = web_sys::BlobPropertyBag::new();
+    bag.set_type("text/javascript"); // module workers require a JS MIME on the script
+    let blob = web_sys::Blob::new_with_str_sequence_and_options(&parts, &bag).ok()?;
     let url = web_sys::Url::create_object_url_with_blob(&blob).ok()?;
     let opts = web_sys::WorkerOptions::new();
     opts.set_type(web_sys::WorkerType::Module);
     let worker = web_sys::Worker::new_with_options(&url, &opts).ok()?;
     let _ = web_sys::Url::revoke_object_url(&url); // the worker has captured the script
 
-    // Reply handler: pair the labels with the pending (idx, gen) and finish on the main thread.
+    // Reply handler: only finish the reply whose job id matches the pending one (a superseded job's
+    // late reply carries a stale id and is ignored).
     let gfx_msg = gfx.clone();
     let cb = wasm_bindgen::closure::Closure::<dyn FnMut(web_sys::MessageEvent)>::new(
         move |e: web_sys::MessageEvent| {
-            let Some(labels) = js_sys::Reflect::get(&e.data(), &JsValue::from_str("labels"))
-                .ok()
+            let data = e.data();
+            let get = |k: &str| js_sys::Reflect::get(&data, &JsValue::from_str(k)).ok();
+            let Some(labels) = get("labels")
                 .and_then(|v| v.dyn_into::<js_sys::Int32Array>().ok())
                 .map(|a| a.to_vec())
             else {
                 return;
             };
-            if let Some((idx, gen)) = gfx_msg.borrow_mut().cluster_pending.take() {
+            let reply_job = get("job").and_then(|v| v.as_f64()).map(|f| f as u64);
+            let job = {
+                let g = gfx_msg.borrow();
+                match (&g.cluster_pending, reply_job) {
+                    (Some((_, _, pj)), Some(rj)) if *pj == rj => Some(rj),
+                    _ => None, // no pending / superseded job — drop this reply
+                }
+            };
+            if job.is_none() {
+                return;
+            }
+            if let Some((idx, gen, _)) = gfx_msg.borrow_mut().cluster_pending.take() {
+                if labels.len() != idx.len() {
+                    return; // malformed reply — never index past the survivor set
+                }
                 let k = labels.iter().copied().max().map_or(0, |m| (m + 1).max(0) as usize);
                 finish_clustering(&gfx_msg, idx, labels, k, gen);
             }
@@ -1602,28 +1637,32 @@ fn create_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
     worker.set_onmessage(Some(cb.as_ref().unchecked_ref()));
     cb.forget(); // the worker lives for the app's lifetime
 
-    // If the worker fails (e.g. its wasm can't load), drop it so the next Run uses the main thread,
-    // and release any stuck pending job.
-    let gfx_err = gfx.clone();
-    add_listener(worker.as_ref(), "error", move |_e: web_sys::Event| {
-        let mut g = gfx_err.borrow_mut();
-        g.cluster_pending = None;
-        g.cluster_worker = None;
-        drop(g);
-        show_status("clustering worker unavailable — runs on the main thread");
-    });
+    // A runtime failure (e.g. the worker's wasm can't load, or a message can't deserialize) latches
+    // `cluster_worker_failed` so every later Run uses the main thread instead of rebuilding a broken
+    // worker; also release any stuck pending job.
+    for ev in ["error", "messageerror"] {
+        let gfx_err = gfx.clone();
+        add_listener(worker.as_ref(), ev, move |_e: web_sys::Event| {
+            let mut g = gfx_err.borrow_mut();
+            g.cluster_pending = None;
+            g.cluster_worker = None;
+            g.cluster_worker_failed = true;
+            drop(g);
+            show_status("clustering worker unavailable — runs on the main thread");
+        });
+    }
     Some(worker)
 }
 
 /// Post a clustering job (the flat positions buffer is transferred, not copied) to the worker.
-fn post_cluster_job(worker: &web_sys::Worker, flat: &[f32], eps: f32, min_pts: usize) -> bool {
+fn post_cluster_job(worker: &web_sys::Worker, flat: &[f32], eps: f32, min_pts: usize, job: u64) -> bool {
     let arr = js_sys::Float32Array::from(flat);
     let msg = js_sys::Object::new();
     let set = |k: &str, v: &JsValue| js_sys::Reflect::set(&msg, &JsValue::from_str(k), v).is_ok();
     if !set("flat", &arr.buffer()) || !set("eps", &JsValue::from_f64(eps as f64)) {
         return false;
     }
-    if !set("min_pts", &JsValue::from_f64(min_pts as f64)) {
+    if !set("min_pts", &JsValue::from_f64(min_pts as f64)) || !set("job", &JsValue::from_f64(job as f64)) {
         return false;
     }
     let transfer = js_sys::Array::of1(&arr.buffer());
@@ -1640,6 +1679,10 @@ fn reupload_points(g: &mut Gfx) {
 
 /// Write DBSCAN labels into the GPU buffer + recolor by cluster, compute stats, then update the UI.
 fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, k: usize, gen: u64) {
+    if labels.len() != idx.len() {
+        show_status(""); // malformed result — never index past the survivor set
+        return;
+    }
     let noise = labels.iter().filter(|&&l| l < 0).count();
     let n_in = idx.len();
     {

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -962,6 +962,11 @@ async fn fetch_cluster(svc: &str, flat: &[f32], eps: f32, min_pts: usize) -> Res
     )
     .await
     .map_err(|e| format!("body read failed: {e:?}"))?;
+    if let Some(ab) = buf.dyn_ref::<js_sys::ArrayBuffer>() {
+        if ab.byte_length() % 4 != 0 {
+            return Err("cluster response not int32-aligned".to_string());
+        }
+    }
     Ok(js_sys::Int32Array::new(&buf).to_vec())
 }
 
@@ -1964,16 +1969,25 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     // colour by its labels. The wasm path below is the default when no service is configured.
     if let Some(svc) = cluster_service_url() {
         let flat: Vec<f32> = positions.iter().flatten().copied().collect();
-        gfx.borrow_mut().cluster_pending = Some((idx, gen, 0));
+        let job = {
+            let mut g = gfx.borrow_mut();
+            g.next_cluster_job = g.next_cluster_job.wrapping_add(1);
+            g.cluster_pending = Some((idx, gen, g.next_cluster_job));
+            g.next_cluster_job
+        };
         set_cluster_running(true);
         show_status("clustering (python)…");
         let gfx2 = gfx.clone();
         wasm_bindgen_futures::spawn_local(async move {
             let result = fetch_cluster(&svc, &flat, eps, min_pts).await;
-            // Pair with the pending job (cleared by invalidate/reload -> drop a stale reply).
-            let Some((idx, gen, _)) = gfx2.borrow_mut().cluster_pending.take() else {
+            // Only consume the reply if it's still THIS job — a Stop / invalidate / newer Run
+            // supersedes it (the un-aborted fetch would otherwise steal the new pending job).
+            let mut g = gfx2.borrow_mut();
+            if !matches!(&g.cluster_pending, Some((_, _, pj)) if *pj == job) {
                 return;
-            };
+            }
+            let (idx, gen, _) = g.cluster_pending.take().unwrap();
+            drop(g);
             match result {
                 Ok(labels) if labels.len() == idx.len() => {
                     let k = labels.iter().copied().max().map_or(0, |m| (m + 1).max(0) as usize);
@@ -2301,6 +2315,13 @@ fn render_cluster_panel(s: &ClusterStats, sel: Option<i32>) {
     set_hist_svg("csh-mz", &hist_bins(&s.mz_extent, 24));
     set_hist_svg("csh-im", &hist_bins(&s.im_extent, 24));
     set_hist_svg("csh-rt", &hist_bins(&s.rt_extent, 24));
+    // X-axis right edge = the max extent (the bins span [0, max]); show it in real units so the
+    // spread is physically meaningful.
+    let max_of = |v: &[f64]| v.iter().cloned().fold(0.0f64, f64::max);
+    set_text("csx-size", &format!("{} pts", max_of(&s.sizes) as u64));
+    set_text("csx-mz", &format!("{:.3} m/z", max_of(&s.mz_extent)));
+    set_text("csx-im", &format!("{:.4} 1/K₀", max_of(&s.im_extent)));
+    set_text("csx-rt", &format!("{:.1} s", max_of(&s.rt_extent)));
 
     // Clickable cluster list — top 50 by size, plus a "Show all" row when isolated.
     let mut order: Vec<usize> = (0..s.k).collect();

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -108,6 +108,9 @@ const DEFAULT_ACQ_PORT: u16 = 8092;
 /// Trailing-window size for acquisition playback: the renderer keeps only the last this-many points
 /// (ring buffer), so an unbounded stream can't grind the GPU. Clamped to the GPU cap.
 const ACQ_RING_POINTS: usize = 1_200_000;
+/// Idle heartbeat: even with no change/interaction, re-render every Nth frame (~3×/s at 60 fps) so a
+/// missed `needs_redraw` wake-source self-heals instead of the view freezing.
+const IDLE_HEARTBEAT: u32 = 20;
 /// Frames per `/acq/frames` prefetch request (built in parallel server-side).
 const ACQ_BATCH: u32 = 64;
 /// Kick the next prefetch when fewer than this many decoded frames remain buffered.
@@ -360,6 +363,10 @@ struct Gfx {
     fps_ema: f32,
     fps_t: f64,
     hud_tick: u32,
+    /// Idle throttling: skip the (multi-million-point) draw when nothing changed and nothing is
+    /// animating. Set at interactions/loads (+ piggybacked on `filter_dirty`); a heartbeat every
+    /// `IDLE_HEARTBEAT` frames renders anyway so a missed wake-source self-heals instead of freezing.
+    needs_redraw: bool,
     /// Real-unit axis ranges `[mz, im, rt]` from `/meta`, for crop labels; `None` => show %.
     axis_bounds: Option<[(f64, f64); 3]>,
     /// Mean RT seconds per cycle (from `/meta`); 0 if unknown. Clusters RT in cycle units.
@@ -497,6 +504,7 @@ impl Gfx {
         self.config.height = h;
         self.surface.configure(&self.device, &self.config);
         self.depth_view = create_depth(&self.device, w, h);
+        self.needs_redraw = true; // a resize changes the surface — redraw next frame
     }
 
     /// Project each axis label's cube position to the canvas and position its DOM element.
@@ -595,6 +603,7 @@ impl Gfx {
         }
         // Recompute the displayed (filter-surviving) count when the filter/draw-count changed.
         if self.filter_dirty {
+            self.needs_redraw = true; // a filter/param/load change must trigger a redraw
             let shown = recount_displayed(self);
             let resident = self.renderer.resident() as usize;
             let txt = if self.points_base.is_empty() {
@@ -606,6 +615,14 @@ impl Gfx {
             };
             set_text("hud-points", &txt);
             self.filter_dirty = false;
+        }
+
+        // Idle skip: if nothing changed and nothing is animating, keep the rAF loop alive but skip
+        // the (multi-million-point) draw — idle GPU ~0. IDLE_HEARTBEAT forces a periodic redraw so a
+        // missed wake-source recovers in a fraction of a second rather than freezing the view.
+        let animating = self.auto_rotate || self.dragging.is_some() || self.acq_playing;
+        if !self.needs_redraw && !animating && self.hud_tick % IDLE_HEARTBEAT != 0 {
+            return true;
         }
 
         if self.auto_rotate {
@@ -694,6 +711,7 @@ impl Gfx {
         }
         self.queue.submit(std::iter::once(enc.finish()));
         surface_tex.present();
+        self.needs_redraw = false; // drawn this frame; go idle until the next change/interaction
         true
     }
 }
@@ -866,6 +884,7 @@ async fn run() -> Result<(), String> {
         fps_ema: 0.0,
         fps_t: 0.0,
         hud_tick: 0,
+        needs_redraw: true,
         axis_bounds,
         cycle_duration: server_meta.as_ref().map(|m| m.cycle_duration).unwrap_or(0.0),
         points_base: if is_demo_fallback { String::new() } else { url.clone() },
@@ -4140,7 +4159,11 @@ fn bind_value(
         let (gfx, apply, s, n) = (gfx.clone(), apply.clone(), slider.clone(), num.clone());
         add_listener(slider.as_ref(), "input", move |_e: web_sys::Event| {
             let v = s.value_as_number();
-            apply(&mut gfx.borrow_mut(), v);
+            {
+                let mut g = gfx.borrow_mut();
+                apply(&mut g, v);
+                g.needs_redraw = true; // slider/number change redraws (idle-throttle wake-up)
+            }
             n.set_value(&format!("{v:.prec$}"));
         });
     }
@@ -4156,7 +4179,11 @@ fn bind_value(
             let v = raw.clamp(lo, hi);
             n.set_value(&format!("{v:.prec$}"));
             s.set_value(&v.to_string());
-            apply(&mut gfx.borrow_mut(), v);
+            {
+                let mut g = gfx.borrow_mut();
+                apply(&mut g, v);
+                g.needs_redraw = true; // slider/number change redraws (idle-throttle wake-up)
+            }
         });
     }
 }
@@ -4241,7 +4268,9 @@ fn on_toggle(id: &str, gfx: &Rc<RefCell<Gfx>>, mut f: impl FnMut(&mut Gfx, bool)
     if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
         let (gfx, el) = (gfx.clone(), inp.clone());
         add_listener(inp.as_ref(), "change", move |_e: web_sys::Event| {
-            f(&mut gfx.borrow_mut(), el.checked());
+            let mut g = gfx.borrow_mut();
+            f(&mut g, el.checked());
+            g.needs_redraw = true; // any control change redraws (idle-throttle wake-up)
         });
     }
 }
@@ -4250,7 +4279,11 @@ fn on_toggle(id: &str, gfx: &Rc<RefCell<Gfx>>, mut f: impl FnMut(&mut Gfx, bool)
 fn on_click(id: &str, gfx: &Rc<RefCell<Gfx>>, mut f: impl FnMut(&mut Gfx) + 'static) {
     if let Some(el) = document().and_then(|d| d.get_element_by_id(id)) {
         let gfx = gfx.clone();
-        add_listener(el.as_ref(), "click", move |_e: web_sys::Event| f(&mut gfx.borrow_mut()));
+        add_listener(el.as_ref(), "click", move |_e: web_sys::Event| {
+            let mut g = gfx.borrow_mut();
+            f(&mut g);
+            g.needs_redraw = true; // any control click redraws (idle-throttle wake-up)
+        });
     }
 }
 
@@ -4288,7 +4321,11 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
         add_listener(sel.as_ref(), "change", move |_e: web_sys::Event| {
             // Read the option's own value (don't rely on DOM order matching COLORMAP_NAMES).
             let id = el.value().parse::<u32>().unwrap_or(0).min(COLORMAP_NAMES.len() as u32 - 1);
-            gfx.borrow_mut().params.colormap_id = id;
+            {
+                let mut g = gfx.borrow_mut();
+                g.params.colormap_id = id;
+                g.needs_redraw = true;
+            }
             set_cbar(id);
         });
     }
@@ -4419,6 +4456,7 @@ fn wire_input(gfx: &Rc<RefCell<Gfx>>, window: &web_sys::Window, canvas: &web_sys
             let mut g = gfx.borrow_mut();
             g.auto_rotate = false;
             g.dragging = Some(e.button());
+            g.needs_redraw = true;
             set_checked("ar", false); // keep the Auto-orbit switch in sync
         });
     }
@@ -4433,13 +4471,16 @@ fn wire_input(gfx: &Rc<RefCell<Gfx>>, window: &web_sys::Window, canvas: &web_sys
                 } else {
                     g.camera.pan(dx, dy);
                 }
+                g.needs_redraw = true;
             }
         });
     }
     {
         let gfx = gfx.clone();
         add_listener(window.as_ref(), "mouseup", move |_e: web_sys::MouseEvent| {
-            gfx.borrow_mut().dragging = None;
+            let mut g = gfx.borrow_mut();
+            g.dragging = None;
+            g.needs_redraw = true;
         });
     }
     {
@@ -4449,6 +4490,7 @@ fn wire_input(gfx: &Rc<RefCell<Gfx>>, window: &web_sys::Window, canvas: &web_sys
             let mut g = gfx.borrow_mut();
             g.auto_rotate = false; // zoom is an interaction too — hand control to the user
             g.camera.zoom(-(e.delta_y() as f32) / 100.0);
+            g.needs_redraw = true;
             set_checked("ar", false);
         });
     }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -929,6 +929,42 @@ fn points_url() -> String {
     format!("http://localhost:{port}/points")
 }
 
+/// Optional Python clustering service URL from `?cluster=<url>` — when set, Run posts points to it
+/// (sklearn DBSCAN) instead of the in-wasm DBSCAN.
+fn cluster_service_url() -> Option<String> {
+    let search = web_sys::window().and_then(|w| w.location().search().ok()).unwrap_or_default();
+    search
+        .trim_start_matches('?')
+        .split('&')
+        .find_map(|kv| kv.strip_prefix("cluster="))
+        .filter(|v| !v.is_empty())
+        .and_then(|v| js_sys::decode_uri_component(v).ok().and_then(|s| s.as_string()))
+}
+
+/// POST the (already axis-scaled) flat positions to the Python clustering service and read back the
+/// per-point labels. Same wire format as the wasm worker: float32 xyz triples in, int32 labels out.
+async fn fetch_cluster(svc: &str, flat: &[f32], eps: f32, min_pts: usize) -> Result<Vec<i32>, String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let arr = js_sys::Float32Array::from(flat);
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_body(&arr.buffer());
+    let url = with_query(svc, &format!("eps={eps}&min={min_pts}"));
+    let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str_and_init(&url, &opts))
+        .await
+        .map_err(|e| format!("fetch failed: {e:?}"))?;
+    let resp: web_sys::Response = resp_val.dyn_into().map_err(|_| "not a Response".to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let buf = wasm_bindgen_futures::JsFuture::from(
+        resp.array_buffer().map_err(|e| format!("array_buffer: {e:?}"))?,
+    )
+    .await
+    .map_err(|e| format!("body read failed: {e:?}"))?;
+    Ok(js_sys::Int32Array::new(&buf).to_vec())
+}
+
 /// Fetch packed `GpuPoint` bytes from the server and reinterpret them (the server already
 /// normalized positions to the `[-1, 1]` cube, so they upload as-is).
 async fn fetch_points(url: &str) -> Result<Vec<GpuPoint>, String> {
@@ -1923,6 +1959,39 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         return;
     }
     gfx.borrow_mut().cluster_run_params = Some(run_params); // before dispatch, for the export JSON
+
+    // Python backend (if `?cluster=<url>` is set): POST the scaled points to the sklearn service and
+    // colour by its labels. The wasm path below is the default when no service is configured.
+    if let Some(svc) = cluster_service_url() {
+        let flat: Vec<f32> = positions.iter().flatten().copied().collect();
+        gfx.borrow_mut().cluster_pending = Some((idx, gen, 0));
+        set_cluster_running(true);
+        show_status("clustering (python)…");
+        let gfx2 = gfx.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            let result = fetch_cluster(&svc, &flat, eps, min_pts).await;
+            // Pair with the pending job (cleared by invalidate/reload -> drop a stale reply).
+            let Some((idx, gen, _)) = gfx2.borrow_mut().cluster_pending.take() else {
+                return;
+            };
+            match result {
+                Ok(labels) if labels.len() == idx.len() => {
+                    let k = labels.iter().copied().max().map_or(0, |m| (m + 1).max(0) as usize);
+                    finish_clustering(&gfx2, idx, labels, k, gen);
+                }
+                Ok(_) => {
+                    set_cluster_running(false);
+                    show_status("python clustering: label/point count mismatch");
+                }
+                Err(e) => {
+                    set_cluster_running(false);
+                    show_status(&format!("python clustering failed: {e}"));
+                }
+            }
+        });
+        return;
+    }
+
     show_status("clustering…");
     // Small inputs cluster in well under a second, so run them on the main thread (deferred one
     // macrotask so the status paints): instant, with none of the worker's one-time wasm spin-up

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -94,6 +94,9 @@ const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 const CANVAS_ID: &str = "tims-canvas";
 /// Default point-server port (`tims-viewer DEMO --serve 8090`). Override with `?port=N` in the URL.
 const DEFAULT_SERVER_PORT: u16 = 8090;
+/// Default Python (sklearn) clustering-service port (`cluster_service.py --port 8091`). Override with
+/// `?clusterport=N`, or a full URL via `?cluster=<url>`.
+const DEFAULT_CLUSTER_PORT: u16 = 8091;
 
 /// wasm entry point — Trunk/wasm-bindgen call this on load.
 #[wasm_bindgen(start)]
@@ -258,6 +261,9 @@ struct Gfx {
     cluster_sel: Option<i32>,
     /// When clustered + colouring, hide the un-clustered (noise) points (color_mode 2 vs 1).
     hide_noise: bool,
+    /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
+    /// the startup probe when the service is reachable; toggleable in the Cluster tab.
+    use_python_cluster: bool,
     /// Persistent DBSCAN worker (lazily created; `None` if workers are unavailable → main-thread
     /// fallback), and the in-flight job's (survivor idx, data generation, job id) awaiting its reply.
     /// `job_id` distinguishes a superseded job's late reply; `worker_failed` latches a runtime failure
@@ -688,6 +694,7 @@ async fn run() -> Result<(), String> {
         cluster_labels: Vec::new(),
         cluster_sel: None,
         hide_noise: false,
+        use_python_cluster: false,
         cluster_worker: None,
         cluster_pending: None,
         next_cluster_job: 0,
@@ -731,6 +738,8 @@ async fn run() -> Result<(), String> {
     bind_cluster(&gfx);
     // DIA isolation-window overlay.
     bind_windows(&gfx);
+    // Probe the Python clustering service; auto-enable the backend toggle if it's up.
+    wasm_bindgen_futures::spawn_local(probe_cluster_service(gfx.clone()));
     // Collapsible section headers + tab switching.
     bind_panel_chrome(&gfx);
 
@@ -929,16 +938,44 @@ fn points_url() -> String {
     format!("http://localhost:{port}/points")
 }
 
-/// Optional Python clustering service URL from `?cluster=<url>` — when set, Run posts points to it
-/// (sklearn DBSCAN) instead of the in-wasm DBSCAN.
-fn cluster_service_url() -> Option<String> {
+/// The Python clustering service URL: a `?cluster=<url>` override, else the default
+/// `http://localhost:<DEFAULT_CLUSTER_PORT>/cluster` (or `?clusterport=N`). Always returns a URL so
+/// the Python backend is reachable from the plain page — a startup probe decides if it's actually up.
+fn cluster_service_url() -> String {
     let search = web_sys::window().and_then(|w| w.location().search().ok()).unwrap_or_default();
-    search
-        .trim_start_matches('?')
+    let params = search.trim_start_matches('?');
+    if let Some(v) = params.split('&').find_map(|kv| kv.strip_prefix("cluster=")).filter(|v| !v.is_empty())
+    {
+        if let Some(decoded) = js_sys::decode_uri_component(v).ok().and_then(|s| s.as_string()) {
+            return decoded;
+        }
+    }
+    let port = params
         .split('&')
-        .find_map(|kv| kv.strip_prefix("cluster="))
-        .filter(|v| !v.is_empty())
-        .and_then(|v| js_sys::decode_uri_component(v).ok().and_then(|s| s.as_string()))
+        .find_map(|kv| kv.strip_prefix("clusterport=").and_then(|v| v.parse::<u16>().ok()))
+        .unwrap_or(DEFAULT_CLUSTER_PORT);
+    format!("http://localhost:{port}/cluster")
+}
+
+/// Probe the cluster service (GET its health route); on success enable + auto-select the Python
+/// backend so it's a ready option from the plain page (no `?cluster=` needed).
+async fn probe_cluster_service(gfx: Rc<RefCell<Gfx>>) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let ok = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&cluster_service_url())).await {
+        Ok(v) => v.dyn_into::<web_sys::Response>().map(|r| r.ok()).unwrap_or(false),
+        Err(_) => false,
+    };
+    if ok {
+        gfx.borrow_mut().use_python_cluster = true; // prefer sklearn when it's available
+        set_checked("cl-python", true);
+        set_disabled("cl-python", false);
+        set_text("cl-python-status", "sklearn ✓");
+    } else {
+        set_disabled("cl-python", true);
+        set_text("cl-python-status", "not running");
+    }
 }
 
 /// POST the (already axis-scaled) flat positions to the Python clustering service and read back the
@@ -1965,9 +2002,10 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     }
     gfx.borrow_mut().cluster_run_params = Some(run_params); // before dispatch, for the export JSON
 
-    // Python backend (if `?cluster=<url>` is set): POST the scaled points to the sklearn service and
-    // colour by its labels. The wasm path below is the default when no service is configured.
-    if let Some(svc) = cluster_service_url() {
+    // Python backend (when the "Python (sklearn)" toggle is on — auto-enabled by the startup probe):
+    // POST the scaled points to the service and colour by its labels. Else the wasm path below.
+    if gfx.borrow().use_python_cluster {
+        let svc = cluster_service_url();
         let flat: Vec<f32> = positions.iter().flatten().copied().collect();
         let job = {
             let mut g = gfx.borrow_mut();
@@ -2403,6 +2441,7 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(2));
     bind_value(gfx, "cl-rtc", "cl-rtc-n", 0, |g, v| g.cluster_rt_cycles = v.round().max(1.0));
     bind_value(gfx, "cl-mzw", "cl-mzw-n", 1, |g, v| g.cluster_mz_peak_widths = v.max(0.1));
+    on_toggle("cl-python", gfx, |g, on| g.use_python_cluster = on);
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-run") {
         let gfx = gfx.clone();
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| {
@@ -3178,6 +3217,8 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_checked("cl-color", true); // colour by cluster is on by default (applies after a Run)
     set_checked("hide-noise", false);
     set_checked("show-windows", false); // off by default (defeats browser form-restore)
+    set_checked("cl-python", false); // enabled + auto-checked by the startup service probe
+    set_disabled("cl-python", true);
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);
 }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -43,8 +43,6 @@ pub fn start() {
 
 /// Live GPU + scene state, shared (single-threaded) between the render loop and resize handler.
 struct Gfx {
-    /// Kept alive so it outlives the surface/device (wgpu requires the instance to live longest).
-    _instance: wgpu::Instance,
     canvas: web_sys::HtmlCanvasElement,
     surface: wgpu::Surface<'static>,
     device: wgpu::Device,
@@ -72,6 +70,9 @@ struct Gfx {
     hud_tick: u32,
     /// Real-unit axis ranges `[mz, im, rt]` from `/meta`, for crop labels; `None` => show %.
     axis_bounds: Option<[(f64, f64); 3]>,
+    /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
+    /// everything created from it.
+    _instance: wgpu::Instance,
 }
 
 impl Gfx {
@@ -304,7 +305,6 @@ async fn run() -> Result<(), String> {
     if let Some(m) = &server_meta {
         apply_auto_transfer(&mut params, m);
     }
-    let applied_exposure = params.transfer[3];
 
     // The orientation box (cube + axis edges) + projected DOM tick labels.
     let mut axes = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
@@ -337,22 +337,19 @@ async fn run() -> Result<(), String> {
 
     wire_input(&gfx, &window, &canvas_for_input);
     wire_controls(&gfx);
-    // Browsers restore a control's previous state across reloads, which can leave the Auto-orbit
-    // switch out of sync with the code default — force it to match so the first click works.
-    set_checked("ar", gfx.borrow().auto_rotate);
-    // Reflect the auto-exposure on its slider, and scale the intensity-floor control to the data.
+    // Scale the intensity-floor controls (slider + number) to the data before syncing values.
     if let Some(m) = &server_meta {
-        if let Some(inp) = by_id::<web_sys::HtmlInputElement>("expo") {
-            inp.set_value(&format!("{applied_exposure:.2}"));
-        }
-        set_text("expo-v", &format!("{applied_exposure:.2}"));
         if m.i_p99 > 1.0 {
-            if let Some(inp) = by_id::<web_sys::HtmlInputElement>("floor") {
-                let _ = inp.set_attribute("max", &format!("{:.0}", m.i_p99));
-                let _ = inp.set_attribute("step", &format!("{:.0}", (m.i_p99 / 200.0).max(1.0)));
+            for id in ["floor", "floor-n"] {
+                if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
+                    let _ = inp.set_attribute("max", &format!("{:.0}", m.i_p99));
+                    let _ = inp.set_attribute("step", &format!("{:.0}", (m.i_p99 / 200.0).max(1.0)));
+                }
             }
         }
     }
+    // Push code state onto every DOM control (defeats the browser's cross-reload form restore).
+    sync_controls(&gfx);
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -408,12 +405,14 @@ async fn init_gpu(canvas: &web_sys::HtmlCanvasElement) -> Result<Gpu, String> {
         Some(adapter) => {
             let limits = wgpu::Limits::downlevel_defaults().using_resolution(adapter.limits());
             match adapter.request_device(&device_desc(limits), None).await {
-                Ok((device, queue)) => {
-                    let surface = wgpu_inst
-                        .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
-                        .map_err(|e| format!("create_surface (webgpu): {e}"))?;
-                    return Ok((wgpu_inst, surface, adapter, device, queue, false));
-                }
+                // Surface creation can also fail here — treat that like any WebGPU failure and
+                // fall through to WebGL2 rather than giving up (the canvas has no context yet).
+                Ok((device, queue)) => match wgpu_inst
+                    .create_surface(wgpu::SurfaceTarget::Canvas(canvas.clone()))
+                {
+                    Ok(surface) => return Ok((wgpu_inst, surface, adapter, device, queue, false)),
+                    Err(e) => Some(format!("WebGPU create_surface: {e}")),
+                },
                 Err(e) => Some(format!("WebGPU requestDevice: {e:?}")),
             }
         }
@@ -790,13 +789,103 @@ fn group(n: usize) -> String {
     out
 }
 
-/// Bind an `<input type=range>`: call `f` with the live numeric value on every input.
-fn on_range(id: &str, gfx: &Rc<RefCell<Gfx>>, mut f: impl FnMut(&mut Gfx, f64) + 'static) {
-    if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
-        let (gfx, el) = (gfx.clone(), inp.clone());
-        add_listener(inp.as_ref(), "input", move |_e: web_sys::Event| {
-            f(&mut gfx.borrow_mut(), el.value_as_number());
+/// Bind a slider + its editable number field bidirectionally to a render parameter: dragging the
+/// slider updates the param and the number; typing a number clamps it to the slider's min/max,
+/// moves the slider, and updates the param. `prec` is the displayed decimal count.
+fn bind_value(
+    gfx: &Rc<RefCell<Gfx>>,
+    slider_id: &str,
+    num_id: &str,
+    prec: usize,
+    apply: impl Fn(&mut Gfx, f64) + 'static,
+) {
+    let (Some(slider), Some(num)) = (
+        by_id::<web_sys::HtmlInputElement>(slider_id),
+        by_id::<web_sys::HtmlInputElement>(num_id),
+    ) else {
+        return;
+    };
+    let apply = std::rc::Rc::new(apply);
+    {
+        let (gfx, apply, s, n) = (gfx.clone(), apply.clone(), slider.clone(), num.clone());
+        add_listener(slider.as_ref(), "input", move |_e: web_sys::Event| {
+            let v = s.value_as_number();
+            apply(&mut gfx.borrow_mut(), v);
+            n.set_value(&format!("{v:.prec$}"));
         });
+    }
+    {
+        let (gfx, apply, s, n) = (gfx.clone(), apply.clone(), slider.clone(), num.clone());
+        add_listener(num.as_ref(), "change", move |_e: web_sys::Event| {
+            let raw = n.value_as_number();
+            if raw.is_nan() {
+                return; // empty / non-numeric: leave state as-is
+            }
+            let lo = s.min().parse::<f64>().unwrap_or(f64::NEG_INFINITY);
+            let hi = s.max().parse::<f64>().unwrap_or(f64::INFINITY);
+            let v = raw.clamp(lo, hi);
+            n.set_value(&format!("{v:.prec$}"));
+            s.set_value(&v.to_string());
+            apply(&mut gfx.borrow_mut(), v);
+        });
+    }
+}
+
+/// Set a slider + its number field to `v` without firing handlers (for startup sync).
+fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
+    if let Some(s) = by_id::<web_sys::HtmlInputElement>(slider_id) {
+        s.set_value(&v.to_string());
+    }
+    if let Some(n) = by_id::<web_sys::HtmlInputElement>(num_id) {
+        n.set_value(&format!("{v:.prec$}"));
+    }
+}
+
+/// Push the current Rust render state onto every DOM control. Browsers restore a control's prior
+/// value across reloads, which can silently desync the radios/checkbox/select/sliders from the
+/// actual params (a checked-but-stale radio won't emit `change` when clicked); calling this after
+/// wiring re-asserts the truth so the panel always reflects what's rendering.
+fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
+    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor) = {
+        let g = gfx.borrow();
+        (
+            g.auto_rotate,
+            g.params.render_mode,
+            g.params.transfer[0] as i32,
+            g.params.ms_mask,
+            g.params.colormap_id,
+            g.params.point_size as f64,
+            g.params.opacity as f64,
+            g.params.transfer[3] as f64,
+            g.params.filter_min[3] as f64,
+        )
+    };
+    set_checked("ar", auto);
+    set_checked("m-add", rmode == 0);
+    set_checked("m-opq", rmode == 1);
+    set_checked("xf-lin", xf == 0);
+    set_checked("xf-sqrt", xf == 1);
+    set_checked("xf-log", xf == 2);
+    set_checked("ms-1", ms == 0b01);
+    set_checked("ms-2", ms == 0b10);
+    set_checked("ms-b", ms == 0b11);
+    if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cmap") {
+        sel.set_value(&cmap.to_string());
+    }
+    set_cbar(cmap);
+    set_value_pair("psize", "psize-n", psize, 1);
+    set_value_pair("opac", "opac-n", opac, 2);
+    set_value_pair("expo", "expo-n", expo, 2);
+    set_value_pair("floor", "floor-n", floor, 0);
+    // Crops start at full range; crop_apply also resets the fill bars + real-unit readouts.
+    for (axis, prefix) in [(0usize, "cmz"), (1, "cim"), (2, "crt")] {
+        if let Some(lo) = by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-lo")) {
+            lo.set_value("0");
+        }
+        if let Some(hi) = by_id::<web_sys::HtmlInputElement>(&format!("{prefix}-hi")) {
+            hi.set_value("1000");
+        }
+        crop_apply(gfx, axis, prefix, 0.0, 1000.0);
     }
 }
 
@@ -856,27 +945,15 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
             set_cbar(id);
         });
     }
-    on_range("psize", gfx, |g, v| {
-        g.params.point_size = v as f32;
-        set_text("psize-v", &format!("{v:.1}"));
-    });
-    on_range("opac", gfx, |g, v| {
-        g.params.opacity = v as f32;
-        set_text("opac-v", &format!("{v:.2}"));
-    });
+    bind_value(gfx, "psize", "psize-n", 1, |g, v| g.params.point_size = v as f32);
+    bind_value(gfx, "opac", "opac-n", 2, |g, v| g.params.opacity = v as f32);
 
     // Intensity transfer
     on_toggle("xf-lin", gfx, |g, on| if on { g.params.transfer[0] = 0.0; });
     on_toggle("xf-sqrt", gfx, |g, on| if on { g.params.transfer[0] = 1.0; });
     on_toggle("xf-log", gfx, |g, on| if on { g.params.transfer[0] = 2.0; });
-    on_range("expo", gfx, |g, v| {
-        g.params.transfer[3] = v as f32;
-        set_text("expo-v", &format!("{v:.2}"));
-    });
-    on_range("floor", gfx, |g, v| {
-        g.params.filter_min[3] = v as f32; // intensity floor (real units)
-        set_text("floor-v", &format!("{v:.0}"));
-    });
+    bind_value(gfx, "expo", "expo-n", 2, |g, v| g.params.transfer[3] = v as f32);
+    bind_value(gfx, "floor", "floor-n", 0, |g, v| g.params.filter_min[3] = v as f32);
 
     // Filters
     on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; });
@@ -902,6 +979,8 @@ fn bind_crop(gfx: &Rc<RefCell<Gfx>>, prefix: &str, axis: usize) {
     {
         let (gfx_c, lo_c, hi_c, p) = (gfx.clone(), lo.clone(), hi.clone(), prefix.to_string());
         add_listener(lo.as_ref(), "input", move |_e: web_sys::Event| {
+            let _ = lo_c.style().set_property("z-index", "5"); // active thumb on top
+            let _ = hi_c.style().set_property("z-index", "4");
             if lo_c.value_as_number() > hi_c.value_as_number() {
                 hi_c.set_value(&lo_c.value());
             }
@@ -912,6 +991,8 @@ fn bind_crop(gfx: &Rc<RefCell<Gfx>>, prefix: &str, axis: usize) {
     {
         let (gfx_c, lo_c, hi_c, p) = (gfx.clone(), lo.clone(), hi.clone(), prefix.to_string());
         add_listener(hi.as_ref(), "input", move |_e: web_sys::Event| {
+            let _ = hi_c.style().set_property("z-index", "5"); // active thumb on top
+            let _ = lo_c.style().set_property("z-index", "4");
             if hi_c.value_as_number() < lo_c.value_as_number() {
                 lo_c.set_value(&hi_c.value());
             }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -663,20 +663,23 @@ async fn run() -> Result<(), String> {
     // Collapsible section headers + tab switching.
     bind_panel_chrome(&gfx);
 
-    // Fetch the run-level DIA windows once; build the overlay + enable the toggle when they arrive.
+    // Fetch the run-level DIA windows once; build the overlay + legend when they arrive. The toggle
+    // stays clickable regardless (it reports "no windows" on click if the fetch failed / non-DIA).
     if !url.is_empty() {
         let gfx = gfx.clone();
         let wurl = windows_url(&url);
         wasm_bindgen_futures::spawn_local(async move {
-            if let Ok((rects, max_group)) = fetch_windows(&wurl).await {
-                {
-                    let mut g = gfx.borrow_mut();
-                    g.window_rects = rects;
-                    g.max_window_group = max_group;
+            match fetch_windows(&wurl).await {
+                Ok((rects, max_group)) => {
+                    {
+                        let mut g = gfx.borrow_mut();
+                        g.window_rects = rects;
+                        g.max_window_group = max_group;
+                    }
+                    rebuild_window_overlay(&gfx);
+                    render_window_legend(&gfx);
                 }
-                rebuild_window_overlay(&gfx);
-                render_window_legend(&gfx);
-                set_disabled("show-windows", gfx.borrow().max_window_group == 0);
+                Err(e) => log::warn!("/windows fetch failed (restart the point server?): {e}"),
             }
         });
     }
@@ -2129,7 +2132,11 @@ fn bind_windows(gfx: &Rc<RefCell<Gfx>>) {
             gfx.borrow_mut().show_windows = on;
             set_body_class("show-windows", on); // reveals the group legend
             if on {
-                render_window_legend(&gfx);
+                if gfx.borrow().window_rects.is_empty() {
+                    show_status("no DIA windows for this run (not DIA, or restart the point server)");
+                } else {
+                    render_window_legend(&gfx);
+                }
             }
         });
     }
@@ -2793,8 +2800,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
     set_checked("cl-color", false);
-    set_checked("show-windows", false); // off until /windows loads (then enabled if groups exist)
-    set_disabled("show-windows", true);
+    set_checked("show-windows", false); // off by default (defeats browser form-restore)
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);
 }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -37,10 +37,16 @@ const WORKER_THRESHOLD: usize = 300_000;
 /// RT is scaled so a cluster's elution stays connected across cycles regardless of the RT zoom.
 const CLUSTER_RT_CYCLES: f64 = 2.0;
 
+/// Reference eps the RT/m/z axis scalings are calibrated to (the slider default). The scalings use
+/// this fixed value — not the live eps — so the live eps still scales the reach on every axis
+/// proportionally (otherwise eps cancels out on the transformed axes).
+const CLUSTER_EPS_REF: f64 = 0.012;
+
 /// Nominal TOF resolution for the m/z peak-width transform (peak width ≈ m/z / resolution).
 const MZ_RESOLUTION: f64 = 50_000.0;
-/// Cap on how many m/z peak-widths `eps` may span: the m/z axis is expanded so `eps` never bridges
-/// more than this, keeping adjacent isotopes (tens of peak-widths apart) as separate clusters.
+/// Default for the m/z-peak-width lever (`Gfx::cluster_mz_peak_widths`): how many m/z peak-widths
+/// `eps` may span. The m/z axis is expanded so `eps` never bridges more than this, keeping adjacent
+/// isotopes (tens of peak-widths apart) as separate clusters.
 const CLUSTER_MZ_PEAK_WIDTHS: f64 = 6.0;
 
 /// Hard ceiling on points loaded into the (32-bit) wasm heap, regardless of the server `--budget` or
@@ -215,6 +221,8 @@ struct Gfx {
     // ---- clustering (CLUSTERING_WEB_PLAN.md) ----
     cluster_eps: f32,
     cluster_min_pts: usize,
+    /// User lever: max m/z peak-widths `eps` may span (lower = isotopes separate harder).
+    cluster_mz_peak_widths: f64,
     /// True while a DBSCAN result is colouring the cloud (`params.color_mode == 1`). Invalidated on
     /// reload / focus / filter change.
     clustered: bool,
@@ -647,6 +655,7 @@ async fn run() -> Result<(), String> {
         vol_i_max: 2.0,
         cluster_eps: 0.012,
         cluster_min_pts: 8,
+        cluster_mz_peak_widths: CLUSTER_MZ_PEAK_WIDTHS,
         clustered: false,
         cluster_stats: None,
         cluster_idx: Vec::new(),
@@ -865,13 +874,26 @@ fn points_url() -> String {
         .and_then(|w| w.location().search().ok())
         .unwrap_or_default();
     let params = search.trim_start_matches('?');
-    // Explicit full-URL override (percent-decoded).
+    // Explicit full-URL override (percent-decoded). Strip any baked-in `n=` so our budget caps stay
+    // authoritative (with_query appends `n=n_cap`; a leftover n would double up).
     if let Some(v) = params.split('&').find_map(|kv| kv.strip_prefix("points=")) {
         if !v.is_empty() {
-            return js_sys::decode_uri_component(v)
+            let decoded = js_sys::decode_uri_component(v)
                 .ok()
                 .and_then(|s| s.as_string())
                 .unwrap_or_else(|| v.to_string());
+            return match decoded.split_once('?') {
+                Some((path, query)) => {
+                    let kept: Vec<&str> =
+                        query.split('&').filter(|kv| !kv.starts_with("n=")).collect();
+                    if kept.is_empty() {
+                        path.to_string()
+                    } else {
+                        format!("{path}?{}", kept.join("&"))
+                    }
+                }
+                None => decoded,
+            };
         }
     }
     let port = params
@@ -1460,11 +1482,15 @@ async fn load_region(gfx: Rc<RefCell<Gfx>>, region: Region, budget: Option<usize
         g.reloading = true;
     }
     refresh_controls(&gfx); // disable focus/back/load while a load is in flight
-    let base = gfx.borrow().points_base.clone();
-    let q = budget.map(|b| region_query(&region, b));
-    let purl = q.as_ref().map_or_else(|| base.clone(), |q| with_query(&base, q));
-    let mbase = meta_url(&base);
-    let murl = q.as_ref().map_or(mbase.clone(), |q| with_query(&mbase, q));
+    let (base, n_cap) = {
+        let g = gfx.borrow();
+        (g.points_base.clone(), g.n_cap)
+    };
+    // Always cap n (None = the root entry) so Back-to-root can't fetch the server's full --budget
+    // uncapped and OOM the wasm heap, mirroring the initial load.
+    let q = region_query(&region, budget.unwrap_or(n_cap).min(n_cap));
+    let purl = with_query(&base, &q);
+    let murl = with_query(&meta_url(&base), &q);
     show_status("loading…");
     // Require BOTH meta and points: applying points without their matching meta would leave
     // axis_bounds stale while the buffer is normalized to the new region (breaks nested Focus).
@@ -1729,7 +1755,13 @@ fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
 /// Revert cluster colouring (a filter/load changed the set, so the labels are stale). Cheap — just
 /// flips `color_mode` back to intensity; the stale `_pad[0]` ids stay unused until the next Run.
 fn invalidate_clusters_mut(g: &mut Gfx) {
-    g.cluster_pending = None; // abandon any in-flight worker job (its reply will be ignored)
+    // Abandon any in-flight worker job AND terminate the worker, so it doesn't keep computing a
+    // now-stale result with the next Run queued behind it. The next Run rebuilds a fresh worker.
+    if g.cluster_pending.take().is_some() {
+        if let Some(w) = g.cluster_worker.take() {
+            w.terminate();
+        }
+    }
     set_cluster_progress(None);
     set_cluster_running(false);
     if g.clustered {
@@ -1789,30 +1821,31 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             idx.push(i);
             positions.push(pos);
         }
-        // Compress the RT axis into ~cycle units so eps bridges several cycles. Precursor RT is
-        // quantized at the cycle period (one MS1 per cycle); after a focus the per-cycle gap can
-        // exceed eps in normalized space and shatter every elution into one-cycle clusters. Scaling
-        // RT down (<=1) makes eps reach CLUSTER_RT_CYCLES cycles regardless of the RT zoom; m/z and
-        // 1/K0 keep the user's eps. (The metric only; labels/stats use the unscaled points.)
+        // Per-axis equi-distancing, calibrated to CLUSTER_EPS_REF (not the live eps) so the live eps
+        // still scales the reach on every axis proportionally. (The metric only; labels/stats use the
+        // unscaled points.)
         let eps = g.cluster_eps;
+        // RT: compress into ~cycle units so eps bridges CLUSTER_RT_CYCLES cycles regardless of the RT
+        // zoom — precursor RT is quantized at the cycle period, so an un-scaled eps shatters elutions.
         let rt_scale = match g.axis_bounds {
             Some(b) if g.cycle_duration > 0.0 && (b[2].1 - b[2].0).abs() > 0.0 => {
                 let cycle_gap_norm = 2.0 * g.cycle_duration / (b[2].1 - b[2].0).abs();
-                let desired = (CLUSTER_RT_CYCLES * cycle_gap_norm).max(eps as f64);
-                (eps as f64 / desired) as f32
+                let desired = (CLUSTER_RT_CYCLES * cycle_gap_norm).max(CLUSTER_EPS_REF);
+                (CLUSTER_EPS_REF / desired) as f32
             }
             _ => 1.0,
         };
-        // Expand the m/z axis into ~peak-width units so eps spans only a few peak-widths and can't
-        // bridge across isotopes (tens of peak-widths apart). Linear over the region (peak width at
-        // the m/z center); max(1) so a narrow focus only ever sharpens m/z, never loosens it.
+        // m/z: expand into ~peak-width units so eps spans at most `cluster_mz_peak_widths` peak-widths
+        // (peak width ≈ m/z / resolution) and can't bridge across isotopes. The cap is a user lever,
+        // independent of eps; max(1) so a narrow focus only sharpens m/z, never loosens it.
         let mz_scale = match g.axis_bounds {
             Some(b) => {
                 let mz_center = ((b[0].0 + b[0].1) * 0.5).abs();
                 let mz_range = (b[0].1 - b[0].0).abs();
                 let peak_width = mz_center / MZ_RESOLUTION;
+                let pw = g.cluster_mz_peak_widths.max(0.1);
                 if mz_center > 0.0 && mz_range > 0.0 && peak_width > 0.0 {
-                    (eps as f64 * mz_range / (2.0 * CLUSTER_MZ_PEAK_WIDTHS * peak_width)).max(1.0) as f32
+                    (CLUSTER_EPS_REF * mz_range / (2.0 * pw * peak_width)).max(1.0) as f32
                 } else {
                     1.0
                 }
@@ -2228,6 +2261,7 @@ fn defer<F: FnOnce() + 'static>(f: F) {
 fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-eps", "cl-eps-n", 3, |g, v| g.cluster_eps = v as f32);
     bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(2));
+    bind_value(gfx, "cl-mzw", "cl-mzw-n", 1, |g, v| g.cluster_mz_peak_widths = v.max(0.1));
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-run") {
         let gfx = gfx.clone();
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| {
@@ -2920,7 +2954,7 @@ fn set_value_pair(slider_id: &str, num_id: &str, v: f64, prec: usize) {
 /// actual params (a checked-but-stale radio won't emit `change` when clicked); calling this after
 /// wiring re-asserts the truth so the panel always reflects what's rendering.
 fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
-    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min) = {
+    let (auto, rmode, xf, ms, cmap, psize, opac, expo, floor, cl_eps, cl_min, cl_mzw) = {
         let g = gfx.borrow();
         (
             g.auto_rotate,
@@ -2934,6 +2968,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
             g.params.filter_min[3] as f64,
             g.cluster_eps as f64,
             g.cluster_min_pts as f64,
+            g.cluster_mz_peak_widths,
         )
     };
     set_checked("ar", auto);
@@ -2956,6 +2991,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     // Cluster controls (defeat browser form-restore; no result yet, so colour off).
     set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
+    set_value_pair("cl-mzw", "cl-mzw-n", cl_mzw, 1);
     set_checked("cl-color", true); // colour by cluster is on by default (applies after a Run)
     set_checked("hide-noise", false);
     set_checked("show-windows", false); // off by default (defeats browser form-restore)

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -856,23 +856,53 @@ fn group(n: usize) -> String {
 /// performance live, with no re-upload. Points are shuffled server-side, so the drawn prefix is a
 /// representative subsample at any fraction. Also reflects the drawn count in the HUD.
 fn bind_display(gfx: &Rc<RefCell<Gfx>>) {
-    let Some(slider) = by_id::<web_sys::HtmlInputElement>("disp") else {
+    let (Some(slider), Some(num)) = (
+        by_id::<web_sys::HtmlInputElement>("disp"),
+        by_id::<web_sys::HtmlInputElement>("disp-n"),
+    ) else {
         return;
     };
-    let total = gfx.borrow().renderer.resident();
-    let apply: std::rc::Rc<dyn Fn()> = {
-        let (gfx, s) = (gfx.clone(), slider.clone());
-        std::rc::Rc::new(move || {
+    // slider(%) -> count: update the count field + HUD
+    {
+        let (gfx, s, n) = (gfx.clone(), slider.clone(), num.clone());
+        add_listener(slider.as_ref(), "input", move |_e: web_sys::Event| {
+            let total = gfx.borrow().renderer.resident().max(1);
             let pct = (s.value_as_number() / 100.0).clamp(0.0, 1.0);
-            let k = ((total as f64) * pct).round().max(1.0) as u32;
-            gfx.borrow_mut().renderer.set_draw_count(k);
-            set_text("disp-v", &group(k as usize));
-            set_text("hud-points", &group(k as usize));
-        })
-    };
-    apply(); // honor the slider's current (possibly browser-restored) value on startup
-    let apply_c = apply.clone();
-    add_listener(slider.as_ref(), "input", move |_e: web_sys::Event| apply_c());
+            let (k, _) = display_apply(&gfx, ((total as f64) * pct).round() as u32);
+            n.set_value(&k.to_string());
+        });
+    }
+    // count -> %: update the slider + HUD
+    {
+        let (gfx, s, n) = (gfx.clone(), slider.clone(), num.clone());
+        add_listener(num.as_ref(), "change", move |_e: web_sys::Event| {
+            let raw = n.value_as_number();
+            if raw.is_nan() {
+                return;
+            }
+            let (k, total) = display_apply(&gfx, raw.max(1.0) as u32);
+            s.set_value(&format!("{:.0}", 100.0 * (k as f64) / (total as f64)));
+            n.set_value(&k.to_string());
+        });
+    }
+    // Initialize draw count + count field from the slider's current value.
+    let total = gfx.borrow().renderer.resident().max(1);
+    let pct = (slider.value_as_number() / 100.0).clamp(0.0, 1.0);
+    let (k0, _) = display_apply(gfx, ((total as f64) * pct).round() as u32);
+    num.set_value(&k0.to_string());
+    let _ = num.set_attribute("max", &total.to_string());
+}
+
+/// Set the renderer's draw count (clamped to the live resident pool) and update the HUD.
+/// Returns `(applied_count, pool_total)`.
+fn display_apply(gfx: &Rc<RefCell<Gfx>>, k: u32) -> (u32, u32) {
+    let mut g = gfx.borrow_mut();
+    let total = g.renderer.resident().max(1);
+    let kk = k.clamp(1, total);
+    g.renderer.set_draw_count(kk);
+    drop(g);
+    set_text("hud-points", &group(kk as usize));
+    (kk, total)
 }
 
 /// Bind a slider + its editable number field bidirectionally to a render parameter: dragging the

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -350,6 +350,10 @@ async fn run() -> Result<(), String> {
     }
     // Push code state onto every DOM control (defeats the browser's cross-reload form restore).
     sync_controls(&gfx);
+    // Draw the per-axis distribution strips above the crop sliders.
+    if let Some(h) = server_meta.as_ref().and_then(|m| m.hist.as_ref()) {
+        draw_hist_backdrops(h);
+    }
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -538,6 +542,9 @@ struct MetaInfo {
     i_p50: f64,
     i_p99: f64,
     stride: f64,
+    /// Per-axis density histograms `[mz, im, rt]` (each over the full axis range), for the crop
+    /// distribution strips. `None` if the server didn't provide them.
+    hist: Option<[Vec<u32>; 3]>,
 }
 
 /// Derive the `/meta` URL from the `/points` URL: replace only the trailing path endpoint and keep
@@ -614,12 +621,36 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
     let stride = jnum(&v, "downsample_stride")
         .filter(|x| x.is_finite() && *x >= 1.0)
         .unwrap_or(1.0);
+
+    // Optional per-axis density histograms.
+    let h = jget(&v, "hist");
+    let read_u32_array = |key: &str| -> Option<Vec<u32>> {
+        let a = jget(&h, key);
+        if !a.is_object() {
+            return None;
+        }
+        let arr = js_sys::Array::from(&a);
+        if arr.length() == 0 {
+            return None;
+        }
+        Some((0..arr.length()).map(|i| arr.get(i).as_f64().unwrap_or(0.0).max(0.0) as u32).collect())
+    };
+    let hist = if h.is_object() {
+        match (read_u32_array("mz"), read_u32_array("im"), read_u32_array("rt")) {
+            (Some(mz), Some(im), Some(rt)) => Some([mz, im, rt]),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
     Ok(MetaInfo {
         bounds,
         i_p1: pos("p1").unwrap_or(0.0),
         i_p50: pos("p50").unwrap_or(0.0),
         i_p99: pos("p99").unwrap_or(0.0),
         stride,
+        hist,
     })
 }
 
@@ -1020,6 +1051,36 @@ fn crop_apply(gfx: &Rc<RefCell<Gfx>>, axis: usize, prefix: &str, lo_val: f64, hi
         let st = fill.style();
         let _ = st.set_property("left", &format!("{:.2}%", lo_val / 10.0));
         let _ = st.set_property("width", &format!("{:.2}%", (hi_val - lo_val).max(0.0) / 10.0));
+    }
+}
+
+/// Inject an SVG area chart of `bins` into element `id` (sqrt height so low bins stay visible).
+fn set_hist_svg(id: &str, bins: &[u32]) {
+    let Some(el) = document().and_then(|d| d.get_element_by_id(id)) else {
+        return;
+    };
+    if bins.len() < 2 {
+        return;
+    }
+    let max = (*bins.iter().max().unwrap_or(&1)).max(1) as f32;
+    let last = bins.len() - 1;
+    let mut d = String::from("M0,100");
+    for (i, &c) in bins.iter().enumerate() {
+        let h = (c as f32 / max).sqrt() * 100.0;
+        d.push_str(&format!(" L{i},{:.1}", 100.0 - h));
+    }
+    d.push_str(&format!(" L{last},100 Z"));
+    el.set_inner_html(&format!(
+        "<svg viewBox=\"0 0 {last} 100\" preserveAspectRatio=\"none\">\
+         <path d=\"{d}\" fill=\"rgba(120,150,190,0.30)\" stroke=\"rgba(150,180,220,0.55)\" stroke-width=\"0.6\"/>\
+         </svg>"
+    ));
+}
+
+/// Draw the per-axis distribution strips above the crop sliders, aligned to their range.
+fn draw_hist_backdrops(hist: &[Vec<u32>; 3]) {
+    for (axis, prefix) in [(0usize, "cmz"), (1, "cim"), (2, "crt")] {
+        set_hist_svg(&format!("{prefix}-hist"), &hist[axis]);
     }
 }
 

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -764,7 +764,7 @@ async fn run() -> Result<(), String> {
         acq_meta: None,
         acq_playing: false,
         acq_cursor: 0,
-        acq_speed: 20.0, // chunk-1 default: lively build-up (no speed slider yet; ~fetch-limited)
+        acq_speed: 1.0, // real-time (the device's true frame rate); the speed selector changes it live
         acq_buffer: std::collections::VecDeque::new(),
         acq_fetch_next: 0,
         acq_fetching: false,
@@ -827,6 +827,18 @@ async fn run() -> Result<(), String> {
     if let Some(btn) = by_id::<web_sys::HtmlElement>("acq-play") {
         let gfx = gfx.clone();
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| toggle_acquisition(&gfx));
+    }
+    if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("acq-speed") {
+        let gfx = gfx.clone();
+        // Live: the play-loop reads acq_speed every tick, so this retimes playback mid-run. "Max"
+        // (a big multiplier) drives the cadence toward 0 so it runs as fast as frames are fetched.
+        add_listener(sel.as_ref(), "change", move |_e: web_sys::Event| {
+            if let Some(s) = by_id::<web_sys::HtmlSelectElement>("acq-speed") {
+                if let Ok(v) = s.value().parse::<f64>() {
+                    gfx.borrow_mut().acq_speed = v.max(0.05);
+                }
+            }
+        });
     }
     // ① Data: fill the meta summary now (points/ranges/cycle); the dataset name arrives via /datasets.
     fill_data_summary(server_meta.as_ref());
@@ -2224,6 +2236,12 @@ enum StackOp {
 async fn load_region(gfx: Rc<RefCell<Gfx>>, region: Region, budget: Option<usize>, op: StackOp) {
     {
         let mut g = gfx.borrow_mut();
+        if g.acq_playing {
+            // A region load rebuilds the renderer; doing that under the running play-loop would
+            // desync the two. Make the user stop playback first.
+            show_status("stop live acquisition before focusing a region");
+            return;
+        }
         if g.reloading || g.focus_stack.is_empty() {
             return;
         }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -54,6 +54,20 @@ pub fn start() {
     });
 }
 
+/// Summary of a clustering result, for the MIDIA-style stats panel.
+struct ClusterStats {
+    k: usize,
+    signal_pts: u64,
+    noise_pts: u64,
+    signal_int: f64,
+    noise_int: f64,
+    /// Per-cluster point count + real-unit extent on each axis (for the histograms).
+    sizes: Vec<f64>,
+    mz_extent: Vec<f64>,
+    im_extent: Vec<f64>,
+    rt_extent: Vec<f64>,
+}
+
 /// A 4D region of the run in real units (the focus lens). `imin` is the intensity floor in counts.
 #[derive(Clone, Copy)]
 struct Region {
@@ -134,6 +148,8 @@ struct Gfx {
     /// True while a DBSCAN result is colouring the cloud (`params.color_mode == 1`). Invalidated on
     /// reload / focus / filter change.
     clustered: bool,
+    /// The last clustering result's stats (for the right-hand panel); cleared on invalidate.
+    cluster_stats: Option<ClusterStats>,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -525,6 +541,7 @@ async fn run() -> Result<(), String> {
         cluster_eps: 0.012,
         cluster_min_pts: 8,
         clustered: false,
+        cluster_stats: None,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -1089,6 +1106,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         g.vol_needs_grid = true; // the volume density grid is rebuilt from the new points
         g.params.color_mode = 0; // the fresh buffer has no cluster ids
         g.clustered = false;
+        g.cluster_stats = None;
         // Re-apply auto-transfer (exposure + floor range) and bounds from the new meta; keep the
         // user's colormap / point size / opacity / MS mask.
         if let Some(m) = &meta {
@@ -1127,6 +1145,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
     reset_display(gfx, n);
     set_text("cl-readout", "—"); // clustering is invalidated by a new load
     set_checked("cl-color", false);
+    set_body_class("has-clusters", false);
 }
 
 /// Build the region + budget query string for `/points` and `/meta`.
@@ -1397,8 +1416,10 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
     if g.clustered {
         g.params.color_mode = 0;
         g.clustered = false;
+        g.cluster_stats = None;
         set_text("cl-readout", "—");
         set_checked("cl-color", false);
+        set_body_class("has-clusters", false);
     }
 }
 
@@ -1455,12 +1476,13 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     });
 }
 
-/// Write DBSCAN labels into the GPU buffer + recolor by cluster, then update the UI.
+/// Write DBSCAN labels into the GPU buffer + recolor by cluster, compute stats, then update the UI.
 fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: usize) {
     let noise = labels.iter().filter(|&&l| l < 0).count();
     {
         let mut gb = gfx.borrow_mut();
         let g: &mut Gfx = &mut gb; // &mut Gfx so renderer/queue/cpu_points field-split
+        let stats = compute_cluster_stats(idx, labels, k, &g.cpu_points, g.axis_bounds);
         for pt in g.cpu_points.iter_mut() {
             pt._pad[0] = GpuPoint::NO_CLUSTER;
         }
@@ -1475,6 +1497,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: u
         g.cpu_points = pts;
         g.params.color_mode = 1;
         g.clustered = true;
+        g.cluster_stats = Some(stats);
         g.view_mode = ViewMode::Points; // cluster colour is a point concept
         g.filter_dirty = true; // refresh the displayed-count HUD
     }
@@ -1486,7 +1509,117 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: u
         "cl-readout",
         &format!("{k} clusters · {} noise · {} pts", group(noise), group(idx.len())),
     );
+    if let Some(s) = gfx.borrow().cluster_stats.as_ref() {
+        render_cluster_panel(s);
+    }
+    set_body_class("has-clusters", true);
     show_status("");
+}
+
+/// Aggregate per-cluster stats from the DBSCAN labels (intensity weighted by `weight` so it's
+/// downsample-independent; extents in real units via `axis_bounds`).
+fn compute_cluster_stats(
+    idx: &[usize],
+    labels: &[i32],
+    k: usize,
+    pts: &[GpuPoint],
+    bounds: Option<[(f64, f64); 3]>,
+) -> ClusterStats {
+    let mut sizes = vec![0f64; k];
+    let mut lo = vec![[f32::INFINITY; 3]; k];
+    let mut hi = vec![[f32::NEG_INFINITY; 3]; k];
+    let (mut signal_pts, mut noise_pts) = (0u64, 0u64);
+    let (mut signal_int, mut noise_int) = (0f64, 0f64);
+    for (j, &l) in labels.iter().enumerate() {
+        let pt = &pts[idx[j]];
+        let contrib = (pt.intensity * pt.weight) as f64;
+        if l < 0 {
+            noise_pts += 1;
+            noise_int += contrib;
+        } else {
+            let c = l as usize;
+            sizes[c] += 1.0;
+            signal_pts += 1;
+            signal_int += contrib;
+            for a in 0..3 {
+                lo[c][a] = lo[c][a].min(pt.pos[a]);
+                hi[c][a] = hi[c][a].max(pt.pos[a]);
+            }
+        }
+    }
+    // Normalized [-1,1] span -> real-unit extent on each axis.
+    let extent = |a: usize| -> Vec<f64> {
+        (0..k)
+            .map(|c| {
+                if sizes[c] == 0.0 {
+                    return 0.0;
+                }
+                let span = (hi[c][a] - lo[c][a]).max(0.0) as f64;
+                match bounds {
+                    Some(b) => span * 0.5 * (b[a].1 - b[a].0).abs(),
+                    None => span,
+                }
+            })
+            .collect()
+    };
+    ClusterStats {
+        k,
+        signal_pts,
+        noise_pts,
+        signal_int,
+        noise_int,
+        mz_extent: extent(0),
+        im_extent: extent(1),
+        rt_extent: extent(2),
+        sizes,
+    }
+}
+
+/// Fill the cluster stats panel: the summary table + four per-cluster histograms.
+fn render_cluster_panel(s: &ClusterStats) {
+    let total_pts = s.signal_pts + s.noise_pts;
+    let total_int = s.signal_int + s.noise_int;
+    set_text("cs-pts-t", &group_short(total_pts as usize));
+    set_text("cs-pts-c", &group_short(s.signal_pts as usize));
+    set_text("cs-pts-n", &group_short(s.noise_pts as usize));
+    set_text("cs-int-t", &group_short(total_int as usize));
+    set_text("cs-int-c", &group_short(s.signal_int as usize));
+    set_text("cs-int-n", &group_short(s.noise_int as usize));
+    set_text("cs-k", &s.k.to_string());
+    set_text(
+        "cs-ratio",
+        &if s.noise_pts > 0 {
+            format!("{:.1}×", s.signal_pts as f64 / s.noise_pts as f64)
+        } else {
+            "∞".into()
+        },
+    );
+    set_text("cs-sub", &format!("{} clusters · {} pts", s.k, group_short(total_pts as usize)));
+    set_hist_svg("csh-size", &hist_bins(&s.sizes, 24));
+    set_hist_svg("csh-mz", &hist_bins(&s.mz_extent, 24));
+    set_hist_svg("csh-im", &hist_bins(&s.im_extent, 24));
+    set_hist_svg("csh-rt", &hist_bins(&s.rt_extent, 24));
+}
+
+/// Bin non-negative values into `n` equal bins over `[0, max]` (counts per bin).
+fn hist_bins(values: &[f64], n: usize) -> Vec<u32> {
+    let mut h = vec![0u32; n.max(1)];
+    let max = values.iter().cloned().fold(0.0f64, f64::max);
+    if max <= 0.0 {
+        return h;
+    }
+    for &v in values {
+        let b = ((v / max) * (n as f64 - 1.0)).clamp(0.0, n as f64 - 1.0) as usize;
+        h[b] += 1;
+    }
+    h
+}
+
+/// Toggle a class on `<body>`.
+fn set_body_class(class: &str, on: bool) {
+    if let Some(body) = document().and_then(|d| d.body()) {
+        let _ = body.class_list().toggle_with_force(class, on);
+    }
 }
 
 /// Run a closure on the next macrotask (after a browser paint) via `setTimeout(0)`.

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1398,9 +1398,11 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
     reset_crops(gfx);
     reset_display(gfx, n);
     set_text("cl-readout", "—"); // clustering is invalidated by a new load
-    set_checked("cl-color", false);
+    set_checked("cl-color", true); // back to the default (applies once re-clustered)
     set_body_class("has-clusters", false);
     set_body_class("cluster-color", false);
+    set_cluster_progress(None); // a load mid-run abandons it — clear the bar + Run button
+    set_cluster_running(false);
     rebuild_window_overlay(gfx); // re-normalize the DIA windows to the new region
 }
 
@@ -1610,6 +1612,27 @@ fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
     );
 }
 
+/// Flip the Run/Stop button: while a (worker) clustering is in flight it becomes a red "Stop".
+fn set_cluster_running(running: bool) {
+    set_text("cl-run", if running { "⬡ Stop clustering" } else { "⬡ Run clustering" });
+    set_class("cl-run", "stop", running);
+}
+
+/// Cancel an in-flight worker clustering: terminate the worker (taking it so the next Run rebuilds a
+/// fresh one), drop the pending job, and reset the UI.
+fn stop_clustering(gfx: &Rc<RefCell<Gfx>>) {
+    {
+        let mut g = gfx.borrow_mut();
+        if let Some(w) = g.cluster_worker.take() {
+            w.terminate();
+        }
+        g.cluster_pending = None;
+    }
+    set_cluster_progress(None);
+    set_cluster_running(false);
+    show_status("clustering stopped");
+}
+
 /// Show the clustering progress bar at `frac` (0..1), or hide it with `None`.
 fn set_cluster_progress(frac: Option<f32>) {
     if let Some(el) = by_id::<web_sys::HtmlElement>("cl-prog") {
@@ -1683,6 +1706,7 @@ fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
 fn invalidate_clusters_mut(g: &mut Gfx) {
     g.cluster_pending = None; // abandon any in-flight worker job (its reply will be ignored)
     set_cluster_progress(None);
+    set_cluster_running(false);
     if g.clustered {
         g.params.color_mode = 0;
         g.clustered = false;
@@ -1765,6 +1789,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             if post_cluster_job(&worker, &flat, eps, min_pts, job) {
                 gfx.borrow_mut().cluster_pending = Some((idx, gen, job));
                 set_cluster_progress(Some(0.0)); // worker reports ticks back; bar advances live
+                set_cluster_running(true); // button becomes "Stop clustering"
                 return;
             }
         }
@@ -1885,6 +1910,7 @@ fn create_cluster_worker(gfx: &Rc<RefCell<Gfx>>) -> Option<web_sys::Worker> {
             g.cluster_worker_failed = true;
             drop(g);
             set_cluster_progress(None);
+            set_cluster_running(false);
             show_status("clustering worker unavailable — runs on the main thread");
         });
     }
@@ -1955,6 +1981,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, 
     set_text("cl-readout", &format!("{k} clusters · {} noise · {} pts", group(noise), group(n_in)));
     set_body_class("cluster-color", true); // cluster coloring active -> hide the intensity colorbar
     set_cluster_progress(None); // done — hide the progress bar
+    set_cluster_running(false); // restore the Run button
     update_cluster_panel(gfx); // we ran from the Cluster tab, so this shows + renders the panel
     show_status("");
 }
@@ -2134,7 +2161,14 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(2));
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-run") {
         let gfx = gfx.clone();
-        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| run_clustering(&gfx));
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| {
+            // Run, or Stop if a worker clustering is in flight.
+            if gfx.borrow().cluster_pending.is_some() {
+                stop_clustering(&gfx);
+            } else {
+                run_clustering(&gfx);
+            }
+        });
     }
     on_toggle("cl-color", gfx, |g, on| {
         if g.clustered {

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -29,6 +29,10 @@ use tims_viewer::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
 /// first. Mirrors the native CLUSTER_CAP.
 const CLUSTER_CAP: usize = 2_000_000;
 
+/// Below this many filtered points, DBSCAN runs on the main thread (instant, no worker spin-up);
+/// at/above it, the off-main-thread worker is used so the tab doesn't freeze.
+const WORKER_THRESHOLD: usize = 300_000;
+
 /// RT slices each DIA window footprint is drawn at (mirrors the native loader's `DIA_WINDOW_RT_SLICES`,
 /// which lives in the native-only loader module).
 const DIA_WINDOW_RT_SLICES: usize = 6;
@@ -1742,22 +1746,28 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
         return;
     }
     show_status("clustering…");
-    // Off-main-thread: post to the persistent DBSCAN worker so the tab stays responsive. The worker
-    // replies via its onmessage handler, which calls finish_clustering.
-    if let Some(worker) = ensure_cluster_worker(gfx) {
-        let flat: Vec<f32> = positions.iter().flatten().copied().collect();
-        let job = {
-            let mut g = gfx.borrow_mut();
-            g.next_cluster_job = g.next_cluster_job.wrapping_add(1);
-            g.next_cluster_job
-        };
-        if post_cluster_job(&worker, &flat, eps, min_pts, job) {
-            gfx.borrow_mut().cluster_pending = Some((idx, gen, job));
-            set_cluster_progress(Some(0.0)); // worker reports ticks back; bar advances live
-            return;
+    // Small inputs cluster in well under a second, so run them on the main thread (deferred one
+    // macrotask so the status paints): instant, with none of the worker's one-time wasm spin-up
+    // latency. Only large inputs — where DBSCAN would freeze the tab for seconds — go to the worker,
+    // whose init cost is then negligible against the run and whose progress bar actually has time to
+    // move.
+    if idx.len() > WORKER_THRESHOLD {
+        if let Some(worker) = ensure_cluster_worker(gfx) {
+            let flat: Vec<f32> = positions.iter().flatten().copied().collect();
+            let job = {
+                let mut g = gfx.borrow_mut();
+                g.next_cluster_job = g.next_cluster_job.wrapping_add(1);
+                g.next_cluster_job
+            };
+            if post_cluster_job(&worker, &flat, eps, min_pts, job) {
+                gfx.borrow_mut().cluster_pending = Some((idx, gen, job));
+                set_cluster_progress(Some(0.0)); // worker reports ticks back; bar advances live
+                return;
+            }
         }
     }
-    // Fallback (no worker): defer the blocking DBSCAN one macrotask so the status paints first.
+    // Main thread (small input, or worker unavailable): defer one macrotask so the status paints,
+    // then run the (brief) blocking DBSCAN.
     let gfx = gfx.clone();
     defer(move || {
         let (labels, k) = dbscan(&positions, eps, min_pts);
@@ -2828,7 +2838,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     // Cluster controls (defeat browser form-restore; no result yet, so colour off).
     set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
-    set_checked("cl-color", false);
+    set_checked("cl-color", true); // colour by cluster is on by default (applies after a Run)
     set_checked("show-windows", false); // off by default (defeats browser form-restore)
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1280,6 +1280,11 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
             // Intensity transfer so faint peaks shrink/recede: sqrt over [1, i_p99].
             let i_p99 = g.acq_meta.as_ref().map(|m| m.i_p99.max(2.0)).unwrap_or(1000.0);
             g.params.transfer = [1.0, 1.0, i_p99, 1.0];
+            // Sync speed to whatever the selector currently shows (covers browser form-restore where
+            // the <select> value survives a reload but g.acq_speed reset to its default).
+            g.acq_speed = by_id::<web_sys::HtmlSelectElement>("acq-speed")
+                .and_then(|s| s.value().parse::<f64>().ok())
+                .map_or(1.0, |v| v.max(0.05));
             g.acq_cursor = 0;
             g.acq_buffer.clear();
             g.acq_fetch_next = 0;

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -122,6 +122,10 @@ const DEFAULT_ACQ_PORT: u16 = 8092;
 /// Trailing-window size for acquisition playback: the renderer keeps only the last this-many points
 /// (ring buffer), so an unbounded stream can't grind the GPU. Clamped to the GPU cap.
 const ACQ_RING_POINTS: usize = 1_200_000;
+/// Frames per `/acq/frames` prefetch request (built in parallel server-side).
+const ACQ_BATCH: u32 = 64;
+/// Kick the next prefetch when fewer than this many decoded frames remain buffered.
+const ACQ_LOOKAHEAD: usize = 128;
 
 /// wasm entry point — Trunk/wasm-bindgen call this on load.
 #[wasm_bindgen(start)]
@@ -293,11 +297,22 @@ struct Gfx {
     /// Acquisition-playback metadata from the sidecar's `/acq/meta` (None = no sidecar). Populated by
     /// the startup probe; drives the live playback engine.
     acq_meta: Option<AcqMeta>,
-    /// Live-acquisition playback state. `acq_playing` gates the async play-loop; `acq_cursor` is the
-    /// next frame index to fetch; `acq_speed` multiplies the real device cadence.
+    /// Live-acquisition playback state. `acq_playing` gates the async play-loop; `acq_cursor` is how
+    /// many frames have been displayed (the fetch frontier is `acq_fetch_next`); `acq_speed`
+    /// multiplies the real device cadence.
     acq_playing: bool,
     acq_cursor: u32,
     acq_speed: f64,
+    /// Prefetch ring: decoded frames waiting to be displayed (front = next). Filled ahead of the
+    /// cursor by a detached batch fetch so the play-loop never blocks on a build.
+    acq_buffer: std::collections::VecDeque<Vec<GpuPoint>>,
+    /// Next frame index to request (the prefetch frontier); `acq_cursor` is how many we've displayed.
+    acq_fetch_next: u32,
+    /// A batch fetch is in flight (single-flight — the sidecar serializes builds anyway).
+    acq_fetching: bool,
+    /// Bumped each time playback (re)starts, so an in-flight prefetch from a previous session can tell
+    /// it's stale and drop its result instead of contaminating the new run's buffer.
+    acq_gen: u32,
     /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
     /// the startup probe when the service is reachable; toggleable in the Cluster tab.
     use_python_cluster: bool,
@@ -750,6 +765,10 @@ async fn run() -> Result<(), String> {
         acq_playing: false,
         acq_cursor: 0,
         acq_speed: 20.0, // chunk-1 default: lively build-up (no speed slider yet; ~fetch-limited)
+        acq_buffer: std::collections::VecDeque::new(),
+        acq_fetch_next: 0,
+        acq_fetching: false,
+        acq_gen: 0,
         dataset_name: String::new(),
         dataset_id: dataset_id(), // raw URL value; clamped to the registry by populate_datasets
         use_python_cluster: false,
@@ -1111,16 +1130,37 @@ async fn fetch_acq_meta(base: &str) -> Option<AcqMeta> {
     })
 }
 
-/// Fetch `<base>/acq/frame?id=N` (24-byte/peak records) and build normalized `GpuPoint`s:
-/// `_pad[0]` = peptide_id (color key), `flags` bit0 = fragment. `id` is a 0-based frame INDEX
-/// (`0..n_frames`). Used by the playback loop.
-async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoint>, String> {
+/// Decode one 24-byte wire record into a normalized `GpuPoint` (`_pad[0]` = peptide_id, `flags` bit0 =
+/// fragment). `c` must be exactly 24 bytes.
+fn decode_acq_record(c: &[u8], m: &AcqMeta) -> GpuPoint {
+    let f = |o: usize| f32::from_le_bytes([c[o], c[o + 1], c[o + 2], c[o + 3]]);
+    let u = |o: usize| u32::from_le_bytes([c[o], c[o + 1], c[o + 2], c[o + 3]]);
+    GpuPoint {
+        pos: [
+            m.mz.normalize(f(0) as f64),
+            m.im.normalize(f(4) as f64),
+            m.rt.normalize(f(8) as f64),
+        ],
+        intensity: f(12),
+        weight: 1.0,
+        flags: u(20),
+        _pad: [u(16), 0],
+    }
+}
+
+/// GET a binary acquisition endpoint and return the raw bytes. Aborts after 20s so a hung/half-open
+/// sidecar can't leave a prefetch in flight forever (which would stall the play-loop).
+async fn fetch_acq_bytes(url: &str) -> Result<Vec<u8>, String> {
     let window = web_sys::window().ok_or("no window")?;
-    let resp_val = wasm_bindgen_futures::JsFuture::from(
-        window.fetch_with_str(&format!("{base}/acq/frame?id={id}")),
-    )
-    .await
-    .map_err(|e| format!("fetch failed: {e:?}"))?;
+    let opts = web_sys::RequestInit::new();
+    if let Ok(controller) = web_sys::AbortController::new() {
+        opts.set_signal(Some(&controller.signal()));
+        let cb = wasm_bindgen::closure::Closure::once_into_js(move || controller.abort());
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 20_000);
+    }
+    let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str_and_init(url, &opts))
+        .await
+        .map_err(|e| format!("fetch failed: {e:?}"))?;
     let resp: web_sys::Response = resp_val.dyn_into().map_err(|_| "not a Response".to_string())?;
     if !resp.ok() {
         return Err(format!("HTTP {}", resp.status()));
@@ -1130,27 +1170,63 @@ async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoin
     )
     .await
     .map_err(|e| format!("body read failed: {e:?}"))?;
-    let bytes = js_sys::Uint8Array::new(&buf).to_vec();
+    Ok(js_sys::Uint8Array::new(&buf).to_vec())
+}
+
+/// Fetch a single frame (`<base>/acq/frame?id=N`, `id` a 0-based frame index) as `GpuPoint`s.
+#[allow(dead_code)] // kept for debugging / single-frame probes; playback uses the batch path
+async fn fetch_acq_frame(base: &str, id: u32, m: &AcqMeta) -> Result<Vec<GpuPoint>, String> {
+    let bytes = fetch_acq_bytes(&format!("{base}/acq/frame?id={id}")).await?;
     if bytes.len() % 24 != 0 {
         return Err(format!("acq frame body not 24-byte aligned ({} bytes)", bytes.len()));
     }
-    let mut pts = Vec::with_capacity(bytes.len() / 24);
-    for c in bytes.chunks_exact(24) {
-        let f = |o: usize| f32::from_le_bytes([c[o], c[o + 1], c[o + 2], c[o + 3]]);
-        let u = |o: usize| u32::from_le_bytes([c[o], c[o + 1], c[o + 2], c[o + 3]]);
-        pts.push(GpuPoint {
-            pos: [
-                m.mz.normalize(f(0) as f64),
-                m.im.normalize(f(4) as f64),
-                m.rt.normalize(f(8) as f64),
-            ],
-            intensity: f(12),
-            weight: 1.0,
-            flags: u(20),
-            _pad: [u(16), 0],
-        });
+    Ok(bytes.chunks_exact(24).map(|c| decode_acq_record(c, m)).collect())
+}
+
+/// Fetch a parallel batch (`<base>/acq/frames?start=N&count=K`) and split it into per-frame
+/// `GpuPoint` lists. Wire layout: `u32 count`, `count × [u32 frame_index, u32 n_peaks]`, then the
+/// concatenated 24-byte records for each frame in order.
+async fn fetch_acq_frames(base: &str, start: u32, count: u32, m: &AcqMeta) -> Result<Vec<Vec<GpuPoint>>, String> {
+    let bytes = fetch_acq_bytes(&format!("{base}/acq/frames?start={start}&count={count}")).await?;
+    if bytes.len() < 4 {
+        return Err("acq batch response too short".into());
     }
-    Ok(pts)
+    let rd_u32 = |o: usize| u32::from_le_bytes([bytes[o], bytes[o + 1], bytes[o + 2], bytes[o + 3]]);
+    // The server returns exactly the frames we asked for; validating up front bounds `n` (so the
+    // header arithmetic below can't overflow) and stops a malformed/short batch from desyncing the
+    // fetch frontier (we advanced `acq_fetch_next` by `count` already).
+    let n = rd_u32(0) as usize;
+    if n != count as usize {
+        return Err(format!("acq batch returned {n} frames, requested {count}"));
+    }
+    let table_end = 4 + n * 8; // n == count <= ACQ_BATCH, so no overflow
+    if bytes.len() < table_end {
+        return Err("acq batch header truncated".into());
+    }
+    let mut counts = Vec::with_capacity(n);
+    for i in 0..n {
+        let idx = rd_u32(4 + i * 8);
+        if idx != start + i as u32 {
+            return Err(format!("acq batch frame_index {idx} != expected {}", start + i as u32));
+        }
+        counts.push(rd_u32(4 + i * 8 + 4) as usize);
+    }
+    let recs = &bytes[table_end..];
+    let total: usize = counts.iter().sum();
+    if total.checked_mul(24) != Some(recs.len()) {
+        return Err(format!("acq batch body {} B != {total} records", recs.len()));
+    }
+    let mut frames = Vec::with_capacity(n);
+    let mut off = 0usize;
+    for c in counts {
+        let mut pts = Vec::with_capacity(c);
+        for k in 0..c {
+            pts.push(decode_acq_record(&recs[off + k * 24..off + k * 24 + 24], m));
+        }
+        off += c * 24;
+        frames.push(pts);
+    }
+    Ok(frames)
 }
 
 /// Await `ms` milliseconds (wasm has no blocking sleep): a `setTimeout`-backed Promise.
@@ -1187,6 +1263,10 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
             let i_p99 = g.acq_meta.as_ref().map(|m| m.i_p99.max(2.0)).unwrap_or(1000.0);
             g.params.transfer = [1.0, 1.0, i_p99, 1.0];
             g.acq_cursor = 0;
+            g.acq_buffer.clear();
+            g.acq_fetch_next = 0;
+            g.acq_fetching = false;
+            g.acq_gen = g.acq_gen.wrapping_add(1); // invalidate any in-flight prefetch from a prior run
             g.filter_dirty = true;
         }
         g.acq_playing
@@ -1198,77 +1278,100 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
     }
 }
 
-/// The async playback loop: fetch the cursor's frame, append it, advance, sleep one (speed-scaled)
-/// device cadence, repeat — until stopped or the run ends. No prefetch ring yet, so dense frames play
-/// "build-limited" (slower than real time); that's the accepted v1 behaviour.
-async fn play_loop(gfx: Rc<RefCell<Gfx>>) {
+/// Detached prefetch: fetch one parallel batch and push its decoded frames into `acq_buffer`, then
+/// clear the in-flight flag so the play-loop can request the next. Single-flight (the sidecar
+/// serializes builds anyway). Forward-only: the streamed frames are consumed as displayed.
+async fn acq_prefetch(gfx: Rc<RefCell<Gfx>>, start: u32, count: u32, meta: AcqMeta, gen: u32) {
     let base = acq_service_url();
-    let mut errors = 0u32;
-    loop {
-        // Snapshot the run state without holding the borrow across the await.
-        let snap = {
-            let g = gfx.borrow();
-            match g.acq_meta.clone() {
-                Some(m) if g.acq_playing && g.acq_cursor < m.n_frames => {
-                    Some((m, g.acq_cursor, g.acq_speed.max(0.05)))
-                }
-                _ => None,
-            }
-        };
-        let Some((meta, cursor, speed)) = snap else {
-            // Stopped, or ran off the end — settle the UI and exit.
-            let done = {
-                let g = gfx.borrow();
-                g.acq_meta.as_ref().is_some_and(|m| g.acq_cursor >= m.n_frames)
-            };
-            if done {
-                gfx.borrow_mut().acq_playing = false;
-                set_text("acq-play", "▶ Live acquisition");
-                show_status("acquisition complete");
-            }
-            return;
-        };
-        match fetch_acq_frame(&base, cursor, &meta).await {
-            Ok(pts) => {
-                errors = 0;
-                let resident = {
-                    let g = &mut *gfx.borrow_mut();
-                    if !g.acq_playing {
-                        return; // stopped while the fetch was in flight
-                    }
-                    if !pts.is_empty() {
-                        g.renderer.append(&g.queue, &pts);
-                        g.renderer.set_draw_count(u32::MAX);
-                        g.filter_dirty = true;
-                    }
-                    g.acq_cursor = cursor + 1;
-                    g.renderer.resident()
-                };
-                // Live readout (doubles as a timeline until chunk 2's scrubber); also overwrites the
-                // stale "demo cloud" status.
-                show_status(&format!(
-                    "▶ frame {} / {} · RT {:.0}s · {} pts",
-                    cursor + 1,
-                    meta.n_frames,
-                    (cursor as f64 + 1.0) * meta.rt_cycle_length,
-                    group_short(resident as usize),
-                ));
-            }
-            Err(e) => {
-                // Skip a bad/transient frame rather than killing the whole run; bail only if it's
-                // clearly broken (many in a row).
-                errors += 1;
-                log::warn!("acq frame {cursor} failed ({e}); skipping");
-                if errors > 8 {
-                    show_status("acquisition stopped (repeated frame errors)");
-                    gfx.borrow_mut().acq_playing = false;
-                    set_text("acq-play", "▶ Live acquisition");
-                    return;
-                }
-                gfx.borrow_mut().acq_cursor = cursor + 1;
+    let result = fetch_acq_frames(&base, start, count, &meta).await;
+    let g = &mut *gfx.borrow_mut();
+    if g.acq_gen != gen {
+        return; // a newer playback session started while we were in flight — drop this result
+    }
+    g.acq_fetching = false;
+    match result {
+        Ok(frames) => {
+            if g.acq_playing {
+                g.acq_buffer.extend(frames);
             }
         }
-        sleep_ms((meta.rt_cycle_length * 1000.0 / speed) as i32).await;
+        Err(e) => log::warn!("acq batch [{start},{}) failed: {e}", start + count),
+    }
+}
+
+/// The async playback loop. Each tick it (1) kicks a prefetch batch if the buffer is running low and
+/// none is in flight, and (2) pops one ready frame and appends it at the (speed-scaled) device
+/// cadence. Fetching overlaps display, so playback isn't build-limited — it runs at real time with
+/// headroom to fast-forward, bounded by the prefetch throughput.
+async fn play_loop(gfx: Rc<RefCell<Gfx>>) {
+    let gen = gfx.borrow().acq_gen; // this session's id; a newer toggle supersedes us
+    loop {
+        enum Next {
+            Displayed { cur: u32, n_frames: u32, rt: f64, resident: u32, cadence_ms: i32 },
+            Wait,
+            Done(u32),
+        }
+        let (prefetch, next) = {
+            let g = &mut *gfx.borrow_mut();
+            if !g.acq_playing || g.acq_gen != gen {
+                return;
+            }
+            let Some(meta) = g.acq_meta.clone() else { return };
+            // (1) keep the buffer filled ahead of the cursor.
+            let prefetch = if !g.acq_fetching
+                && g.acq_buffer.len() < ACQ_LOOKAHEAD
+                && g.acq_fetch_next < meta.n_frames
+            {
+                let start = g.acq_fetch_next;
+                let count = ACQ_BATCH.min(meta.n_frames - start);
+                g.acq_fetch_next += count;
+                g.acq_fetching = true;
+                Some((start, count, meta.clone()))
+            } else {
+                None
+            };
+            // (2) display one buffered frame.
+            let next = if let Some(frame) = g.acq_buffer.pop_front() {
+                if !frame.is_empty() {
+                    g.renderer.append(&g.queue, &frame);
+                    g.renderer.set_draw_count(u32::MAX);
+                    g.filter_dirty = true;
+                }
+                g.acq_cursor += 1;
+                Next::Displayed {
+                    cur: g.acq_cursor,
+                    n_frames: meta.n_frames,
+                    rt: g.acq_cursor as f64 * meta.rt_cycle_length,
+                    resident: g.renderer.resident(),
+                    cadence_ms: (meta.rt_cycle_length * 1000.0 / g.acq_speed.max(0.05)) as i32,
+                }
+            } else if g.acq_fetch_next >= meta.n_frames && !g.acq_fetching {
+                Next::Done(meta.n_frames) // buffer drained and nothing left to fetch
+            } else {
+                Next::Wait // buffer momentarily empty — prefetch is catching up
+            };
+            (prefetch, next)
+        };
+        if let Some((start, count, meta)) = prefetch {
+            wasm_bindgen_futures::spawn_local(acq_prefetch(gfx.clone(), start, count, meta, gen));
+        }
+        match next {
+            Next::Displayed { cur, n_frames, rt, resident, cadence_ms } => {
+                show_status(&format!(
+                    "▶ frame {cur} / {n_frames} · RT {rt:.0}s · {} pts",
+                    group_short(resident as usize),
+                ));
+                sleep_ms(cadence_ms).await;
+            }
+            Next::Wait => sleep_ms(8).await,
+            Next::Done(n) => {
+                let g = &mut *gfx.borrow_mut();
+                g.acq_playing = false;
+                set_text("acq-play", "▶ Live acquisition");
+                show_status(&format!("acquisition complete — {n} frames"));
+                return;
+            }
+        }
     }
 }
 

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -119,6 +119,9 @@ const DEFAULT_CLUSTER_PORT: u16 = 8091;
 /// Default acquisition-sidecar port (`acquisition_service.py --port 8092`). Override with
 /// `?acqport=N`, or a full base URL via `?acq=<url>`.
 const DEFAULT_ACQ_PORT: u16 = 8092;
+/// Trailing-window size for acquisition playback: the renderer keeps only the last this-many points
+/// (ring buffer), so an unbounded stream can't grind the GPU. Clamped to the GPU cap.
+const ACQ_RING_POINTS: usize = 1_200_000;
 
 /// wasm entry point — Trunk/wasm-bindgen call this on load.
 #[wasm_bindgen(start)]
@@ -1170,11 +1173,12 @@ fn toggle_acquisition(gfx: &Rc<RefCell<Gfx>>) {
         }
         g.acq_playing = !g.acq_playing;
         if g.acq_playing {
-            // Re-create the buffer at the full GPU capacity: the initial buffer was sized to the
-            // loaded (or demo) cloud, which would fill in a few frames as acquisition accumulates.
-            let cap = g.n_cap.max(1) as u32;
+            // Fresh ring buffer bounded to a trailing window: the initial buffer was sized to the
+            // loaded (or demo) cloud, and unbounded accumulation would grind the GPU after ~1 min.
+            let cap = g.n_cap.min(ACQ_RING_POINTS).max(1) as u32;
             g.renderer =
                 PointCloudRenderer::new(&g.device, &g.queue, g.config.format, DEPTH_FORMAT, cap, g.supports_compaction);
+            g.renderer.enable_ring(); // append wraps + overwrites oldest -> bounded resident
             g.renderer.set_draw_count(u32::MAX);
             g.cpu_points.clear(); // acquisition drives the GPU buffer directly
             g.params.color_mode = 3; // colour by _pad[0] = peptide_id + size-by-intensity (acq shader path)

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -20,9 +20,14 @@ use tims_viewer::data::point::{AxisTransform, GpuPoint};
 use tims_viewer::render::annotation::{AnnotationRenderer, LineVertex};
 use tims_viewer::ticks::{fmt_tick, ticks_for, Axis, RT_MINUTES_SPAN};
 use tims_viewer::render::colormap::{sample as colormap_sample, COLORMAP_NAMES};
+use tims_viewer::cluster::dbscan;
 use tims_viewer::render::point_cloud::{PointCloudRenderer, PointMode};
 use tims_viewer::render::uniforms::{ParamsUniform, VolumeUniform};
 use tims_viewer::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
+
+/// Max points DBSCAN runs on in the browser (it blocks the main thread). Beyond this, Focus a region
+/// first. Mirrors the native CLUSTER_CAP.
+const CLUSTER_CAP: usize = 2_000_000;
 
 /// Points (the splat cloud) vs Volume (raymarched density grid).
 #[derive(Clone, Copy, PartialEq)]
@@ -123,6 +128,12 @@ struct Gfx {
     /// Volume density transfer range (raw density percentiles), auto-ranged on grid build.
     vol_i_min: f32,
     vol_i_max: f32,
+    // ---- clustering (CLUSTERING_WEB_PLAN.md) ----
+    cluster_eps: f32,
+    cluster_min_pts: usize,
+    /// True while a DBSCAN result is colouring the cloud (`params.color_mode == 1`). Invalidated on
+    /// reload / focus / filter change.
+    clustered: bool,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -318,7 +329,13 @@ impl Gfx {
             if volume_view {
                 self.volume.as_ref().unwrap().render(&mut rpass);
             } else {
-                self.renderer.render(&mut rpass, self.point_mode);
+                // Cluster hues mush under additive blending — force opaque while cluster-colored.
+                let pm = if self.params.color_mode == 1 {
+                    PointMode::StructuralOpaque
+                } else {
+                    self.point_mode
+                };
+                self.renderer.render(&mut rpass, pm);
             }
             self.axes.render(&mut rpass);
         }
@@ -505,6 +522,9 @@ async fn run() -> Result<(), String> {
         vol_style: 0,
         vol_i_min: 1.0,
         vol_i_max: 2.0,
+        cluster_eps: 0.012,
+        cluster_min_pts: 8,
+        clustered: false,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -540,6 +560,8 @@ async fn run() -> Result<(), String> {
     bind_maps(&gfx);
     // Points/Volume view mode + volume controls.
     bind_volume(&gfx);
+    // Clustering (DBSCAN on the focused set).
+    bind_cluster(&gfx);
     // Collapsible section headers + tab switching.
     bind_panel_chrome();
 
@@ -1065,6 +1087,8 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         cpu.truncate(cap as usize);
         g.cpu_points = cpu;
         g.vol_needs_grid = true; // the volume density grid is rebuilt from the new points
+        g.params.color_mode = 0; // the fresh buffer has no cluster ids
+        g.clustered = false;
         // Re-apply auto-transfer (exposure + floor range) and bounds from the new meta; keep the
         // user's colormap / point size / opacity / MS mask.
         if let Some(m) = &meta {
@@ -1101,6 +1125,8 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
     }
     reset_crops(gfx);
     reset_display(gfx, n);
+    set_text("cl-readout", "—"); // clustering is invalidated by a new load
+    set_checked("cl-color", false);
 }
 
 /// Build the region + budget query string for `/points` and `/meta`.
@@ -1365,6 +1391,112 @@ fn bind_volume(gfx: &Rc<RefCell<Gfx>>) {
     }
 }
 
+/// Revert cluster colouring (a filter/load changed the set, so the labels are stale). Cheap — just
+/// flips `color_mode` back to intensity; the stale `_pad[0]` ids stay unused until the next Run.
+fn invalidate_clusters_mut(g: &mut Gfx) {
+    if g.clustered {
+        g.params.color_mode = 0;
+        g.clustered = false;
+        set_text("cl-readout", "—");
+        set_checked("cl-color", false);
+    }
+}
+
+/// Run DBSCAN on the filtered resident points, write cluster ids into the GPU buffer, and colour by
+/// cluster. Synchronous (blocks the main thread) — Focus first if the filtered set is large.
+fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
+    // Gather the filtered survivors (spatial crop + intensity floor + MS) and their cube positions.
+    let (idx, positions, eps, min_pts) = {
+        let g = gfx.borrow();
+        let p = &g.params;
+        let (fmin, fmax, ms) = (p.filter_min, p.filter_max, p.ms_mask);
+        let mut idx: Vec<usize> = Vec::new();
+        let mut positions: Vec<[f32; 3]> = Vec::new();
+        for (i, pt) in g.cpu_points.iter().enumerate() {
+            let pos = pt.pos;
+            if pos[0] < fmin[0]
+                || pos[0] > fmax[0]
+                || pos[1] < fmin[1]
+                || pos[1] > fmax[1]
+                || pos[2] < fmin[2]
+                || pos[2] > fmax[2]
+                || pt.intensity < fmin[3]
+            {
+                continue;
+            }
+            let is_ms2 = pt.flags & GpuPoint::MS2_FLAG != 0;
+            if !(if is_ms2 { ms & 0b10 != 0 } else { ms & 0b01 != 0 }) {
+                continue;
+            }
+            idx.push(i);
+            positions.push(pos);
+        }
+        (idx, positions, g.cluster_eps, g.cluster_min_pts)
+    };
+    if idx.is_empty() {
+        show_status("nothing to cluster — adjust the filter");
+        return;
+    }
+    if idx.len() > CLUSTER_CAP {
+        show_status(&format!(
+            "{} points — Focus a region first (cap {})",
+            group(idx.len()),
+            group(CLUSTER_CAP)
+        ));
+        return;
+    }
+    show_status("clustering…");
+    let (labels, k) = dbscan(&positions, eps, min_pts);
+    let noise = labels.iter().filter(|&&l| l < 0).count();
+    {
+        let mut gb = gfx.borrow_mut();
+        let g: &mut Gfx = &mut gb; // &mut Gfx so renderer/queue/cpu_points field-split
+        // Clear all ids, then write the survivors' labels (noise stays NO_CLUSTER).
+        for pt in g.cpu_points.iter_mut() {
+            pt._pad[0] = GpuPoint::NO_CLUSTER;
+        }
+        for (j, &i) in idx.iter().enumerate() {
+            if labels[j] >= 0 {
+                g.cpu_points[i]._pad[0] = labels[j] as u32;
+            }
+        }
+        // Take the points out so renderer (mut) and the points (shared) don't overlap.
+        let pts = std::mem::take(&mut g.cpu_points);
+        g.renderer.reset();
+        g.renderer.append(&g.queue, &pts);
+        g.cpu_points = pts;
+        g.params.color_mode = 1;
+        g.clustered = true;
+        g.view_mode = ViewMode::Points; // cluster colour is a point concept
+        g.filter_dirty = true; // refresh the displayed-count HUD
+    }
+
+    set_checked("v-pts", true);
+    set_checked("v-vol", false);
+    set_volmode(false);
+    set_checked("cl-color", true);
+    set_text(
+        "cl-readout",
+        &format!("{k} clusters · {} noise · {} pts", group(noise), group(idx.len())),
+    );
+    show_status("");
+}
+
+/// Wire the Cluster tab: eps / min-pts, Run, and the Color-by-cluster toggle.
+fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
+    bind_value(gfx, "cl-eps", "cl-eps-n", 3, |g, v| g.cluster_eps = v as f32);
+    bind_value(gfx, "cl-min", "cl-min-n", 0, |g, v| g.cluster_min_pts = (v as usize).max(1));
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-run") {
+        let gfx = gfx.clone();
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| run_clustering(&gfx));
+    }
+    on_toggle("cl-color", gfx, |g, on| {
+        if g.clustered {
+            g.params.color_mode = if on { 1 } else { 0 };
+        }
+    });
+}
+
 /// Wire the Focus / Back buttons; control enable/disable is driven by `refresh_controls`.
 fn bind_focus(gfx: &Rc<RefCell<Gfx>>) {
     if let Some(btn) = by_id::<web_sys::HtmlElement>("focus-go") {
@@ -1435,7 +1567,7 @@ fn set_class(id: &str, class: &str, on: bool) {
 
 /// Show one tab pane (`view`/`focus`) and highlight its button; hide the others.
 fn switch_tab(name: &str) {
-    for t in ["view", "focus"] {
+    for t in ["view", "focus", "cluster"] {
         set_class(&format!("tabbtn-{t}"), "active", t == name);
         set_class(&format!("tab-{t}"), "active", t == name);
     }
@@ -1978,12 +2110,13 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "floor", "floor-n", 0, |g, v| {
         g.params.filter_min[3] = v as f32;
         g.filter_dirty = true;
+        invalidate_clusters_mut(g);
     });
 
     // Filters
-    on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; g.filter_dirty = true; g.vol_needs_grid = true; });
-    on_toggle("ms-2", gfx, |g, on| if on { g.params.ms_mask = 0b10; g.filter_dirty = true; g.vol_needs_grid = true; });
-    on_toggle("ms-b", gfx, |g, on| if on { g.params.ms_mask = 0b11; g.filter_dirty = true; g.vol_needs_grid = true; });
+    on_toggle("ms-1", gfx, |g, on| if on { g.params.ms_mask = 0b01; g.filter_dirty = true; g.vol_needs_grid = true; invalidate_clusters_mut(g); });
+    on_toggle("ms-2", gfx, |g, on| if on { g.params.ms_mask = 0b10; g.filter_dirty = true; g.vol_needs_grid = true; invalidate_clusters_mut(g); });
+    on_toggle("ms-b", gfx, |g, on| if on { g.params.ms_mask = 0b11; g.filter_dirty = true; g.vol_needs_grid = true; invalidate_clusters_mut(g); });
     bind_crop(gfx, "cmz", 0);
     bind_crop(gfx, "cim", 1);
     bind_crop(gfx, "crt", 2);
@@ -2036,6 +2169,7 @@ fn crop_apply(gfx: &Rc<RefCell<Gfx>>, axis: usize, prefix: &str, lo_val: f64, hi
         g.params.filter_min[axis] = a;
         g.params.filter_max[axis] = b;
         g.filter_dirty = true;
+        invalidate_clusters_mut(&mut g);
         g.axis_bounds
     };
     set_text(&format!("{prefix}-v"), &crop_label(bounds, axis, a, b));

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -41,6 +41,15 @@ pub fn start() {
     });
 }
 
+/// A 4D region of the run in real units (the focus lens). `imin` is the intensity floor in counts.
+#[derive(Clone, Copy)]
+struct Region {
+    mz: (f64, f64),
+    im: (f64, f64),
+    rt: (f64, f64),
+    imin: f32,
+}
+
 /// Live GPU + scene state, shared (single-threaded) between the render loop and resize handler.
 struct Gfx {
     canvas: web_sys::HtmlCanvasElement,
@@ -85,6 +94,9 @@ struct Gfx {
     /// Set when the active filter or draw count changes; the next frame recomputes the displayed
     /// count (CPU-side over `cpu_points`) — camera-independent, so it need not run every frame.
     filter_dirty: bool,
+    /// Focus stack of loaded regions (`last()` = current view; index 0 = the full run). Focus
+    /// pushes; Back pops. Empty in the demo fallback (focus disabled).
+    focus_stack: Vec<Region>,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -377,6 +389,9 @@ async fn run() -> Result<(), String> {
         floor_hi,
         reloading: false,
         filter_dirty: true,
+        focus_stack: axis_bounds
+            .map(|b| vec![Region { mz: b[0], im: b[1], rt: b[2], imin: 0.0 }])
+            .unwrap_or_default(),
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -404,6 +419,8 @@ async fn run() -> Result<(), String> {
     bind_display(&gfx);
     // Load-budget control: re-fetch a different number of points from the server.
     bind_load(&gfx);
+    // Focus / Back: drill into the crop+floor region at full budget, and pop back out.
+    bind_focus(&gfx);
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -938,9 +955,18 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
     reset_display(gfx, n);
 }
 
-/// Re-fetch the run at a new budget (full bounds) and rebuild the GPU buffer. Debounced via
-/// `reloading`. Focus/Back will drive the same path with a region query.
-async fn reload(gfx: Rc<RefCell<Gfx>>, budget: usize) {
+/// Build the region + budget query string for `/points` and `/meta`.
+fn region_query(r: &Region, budget: usize) -> String {
+    format!(
+        "mz0={}&mz1={}&im0={}&im1={}&rt0={}&rt1={}&imin={}&n={budget}",
+        r.mz.0, r.mz.1, r.im.0, r.im.1, r.rt.0, r.rt.1, r.imin,
+    )
+}
+
+/// The focus-lens load primitive: re-fetch a region at a budget and rebuild the GPU buffer.
+/// `push` records the region on the focus stack (Focus); Back / Load-budget pass `false`.
+/// Debounced via `reloading`.
+async fn load_region(gfx: Rc<RefCell<Gfx>>, region: Region, budget: usize, push: bool) {
     {
         let mut g = gfx.borrow_mut();
         if g.reloading || g.points_base.is_empty() {
@@ -949,7 +975,7 @@ async fn reload(gfx: Rc<RefCell<Gfx>>, budget: usize) {
         g.reloading = true;
     }
     let base = gfx.borrow().points_base.clone();
-    let q = format!("n={budget}");
+    let q = region_query(&region, budget);
     let purl = with_query(&base, &q);
     let murl = with_query(&meta_url(&base), &q);
     show_status("loading…");
@@ -959,11 +985,102 @@ async fn reload(gfx: Rc<RefCell<Gfx>>, budget: usize) {
     match result {
         Ok(pts) if !pts.is_empty() => {
             apply_load(&gfx, meta, pts);
+            if push {
+                gfx.borrow_mut().focus_stack.push(region);
+            }
+            update_back_button(&gfx);
             show_status("");
         }
-        Ok(_) => show_status("load returned no points"),
+        Ok(_) => show_status("region is empty — nothing matched"),
         Err(e) => show_status(&format!("load failed: {e}")),
     }
+}
+
+/// The current crop box + intensity floor, mapped from the normalized cube back to real units of
+/// the current view — the region to focus on. `None` for the demo (no real bounds) or a degenerate
+/// (zero-width) box that would divide-by-zero when re-normalized.
+fn compute_focus_region(g: &Gfx) -> Option<Region> {
+    let b = g.axis_bounds?;
+    let p = &g.params;
+    let lerp = |rng: (f64, f64), norm: f32| rng.0 + ((norm as f64 + 1.0) * 0.5) * (rng.1 - rng.0);
+    let mk = |axis: usize| {
+        let a = lerp(b[axis], p.filter_min[axis]);
+        let c = lerp(b[axis], p.filter_max[axis]);
+        (a.min(c), a.max(c))
+    };
+    let (mz, im, rt) = (mk(0), mk(1), mk(2));
+    let wide = |r: (f64, f64), full: (f64, f64)| (r.1 - r.0) > (full.1 - full.0).abs() * 1e-4;
+    if !wide(mz, b[0]) || !wide(im, b[1]) || !wide(rt, b[2]) {
+        return None;
+    }
+    Some(Region { mz, im, rt, imin: p.filter_min[3].max(0.0) })
+}
+
+/// Focus on the current crop+floor box: push it and re-load at full budget (high local detail).
+fn do_focus(gfx: &Rc<RefCell<Gfx>>) {
+    let region = match compute_focus_region(&gfx.borrow()) {
+        Some(r) => r,
+        None => {
+            show_status("crop a region (or set a floor) before focusing");
+            return;
+        }
+    };
+    let budget = gfx.borrow().n_cap;
+    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), region, budget, true));
+}
+
+/// Pop the focus stack and re-load the previous (coarser) region.
+fn do_back(gfx: &Rc<RefCell<Gfx>>) {
+    let region = {
+        let mut g = gfx.borrow_mut();
+        if g.focus_stack.len() <= 1 {
+            return;
+        }
+        g.focus_stack.pop();
+        match g.focus_stack.last() {
+            Some(r) => *r,
+            None => return,
+        }
+    };
+    let budget = gfx.borrow().n_cap;
+    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), region, budget, false));
+}
+
+/// Enable Back only when focused, and show the focus depth.
+fn update_back_button(gfx: &Rc<RefCell<Gfx>>) {
+    let depth = gfx.borrow().focus_stack.len();
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("focus-back") {
+        if depth > 1 {
+            let _ = btn.remove_attribute("disabled");
+        } else {
+            let _ = btn.set_attribute("disabled", "true");
+        }
+    }
+    set_text(
+        "focus-depth",
+        &if depth > 1 { format!("L{}", depth - 1) } else { String::new() },
+    );
+}
+
+/// Wire the Focus / Back buttons (disabled in the demo fallback).
+fn bind_focus(gfx: &Rc<RefCell<Gfx>>) {
+    if gfx.borrow().points_base.is_empty() {
+        for id in ["focus-go", "focus-back"] {
+            if let Some(btn) = by_id::<web_sys::HtmlElement>(id) {
+                let _ = btn.set_attribute("disabled", "true");
+            }
+        }
+        return;
+    }
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("focus-go") {
+        let gfx = gfx.clone();
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| do_focus(&gfx));
+    }
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("focus-back") {
+        let gfx = gfx.clone();
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| do_back(&gfx));
+    }
+    update_back_button(gfx);
 }
 
 /// Wire the Load control: show N_cap, initialize to the resident count, and re-fetch the run at the
@@ -993,7 +1110,11 @@ fn bind_load(gfx: &Rc<RefCell<Gfx>>) {
             let v = num.value_as_number();
             if v.is_finite() && v >= 1.0 {
                 let budget = (v as usize).min(n_cap).max(1);
-                wasm_bindgen_futures::spawn_local(reload(gfx.clone(), budget));
+                // Re-load the CURRENT region (focus stack top) at the new budget — no stack change.
+                let region = gfx.borrow().focus_stack.last().copied();
+                if let Some(region) = region {
+                    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), region, budget, false));
+                }
             }
         }
     };

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -1168,9 +1168,14 @@ fn set_disabled(id: &str, disabled: bool) {
 /// Reflect the current load/focus state onto the controls: Focus/Load active only with a server +
 /// a non-empty stack and no load in flight; Back active only when focused; show the focus depth.
 fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
-    let (busy, has_server, depth) = {
+    let (busy, has_server, depth, committed_imin) = {
         let g = gfx.borrow();
-        (g.reloading, !g.points_base.is_empty(), g.focus_stack.len())
+        (
+            g.reloading,
+            !g.points_base.is_empty(),
+            g.focus_stack.len(),
+            g.focus_stack.last().map(|(r, _)| r.imin).unwrap_or(0.0),
+        )
     };
     let active = has_server && depth >= 1 && !busy;
     for id in ["focus-go", "load-go", "load-n"] {
@@ -1180,6 +1185,16 @@ fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_text(
         "focus-depth",
         &if depth > 1 { format!("L{}", depth - 1) } else { String::new() },
+    );
+    // When the current view was loaded with an intensity cutoff, the low-intensity points aren't
+    // resident — make that explicit so a floor parked at 0 isn't mistaken for "all points".
+    set_text(
+        "floor-src",
+        &if committed_imin > 0.0 {
+            format!("· baked ≥ {committed_imin:.0} (Back to lower)")
+        } else {
+            String::new()
+        },
     );
 }
 

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -94,9 +94,10 @@ struct Gfx {
     /// Set when the active filter or draw count changes; the next frame recomputes the displayed
     /// count (CPU-side over `cpu_points`) — camera-independent, so it need not run every frame.
     filter_dirty: bool,
-    /// Focus stack of loaded regions (`last()` = current view; index 0 = the full run). Focus
-    /// pushes; Back pops. Empty in the demo fallback (focus disabled).
-    focus_stack: Vec<Region>,
+    /// Focus stack of `(region, budget)` (`last()` = current view; index 0 = the full run). The
+    /// root's budget is `None` => loaded via no-query so it hits the server's pinned full-run cache.
+    /// Focus pushes; Back pops. Empty in the demo fallback (focus disabled).
+    focus_stack: Vec<(Region, Option<usize>)>,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -390,7 +391,7 @@ async fn run() -> Result<(), String> {
         reloading: false,
         filter_dirty: true,
         focus_stack: axis_bounds
-            .map(|b| vec![Region { mz: b[0], im: b[1], rt: b[2], imin: 0.0 }])
+            .map(|b| vec![(Region { mz: b[0], im: b[1], rt: b[2], imin: 0.0 }, None)])
             .unwrap_or_default(),
     }));
 
@@ -604,7 +605,7 @@ async fn fetch_points(url: &str) -> Result<Vec<GpuPoint>, String> {
     let len = bytes.length();
     let stride = std::mem::size_of::<GpuPoint>() as u32;
     if len == 0 {
-        return Err("empty body".into());
+        return Ok(Vec::new()); // a valid empty region (the caller decides what to show)
     }
     if len % stride != 0 {
         return Err(format!("body {len} bytes is not a multiple of the {stride}-byte point stride"));
@@ -963,42 +964,80 @@ fn region_query(r: &Region, budget: usize) -> String {
     )
 }
 
-/// The focus-lens load primitive: re-fetch a region at a budget and rebuild the GPU buffer.
-/// `push` records the region on the focus stack (Focus); Back / Load-budget pass `false`.
-/// Debounced via `reloading`.
-async fn load_region(gfx: Rc<RefCell<Gfx>>, region: Region, budget: usize, push: bool) {
+/// Which way `load_region` mutates the focus stack — applied only AFTER a successful load.
+#[derive(Clone, Copy)]
+enum StackOp {
+    Push,
+    Pop,
+    Keep,
+}
+
+/// The focus-lens load primitive: re-fetch a region and rebuild the GPU buffer. `budget == None`
+/// loads the pinned full run via no-query (cache hit for Back-to-root); `Some(b)` is an explicit
+/// region+budget query. The stack op is applied only after the load succeeds, so a debounced or
+/// failed load never desyncs the stack from the displayed view. Debounced via `reloading`.
+async fn load_region(gfx: Rc<RefCell<Gfx>>, region: Region, budget: Option<usize>, op: StackOp) {
     {
         let mut g = gfx.borrow_mut();
-        if g.reloading || g.points_base.is_empty() {
+        if g.reloading || g.focus_stack.is_empty() {
             return;
         }
         g.reloading = true;
     }
+    refresh_controls(&gfx); // disable focus/back/load while a load is in flight
     let base = gfx.borrow().points_base.clone();
-    let q = region_query(&region, budget);
-    let purl = with_query(&base, &q);
-    let murl = with_query(&meta_url(&base), &q);
+    let q = budget.map(|b| region_query(&region, b));
+    let purl = q.as_ref().map_or_else(|| base.clone(), |q| with_query(&base, q));
+    let mbase = meta_url(&base);
+    let murl = q.as_ref().map_or(mbase.clone(), |q| with_query(&mbase, q));
     show_status("loading…");
-    let meta = fetch_meta(&murl).await.ok();
-    let result = fetch_points(&purl).await;
+    // Require BOTH meta and points: applying points without their matching meta would leave
+    // axis_bounds stale while the buffer is normalized to the new region (breaks nested Focus).
+    let meta = fetch_meta(&murl).await;
+    let pts = fetch_points(&purl).await;
     gfx.borrow_mut().reloading = false;
-    match result {
-        Ok(pts) if !pts.is_empty() => {
-            apply_load(&gfx, meta, pts);
-            if push {
-                gfx.borrow_mut().focus_stack.push(region);
+    match (meta, pts) {
+        (Ok(meta), Ok(pts)) if !pts.is_empty() => {
+            apply_load(&gfx, Some(meta), pts);
+            // Maintain the stack from the SERVER-canonical bounds (apply_load set axis_bounds), so
+            // `stack.last()` always matches the displayed view.
+            let canonical = gfx.borrow().axis_bounds.map(|b| Region {
+                mz: b[0],
+                im: b[1],
+                rt: b[2],
+                imin: region.imin,
+            });
+            {
+                let mut g = gfx.borrow_mut();
+                match op {
+                    StackOp::Push => {
+                        if let Some(c) = canonical {
+                            g.focus_stack.push((c, budget));
+                        }
+                    }
+                    StackOp::Pop => {
+                        if g.focus_stack.len() > 1 {
+                            g.focus_stack.pop();
+                        }
+                    }
+                    StackOp::Keep => {
+                        if let (Some(c), Some(top)) = (canonical, g.focus_stack.last_mut()) {
+                            *top = (c, budget);
+                        }
+                    }
+                }
             }
-            update_back_button(&gfx);
             show_status("");
         }
-        Ok(_) => show_status("region is empty — nothing matched"),
-        Err(e) => show_status(&format!("load failed: {e}")),
+        (Ok(_), Ok(_)) => show_status("region is empty — nothing matched"),
+        (Err(e), _) | (_, Err(e)) => show_status(&format!("load failed: {e}")),
     }
+    refresh_controls(&gfx);
 }
 
 /// The current crop box + intensity floor, mapped from the normalized cube back to real units of
 /// the current view — the region to focus on. `None` for the demo (no real bounds) or a degenerate
-/// (zero-width) box that would divide-by-zero when re-normalized.
+/// (zero/negative-width or non-finite) box that would divide-by-zero when re-normalized.
 fn compute_focus_region(g: &Gfx) -> Option<Region> {
     let b = g.axis_bounds?;
     let p = &g.params;
@@ -1009,15 +1048,18 @@ fn compute_focus_region(g: &Gfx) -> Option<Region> {
         (a.min(c), a.max(c))
     };
     let (mz, im, rt) = (mk(0), mk(1), mk(2));
-    let wide = |r: (f64, f64), full: (f64, f64)| (r.1 - r.0) > (full.1 - full.0).abs() * 1e-4;
-    if !wide(mz, b[0]) || !wide(im, b[1]) || !wide(rt, b[2]) {
+    let ok = |r: (f64, f64)| r.0.is_finite() && r.1.is_finite() && r.1 > r.0;
+    if !ok(mz) || !ok(im) || !ok(rt) {
         return None;
     }
     Some(Region { mz, im, rt, imin: p.filter_min[3].max(0.0) })
 }
 
-/// Focus on the current crop+floor box: push it and re-load at full budget (high local detail).
+/// Focus on the current crop+floor box: re-load it at full budget and push it on success.
 fn do_focus(gfx: &Rc<RefCell<Gfx>>) {
+    if gfx.borrow().reloading {
+        return;
+    }
     let region = match compute_focus_region(&gfx.borrow()) {
         Some(r) => r,
         None => {
@@ -1026,52 +1068,52 @@ fn do_focus(gfx: &Rc<RefCell<Gfx>>) {
         }
     };
     let budget = gfx.borrow().n_cap;
-    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), region, budget, true));
+    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), region, Some(budget), StackOp::Push));
 }
 
-/// Pop the focus stack and re-load the previous (coarser) region.
+/// Re-load the region one level down the stack; pop only after it succeeds.
 fn do_back(gfx: &Rc<RefCell<Gfx>>) {
-    let region = {
-        let mut g = gfx.borrow_mut();
-        if g.focus_stack.len() <= 1 {
+    let target = {
+        let g = gfx.borrow();
+        if g.reloading || g.focus_stack.len() <= 1 {
             return;
         }
-        g.focus_stack.pop();
-        match g.focus_stack.last() {
-            Some(r) => *r,
-            None => return,
-        }
+        g.focus_stack[g.focus_stack.len() - 2] // peek; load_region pops on success
     };
-    let budget = gfx.borrow().n_cap;
-    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), region, budget, false));
+    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), target.0, target.1, StackOp::Pop));
 }
 
-/// Enable Back only when focused, and show the focus depth.
-fn update_back_button(gfx: &Rc<RefCell<Gfx>>) {
-    let depth = gfx.borrow().focus_stack.len();
-    if let Some(btn) = by_id::<web_sys::HtmlElement>("focus-back") {
-        if depth > 1 {
-            let _ = btn.remove_attribute("disabled");
+/// Set/clear the `disabled` attribute on an element.
+fn set_disabled(id: &str, disabled: bool) {
+    if let Some(el) = by_id::<web_sys::HtmlElement>(id) {
+        if disabled {
+            let _ = el.set_attribute("disabled", "true");
         } else {
-            let _ = btn.set_attribute("disabled", "true");
+            let _ = el.remove_attribute("disabled");
         }
     }
+}
+
+/// Reflect the current load/focus state onto the controls: Focus/Load active only with a server +
+/// a non-empty stack and no load in flight; Back active only when focused; show the focus depth.
+fn refresh_controls(gfx: &Rc<RefCell<Gfx>>) {
+    let (busy, has_server, depth) = {
+        let g = gfx.borrow();
+        (g.reloading, !g.points_base.is_empty(), g.focus_stack.len())
+    };
+    let active = has_server && depth >= 1 && !busy;
+    for id in ["focus-go", "load-go", "load-n"] {
+        set_disabled(id, !active);
+    }
+    set_disabled("focus-back", busy || !has_server || depth <= 1);
     set_text(
         "focus-depth",
         &if depth > 1 { format!("L{}", depth - 1) } else { String::new() },
     );
 }
 
-/// Wire the Focus / Back buttons (disabled in the demo fallback).
+/// Wire the Focus / Back buttons; control enable/disable is driven by `refresh_controls`.
 fn bind_focus(gfx: &Rc<RefCell<Gfx>>) {
-    if gfx.borrow().points_base.is_empty() {
-        for id in ["focus-go", "focus-back"] {
-            if let Some(btn) = by_id::<web_sys::HtmlElement>(id) {
-                let _ = btn.set_attribute("disabled", "true");
-            }
-        }
-        return;
-    }
     if let Some(btn) = by_id::<web_sys::HtmlElement>("focus-go") {
         let gfx = gfx.clone();
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| do_focus(&gfx));
@@ -1080,7 +1122,7 @@ fn bind_focus(gfx: &Rc<RefCell<Gfx>>) {
         let gfx = gfx.clone();
         add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| do_back(&gfx));
     }
-    update_back_button(gfx);
+    refresh_controls(gfx);
 }
 
 /// Wire the Load control: show N_cap, initialize to the resident count, and re-fetch the run at the
@@ -1110,10 +1152,16 @@ fn bind_load(gfx: &Rc<RefCell<Gfx>>) {
             let v = num.value_as_number();
             if v.is_finite() && v >= 1.0 {
                 let budget = (v as usize).min(n_cap).max(1);
-                // Re-load the CURRENT region (focus stack top) at the new budget — no stack change.
-                let region = gfx.borrow().focus_stack.last().copied();
+                // Re-load the CURRENT region (focus stack top) at the new budget — Keep updates the
+                // top entry's budget, no push/pop.
+                let region = gfx.borrow().focus_stack.last().map(|(r, _)| *r);
                 if let Some(region) = region {
-                    wasm_bindgen_futures::spawn_local(load_region(gfx.clone(), region, budget, false));
+                    wasm_bindgen_futures::spawn_local(load_region(
+                        gfx.clone(),
+                        region,
+                        Some(budget),
+                        StackOp::Keep,
+                    ));
                 }
             }
         }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -98,6 +98,9 @@ struct Gfx {
     /// root's budget is `None` => loaded via no-query so it hits the server's pinned full-run cache.
     /// Focus pushes; Back pops. Empty in the demo fallback (focus disabled).
     focus_stack: Vec<(Region, Option<usize>)>,
+    /// Whether the projection maps reflect the current view (valid grids drawn); box-select is gated
+    /// on it so a drag never focuses against stale/blank maps.
+    maps_ok: bool,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -393,6 +396,7 @@ async fn run() -> Result<(), String> {
         focus_stack: axis_bounds
             .map(|b| vec![(Region { mz: b[0], im: b[1], rt: b[2], imin: 0.0 }, None)])
             .unwrap_or_default(),
+        maps_ok: false, // set by the initial render_maps below
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -415,7 +419,8 @@ async fn run() -> Result<(), String> {
         if let Some(ih) = &m.i_hist {
             set_hist_svg("floor-hist", ih);
         }
-        render_maps(m);
+        let ok = render_maps(m);
+        gfx.borrow_mut().maps_ok = ok;
     }
     // Runtime detail/performance control over how many of the loaded points are drawn.
     bind_display(&gfx);
@@ -723,20 +728,24 @@ async fn fetch_meta(url: &str) -> Result<MetaInfo, String> {
     };
     let i_hist = js_u32_array(&it, "hist");
 
-    // 2D projections for the box-select maps.
+    // 2D projections for the box-select maps. Use the server's explicit `bins` and require all
+    // three grids to be exactly `bins²`, else drop them (so the maps never show a malformed grid).
     let pj = jget(&v, "proj");
+    let bins = jnum(&pj, "bins").filter(|x| x.is_finite() && *x >= 1.0).map(|x| x as usize);
     let proj = match (
+        bins,
         js_u32_array(&pj, "mz_im"),
         js_u32_array(&pj, "mz_rt"),
         js_u32_array(&pj, "im_rt"),
     ) {
-        (Some(a), Some(b), Some(c)) => Some([a, b, c]),
+        (Some(b), Some(a), Some(c), Some(d))
+            if a.len() == b * b && c.len() == b * b && d.len() == b * b =>
+        {
+            Some([a, c, d])
+        }
         _ => None,
     };
-    let proj_bins = proj
-        .as_ref()
-        .map(|p| (p[0].len() as f64).sqrt().round() as usize)
-        .unwrap_or(0);
+    let proj_bins = if proj.is_some() { bins.unwrap_or(0) } else { 0 };
 
     Ok(MetaInfo {
         bounds,
@@ -971,7 +980,8 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         if let Some(ih) = &m.i_hist {
             set_hist_svg("floor-hist", ih);
         }
-        render_maps(m);
+        let ok = render_maps(m);
+        gfx.borrow_mut().maps_ok = ok;
     }
     for id in ["floor", "floor-n"] {
         if let Some(inp) = by_id::<web_sys::HtmlInputElement>(id) {
@@ -1277,12 +1287,38 @@ fn render_heatmap(canvas_id: &str, data: &[u32], bins: usize) {
     }
 }
 
-/// Render all three projection minimaps from a load's meta.
-fn render_maps(meta: &MetaInfo) {
-    if let Some(proj) = &meta.proj {
-        for (i, id) in ["map-0", "map-1", "map-2"].iter().enumerate() {
-            render_heatmap(id, &proj[i], meta.proj_bins);
+/// Render all three projection minimaps from a load's meta. Returns whether valid maps were drawn;
+/// when the meta lacks usable projections the stale canvases are cleared (so box-select can be
+/// disabled rather than acting on a previous view).
+fn render_maps(meta: &MetaInfo) -> bool {
+    match &meta.proj {
+        Some(proj) if meta.proj_bins > 0 => {
+            for (i, id) in ["map-0", "map-1", "map-2"].iter().enumerate() {
+                render_heatmap(id, &proj[i], meta.proj_bins);
+            }
+            true
         }
+        _ => {
+            for id in ["map-0", "map-1", "map-2"] {
+                clear_canvas(id);
+            }
+            false
+        }
+    }
+}
+
+/// Clear a canvas (so it can't show a stale view from a prior load).
+fn clear_canvas(id: &str) {
+    let Some(canvas) = by_id::<web_sys::HtmlCanvasElement>(id) else {
+        return;
+    };
+    if let Some(ctx) = canvas
+        .get_context("2d")
+        .ok()
+        .flatten()
+        .and_then(|c| c.dyn_into::<web_sys::CanvasRenderingContext2d>().ok())
+    {
+        ctx.clear_rect(0.0, 0.0, canvas.width() as f64, canvas.height() as f64);
     }
 }
 
@@ -1359,6 +1395,12 @@ fn bind_maps(gfx: &Rc<RefCell<Gfx>>) {
             let Some((proj, x0, y0)) = *drag.borrow() else {
                 return;
             };
+            // No button held => the mouseup happened off-window; cancel the drag + overlay.
+            if e.buttons() == 0 {
+                *drag.borrow_mut() = None;
+                set_sel_box(proj, 0.0, 0.0, 0.0, 0.0, false);
+                return;
+            }
             if let Some(mw) = by_id::<web_sys::HtmlElement>(&format!("mw-{proj}")) {
                 let (nx, ny) = map_frac(&mw, &e);
                 set_sel_box(proj, x0, y0, nx, ny, true);
@@ -1378,8 +1420,14 @@ fn bind_maps(gfx: &Rc<RefCell<Gfx>>) {
             let (nx, ny) = map_frac(&mw, &e);
             let (xa, xb) = (x0.min(nx), x0.max(nx));
             let (ya, yb) = (y0.min(ny), y0.max(ny));
-            if (xb - xa) < 0.02 || (yb - ya) < 0.02 || gfx.borrow().reloading {
-                return; // ignore clicks / tiny drags / mid-load
+            if (xb - xa) < 0.02 || (yb - ya) < 0.02 {
+                return; // ignore clicks / tiny drags
+            }
+            {
+                let g = gfx.borrow();
+                if g.reloading || !g.maps_ok {
+                    return; // mid-load, or maps don't reflect the current view
+                }
             }
             if let Some(r) = region_from_box(&gfx.borrow(), proj, (xa, xb), (ya, yb)) {
                 let budget = gfx.borrow().n_cap;

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -276,6 +276,9 @@ struct Gfx {
     /// Route Run through the Python (sklearn) service instead of the in-wasm DBSCAN. Auto-enabled by
     /// the startup probe when the service is reachable; toggleable in the Cluster tab.
     use_python_cluster: bool,
+    /// Set once the user picks an algorithm from the dropdown, so the async service probe won't
+    /// stomp their choice with its auto-select.
+    cluster_algo_user_set: bool,
     /// Algorithm (Python service only; wasm is always DBSCAN) + its HDBSCAN parameters.
     cluster_method: ClusterMethod,
     cluster_min_cluster_size: usize,
@@ -712,6 +715,7 @@ async fn run() -> Result<(), String> {
         cluster_sel: None,
         hide_noise: false,
         use_python_cluster: false,
+        cluster_algo_user_set: false,
         cluster_method: ClusterMethod::Dbscan,
         cluster_min_cluster_size: 7,
         cluster_hdb_min_samples: 0,
@@ -984,17 +988,31 @@ async fn probe_cluster_service(gfx: Rc<RefCell<Gfx>>) {
     let Some(window) = web_sys::window() else {
         return;
     };
+    // Verify it's actually our service (a 200 from some other process on the port isn't enough).
     let ok = match wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(&cluster_service_url())).await {
-        Ok(v) => v.dyn_into::<web_sys::Response>().map(|r| r.ok()).unwrap_or(false),
+        Ok(v) => match v.dyn_into::<web_sys::Response>() {
+            Ok(r) if r.ok() => match r.text() {
+                Ok(p) => wasm_bindgen_futures::JsFuture::from(p)
+                    .await
+                    .ok()
+                    .and_then(|t| t.as_string())
+                    .is_some_and(|s| s.contains("cluster service")),
+                Err(_) => false,
+            },
+            _ => false,
+        },
         Err(_) => false,
     };
     if ok {
         set_disabled("opt-sklearn", false);
         set_disabled("opt-hdbscan", false);
-        if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
-            sel.set_value("sklearn"); // prefer sklearn DBSCAN when the service is up
+        // Prefer sklearn DBSCAN when the service is up — unless the user already picked an algorithm.
+        if !gfx.borrow().cluster_algo_user_set {
+            if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
+                sel.set_value("sklearn");
+            }
+            apply_cluster_algo(&gfx, "sklearn");
         }
-        apply_cluster_algo(&gfx, "sklearn");
         set_text("cl-algo-status", "sklearn ✓");
     } else {
         set_text("cl-algo-status", "offline · built-in");
@@ -2500,6 +2518,7 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     if let Some(sel) = by_id::<web_sys::HtmlSelectElement>("cl-algo") {
         let (gfx, el) = (gfx.clone(), sel.clone());
         add_listener(sel.as_ref(), "change", move |_e: web_sys::Event| {
+            gfx.borrow_mut().cluster_algo_user_set = true; // the probe must not override a manual pick
             apply_cluster_algo(&gfx, &el.value());
         });
     }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -209,6 +209,8 @@ struct Gfx {
     cluster_idx: Vec<usize>,
     cluster_labels: Vec<i32>,
     cluster_sel: Option<i32>,
+    /// When clustered + colouring, hide the un-clustered (noise) points (color_mode 2 vs 1).
+    hide_noise: bool,
     /// Persistent DBSCAN worker (lazily created; `None` if workers are unavailable → main-thread
     /// fallback), and the in-flight job's (survivor idx, data generation, job id) awaiting its reply.
     /// `job_id` distinguishes a superseded job's late reply; `worker_failed` latches a runtime failure
@@ -419,7 +421,7 @@ impl Gfx {
                 self.volume.as_ref().unwrap().render(&mut rpass);
             } else {
                 // Cluster hues mush under additive blending — force opaque while cluster-colored.
-                let pm = if self.params.color_mode == 1 {
+                let pm = if self.params.color_mode >= 1 {
                     PointMode::StructuralOpaque
                 } else {
                     self.point_mode
@@ -630,6 +632,7 @@ async fn run() -> Result<(), String> {
         cluster_idx: Vec::new(),
         cluster_labels: Vec::new(),
         cluster_sel: None,
+        hide_noise: false,
         cluster_worker: None,
         cluster_pending: None,
         next_cluster_job: 0,
@@ -1936,7 +1939,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, 
             }
         }
         reupload_points(g);
-        g.params.color_mode = 1;
+        g.params.color_mode = if g.hide_noise { 2 } else { 1 };
         g.clustered = true;
         g.cluster_stats = Some(stats);
         g.cluster_idx = idx;
@@ -2135,8 +2138,19 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     }
     on_toggle("cl-color", gfx, |g, on| {
         if g.clustered {
-            g.params.color_mode = if on { 1 } else { 0 };
+            g.params.color_mode = if on {
+                if g.hide_noise { 2 } else { 1 }
+            } else {
+                0
+            };
             set_body_class("cluster-color", on); // toggles the intensity colorbar back on when off
+        }
+    });
+    on_toggle("hide-noise", gfx, |g, on| {
+        g.hide_noise = on;
+        // Only meaningful while cluster-colouring; flips between color_mode 1 (show) and 2 (hide).
+        if g.clustered && g.params.color_mode != 0 {
+            g.params.color_mode = if on { 2 } else { 1 };
         }
     });
     // Click a row in the cluster list to isolate it (data-cl="-1" = show all).
@@ -2331,7 +2345,8 @@ fn isolate_cluster(gfx: &Rc<RefCell<Gfx>>, sel: Option<i32>) {
         }
         reupload_points(g);
         g.cluster_sel = sel;
-        g.params.color_mode = 1; // isolate is only visible under cluster coloring
+        g.params.color_mode = if g.hide_noise { 2 } else { 1 }; // isolate needs cluster colouring
+
         g.view_mode = ViewMode::Points; // cluster ids are invisible in Volume
     }
     set_checked("cl-color", true);
@@ -2839,6 +2854,7 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
     set_checked("cl-color", true); // colour by cluster is on by default (applies after a Run)
+    set_checked("hide-noise", false);
     set_checked("show-windows", false); // off by default (defeats browser form-restore)
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -61,8 +61,9 @@ struct ClusterStats {
     noise_pts: u64,
     signal_int: f64,
     noise_int: f64,
-    /// Per-cluster point count + real-unit extent on each axis (for the histograms).
+    /// Per-cluster point count, intensity sum, and real-unit extent on each axis.
     sizes: Vec<f64>,
+    int_sum: Vec<f64>,
     mz_extent: Vec<f64>,
     im_extent: Vec<f64>,
     rt_extent: Vec<f64>,
@@ -150,6 +151,11 @@ struct Gfx {
     clustered: bool,
     /// The last clustering result's stats (for the right-hand panel); cleared on invalidate.
     cluster_stats: Option<ClusterStats>,
+    /// Retained DBSCAN result for isolation: the survivor `cpu_points` indices + their labels, and
+    /// which cluster is currently isolated (`None` = show all). Cleared on invalidate.
+    cluster_idx: Vec<usize>,
+    cluster_labels: Vec<i32>,
+    cluster_sel: Option<i32>,
     /// Declared last so it drops AFTER the surface/device — wgpu requires the instance to outlive
     /// everything created from it.
     _instance: wgpu::Instance,
@@ -542,6 +548,9 @@ async fn run() -> Result<(), String> {
         cluster_min_pts: 8,
         clustered: false,
         cluster_stats: None,
+        cluster_idx: Vec::new(),
+        cluster_labels: Vec::new(),
+        cluster_sel: None,
     }));
 
     wire_input(&gfx, &window, &canvas_for_input);
@@ -1107,6 +1116,9 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         g.params.color_mode = 0; // the fresh buffer has no cluster ids
         g.clustered = false;
         g.cluster_stats = None;
+        g.cluster_idx = Vec::new();
+        g.cluster_labels = Vec::new();
+        g.cluster_sel = None;
         // Re-apply auto-transfer (exposure + floor range) and bounds from the new meta; keep the
         // user's colormap / point size / opacity / MS mask.
         if let Some(m) = &meta {
@@ -1418,6 +1430,9 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
         g.params.color_mode = 0;
         g.clustered = false;
         g.cluster_stats = None;
+        g.cluster_idx = Vec::new();
+        g.cluster_labels = Vec::new();
+        g.cluster_sel = None;
         set_text("cl-readout", "—");
         set_checked("cl-color", false);
         set_body_class("has-clusters", false);
@@ -1474,17 +1489,26 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     let gfx = gfx.clone();
     defer(move || {
         let (labels, k) = dbscan(&positions, eps, min_pts);
-        finish_clustering(&gfx, &idx, &labels, k);
+        finish_clustering(&gfx, idx, labels, k);
     });
 }
 
+/// Re-upload the resident `cpu_points` to the GPU (the only path to refresh the cluster ids).
+fn reupload_points(g: &mut Gfx) {
+    let pts = std::mem::take(&mut g.cpu_points);
+    g.renderer.reset();
+    g.renderer.append(&g.queue, &pts);
+    g.cpu_points = pts;
+}
+
 /// Write DBSCAN labels into the GPU buffer + recolor by cluster, compute stats, then update the UI.
-fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: usize) {
+fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, k: usize) {
     let noise = labels.iter().filter(|&&l| l < 0).count();
+    let n_in = idx.len();
     {
         let mut gb = gfx.borrow_mut();
         let g: &mut Gfx = &mut gb; // &mut Gfx so renderer/queue/cpu_points field-split
-        let stats = compute_cluster_stats(idx, labels, k, &g.cpu_points, g.axis_bounds);
+        let stats = compute_cluster_stats(&idx, &labels, k, &g.cpu_points, g.axis_bounds);
         for pt in g.cpu_points.iter_mut() {
             pt._pad[0] = GpuPoint::NO_CLUSTER;
         }
@@ -1493,13 +1517,13 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: u
                 g.cpu_points[i]._pad[0] = labels[j] as u32;
             }
         }
-        let pts = std::mem::take(&mut g.cpu_points);
-        g.renderer.reset();
-        g.renderer.append(&g.queue, &pts);
-        g.cpu_points = pts;
+        reupload_points(g);
         g.params.color_mode = 1;
         g.clustered = true;
         g.cluster_stats = Some(stats);
+        g.cluster_idx = idx;
+        g.cluster_labels = labels;
+        g.cluster_sel = None;
         g.view_mode = ViewMode::Points; // cluster colour is a point concept
         g.filter_dirty = true; // refresh the displayed-count HUD
     }
@@ -1507,10 +1531,7 @@ fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: &[usize], labels: &[i32], k: u
     set_checked("v-vol", false);
     set_volmode(false);
     set_checked("cl-color", true);
-    set_text(
-        "cl-readout",
-        &format!("{k} clusters · {} noise · {} pts", group(noise), group(idx.len())),
-    );
+    set_text("cl-readout", &format!("{k} clusters · {} noise · {} pts", group(noise), group(n_in)));
     set_body_class("cluster-color", true); // cluster coloring active -> hide the intensity colorbar
     update_cluster_panel(gfx); // we ran from the Cluster tab, so this shows + renders the panel
     show_status("");
@@ -1526,6 +1547,7 @@ fn compute_cluster_stats(
     bounds: Option<[(f64, f64); 3]>,
 ) -> ClusterStats {
     let mut sizes = vec![0f64; k];
+    let mut int_sum = vec![0f64; k];
     let mut lo = vec![[f32::INFINITY; 3]; k];
     let mut hi = vec![[f32::NEG_INFINITY; 3]; k];
     let (mut signal_pts, mut noise_pts) = (0u64, 0u64);
@@ -1539,6 +1561,7 @@ fn compute_cluster_stats(
         } else {
             let c = l as usize;
             sizes[c] += 1.0;
+            int_sum[c] += contrib;
             signal_pts += 1;
             signal_int += contrib;
             for a in 0..3 {
@@ -1572,11 +1595,19 @@ fn compute_cluster_stats(
         im_extent: extent(1),
         rt_extent: extent(2),
         sizes,
+        int_sum,
     }
 }
 
-/// Fill the cluster stats panel: the summary table + four per-cluster histograms.
-fn render_cluster_panel(s: &ClusterStats) {
+/// CSS color matching the shader's per-cluster hue (`hsv2rgb(fract(id*0.618), 0.65, 1.0)`).
+fn cluster_css_color(id: usize) -> String {
+    let hue = (id as f64 * 0.618_033_988_75).fract() * 360.0;
+    format!("hsl({hue:.0}, 100%, 68%)")
+}
+
+/// Fill the cluster stats panel: summary table, four per-cluster histograms, and the clickable
+/// cluster list (top clusters by size; `sel` marks the isolated one).
+fn render_cluster_panel(s: &ClusterStats, sel: Option<i32>) {
     let total_pts = s.signal_pts + s.noise_pts;
     let total_int = s.signal_int + s.noise_int;
     set_text("cs-pts-t", &group_short(total_pts as usize));
@@ -1600,6 +1631,27 @@ fn render_cluster_panel(s: &ClusterStats) {
     set_hist_svg("csh-mz", &hist_bins(&s.mz_extent, 24));
     set_hist_svg("csh-im", &hist_bins(&s.im_extent, 24));
     set_hist_svg("csh-rt", &hist_bins(&s.rt_extent, 24));
+
+    // Clickable cluster list — top 50 by size, plus a "Show all" row when isolated.
+    let mut order: Vec<usize> = (0..s.k).collect();
+    order.sort_by(|&a, &b| s.sizes[b].total_cmp(&s.sizes[a]));
+    let mut html = String::new();
+    if sel.is_some() {
+        html.push_str("<button class=\"cs-row show-all\" data-cl=\"-1\">← Show all clusters</button>");
+    }
+    for &c in order.iter().take(50) {
+        let active = if sel == Some(c as i32) { " active" } else { "" };
+        html.push_str(&format!(
+            "<button class=\"cs-row{active}\" data-cl=\"{c}\"><span class=\"cs-dot\" style=\"background:{}\"></span>#{c}<span class=\"cs-meta\">{} · {}</span></button>",
+            cluster_css_color(c),
+            fmt_count(s.sizes[c]),
+            fmt_count(s.int_sum[c]),
+        ));
+    }
+    if s.k > 50 {
+        html.push_str(&format!("<div class=\"cs-more\">+{} more</div>", s.k - 50));
+    }
+    set_html("cs-list", &html);
 }
 
 /// Bin non-negative finite values into `n` equal-width bins over `[0, max]`. Everything collapses to
@@ -1668,6 +1720,24 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
             set_body_class("cluster-color", on); // toggles the intensity colorbar back on when off
         }
     });
+    // Click a row in the cluster list to isolate it (data-cl="-1" = show all).
+    if let Some(list) = by_id::<web_sys::HtmlElement>("cs-list") {
+        let gfx = gfx.clone();
+        add_listener(list.as_ref(), "click", move |e: web_sys::Event| {
+            let Some(t) = e.target().and_then(|t| t.dyn_into::<web_sys::Element>().ok()) else {
+                return;
+            };
+            if let Ok(Some(row)) = t.closest(".cs-row") {
+                if let Some(cl) = row.get_attribute("data-cl").and_then(|s| s.parse::<i32>().ok()) {
+                    isolate_cluster(&gfx, if cl < 0 { None } else { Some(cl) });
+                }
+            }
+        });
+    }
+    if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-export") {
+        let gfx = gfx.clone();
+        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| export_clusters(&gfx));
+    }
 }
 
 /// Wire the Focus / Back buttons; control enable/disable is driven by `refresh_controls`.
@@ -1778,9 +1848,73 @@ fn update_cluster_panel(gfx: &Rc<RefCell<Gfx>>) {
     let show = on_cluster_tab && gfx.borrow().clustered;
     set_body_class("has-clusters", show);
     if show {
-        if let Some(s) = gfx.borrow().cluster_stats.as_ref() {
-            render_cluster_panel(s);
+        let g = gfx.borrow();
+        if let Some(s) = g.cluster_stats.as_ref() {
+            render_cluster_panel(s, g.cluster_sel);
         }
+    }
+}
+
+/// Isolate one cluster on the cloud (others greyed to noise), or show all (`sel = None`). Clicking
+/// the already-isolated cluster toggles back to all.
+fn isolate_cluster(gfx: &Rc<RefCell<Gfx>>, sel: Option<i32>) {
+    {
+        let mut gb = gfx.borrow_mut();
+        let g: &mut Gfx = &mut gb;
+        if !g.clustered {
+            return;
+        }
+        let sel = if g.cluster_sel == sel { None } else { sel }; // toggle off if re-clicked
+        for (j, &i) in g.cluster_idx.iter().enumerate() {
+            let l = g.cluster_labels[j];
+            let shown = l >= 0 && sel.map_or(true, |s| l == s);
+            g.cpu_points[i]._pad[0] = if shown { l as u32 } else { GpuPoint::NO_CLUSTER };
+        }
+        reupload_points(g);
+        g.cluster_sel = sel;
+        g.params.color_mode = 1; // isolate is only visible under cluster coloring
+    }
+    set_checked("cl-color", true);
+    set_body_class("cluster-color", true);
+    update_cluster_panel(gfx); // re-render the list with the active row marked
+}
+
+/// Download the per-cluster summary as CSV (a data-URL anchor — no Blob/Url features needed).
+fn export_clusters(gfx: &Rc<RefCell<Gfx>>) {
+    let g = gfx.borrow();
+    let Some(s) = g.cluster_stats.as_ref() else {
+        return;
+    };
+    let mut csv = String::from("cluster,size,intensity,mz_extent,im_extent,rt_extent\n");
+    for c in 0..s.k {
+        csv.push_str(&format!(
+            "{c},{},{},{:.6},{:.6},{:.6}\n",
+            s.sizes[c] as u64, s.int_sum[c], s.mz_extent[c], s.im_extent[c], s.rt_extent[c]
+        ));
+    }
+    download_text("clusters.csv", "text/csv", &csv);
+}
+
+/// Trigger a file download of `content` via a `data:` URL anchor.
+fn download_text(filename: &str, mime: &str, content: &str) {
+    let Some(doc) = document() else {
+        return;
+    };
+    let Ok(a) = doc.create_element("a") else {
+        return;
+    };
+    let encoded = String::from(js_sys::encode_uri_component(content));
+    let _ = a.set_attribute("href", &format!("data:{mime};charset=utf-8,{encoded}"));
+    let _ = a.set_attribute("download", filename);
+    if let Ok(el) = a.dyn_into::<web_sys::HtmlElement>() {
+        el.click();
+    }
+}
+
+/// Set an element's inner HTML by id.
+fn set_html(id: &str, html: &str) {
+    if let Some(el) = by_id::<web_sys::HtmlElement>(id) {
+        el.set_inner_html(html);
     }
 }
 

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -119,6 +119,9 @@ struct Gfx {
     floor_hi: f64,
     /// True while a reload is in flight (debounces overlapping Load/Focus requests).
     reloading: bool,
+    /// Bumped whenever `cpu_points` is replaced (a load). Captured at clustering Run so a deferred
+    /// DBSCAN that resolves after a reload can detect the stale point set and abort.
+    data_gen: u64,
     /// Set when the active filter or draw count changes; the next frame recomputes the displayed
     /// count (CPU-side over `cpu_points`) — camera-independent, so it need not run every frame.
     filter_dirty: bool,
@@ -531,6 +534,7 @@ async fn run() -> Result<(), String> {
         cpu_points,
         floor_hi,
         reloading: false,
+        data_gen: 0,
         filter_dirty: true,
         focus_stack: axis_bounds
             .map(|b| vec![(Region { mz: b[0], im: b[1], rt: b[2], imin: 0.0 }, None)])
@@ -1112,6 +1116,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
         let mut cpu = pts;
         cpu.truncate(cap as usize);
         g.cpu_points = cpu;
+        g.data_gen = g.data_gen.wrapping_add(1); // invalidate any in-flight clustering Run
         g.vol_needs_grid = true; // the volume density grid is rebuilt from the new points
         g.params.color_mode = 0; // the fresh buffer has no cluster ids
         g.clustered = false;
@@ -1443,8 +1448,12 @@ fn invalidate_clusters_mut(g: &mut Gfx) {
 /// Run DBSCAN on the filtered resident points, write cluster ids into the GPU buffer, and colour by
 /// cluster. Synchronous (blocks the main thread) — Focus first if the filtered set is large.
 fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
+    if gfx.borrow().reloading {
+        show_status("loading — try clustering again in a moment");
+        return;
+    }
     // Gather the filtered survivors (spatial crop + intensity floor + MS) and their cube positions.
-    let (idx, positions, eps, min_pts) = {
+    let (idx, positions, eps, min_pts, gen) = {
         let g = gfx.borrow();
         let p = &g.params;
         let (fmin, fmax, ms) = (p.filter_min, p.filter_max, p.ms_mask);
@@ -1469,7 +1478,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
             idx.push(i);
             positions.push(pos);
         }
-        (idx, positions, g.cluster_eps, g.cluster_min_pts)
+        (idx, positions, g.cluster_eps, g.cluster_min_pts, g.data_gen)
     };
     if idx.is_empty() {
         show_status("nothing to cluster — adjust the filter");
@@ -1489,7 +1498,7 @@ fn run_clustering(gfx: &Rc<RefCell<Gfx>>) {
     let gfx = gfx.clone();
     defer(move || {
         let (labels, k) = dbscan(&positions, eps, min_pts);
-        finish_clustering(&gfx, idx, labels, k);
+        finish_clustering(&gfx, idx, labels, k, gen);
     });
 }
 
@@ -1502,12 +1511,16 @@ fn reupload_points(g: &mut Gfx) {
 }
 
 /// Write DBSCAN labels into the GPU buffer + recolor by cluster, compute stats, then update the UI.
-fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, k: usize) {
+fn finish_clustering(gfx: &Rc<RefCell<Gfx>>, idx: Vec<usize>, labels: Vec<i32>, k: usize, gen: u64) {
     let noise = labels.iter().filter(|&&l| l < 0).count();
     let n_in = idx.len();
     {
         let mut gb = gfx.borrow_mut();
         let g: &mut Gfx = &mut gb; // &mut Gfx so renderer/queue/cpu_points field-split
+        if g.data_gen != gen {
+            show_status(""); // the point set changed under us — drop this stale result
+            return;
+        }
         let stats = compute_cluster_stats(&idx, &labels, k, &g.cpu_points, g.axis_bounds);
         for pt in g.cpu_points.iter_mut() {
             pt._pad[0] = GpuPoint::NO_CLUSTER;
@@ -1736,7 +1749,10 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     }
     if let Some(btn) = by_id::<web_sys::HtmlElement>("cl-export") {
         let gfx = gfx.clone();
-        add_listener(btn.as_ref(), "click", move |_e: web_sys::Event| export_clusters(&gfx));
+        add_listener(btn.as_ref(), "click", move |e: web_sys::Event| {
+            e.stop_propagation(); // the button sits in an .ey header — don't toggle collapse
+            export_clusters(&gfx);
+        });
     }
 }
 
@@ -1873,9 +1889,13 @@ fn isolate_cluster(gfx: &Rc<RefCell<Gfx>>, sel: Option<i32>) {
         reupload_points(g);
         g.cluster_sel = sel;
         g.params.color_mode = 1; // isolate is only visible under cluster coloring
+        g.view_mode = ViewMode::Points; // cluster ids are invisible in Volume
     }
     set_checked("cl-color", true);
     set_body_class("cluster-color", true);
+    set_checked("v-pts", true);
+    set_checked("v-vol", false);
+    set_volmode(false);
     update_cluster_panel(gfx); // re-render the list with the active row marked
 }
 
@@ -1895,19 +1915,27 @@ fn export_clusters(gfx: &Rc<RefCell<Gfx>>) {
     download_text("clusters.csv", "text/csv", &csv);
 }
 
-/// Trigger a file download of `content` via a `data:` URL anchor.
+/// Trigger a file download of `content` via a `data:` URL anchor (attached to the DOM for the click
+/// so browsers honor it, then removed).
 fn download_text(filename: &str, mime: &str, content: &str) {
     let Some(doc) = document() else {
         return;
     };
-    let Ok(a) = doc.create_element("a") else {
+    let Ok(el) = doc.create_element("a") else {
+        return;
+    };
+    let Ok(a) = el.dyn_into::<web_sys::HtmlElement>() else {
         return;
     };
     let encoded = String::from(js_sys::encode_uri_component(content));
     let _ = a.set_attribute("href", &format!("data:{mime};charset=utf-8,{encoded}"));
     let _ = a.set_attribute("download", filename);
-    if let Ok(el) = a.dyn_into::<web_sys::HtmlElement>() {
-        el.click();
+    if let Some(body) = doc.body() {
+        let _ = body.append_child(&a);
+        a.click();
+        let _ = body.remove_child(&a);
+    } else {
+        a.click();
     }
 }
 

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -29,6 +29,21 @@ use tims_viewer::render::volume::{VolumeGrid, VolumeRenderer, VOLUME_DIMS};
 /// first. Mirrors the native CLUSTER_CAP.
 const CLUSTER_CAP: usize = 2_000_000;
 
+/// RT slices each DIA window footprint is drawn at (mirrors the native loader's `DIA_WINDOW_RT_SLICES`,
+/// which lives in the native-only loader module).
+const DIA_WINDOW_RT_SLICES: usize = 6;
+
+/// A DIA isolation-window footprint in real units (from `/windows`); re-normalized to the focused
+/// region each load to draw the precursor-selection overlay in the m/z × 1/K0 (scan) plane.
+#[derive(Clone, Copy)]
+struct WinRect {
+    g: u32,
+    mz0: f64,
+    mz1: f64,
+    im0: f64,
+    im1: f64,
+}
+
 /// Points (the splat cloud) vs Volume (raymarched density grid).
 #[derive(Clone, Copy, PartialEq)]
 enum ViewMode {
@@ -102,6 +117,12 @@ struct Gfx {
     renderer: PointCloudRenderer,
     /// Wireframe cube + axis edges drawn around the cloud for spatial orientation.
     axes: AnnotationRenderer,
+    /// DIA isolation-window overlay (separate line buffer from the axes), with the run's footprints
+    /// in real units re-normalized to the focused region.
+    windows: AnnotationRenderer,
+    window_rects: Vec<WinRect>,
+    max_window_group: u32,
+    show_windows: bool,
     /// DOM tick/axis labels (element + its world position in the `[-1,1]` cube), projected each
     /// frame onto the canvas. Empty when real-unit bounds are unknown (demo fallback).
     labels: Vec<(web_sys::HtmlElement, [f32; 3])>,
@@ -317,6 +338,7 @@ impl Gfx {
         let cam = self.camera.to_uniform(w / h, [w, h]);
         self.renderer.update_camera(&self.queue, &cam);
         self.axes.update_camera(&self.queue, &cam);
+        self.windows.update_camera(&self.queue, &cam);
         self.update_labels(w / h);
         let volume_view = self.view_mode == ViewMode::Volume && self.volume.is_some();
         if volume_view {
@@ -384,6 +406,9 @@ impl Gfx {
                 self.renderer.render(&mut rpass, pm);
             }
             self.axes.render(&mut rpass);
+            if self.show_windows {
+                self.windows.render(&mut rpass);
+            }
         }
         self.queue.submit(std::iter::once(enc.finish()));
         surface_tex.present();
@@ -523,6 +548,9 @@ async fn run() -> Result<(), String> {
     let mut axes = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
     axes.upload(&device, &cube_box_verts());
     axes.update_filter(&queue, [-2.0, -2.0, -2.0, 0.0], [2.0, 2.0, 2.0, 0.0], 0.0);
+    // DIA window overlay: culled to the cube so off-region windows clip (filled on the /windows fetch).
+    let windows = AnnotationRenderer::new(&device, format, DEPTH_FORMAT);
+    windows.update_filter(&queue, [-1.0, -1.0, -1.0, 0.0], [1.0, 1.0, 1.0, 0.0], 0.0);
     let labels = create_axis_labels(axis_bounds);
 
     let canvas_for_input = canvas.clone();
@@ -539,6 +567,10 @@ async fn run() -> Result<(), String> {
         depth_view,
         renderer,
         axes,
+        windows,
+        window_rects: Vec::new(),
+        max_window_group: 0,
+        show_windows: false,
         labels,
         camera: OrbitCamera::default(),
         params,
@@ -617,8 +649,27 @@ async fn run() -> Result<(), String> {
     bind_volume(&gfx);
     // Clustering (DBSCAN on the focused set).
     bind_cluster(&gfx);
+    // DIA isolation-window overlay.
+    bind_windows(&gfx);
     // Collapsible section headers + tab switching.
     bind_panel_chrome(&gfx);
+
+    // Fetch the run-level DIA windows once; build the overlay + enable the toggle when they arrive.
+    if !url.is_empty() {
+        let gfx = gfx.clone();
+        let wurl = windows_url(&url);
+        wasm_bindgen_futures::spawn_local(async move {
+            if let Ok((rects, max_group)) = fetch_windows(&wurl).await {
+                {
+                    let mut g = gfx.borrow_mut();
+                    g.window_rects = rects;
+                    g.max_window_group = max_group;
+                }
+                rebuild_window_overlay(&gfx);
+                set_disabled("show-windows", gfx.borrow().max_window_group == 0);
+            }
+        });
+    }
 
     // Track CSS/DPR changes (window resize fires on zoom + monitor moves too).
     {
@@ -847,6 +898,88 @@ fn meta_url(points: &str) -> String {
         Some(q) => format!("{meta_path}?{q}"),
         None => meta_path,
     }
+}
+
+/// The run-level `/windows` URL (strip the `/points` query — windows are region-independent).
+fn windows_url(points: &str) -> String {
+    let path = points.split('?').next().unwrap_or(points);
+    path.strip_suffix("/points")
+        .map(|base| format!("{base}/windows"))
+        .unwrap_or_else(|| path.to_string())
+}
+
+/// Fetch the run's DIA isolation-window footprints (real units) + the max group id.
+async fn fetch_windows(url: &str) -> Result<(Vec<WinRect>, u32), String> {
+    let window = web_sys::window().ok_or("no window")?;
+    let resp_val = wasm_bindgen_futures::JsFuture::from(window.fetch_with_str(url))
+        .await
+        .map_err(|e| format!("fetch failed: {e:?}"))?;
+    let resp: web_sys::Response = resp_val.dyn_into().map_err(|_| "not a Response".to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+    let text = wasm_bindgen_futures::JsFuture::from(resp.text().map_err(|e| format!("text: {e:?}"))?)
+        .await
+        .map_err(|e| format!("body read failed: {e:?}"))?
+        .as_string()
+        .ok_or("windows body is not text")?;
+    let v = js_sys::JSON::parse(&text).map_err(|_| "windows is not valid JSON".to_string())?;
+    let max_group = jnum(&v, "max_window_group").unwrap_or(0.0).max(0.0) as u32;
+    let arr = js_sys::Array::from(&jget(&v, "windows"));
+    let mut rects = Vec::with_capacity(arr.length() as usize);
+    for i in 0..arr.length() {
+        let row = js_sys::Array::from(&arr.get(i));
+        if row.length() < 5 {
+            continue;
+        }
+        let f = |k: u32| row.get(k).as_f64().unwrap_or(0.0);
+        rects.push(WinRect { g: f(0) as u32, mz0: f(1), mz1: f(2), im0: f(3), im1: f(4) });
+    }
+    Ok((rects, max_group))
+}
+
+/// Build the window-overlay line vertices: each footprint as an `(m/z × 1/K0)` rectangle at
+/// `DIA_WINDOW_RT_SLICES` RT slices, normalized to the focused region's `bounds` and colored by group.
+fn build_window_verts(rects: &[WinRect], bounds: [(f64, f64); 3], max_group: u32) -> Vec<LineVertex> {
+    let norm = |val: f64, axis: usize| -> f32 {
+        let (lo, hi) = bounds[axis];
+        (((val - lo) / (hi - lo).max(1e-12)) * 2.0 - 1.0) as f32
+    };
+    let mut v: Vec<LineVertex> = Vec::new();
+    let denom = max_group.max(1);
+    for r in rects {
+        let color = tims_viewer::render::colormap::group_color(r.g, denom);
+        let (mz0, mz1) = (norm(r.mz0, 0), norm(r.mz1, 0));
+        let (im0, im1) = (norm(r.im0, 1), norm(r.im1, 1));
+        for i in 0..DIA_WINDOW_RT_SLICES {
+            let rt_real =
+                bounds[2].0 + (bounds[2].1 - bounds[2].0) * (i as f64 + 0.5) / DIA_WINDOW_RT_SLICES as f64;
+            let rt = norm(rt_real, 2);
+            let corners = [[mz0, im0, rt], [mz1, im0, rt], [mz1, im1, rt], [mz0, im1, rt]];
+            for e in 0..4 {
+                v.push(LineVertex::new(corners[e], color));
+                v.push(LineVertex::new(corners[(e + 1) % 4], color));
+            }
+        }
+    }
+    v
+}
+
+/// Re-normalize the run's window footprints to the current region and upload the overlay. A no-op-ish
+/// empty upload when there are no windows or no real-unit bounds.
+fn rebuild_window_overlay(gfx: &Rc<RefCell<Gfx>>) {
+    let verts = {
+        let g = gfx.borrow();
+        match g.axis_bounds {
+            Some(b) if !g.window_rects.is_empty() => {
+                build_window_verts(&g.window_rects, b, g.max_window_group)
+            }
+            _ => Vec::new(),
+        }
+    };
+    let mut g = gfx.borrow_mut();
+    let g = &mut *g;
+    g.windows.upload(&g.device, &verts);
 }
 
 fn jget(obj: &JsValue, key: &str) -> JsValue {
@@ -1190,6 +1323,7 @@ fn apply_load(gfx: &Rc<RefCell<Gfx>>, meta: Option<MetaInfo>, pts: Vec<GpuPoint>
     set_checked("cl-color", false);
     set_body_class("has-clusters", false);
     set_body_class("cluster-color", false);
+    rebuild_window_overlay(gfx); // re-normalize the DIA windows to the new region
 }
 
 /// Build the region + budget query string for `/points` and `/meta`.
@@ -1927,6 +2061,11 @@ fn bind_cluster(gfx: &Rc<RefCell<Gfx>>) {
     }
 }
 
+/// Wire the "Show DIA windows" toggle (enabled only once `/windows` returns groups).
+fn bind_windows(gfx: &Rc<RefCell<Gfx>>) {
+    on_toggle("show-windows", gfx, |g, on| g.show_windows = on);
+}
+
 /// Wire the Focus / Back buttons; control enable/disable is driven by `refresh_controls`.
 fn bind_focus(gfx: &Rc<RefCell<Gfx>>) {
     if let Some(btn) = by_id::<web_sys::HtmlElement>("focus-go") {
@@ -2567,6 +2706,8 @@ fn sync_controls(gfx: &Rc<RefCell<Gfx>>) {
     set_value_pair("cl-eps", "cl-eps-n", cl_eps, 3);
     set_value_pair("cl-min", "cl-min-n", cl_min, 0);
     set_checked("cl-color", false);
+    set_checked("show-windows", false); // off until /windows loads (then enabled if groups exist)
+    set_disabled("show-windows", true);
     // Crops start at the full range (thumbs, fills, readouts).
     reset_crops(gfx);
 }

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -4150,6 +4150,7 @@ fn wire_controls(gfx: &Rc<RefCell<Gfx>>) {
     bind_value(gfx, "floor", "floor-n", 0, |g, v| {
         g.params.filter_min[3] = v as f32;
         g.filter_dirty = true;
+        g.vol_needs_grid = true; // the volume bakes the floor at deposit time — re-voxel so it updates live
         invalidate_clusters_mut(g);
     });
 


### PR DESCRIPTION
Browser (WASM → WebGPU, WebGL2 fallback) point-cloud viewer for raw timsTOF data, plus its point server, an optional clustering sidecar, and a MIDIA Voila dashboard. 143 commits; ~13k insertions.

## What's in it
- **Point server** (`tims-viewer --serve`): streams a downsampled (systematic + brightest-peak-per-cell, budget-capped, reservoir-shuffled) `GpuPoint` payload; per-`(region,budget)` caching; optional zstd compression; `/meta` + `/windows` + `/datasets`.
- **Web viewer** (`web/`): orbit/zoom point cloud, **focus-lens** region reload, **volume** raymarch, intensity/crop filters, box-select minimaps, **DIA isolation-window overlay**, and in-browser **DBSCAN** (wasm worker) with an optional Python **sklearn** sidecar.
- **Live acquisition** playback (`acquisition_service.py`) — **experimental**, streams a *simulated* acquisition; flagged as such in-UI and off by default.
- **MIDIA Voila dashboard** (`imspy-vis`): RT-slice TIC selector, precursor/fragment point clouds, HDBSCAN tuning, intensity surface.
- **Optional PROD telemetry + feedback** (`--telemetry-dir`): self-hosted error/feedback JSONL, off in dev.

## Quality
- **Full code review** (multi-agent): 1 merge-blocker (worker-DBSCAN `RefCell` double-borrow) + server/native/Python robustness fixes — all landed.
- **Perf pass** (5-agent deep-dive → tiered plan → **codex second-opinion** → implement): Tier-1 (fewer buffer copies, countdown gate, quickselects, dense MIDIA lookups) + zstd-body cache + idle-render throttle. Codex re-reviewed the perf diff: behavior-preserving, one memory-regression nit fixed.
- Native tests green (27), web + native + Python compile.

## Known / deferred (tracked in `tims-viewer/PERF_PLAN.md` + memory)
- WebGPU `requestDevice` is rejected on current Chrome (`maxInterStageShaderComponents`) → **runs on WebGL2**; the fix is a deferred wgpu 23+/egui upgrade.
- HDBSCAN removed from the web clustering dropdown (blacked the canvas via a compositor-layer drop; both DBSCAN paths work).
- Behavior-changing perf items (raymarch 256→128, f32 clustering) and Tier-2/3 optims left as post-merge follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
