### PR TITLE
rustdf: SDK-free Bruker axis calibration (TOF↔m/z, scan↔1/K0)

### DIFF
--- a/rustdf/BRUKER_TRANSLATORS.md
+++ b/rustdf/BRUKER_TRANSLATORS.md
@@ -58,18 +58,29 @@ where `T1_frame`, `T2_frame` are the per-frame `Frames.T1`, `Frames.T2`.
 | `C2` | `C2` | quadratic `s²` term of the curve — **used by both ModelTypes** |
 | `C3` | `C3` | cubic `s³` term — **ModelType 1 only** (in ModelType 2 this column duplicates C0 and is dropped) |
 | `C4` | `C4` | "reduced mass" shift `m0` (`x = m − m0`); the element claimed by Bruker patent US 7,851,746 |
-| `C5` | — | ModelType-2 fine correction: a **universal constant** `225.951491` (identical across every dataset inspected) |
-| `C6` | — | ModelType-2 fine correction: per-dataset normalization span |
-| `C7` | — | ModelType-2 fine correction: order flag (= 7) |
-| `C8 … C14` | — | ModelType-2 fine correction coefficients — **not modelled** (see note below) |
+| `C5` | window low  | ModelType-2 fine correction: **lower m/z bound** of the correction window. A **universal constant** `225.951491` across every dataset seen. |
+| `C6` | window high | ModelType-2 fine correction: **upper m/z bound** of the correction window (per-dataset, e.g. 1383.7 / 1519.7). |
+| `C7` | degree | ModelType-2 fine correction: polynomial **degree = 7** (matches the fit below). |
+| `C8 … C14` | coeffs | ModelType-2 fine correction coefficients — **decode unresolved** (see note). |
 
-**Status of the ModelType-2 C8…C14 correction.** After the `C0/C1/C2` quadratic,
-a residual of ~2.5–3.6 ppm (worst at low m/z, and exactly zero at both ends of
-the acquisition m/z range) remains. It is *not* reproducible as an additive
-degree-6 polynomial in `m/z` or `√(m/z)` (a best-fit degree-6 polynomial barely
-dents it), so the role of `C8…C14` is unresolved here — most likely an internal
-SDK spline/interpolation. The base curve is therefore accurate to a few ppm but
-not bit-exact for ModelType 2.
+**Status of the ModelType-2 C8…C14 correction (partially reverse-engineered).**
+After the `C0/C1/C2` quadratic, a smooth residual of ~2.5–3.6 ppm remains.
+Established by fitting against the SDK across several datasets:
+
+- The correction is **windowed to `[C5, C6]` in m/z** — outside that interval the
+  quadratic base is the whole model.
+- Inside the window it is a **smooth degree-7 polynomial** (a degree-7 fit in the
+  normalized window coordinate reproduces the SDK to ~5e-8 m/z — effectively
+  bit-exact). This matches `C7 = 7`.
+- However, the stored `C8…C14` do **not** map onto that polynomial in any tested
+  basis (monomial or Chebyshev) / argument (`m/z`, `√m`, normalized window, time,
+  tof) / target domain (m/z, √m, flight time, ppm) — every combination leaves
+  ~99% residual. The exact encoding of `C8…C14` is still unknown.
+
+Cross-check: **no open-source reader reimplements this** — alphaRaw, alphaDIA,
+opentims, and the SDK-lookup tooling all obtain ModelType-2 m/z from Bruker's
+`libtimsdata` directly. A fully SDK-free, bit-exact ModelType-2 m/z is therefore
+not currently available; the `C0/C1/C2` base here reaches a few ppm.
 
 ---
 

--- a/rustdf/BRUKER_TRANSLATORS.md
+++ b/rustdf/BRUKER_TRANSLATORS.md
@@ -1,0 +1,135 @@
+# Bruker timsTOF axis translators (SDK-free)
+
+Reference for the two axis calibrations that turn raw timsTOF indices into
+physical units **without** the proprietary `libtimsdata` SDK:
+
+- **TOF index → m/z**  (mass axis)
+- **scan number → 1/K0** (inverse reduced ion-mobility axis)
+
+Both are pure-Rust ports living in [`src/data/calibration.rs`](src/data/calibration.rs)
+(`MzCalibrator`, `MobilityCalibrator`), wired into the reader as the
+`BrukerFormulaConverter` variant of `TimsIndexConverter`. The algorithms mirror
+PAPPSO's GPLv3 `libpappsomspp` (`mzcalibrationmodel1.cpp`, `timsframebase.cpp`)
+and are cross-checked against Bruker's published `tims_calibration.py`.
+
+Coefficients come from two SQLite tables in `analysis.tdf`, joined per frame via
+`Frames.MzCalibration` and `Frames.TimsCalibration`.
+
+---
+
+## 1. TOF index → m/z
+
+### Formula
+
+```
+t        = tof_index * DigitizerTimebase + DigitizerDelay      # flight time (digitizer units)
+s        = sqrt(m + C4)                                        # s = sqrt(reduced mass)
+t        = C0 + b*s + C2*s^2 + C3*s^3,   b = sqrt(1e12 / (C1 * tc))
+m/z      = s^2 - C4        (invert the curve for s, given t)
+```
+
+- Forward (`m/z → tof`) is closed form.
+- Inverse (`tof → m/z`) inverts for `s`: closed form for the pure base, otherwise
+  a Newton refinement.
+- **Both ModelTypes use the same quadratic-in-√m curve** `t = C0 + b·s + C2·s²`.
+  This was verified empirically: fitting `t` vs `s` recovers `a0→C0`,
+  `a1→√(1e12/C1)`, `a2→C2`. The cubic `C3·s³` term is real only for ModelType 1
+  (in ModelType 2 the `C3` column duplicates `C0` and is dropped).
+
+**Temperature compensation** (applied to `C1`, and to `c2` for ModelType 1):
+
+```
+tc = 1 + ( dC1*(T1 - T1_frame) + dC2*(T2 - T2_frame) ) / 1e6
+```
+
+where `T1_frame`, `T2_frame` are the per-frame `Frames.T1`, `Frames.T2`.
+
+### `MzCalibration` table parameters
+
+| Column | Symbol | Meaning |
+|---|---|---|
+| `ModelType` | — | 1 = classic cubic-in-√m curve (fully modelled here); 2 = modern base curve **+** proprietary correction polynomial (only the base is modelled) |
+| `DigitizerTimebase` | `timebase` | ns per digitizer sample; scales the TOF index into flight time |
+| `DigitizerDelay` | `delay` | fixed time offset (samples) added before t₀ |
+| `T1`, `T2` | `T1_ref`, `T2_ref` | reference temperatures for compensation |
+| `dC1`, `dC2` | `dC1`, `dC2` | temperature sensitivities (ppm/°C) → `tc` |
+| `C0` | `C0` | constant term of the time↔mass curve (≈ the t-intercept) |
+| `C1` | `C1` | governs the dominant √ term: `b = sqrt(1e12 / C1)` |
+| `C2` | `C2` | quadratic `s²` term of the curve — **used by both ModelTypes** |
+| `C3` | `C3` | cubic `s³` term — **ModelType 1 only** (in ModelType 2 this column duplicates C0 and is dropped) |
+| `C4` | `C4` | "reduced mass" shift `m0` (`x = m − m0`); the element claimed by Bruker patent US 7,851,746 |
+| `C5` | — | ModelType-2 fine correction: a **universal constant** `225.951491` (identical across every dataset inspected) |
+| `C6` | — | ModelType-2 fine correction: per-dataset normalization span |
+| `C7` | — | ModelType-2 fine correction: order flag (= 7) |
+| `C8 … C14` | — | ModelType-2 fine correction coefficients — **not modelled** (see note below) |
+
+**Status of the ModelType-2 C8…C14 correction.** After the `C0/C1/C2` quadratic,
+a residual of ~2.5–3.6 ppm (worst at low m/z, and exactly zero at both ends of
+the acquisition m/z range) remains. It is *not* reproducible as an additive
+degree-6 polynomial in `m/z` or `√(m/z)` (a best-fit degree-6 polynomial barely
+dents it), so the role of `C8…C14` is unresolved here — most likely an internal
+SDK spline/interpolation. The base curve is therefore accurate to a few ppm but
+not bit-exact for ModelType 2.
+
+---
+
+## 2. scan number → 1/K0
+
+### Formula (two steps, both exact)
+
+```
+V     = dv_start + slope * (scan - ttrans - ndelay),   slope = (dv_end - dv_start) / ncycles
+1/K0  = 1 / ( C0m + C1m / V )
+```
+
+`V` (trapping voltage) must lie in `[vmin, vmax]`. The inverse (`1/K0 → scan`)
+solves both steps algebraically and rounds to the nearest scan.
+
+### `TimsCalibration` table parameters (ModelType 2 — the only TIMS model)
+
+| Column | Symbol | Meaning |
+|---|---|---|
+| `ModelType` | — | always 2 (PAPPSO/this port require it) |
+| `C0` | `ndelay` | scan offset (delay), subtracted before scaling |
+| `C1` | `ncycles` | number of TIMS cycles; sets the voltage-vs-scan `slope` |
+| `C2` | `dv_start` | trapping voltage at the **start** of the ramp |
+| `C3` | `dv_end` | trapping voltage at the **end** of the ramp |
+| `C4` | `ttrans` | transit time in cycles, subtracted before scaling |
+| `C5` | — | unused by the mobility formula (polynomial-grade flag, = 1) |
+| `C6` | `C0m` | additive constant of the mobility reciprocal |
+| `C7` | `C1m` | voltage-scaled term of the mobility reciprocal |
+| `C8` | `vmin` | lower voltage validity bound |
+| `C9` | `vmax` | upper voltage validity bound |
+
+---
+
+## Accuracy vs the Bruker SDK
+
+Measured by `examples/compare_calibration.rs` (residual of this formula vs
+`tims_index_to_mz` / `tims_scannum_to_oneoverk0`), full axis grid, per dataset:
+
+| Dataset | m/z ModelType | TOF → m/z residual | scan → 1/K0 residual |
+|---|---|---|---|
+| `synchro-hela.d` | **1** | **0.0000 ppm (bit-exact)** | ~4e-16 (machine ε) |
+| `G8602.d` | **2** | mean 2.5 ppm / max 11.1 ppm | ~7e-16 (machine ε) |
+| `G8027.d` | **2** | mean 3.6 ppm / max 20.8 ppm | ~4e-16 (machine ε) |
+
+(ModelType-2 m/z figures are with the `C0/C1/C2` quadratic; the older base-only
+curve without `C2` was ~9 ppm mean.)
+
+**Takeaways**
+
+- **scan → 1/K0 is exactly the SDK computation** on every dataset (agreement at
+  the floating-point rounding limit). The mobility formula *is* what we were
+  looking for.
+- **TOF → m/z is exact for ModelType-1** data (bit-for-bit). For **ModelType-2**
+  data (modern instruments) the `C0/C1/C2` quadratic reproduces the SDK to a few
+  ppm; the last few ppm come from the `C8…C14` correction whose exact form is not
+  resolved (see the ModelType-2 note above).
+
+## Reproduce
+
+```bash
+cargo run --release --example compare_calibration -- \
+    <path-to-libtimsdata.so> <path-to-.d-folder> [frame_id]
+```

--- a/rustdf/examples/compare_all_converters.rs
+++ b/rustdf/examples/compare_all_converters.rs
@@ -1,0 +1,136 @@
+// Head-to-head accuracy of every rustdf index-converter mode vs the Bruker SDK.
+//
+// Modes compared (see src/data/handle.rs):
+//   Simple      - 2-point boundary model (mz: sqrt-linear from mz bounds;
+//                 1/K0: linear from 1/K0 bounds). No SDK.
+//   Calibrated  - mz: least-squares sqrt(mz)=a+b*tof fit (needs SDK to derive);
+//                 1/K0: same linear boundary model.
+//   Lookup      - mz: same SDK-derived fit; 1/K0: SDK-probed per-scan table
+//                 (exact at integer scans, but built with the SDK).
+//   BrukerLib   - the SDK itself (ground truth, residual 0 by definition).
+//   BrukerFormula (new) - exact published curves from the calibration tables.
+//                 No SDK at build or runtime.
+//
+// Usage:
+//   cargo run --release --example compare_all_converters -- <libtimsdata.so> <data.d> [frame_id]
+
+use rustdf::data::calibration::{MobilityCalibrator, MzCalibrator};
+use rustdf::data::meta::{read_global_meta_sql, read_mz_calibration, read_tims_calibration};
+use rustdf::data::raw::BrukerTimsDataLibrary;
+use rusqlite::Connection;
+use std::env;
+use std::path::Path;
+
+fn pctl(mut v: Vec<f64>, p: f64) -> f64 {
+    if v.is_empty() {
+        return 0.0;
+    }
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[((p / 100.0) * (v.len() - 1) as f64).round() as usize]
+}
+fn stats(v: &[f64]) -> (f64, f64, f64) {
+    (pctl(v.to_vec(), 50.0), pctl(v.to_vec(), 90.0), pctl(v.to_vec(), 100.0))
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: compare_all_converters <libtimsdata.so> <data.d> [frame_id]");
+        std::process::exit(2);
+    }
+    let lib = &args[1];
+    let d = &args[2];
+    let frame: u32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1);
+
+    let g = read_global_meta_sql(d)?;
+    let con = Connection::open(Path::new(d).join("analysis.tdf"))?;
+    let (t1, t2, num_scans, mz_id, tims_id): (f64, f64, i64, i64, i64) = con.query_row(
+        "SELECT T1,T2,NumScans,MzCalibration,TimsCalibration FROM Frames WHERE Id=?1",
+        [frame],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+    )?;
+    let mzc = read_mz_calibration(d)?.into_iter().find(|c| c.id == mz_id).unwrap();
+    let tc = read_tims_calibration(d)?.into_iter().find(|c| c.id == tims_id).unwrap();
+    let tof_max = g.tof_max_index;
+
+    let sdk = BrukerTimsDataLibrary::new(lib, d)?;
+
+    // ---- ground truth ----
+    let tof_grid: Vec<u32> = (1..tof_max).step_by(23).collect();
+    let tof_f: Vec<f64> = tof_grid.iter().map(|&x| x as f64).collect();
+    let mut sdk_mz = vec![0.0; tof_grid.len()];
+    sdk.tims_index_to_mz(frame, &tof_f, &mut sdk_mz)?;
+
+    let scan_grid: Vec<u32> = (0..num_scans as u32).collect();
+    let scan_f: Vec<f64> = scan_grid.iter().map(|&x| x as f64).collect();
+    let mut sdk_im = vec![0.0; scan_grid.len()];
+    sdk.tims_scan_to_inv_mob(frame, &scan_f, &mut sdk_im)?;
+
+    // =================== m/z methods ===================
+    // boundary sqrt-linear (Simple / Lookup fallback)
+    let b_int = g.mz_acquisition_range_lower.sqrt();
+    let b_slope = (g.mz_acquisition_range_upper.sqrt() - b_int) / tof_max as f64;
+    // SDK-regression sqrt-linear (Calibrated / Lookup preferred): least squares on SDK samples
+    let (mut sx, mut sy, mut sxy, mut sxx, mut nn) = (0.0, 0.0, 0.0, 0.0, 0.0);
+    for (i, &tof) in tof_grid.iter().enumerate() {
+        if sdk_mz[i] > 0.0 {
+            let (x, y) = (tof as f64, sdk_mz[i].sqrt());
+            sx += x; sy += y; sxy += x * y; sxx += x * x; nn += 1.0;
+        }
+    }
+    let r_slope = (sxy - sx * sy / nn) / (sxx - sx * sx / nn);
+    let r_int = sy / nn - r_slope * sx / nn;
+    // exact formula (BrukerFormula)
+    let mzconv = MzCalibrator::new(
+        mzc.model_type, mzc.digitizer_timebase, mzc.digitizer_delay, mzc.t1, mzc.t2, mzc.dc1,
+        mzc.dc2, mzc.c0, mzc.c1, mzc.c2, mzc.c3, mzc.c4, t1, t2,
+    );
+
+    let mut e_bound = vec![]; let mut e_reg = vec![]; let mut e_form = vec![];
+    for (i, &tof) in tof_grid.iter().enumerate() {
+        if sdk_mz[i] <= 0.0 { continue; }
+        let m = sdk_mz[i];
+        let bnd = (b_int + b_slope * tof as f64).powi(2);
+        let reg = (r_int + r_slope * tof as f64).powi(2);
+        let frm = mzconv.tof_to_mz(tof);
+        e_bound.push(((bnd - m) / m * 1e6).abs());
+        e_reg.push(((reg - m) / m * 1e6).abs());
+        e_form.push(((frm - m) / m * 1e6).abs());
+    }
+
+    // =================== 1/K0 methods ===================
+    // linear boundary (Simple / Calibrated): scan 0 -> im_max, scan_max -> im_min.
+    // Use the frame's ACTUAL mobility endpoints (fairest: the linear model then
+    // matches the SDK exactly at both ends, isolating pure nonlinearity error).
+    let _ = (g.one_over_k0_range_upper, g.one_over_k0_range_lower);
+    let im_hi = sdk_im[0];
+    let im_lo = sdk_im[sdk_im.len() - 1];
+    let scan_max = (num_scans - 1) as f64;
+    let imconv = MobilityCalibrator::new(tc.c0, tc.c1, tc.c2, tc.c3, tc.c4, tc.c5, tc.c6, tc.c7, tc.c8, tc.c9);
+
+    let mut e_lin = vec![]; let mut e_imform = vec![];
+    for (i, &scan) in scan_grid.iter().enumerate() {
+        let lin = im_hi + (im_lo - im_hi) / scan_max * scan as f64;
+        let frm = imconv.scan_to_one_over_k0(scan);
+        e_lin.push(((lin - sdk_im[i]) / sdk_im[i] * 1e6).abs());
+        e_imform.push(((frm - sdk_im[i]) / sdk_im[i] * 1e6).abs());
+    }
+    // Lookup 1/K0 = SDK-probed table => exact at integer scans (residual 0 by construction)
+
+    println!("dataset {}  frame {}  m/z ModelType {}  1/K0 ModelType {}\n", d, frame, mzc.model_type, tc.model_type);
+    println!("m/z axis (error vs SDK, ppm)          median      p90      max   SDK-free?");
+    let row = |name: &str, e: &[f64], free: &str| {
+        let (m, p, mx) = stats(e);
+        println!("  {:<34} {:8.3} {:8.3} {:8.3}   {}", name, m, p, mx, free);
+    };
+    row("Simple (boundary)", &e_bound, "yes");
+    row("Calibrated / Lookup (SDK regr.)", &e_reg, "no (SDK to fit)");
+    row("BrukerFormula (tables)", &e_form, "yes");
+    println!();
+    println!("1/K0 axis (error vs SDK, ppm)         median      p90      max   SDK-free?");
+    row("Simple / Calibrated (linear)", &e_lin, "yes");
+    println!("  {:<34} {:8.3} {:8.3} {:8.3}   {}", "Lookup (SDK-probed table)", 0.0, 0.0, 0.0, "no (SDK to build)");
+    row("BrukerFormula (tables)", &e_imform, "yes");
+
+    Ok(())
+}

--- a/rustdf/examples/compare_calibration.rs
+++ b/rustdf/examples/compare_calibration.rs
@@ -1,0 +1,189 @@
+// Compare SDK-free Bruker axis calibration against the proprietary SDK.
+//
+// Builds the pure-Rust `MzCalibrator` / `MobilityCalibrator` (see
+// src/data/calibration.rs) from the analysis.tdf calibration tables, then
+// evaluates TOF-index -> m/z and scan -> 1/K0 on a grid and reports the
+// residuals versus the Bruker SDK (`tims_index_to_mz`, `tims_scannum_to_oneoverk0`).
+//
+// Usage:
+//   cargo run --release --example compare_calibration -- \
+//       <path-to-libtimsdata.so> <path-to-.d-folder> [frame_id]
+//
+// A single frame is enough: the calibration coefficients are per-frame but
+// almost always identical across a run.
+
+use rustdf::data::calibration::{MobilityCalibrator, MzCalibrator};
+use rustdf::data::meta::{read_mz_calibration, read_tims_calibration};
+use rustdf::data::raw::BrukerTimsDataLibrary;
+use rusqlite::Connection;
+use std::env;
+use std::path::Path;
+
+/// (min, mean, max) of |v| over a slice, ignoring non-finite entries.
+fn abs_stats(errs: &[f64]) -> (f64, f64, f64) {
+    let mut min = f64::INFINITY;
+    let mut max = 0.0f64;
+    let mut sum = 0.0f64;
+    let mut n = 0.0f64;
+    for &e in errs {
+        if !e.is_finite() {
+            continue;
+        }
+        let a = e.abs();
+        min = min.min(a);
+        max = max.max(a);
+        sum += a;
+        n += 1.0;
+    }
+    if n == 0.0 {
+        (0.0, 0.0, 0.0)
+    } else {
+        (min, sum / n, max)
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!("usage: compare_calibration <libtimsdata.so> <data.d> [frame_id]");
+        std::process::exit(2);
+    }
+    let lib_path = &args[1];
+    let d_path = &args[2];
+    let frame_id: u32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(1);
+
+    // --- read calibration + per-frame context from analysis.tdf ---------------
+    let tdf = Path::new(d_path).join("analysis.tdf");
+    let con = Connection::open(&tdf)?;
+
+    let (frame_t1, frame_t2, num_scans, mz_cal_id, tims_cal_id): (f64, f64, i64, i64, i64) = con
+        .query_row(
+            "SELECT T1, T2, NumScans, MzCalibration, TimsCalibration FROM Frames WHERE Id = ?1",
+            [frame_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )?;
+    let tof_max: u32 = con.query_row(
+        "SELECT Value FROM GlobalMetadata WHERE Key = 'DigitizerNumSamples'",
+        [],
+        |r| {
+            let v: String = r.get(0)?;
+            Ok(v.parse::<u32>().unwrap_or(400_000))
+        },
+    )?;
+
+    let mz_cal = read_mz_calibration(d_path)?
+        .into_iter()
+        .find(|c| c.id == mz_cal_id)
+        .expect("MzCalibration row not found");
+    let tims_cal = read_tims_calibration(d_path)?
+        .into_iter()
+        .find(|c| c.id == tims_cal_id)
+        .expect("TimsCalibration row not found");
+
+    println!("dataset            : {}", d_path);
+    println!("frame_id           : {}", frame_id);
+    println!(
+        "m/z  ModelType     : {}   (PAPPSO implements only ModelType 1)",
+        mz_cal.model_type
+    );
+    println!("1/K0 ModelType     : {}", tims_cal.model_type);
+    println!("num_scans          : {}", num_scans);
+    println!("tof_max (samples)  : {}", tof_max);
+    println!();
+
+    let mz_conv = MzCalibrator::new(
+        mz_cal.model_type,
+        mz_cal.digitizer_timebase,
+        mz_cal.digitizer_delay,
+        mz_cal.t1,
+        mz_cal.t2,
+        mz_cal.dc1,
+        mz_cal.dc2,
+        mz_cal.c0,
+        mz_cal.c1,
+        mz_cal.c2,
+        mz_cal.c3,
+        mz_cal.c4,
+        frame_t1,
+        frame_t2,
+    );
+    let im_conv = MobilityCalibrator::new(
+        tims_cal.c0, tims_cal.c1, tims_cal.c2, tims_cal.c3, tims_cal.c4, tims_cal.c5, tims_cal.c6,
+        tims_cal.c7, tims_cal.c8, tims_cal.c9,
+    );
+
+    // --- SDK ground truth ------------------------------------------------------
+    let sdk = BrukerTimsDataLibrary::new(lib_path, d_path)?;
+
+    // ===== TOF index -> m/z =====
+    let tof_grid: Vec<f64> = (1..tof_max).step_by(97).map(|x| x as f64).collect();
+    let mut sdk_mz = vec![0.0f64; tof_grid.len()];
+    sdk.tims_index_to_mz(frame_id, &tof_grid, &mut sdk_mz)?;
+
+    let mut d_mz_mda = Vec::with_capacity(tof_grid.len());
+    let mut d_mz_ppm = Vec::with_capacity(tof_grid.len());
+    for (i, &tof) in tof_grid.iter().enumerate() {
+        if sdk_mz[i] <= 0.0 {
+            continue;
+        }
+        let mine = mz_conv.tof_to_mz(tof as u32);
+        d_mz_mda.push((mine - sdk_mz[i]) * 1000.0);
+        d_mz_ppm.push((mine - sdk_mz[i]) / sdk_mz[i] * 1.0e6);
+    }
+    let (mn, me, mx) = abs_stats(&d_mz_mda);
+    let (pn, pe, px) = abs_stats(&d_mz_ppm);
+    println!("TOF index -> m/z   ({} grid points, {:.1}..{:.1} m/z)", d_mz_mda.len(), sdk_mz.iter().cloned().filter(|x| *x>0.0).fold(f64::INFINITY,f64::min), sdk_mz.iter().cloned().fold(0.0,f64::max));
+    println!("  |Δ| m/z  [mDa]   min {:.4}  mean {:.4}  max {:.4}", mn, me, mx);
+    println!("  |Δ| m/z  [ppm]   min {:.4}  mean {:.4}  max {:.4}", pn, pe, px);
+
+    // round trip m/z -> tof -> m/z (formula only)
+    let mut rt = Vec::new();
+    for &tof in tof_grid.iter() {
+        let mz = mz_conv.tof_to_mz(tof as u32);
+        if mz <= 0.0 { continue; }
+        let back = mz_conv.mz_to_tof(mz) as f64;
+        rt.push(back - tof);
+    }
+    let (_, rtmean, rtmax) = abs_stats(&rt);
+    println!("  round-trip tof   mean {:.3}  max {:.3}  (index units)", rtmean, rtmax);
+    println!();
+
+    // ===== scan -> 1/K0 =====
+    let scan_grid: Vec<f64> = (0..num_scans as u32).map(|x| x as f64).collect();
+    let mut sdk_im = vec![0.0f64; scan_grid.len()];
+    sdk.tims_scan_to_inv_mob(frame_id, &scan_grid, &mut sdk_im)?;
+
+    let mut d_im = Vec::with_capacity(scan_grid.len());
+    let mut d_im_rel = Vec::with_capacity(scan_grid.len());
+    for (i, &scan) in scan_grid.iter().enumerate() {
+        let mine = im_conv.scan_to_one_over_k0(scan as u32);
+        d_im.push(mine - sdk_im[i]);
+        if sdk_im[i] != 0.0 {
+            d_im_rel.push((mine - sdk_im[i]) / sdk_im[i] * 1.0e6);
+        }
+    }
+    let (in_, ie, ix) = abs_stats(&d_im);
+    let (rn, re, rx) = abs_stats(&d_im_rel);
+    println!(
+        "scan -> 1/K0       ({} scans, {:.4}..{:.4} 1/K0)",
+        scan_grid.len(),
+        sdk_im.iter().cloned().fold(f64::INFINITY, f64::min),
+        sdk_im.iter().cloned().fold(0.0, f64::max)
+    );
+    println!("  |Δ| 1/K0        min {:.3e}  mean {:.3e}  max {:.3e}", in_, ie, ix);
+    println!("  |Δ| 1/K0  [ppm] min {:.4}  mean {:.4}  max {:.4}", rn, re, rx);
+
+    // round trip scan -> 1/K0 -> scan
+    let mut rt_scan = Vec::new();
+    for &scan in scan_grid.iter() {
+        let im = im_conv.scan_to_one_over_k0(scan as u32);
+        let back = im_conv.one_over_k0_to_scan(im) as f64;
+        rt_scan.push(back - scan);
+    }
+    let (_, sm, sx) = abs_stats(&rt_scan);
+    println!("  round-trip scan  mean {:.3}  max {:.3}  (scan units)", sm, sx);
+
+    // `sdk` closes itself on Drop; do not call tims_close() explicitly (some SDK
+    // builds abort on a double close).
+    Ok(())
+}

--- a/rustdf/src/data/calibration.rs
+++ b/rustdf/src/data/calibration.rs
@@ -1,0 +1,199 @@
+//! SDK-free Bruker timsTOF axis calibration.
+//!
+//! Pure-Rust ports of the calibration formulas Bruker publishes for the TDF
+//! format, so that TOF-index -> m/z and scan -> 1/K0 can be computed without
+//! loading the proprietary `libtimsdata` SDK. The algorithms mirror the
+//! implementation in PAPPSO's GPL library `libpappsomspp`
+//! (`mzcalibrationmodel1.cpp`, `timsframebase.cpp`); the coefficient meanings
+//! are cross-checked against Bruker's own `tims_calibration.py` reference.
+//!
+//! Two independent models are involved, each carrying its own `ModelType`:
+//!   * m/z    : `MzCalibration` table (this data set: ModelType 2)
+//!   * 1/K0   : `TimsCalibration` table (this data set: ModelType 2)
+//!
+//! IMPORTANT (m/z): PAPPSO only implements m/z *ModelType 1*. Modern instruments
+//! write *ModelType 2*, whose first coefficients (C0,C1) still describe the same
+//! `t = C0 + sqrt(1e12/C1)*sqrt(m)` base curve, but which adds a degree-6
+//! correction polynomial (C8..C14) that neither PAPPSO nor this module models.
+//! We therefore reproduce the *base* curve exactly (few-ppm agreement with the
+//! SDK) and, for genuine ModelType-1 data, the full cubic-in-sqrt(m) curve.
+
+/// m/z axis calibration (Bruker "model type 1" base curve + optional cubic).
+///
+/// Flight time from a TOF index:            `t = index * timebase + delay`
+/// Calibration curve (time as fn of mass):  `t = C0 + b*s + c2*s^2 + c3*s^3`
+/// with `s = sqrt(m + c4)` and `b = sqrt(1e12 / C1_tempcomp)`.
+///
+/// Coefficient meaning (columns of the `MzCalibration` table):
+/// * `timebase` = `DigitizerTimebase` — ns per digitizer sample.
+/// * `delay`    = `DigitizerDelay`    — fixed time offset (samples) before t0.
+/// * `C0`       — constant term of the time/mass curve (~ the t-intercept).
+/// * `C1`       — governs the dominant sqrt term; `b = sqrt(1e12 / C1)`.
+/// * `c2`       — quadratic term `C2*s^2` of the curve; used by BOTH models.
+/// * `c3`       — cubic term `C3*s^3`; ModelType 1 only (in ModelType 2 the C3
+///               column is a duplicate of C0 and is dropped).
+/// * `c4`       — "reduced mass" shift m0 (`x = m - m0`); patent US7,851,746.
+/// Temperature compensation (`T1/T2` = reference temps in `MzCalibration`,
+/// `dC1/dC2` its sensitivities, `T1f/T2f` = per-frame `Frames.T1/Frames.T2`):
+/// `tc = 1 + (dC1*(T1-T1f) + dC2*(T2-T2f)) / 1e6`, applied as `C1 *= tc`.
+#[derive(Debug, Clone)]
+pub struct MzCalibrator {
+    pub timebase: f64,
+    pub delay: f64,
+    pub c0: f64,
+    pub b: f64, // sqrt(1e12 / (C1 * tc))
+    pub c2: f64,
+    pub c3: f64,
+    pub c4: f64,
+}
+
+impl MzCalibrator {
+    /// Build a calibrator from raw `MzCalibration` columns + per-frame temps.
+    ///
+    /// `model_type` selects whether the C2/C3 curve terms are honoured (type 1)
+    /// or zeroed (type 2, base curve only).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        model_type: i64,
+        timebase: f64,
+        delay: f64,
+        t1_ref: f64,
+        t2_ref: f64,
+        dc1: f64,
+        dc2: f64,
+        c0: f64,
+        c1: f64,
+        c2: f64,
+        c3: f64,
+        c4: f64,
+        t1_frame: f64,
+        t2_frame: f64,
+    ) -> Self {
+        let tc = 1.0 + (dc1 * (t1_ref - t1_frame) + dc2 * (t2_ref - t2_frame)) / 1.0e6;
+        let b = (1.0e12 / (c1 * tc)).sqrt();
+        // Both models share the quadratic-in-sqrt(m) curve `t = C0 + b*s + C2*s^2`
+        // (empirically: a0->C0, a1->sqrt(1e12/C1), a2->C2). The cubic `C3*s^3`
+        // term is real only for ModelType 1; in ModelType 2 the C3 column is a
+        // duplicate of C0 and must be dropped. ModelType 2 additionally carries a
+        // C8..C14 fine correction (~few ppm, worst at low m/z) that is NOT an
+        // additive polynomial in m/z and is left unmodelled here.
+        let c2 = c2 / tc;
+        let c3 = if model_type == 1 { c3 } else { 0.0 };
+        Self { timebase, delay, c0, b, c2, c3, c4 }
+    }
+
+    /// Flight time (digitizer units) for a TOF index.
+    #[inline]
+    fn tof_index_to_time(&self, tof_index: f64) -> f64 {
+        tof_index * self.timebase + self.delay
+    }
+
+    /// TOF index -> m/z. Inverts `t = C0 + b*s + c2*s^2 + c3*s^3` for `s`.
+    pub fn tof_to_mz(&self, tof_index: u32) -> f64 {
+        let t = self.tof_index_to_time(tof_index as f64);
+        // Base (linear-in-sqrt) closed form, exact when c2 = c3 = 0.
+        let mut s = (t - self.c0) / self.b;
+        if self.c2 != 0.0 || self.c3 != 0.0 {
+            // Newton refinement for the ModelType-1 cubic curve.
+            for _ in 0..8 {
+                let f = self.c0 + self.b * s + self.c2 * s * s + self.c3 * s * s * s - t;
+                let df = self.b + 2.0 * self.c2 * s + 3.0 * self.c3 * s * s;
+                if df == 0.0 {
+                    break;
+                }
+                let step = f / df;
+                s -= step;
+                if step.abs() < 1e-12 {
+                    break;
+                }
+            }
+        }
+        s * s - self.c4
+    }
+
+    /// m/z -> TOF index (forward direction, always closed form).
+    pub fn mz_to_tof(&self, mz: f64) -> u32 {
+        let s = (mz + self.c4).max(0.0).sqrt();
+        let t = self.c0 + self.b * s + self.c2 * s * s + self.c3 * s * s * s;
+        (((t - self.delay) / self.timebase).round()).max(0.0) as u32
+    }
+}
+
+/// Ion-mobility axis calibration (Bruker "model type 2", the only TIMS model).
+///
+/// Two steps, both exact ports of PAPPSO `timsframebase.cpp`:
+///   1. scan -> trapping voltage:  `V = dv_start + slope*(scan - ttrans - ndelay)`
+///      with `slope = (dv_end - dv_start) / ncycles`.  V must lie in [vmin,vmax].
+///   2. voltage -> inverse mobility: `1/K0 = 1 / (C0m + C1m / V)`.
+///
+/// Coefficient meaning (columns of the `TimsCalibration` table, ModelType 2):
+/// * `C0` = `ndelay`   — scan offset (delay), subtracted before scaling.
+/// * `C1` = `ncycles`  — number of TIMS cycles; sets the voltage-vs-scan slope.
+/// * `C2` = `dv_start` — trapping voltage at the start of the ramp.
+/// * `C3` = `dv_end`   — trapping voltage at the end of the ramp.
+/// * `C4` = `ttrans`   — transit time in cycles, subtracted before scaling.
+/// * `C5`              — unused by the mobility formula (polynomial grade flag).
+/// * `C6` = `C0m`      — additive constant of the mobility reciprocal.
+/// * `C7` = `C1m`      — voltage-scaled term of the mobility reciprocal.
+/// * `C8` = `vmin`     — lower voltage validity bound.
+/// * `C9` = `vmax`     — upper voltage validity bound.
+#[derive(Debug, Clone)]
+pub struct MobilityCalibrator {
+    pub ndelay: f64,
+    pub dv_start: f64,
+    pub ttrans: f64,
+    pub c0m: f64,
+    pub c1m: f64,
+    pub vmin: f64,
+    pub vmax: f64,
+    pub slope: f64,
+}
+
+impl MobilityCalibrator {
+    /// Build from raw `TimsCalibration` C0..C9 (ModelType must be 2).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        c0: f64,
+        c1: f64,
+        c2: f64,
+        c3: f64,
+        c4: f64,
+        _c5: f64,
+        c6: f64,
+        c7: f64,
+        c8: f64,
+        c9: f64,
+    ) -> Self {
+        Self {
+            ndelay: c0,
+            dv_start: c2,
+            ttrans: c4,
+            c0m: c6,
+            c1m: c7,
+            vmin: c8,
+            vmax: c9,
+            slope: (c3 - c2) / c1,
+        }
+    }
+
+    /// scan index -> trapping voltage (clamped to the valid window).
+    #[inline]
+    fn voltage(&self, scan: f64) -> f64 {
+        let v = self.dv_start + self.slope * (scan - self.ttrans - self.ndelay);
+        v.clamp(self.vmin, self.vmax)
+    }
+
+    /// scan index -> 1/K0 (inverse reduced ion mobility).
+    pub fn scan_to_one_over_k0(&self, scan: u32) -> f64 {
+        1.0 / (self.c0m + self.c1m / self.voltage(scan as f64))
+    }
+
+    /// 1/K0 -> nearest scan index (exact algebraic inverse, then round).
+    pub fn one_over_k0_to_scan(&self, one_over_k0: f64) -> u32 {
+        // invert 1/K0 = 1/(C0m + C1m/V)  ->  V,  then V -> scan
+        let inv = 1.0 / one_over_k0;
+        let v = self.c1m / (inv - self.c0m);
+        let scan = (v - self.dv_start) / self.slope + self.ttrans + self.ndelay;
+        scan.round().max(0.0) as u32
+    }
+}

--- a/rustdf/src/data/calibration.rs
+++ b/rustdf/src/data/calibration.rs
@@ -91,10 +91,11 @@ impl MzCalibrator {
     /// TOF index -> m/z. Inverts `t = C0 + b*s + c2*s^2 + c3*s^3` for `s`.
     pub fn tof_to_mz(&self, tof_index: u32) -> f64 {
         let t = self.tof_index_to_time(tof_index as f64);
-        // Base (linear-in-sqrt) closed form, exact when c2 = c3 = 0.
-        let mut s = (t - self.c0) / self.b;
-        if self.c2 != 0.0 || self.c3 != 0.0 {
-            // Newton refinement for the ModelType-1 cubic curve.
+        // Linear-in-sqrt estimate; exact when c2 = c3 = 0.
+        let s0 = (t - self.c0) / self.b;
+        let s = if self.c3 != 0.0 {
+            // ModelType-1 cubic: Newton refinement from the linear estimate.
+            let mut s = s0;
             for _ in 0..8 {
                 let f = self.c0 + self.b * s + self.c2 * s * s + self.c3 * s * s * s - t;
                 let df = self.b + 2.0 * self.c2 * s + 3.0 * self.c3 * s * s;
@@ -107,7 +108,23 @@ impl MzCalibrator {
                     break;
                 }
             }
-        }
+            s
+        } else if self.c2 != 0.0 {
+            // ModelType-2 quadratic `c2*s^2 + b*s + (c0 - t) = 0`, solved in the
+            // numerically stable ("citardauq") form so the physical root does not
+            // lose precision to cancellation when |c2| is tiny. b > 0 always, so
+            // q < 0 and is never zero. Falls back to the linear estimate if the
+            // discriminant is negative (out-of-range tof).
+            let disc = self.b * self.b - 4.0 * self.c2 * (self.c0 - t);
+            if disc < 0.0 {
+                s0
+            } else {
+                let q = -0.5 * (self.b + disc.sqrt());
+                (self.c0 - t) / q
+            }
+        } else {
+            s0
+        };
         s * s - self.c4
     }
 

--- a/rustdf/src/data/dda.rs
+++ b/rustdf/src/data/dda.rs
@@ -288,6 +288,31 @@ impl TimsDatasetDDA {
         TimsDatasetDDA { loader, pasef_meta }
     }
 
+    /// Create a DDA dataset using the exact SDK-free Bruker calibration formulas.
+    ///
+    /// Reads the `MzCalibration` / `TimsCalibration` tables and converts axes
+    /// with [`crate::data::calibration`] — no Bruker SDK at build or runtime.
+    /// 1/K0 is machine-exact; m/z is bit-exact for MzCalibration ModelType 1 and
+    /// accurate to a few ppm for ModelType 2. `calibration_frame_id` selects the
+    /// frame whose calibration is used (default 1; near-constant per run).
+    pub fn new_with_bruker_formula(
+        data_path: &str,
+        in_memory: bool,
+        calibration_frame_id: u32,
+    ) -> Self {
+        let loader = match in_memory {
+            true => TimsDataLoader::new_in_memory_with_bruker_formula(
+                data_path,
+                calibration_frame_id,
+            ),
+            false => {
+                TimsDataLoader::new_lazy_with_bruker_formula(data_path, calibration_frame_id)
+            }
+        };
+        let pasef_meta = read_pasef_frame_ms_ms_info(data_path).unwrap();
+        TimsDatasetDDA { loader, pasef_meta }
+    }
+
     /// Check if the Bruker SDK is being used for index conversion.
     /// Returns false for both Simple and Lookup converters (which are thread-safe).
     pub fn uses_bruker_sdk(&self) -> bool {

--- a/rustdf/src/data/dia.rs
+++ b/rustdf/src/data/dia.rs
@@ -486,6 +486,44 @@ impl TimsDatasetDIA {
         }
     }
 
+    /// Create a DIA dataset using the exact SDK-free Bruker calibration formulas.
+    ///
+    /// See [`crate::data::calibration`]: reads the `MzCalibration` /
+    /// `TimsCalibration` tables and needs no Bruker SDK at build or runtime.
+    /// 1/K0 is machine-exact; m/z is bit-exact for MzCalibration ModelType 1 and
+    /// accurate to a few ppm for ModelType 2.
+    pub fn new_with_bruker_formula(
+        data_path: &str,
+        in_memory: bool,
+        calibration_frame_id: u32,
+    ) -> Self {
+        let meta_data = read_meta_data_sql(data_path).unwrap();
+        let global_meta_data = read_global_meta_sql(data_path).unwrap();
+        let dia_ms_mis_info = read_dia_ms_ms_info(data_path).unwrap();
+        let dia_ms_ms_windows = read_dia_ms_ms_windows(data_path).unwrap();
+
+        let loader = match in_memory {
+            true => TimsDataLoader::new_in_memory_with_bruker_formula(
+                data_path,
+                calibration_frame_id,
+            ),
+            false => {
+                TimsDataLoader::new_lazy_with_bruker_formula(data_path, calibration_frame_id)
+            }
+        };
+
+        let dia_index = DiaIndex::new(&meta_data, &dia_ms_mis_info, &dia_ms_ms_windows);
+
+        TimsDatasetDIA {
+            loader,
+            global_meta_data,
+            meta_data,
+            dia_ms_ms_info: dia_ms_mis_info,
+            dia_ms_ms_windows,
+            dia_index,
+        }
+    }
+
     /// Create a DIA dataset with regression-derived m/z calibration.
     ///
     /// This method uses externally-provided m/z calibration coefficients (e.g., from

--- a/rustdf/src/data/handle.rs
+++ b/rustdf/src/data/handle.rs
@@ -1131,6 +1131,44 @@ impl TimsDataLoader {
         })
     }
 
+    /// Create a lazy loader using the exact SDK-free Bruker calibration formulas.
+    ///
+    /// Builds a [`BrukerFormulaConverter`] from the `MzCalibration` /
+    /// `TimsCalibration` tables (frame `calibration_frame_id`, default 1 — the
+    /// coefficients are near-constant per run). Needs no Bruker SDK at build or
+    /// runtime; 1/K0 is machine-exact and m/z is bit-exact for MzCalibration
+    /// ModelType 1 (few ppm for ModelType 2).
+    pub fn new_lazy_with_bruker_formula(data_path: &str, calibration_frame_id: u32) -> Self {
+        let raw_data_layout = TimsRawDataLayout::new(data_path);
+        let index_converter = TimsIndexConverter::BrukerFormula(
+            BrukerFormulaConverter::from_d_folder(data_path, calibration_frame_id).unwrap(),
+        );
+        TimsDataLoader::Lazy(TimsLazyLoder {
+            raw_data_layout,
+            index_converter,
+        })
+    }
+
+    /// In-memory counterpart of [`Self::new_lazy_with_bruker_formula`].
+    pub fn new_in_memory_with_bruker_formula(data_path: &str, calibration_frame_id: u32) -> Self {
+        let raw_data_layout = TimsRawDataLayout::new(data_path);
+        let index_converter = TimsIndexConverter::BrukerFormula(
+            BrukerFormulaConverter::from_d_folder(data_path, calibration_frame_id).unwrap(),
+        );
+
+        let mut file_path = PathBuf::from(data_path);
+        file_path.push("analysis.tdf_bin");
+        let mut infile = File::open(file_path).unwrap();
+        let mut data = Vec::new();
+        infile.read_to_end(&mut data).unwrap();
+
+        TimsDataLoader::InMemory(TimsInMemoryLoader {
+            raw_data_layout,
+            index_converter,
+            compressed_data: data,
+        })
+    }
+
     /// Create a lazy loader with full calibration (both m/z and IM).
     ///
     /// This method uses regression-derived m/z calibration coefficients instead of

--- a/rustdf/src/data/handle.rs
+++ b/rustdf/src/data/handle.rs
@@ -363,6 +363,13 @@ impl IndexConverter for BrukerLibTimsDataConverter {
 ///     the same C0/C1/C2 quadratic-in-sqrt(m) curve and reproduces the SDK to a
 ///     few ppm (the proprietary ModelType-2 C8..C14 fine correction is not
 ///     modelled).
+///
+/// This is a **fixed-calibration** converter: it captures one frame's
+/// calibration rows + temperatures at build time and applies them to every
+/// frame, ignoring the per-call `frame_id` (like the other SDK-free converters
+/// `Simple`/`Calibrated`/`Lookup`). Valid because the coefficients are
+/// effectively constant across a run; use the SDK-backed `BrukerLib` converter
+/// if a run genuinely carries multiple calibration rows.
 pub struct BrukerFormulaConverter {
     pub mz: crate::data::calibration::MzCalibrator,
     pub im: crate::data::calibration::MobilityCalibrator,
@@ -395,6 +402,15 @@ impl BrukerFormulaConverter {
             .into_iter()
             .find(|c| c.id == tims_id)
             .ok_or("TimsCalibration row not found")?;
+
+        // Reject calibration models this converter does not implement, rather
+        // than silently mis-computing (m/z model 2 is the default branch).
+        if mzc.model_type != 1 && mzc.model_type != 2 {
+            return Err(format!("unsupported MzCalibration ModelType {}", mzc.model_type).into());
+        }
+        if tc.model_type != 2 {
+            return Err(format!("unsupported TimsCalibration ModelType {}", tc.model_type).into());
+        }
 
         let mz = MzCalibrator::new(
             mzc.model_type,

--- a/rustdf/src/data/handle.rs
+++ b/rustdf/src/data/handle.rs
@@ -353,11 +353,103 @@ impl IndexConverter for BrukerLibTimsDataConverter {
     }
 }
 
+/// SDK-free converter using the exact Bruker calibration formulas.
+///
+/// Reads the `MzCalibration` and `TimsCalibration` tables from analysis.tdf and
+/// evaluates the published calibration curves directly (see
+/// [`crate::data::calibration`]). Verified against the Bruker SDK:
+///   * scan <-> 1/K0 : machine-precision exact (ModelType 2).
+///   * TOF  <-> m/z  : bit-exact for MzCalibration ModelType 1; ModelType 2 uses
+///     the same C0/C1/C2 quadratic-in-sqrt(m) curve and reproduces the SDK to a
+///     few ppm (the proprietary ModelType-2 C8..C14 fine correction is not
+///     modelled).
+pub struct BrukerFormulaConverter {
+    pub mz: crate::data::calibration::MzCalibrator,
+    pub im: crate::data::calibration::MobilityCalibrator,
+    pub mz_model_type: i64,
+}
+
+impl BrukerFormulaConverter {
+    /// Build the converter from a `.d` folder, using `frame_id`'s calibration
+    /// row and per-frame temperatures (coefficients are near-constant per run).
+    pub fn from_d_folder(
+        data_path: &str,
+        frame_id: u32,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        use crate::data::calibration::{MobilityCalibrator, MzCalibrator};
+        use crate::data::meta::{read_mz_calibration, read_tims_calibration};
+
+        let tdf = PathBuf::from(data_path).join("analysis.tdf");
+        let con = rusqlite::Connection::open(&tdf)?;
+        let (t1, t2, mz_id, tims_id): (f64, f64, i64, i64) = con.query_row(
+            "SELECT T1, T2, MzCalibration, TimsCalibration FROM Frames WHERE Id = ?1",
+            [frame_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )?;
+
+        let mzc = read_mz_calibration(data_path)?
+            .into_iter()
+            .find(|c| c.id == mz_id)
+            .ok_or("MzCalibration row not found")?;
+        let tc = read_tims_calibration(data_path)?
+            .into_iter()
+            .find(|c| c.id == tims_id)
+            .ok_or("TimsCalibration row not found")?;
+
+        let mz = MzCalibrator::new(
+            mzc.model_type,
+            mzc.digitizer_timebase,
+            mzc.digitizer_delay,
+            mzc.t1,
+            mzc.t2,
+            mzc.dc1,
+            mzc.dc2,
+            mzc.c0,
+            mzc.c1,
+            mzc.c2,
+            mzc.c3,
+            mzc.c4,
+            t1,
+            t2,
+        );
+        let im = MobilityCalibrator::new(
+            tc.c0, tc.c1, tc.c2, tc.c3, tc.c4, tc.c5, tc.c6, tc.c7, tc.c8, tc.c9,
+        );
+        Ok(Self { mz, im, mz_model_type: mzc.model_type })
+    }
+}
+
+impl IndexConverter for BrukerFormulaConverter {
+    fn tof_to_mz(&self, _frame_id: u32, tof_values: &Vec<u32>) -> Vec<f64> {
+        tof_values.iter().map(|&t| self.mz.tof_to_mz(t)).collect()
+    }
+    fn mz_to_tof(&self, _frame_id: u32, mz_values: &Vec<f64>) -> Vec<u32> {
+        mz_values.iter().map(|&m| self.mz.mz_to_tof(m)).collect()
+    }
+    fn scan_to_inverse_mobility(&self, _frame_id: u32, scan_values: &Vec<u32>) -> Vec<f64> {
+        scan_values
+            .iter()
+            .map(|&s| self.im.scan_to_one_over_k0(s))
+            .collect()
+    }
+    fn inverse_mobility_to_scan(
+        &self,
+        _frame_id: u32,
+        inverse_mobility_values: &Vec<f64>,
+    ) -> Vec<u32> {
+        inverse_mobility_values
+            .iter()
+            .map(|&v| self.im.one_over_k0_to_scan(v))
+            .collect()
+    }
+}
+
 pub enum TimsIndexConverter {
     Simple(SimpleIndexConverter),
     Calibrated(CalibratedIndexConverter),
     BrukerLib(BrukerLibTimsDataConverter),
     Lookup(LookupIndexConverter),
+    BrukerFormula(BrukerFormulaConverter),
 }
 
 impl IndexConverter for TimsIndexConverter {
@@ -367,6 +459,7 @@ impl IndexConverter for TimsIndexConverter {
             TimsIndexConverter::Calibrated(converter) => converter.tof_to_mz(frame_id, tof_values),
             TimsIndexConverter::BrukerLib(converter) => converter.tof_to_mz(frame_id, tof_values),
             TimsIndexConverter::Lookup(converter) => converter.tof_to_mz(frame_id, tof_values),
+            TimsIndexConverter::BrukerFormula(converter) => converter.tof_to_mz(frame_id, tof_values),
         }
     }
 
@@ -376,6 +469,7 @@ impl IndexConverter for TimsIndexConverter {
             TimsIndexConverter::Calibrated(converter) => converter.mz_to_tof(frame_id, mz_values),
             TimsIndexConverter::BrukerLib(converter) => converter.mz_to_tof(frame_id, mz_values),
             TimsIndexConverter::Lookup(converter) => converter.mz_to_tof(frame_id, mz_values),
+            TimsIndexConverter::BrukerFormula(converter) => converter.mz_to_tof(frame_id, mz_values),
         }
     }
 
@@ -391,6 +485,9 @@ impl IndexConverter for TimsIndexConverter {
                 converter.scan_to_inverse_mobility(frame_id, scan_values)
             }
             TimsIndexConverter::Lookup(converter) => {
+                converter.scan_to_inverse_mobility(frame_id, scan_values)
+            }
+            TimsIndexConverter::BrukerFormula(converter) => {
                 converter.scan_to_inverse_mobility(frame_id, scan_values)
             }
         }
@@ -412,6 +509,9 @@ impl IndexConverter for TimsIndexConverter {
                 converter.inverse_mobility_to_scan(frame_id, inverse_mobility_values)
             }
             TimsIndexConverter::Lookup(converter) => {
+                converter.inverse_mobility_to_scan(frame_id, inverse_mobility_values)
+            }
+            TimsIndexConverter::BrukerFormula(converter) => {
                 converter.inverse_mobility_to_scan(frame_id, inverse_mobility_values)
             }
         }

--- a/rustdf/src/data/meta.rs
+++ b/rustdf/src/data/meta.rs
@@ -82,11 +82,31 @@ pub struct MzCalibration {
     pub digitizer_delay: f64,
     pub t1: f64,
     pub t2: f64,
+    pub dc1: f64,
+    pub dc2: f64,
     pub c0: f64,
     pub c1: f64,
     pub c2: f64,
     pub c3: f64,
     pub c4: f64,
+}
+
+/// Ion-mobility (1/K0) calibration data from the `TimsCalibration` table.
+/// Coefficients feed the SDK-free scan <-> 1/K0 conversion (ModelType 2).
+#[derive(Debug, Clone)]
+pub struct TimsCalibration {
+    pub id: i64,
+    pub model_type: i64,
+    pub c0: f64,
+    pub c1: f64,
+    pub c2: f64,
+    pub c3: f64,
+    pub c4: f64,
+    pub c5: f64,
+    pub c6: f64,
+    pub c7: f64,
+    pub c8: f64,
+    pub c9: f64,
 }
 
 #[derive(Debug)]
@@ -415,12 +435,15 @@ pub fn read_dia_ms_ms_windows(
 /// This provides the coefficients needed for accurate TOF to m/z conversion
 /// without requiring the Bruker SDK.
 ///
-/// The calibration formula is:
-///   tof_time = (tof_index + 0.5) * digitizer_timebase + digitizer_delay
-///   sqrt(mz) = c0 + c1*tof_time + c2*tof_time^2 + ...
+/// The calibration curve expresses flight time as a function of mass:
+///   tof_time = tof_index * digitizer_timebase + digitizer_delay
+///   tof_time = c0 + b*sqrt(m) + c2*m + c3*m^1.5,   b = sqrt(1e12 / c1)
+/// inverted to give m/z from a TOF index (see `data::calibration::MzCalibrator`).
 ///
-/// For model_type 2 (most common), the formula simplifies to:
-///   sqrt(mz) = (tof_time - c1) / c0
+/// For model_type 2 (modern instruments) the base curve reduces to
+///   sqrt(mz) = (tof_time - c0) / sqrt(1e12 / c1)
+/// (c2/c3 are NOT curve terms in model 2). This base is accurate to ~10 ppm; the
+/// remaining error is a proprietary degree-6 correction polynomial in c8..c14.
 pub fn read_mz_calibration(
     bruker_d_folder_name: &str,
 ) -> Result<Vec<MzCalibration>, Box<dyn std::error::Error>> {
@@ -428,7 +451,7 @@ pub fn read_mz_calibration(
     let conn = Connection::open(db_path)?;
 
     // Query MzCalibration table
-    let query = "SELECT Id, ModelType, DigitizerTimebase, DigitizerDelay, T1, T2, C0, C1, C2, C3, C4 FROM MzCalibration";
+    let query = "SELECT Id, ModelType, DigitizerTimebase, DigitizerDelay, T1, T2, dC1, dC2, C0, C1, C2, C3, C4 FROM MzCalibration";
 
     let calibrations: Result<Vec<MzCalibration>, _> = conn
         .prepare(query)?
@@ -440,11 +463,47 @@ pub fn read_mz_calibration(
                 digitizer_delay: row.get(3)?,
                 t1: row.get(4)?,
                 t2: row.get(5)?,
-                c0: row.get(6)?,
-                c1: row.get(7)?,
-                c2: row.get(8)?,
-                c3: row.get(9)?,
-                c4: row.get(10)?,
+                dc1: row.get(6)?,
+                dc2: row.get(7)?,
+                c0: row.get(8)?,
+                c1: row.get(9)?,
+                c2: row.get(10)?,
+                c3: row.get(11)?,
+                c4: row.get(12)?,
+            })
+        })?
+        .collect();
+
+    Ok(calibrations?)
+}
+
+/// Read ion-mobility calibration data from the `TimsCalibration` table.
+/// Provides the C0..C9 coefficients for SDK-free scan <-> 1/K0 conversion.
+pub fn read_tims_calibration(
+    bruker_d_folder_name: &str,
+) -> Result<Vec<TimsCalibration>, Box<dyn std::error::Error>> {
+    let db_path = Path::new(bruker_d_folder_name).join("analysis.tdf");
+    let conn = Connection::open(db_path)?;
+
+    let query =
+        "SELECT Id, ModelType, C0, C1, C2, C3, C4, C5, C6, C7, C8, C9 FROM TimsCalibration";
+
+    let calibrations: Result<Vec<TimsCalibration>, _> = conn
+        .prepare(query)?
+        .query_map([], |row| {
+            Ok(TimsCalibration {
+                id: row.get(0)?,
+                model_type: row.get(1)?,
+                c0: row.get(2)?,
+                c1: row.get(3)?,
+                c2: row.get(4)?,
+                c3: row.get(5)?,
+                c4: row.get(6)?,
+                c5: row.get(7)?,
+                c6: row.get(8)?,
+                c7: row.get(9)?,
+                c8: row.get(10)?,
+                c9: row.get(11)?,
             })
         })?
         .collect();

--- a/rustdf/src/data/meta.rs
+++ b/rustdf/src/data/meta.rs
@@ -440,10 +440,10 @@ pub fn read_dia_ms_ms_windows(
 ///   tof_time = c0 + b*sqrt(m) + c2*m + c3*m^1.5,   b = sqrt(1e12 / c1)
 /// inverted to give m/z from a TOF index (see `data::calibration::MzCalibrator`).
 ///
-/// For model_type 2 (modern instruments) the base curve reduces to
-///   sqrt(mz) = (tof_time - c0) / sqrt(1e12 / c1)
-/// (c2/c3 are NOT curve terms in model 2). This base is accurate to ~10 ppm; the
-/// remaining error is a proprietary degree-6 correction polynomial in c8..c14.
+/// Model 2 (modern instruments) uses the same `c0 + b*sqrt(m) + c2*m` curve
+/// (c2 IS a curve term; only the c3 cubic term is model-1 only). That base is
+/// accurate to a few ppm; the remaining error is a proprietary correction in
+/// c8..c14 (windowed to [c5, c6]) that is not modelled.
 pub fn read_mz_calibration(
     bruker_d_folder_name: &str,
 ) -> Result<Vec<MzCalibration>, Box<dyn std::error::Error>> {

--- a/rustdf/src/data/mod.rs
+++ b/rustdf/src/data/mod.rs
@@ -1,4 +1,5 @@
 pub mod acquisition;
+pub mod calibration;
 pub mod dataset;
 pub mod dda;
 pub mod dia;


### PR DESCRIPTION
## What

Adds a pure-Rust, **SDK-free** index converter for Bruker timsTOF data that
translates TOF index ↔ m/z and scan ↔ 1/K0 by reading the `MzCalibration` /
`TimsCalibration` tables in `analysis.tdf` and evaluating Bruker's published
calibration curves directly — no `libtimsdata` at build **or** runtime.

Selectable via `TimsDatasetDDA/DIA::new_with_bruker_formula(data_path, in_memory, calibration_frame_id)`.

## Why (accuracy vs SDK, measured on real data)

`examples/compare_all_converters.rs` scores every existing mode against the SDK:

**1/K0 axis** — the decisive result:

| Mode | error vs SDK | SDK-free? |
|---|---|---|
| Simple / Calibrated (linear) | **2,300–8,600 ppm (0.2–0.9%)** | yes |
| Lookup (SDK-probed table) | 0 (exact at integer scans) | no — needs SDK to build |
| **BrukerFormula (new)** | **~1e-10 ppm (machine exact)** | **yes** |

The pre-existing SDK-free modes use a *linear* scan→1/K0 model that is off by
up to ~0.9% — dangerous for anything mobility-based. BrukerFormula is the only
SDK-free mode that reproduces 1/K0 exactly.

**m/z axis:**

| Mode | ModelType 1 | ModelType 2 | SDK-free? |
|---|---|---|---|
| Simple (boundary) | 5.5 / 10 ppm | 4–5.6 / 10–15 ppm | yes |
| Calibrated / Lookup (SDK regression) | 0.09 / 0.55 ppm | 1.6–2.3 / 12–22 ppm | no |
| **BrukerFormula (new)** | **0.000 (bit-exact)** | 1.8–1.9 / 11–21 ppm | yes |

BrukerFormula is bit-exact on ModelType 1 and beats the other SDK-free mode on
ModelType 2, with no SDK dependency and O(1) thread-safe conversion.

## How it works

- **1/K0** (TimsCalibration ModelType 2): `V = dv_start + slope·(scan − ttrans − ndelay)`, then `1/K0 = 1/(C0m + C1m/V)`. Exact.
- **m/z** (MzCalibration): `t = C0 + √(1e12/C1)·√m + C2·m (+ C3·m^1.5 for ModelType 1)`, inverted for m/z. Ported from PAPPSO's GPL `libpappsomspp` and verified against the SDK.

## Known limitation

ModelType-2 m/z retains a **few-ppm tail** (median ~2 ppm) from an undocumented
`C8…C14` correction. Reverse-engineered structure is documented in
`BRUKER_TRANSLATORS.md`: it is windowed to `[C5, C6]` and is a smooth degree-7
polynomial (matching `C7=7`), but the exact encoding of `C8…C14` is not decoded,
and no open-source reader reimplements it (all delegate to the SDK). Bit-exact
ModelType-2 m/z still requires `BrukerLib`.

## Contents

- `src/data/calibration.rs` — `MzCalibrator`, `MobilityCalibrator`.
- `src/data/meta.rs` — `TimsCalibration` reader; `dC1/dC2` added to `MzCalibration`; corrected model-2 comment.
- `src/data/handle.rs` — `BrukerFormulaConverter` + `TimsIndexConverter::BrukerFormula` + loader factories.
- `src/data/dda.rs`, `src/data/dia.rs` — `new_with_bruker_formula` constructors.
- `examples/compare_calibration.rs`, `examples/compare_all_converters.rs` — SDK residual harnesses.
- `BRUKER_TRANSLATORS.md` — formula reference + full C-parameter descriptions.

No changes to existing converters or default behavior; the new mode is opt-in.