### PR TITLE
perf(tims-viewer): peak-grid struct-of-arrays (Tier-2)

### DIFF
--- a/tims-viewer/PERF_PLAN_TIER2.md
+++ b/tims-viewer/PERF_PLAN_TIER2.md
@@ -4,31 +4,38 @@ Follow-up to Tier-1 (merged in #429). Source: the 5-agent deep-dive. Same loop: 
 implement. Behavior-preserving unless flagged. Scope this round: the loader peak-grid SoA (primary)
 and the volume MS-toggle `combine` (safe, reuses tested code). Double-buffer is a stretch.
 
+> **Claudex (codex) corrections folded in.** My original occupancy premise was wrong (sentinel is
+> `-1.0`, not `0.0`). T2.1 revised to the *safer* SoA (split hot `best_i` only; keep the cold
+> `GpuPoint` — no reconstruction). T2.2 **deferred** this round (intensity-floor rebuild + web-deposits-
+> peaks ambiguity make "behavior-preserving" non-trivial; it's a niche MS-toggle path).
+
 ## T2.1 — Peak-grid Struct-of-Arrays (loader.rs) — PRIMARY, biggest remaining win
 **Now:** the peak grid is `peaks: Vec<(f32, u64, GpuPoint)>` — ~1M cells × ~48 B ≈ **48 MB**. Every
 one of the 100M+ surviving points does `let slot = &mut peaks[peak_cell(pos)]` — a *random* index
 into 48 MB (near-guaranteed L2/L3 miss) + a read of `slot.0` (needs only 4 B) and, on a new max, a
 44-byte write. This random RMW over a 48 MB array is the dominant fold cost (memory-bound).
 
-**Change:** split hot/cold (SoA):
-- `best_i: Vec<f32>` — 1M × 4 B = **4 MB**, cache-resident for the per-point `intensity > best_i[cell]`
-  compare (the hot read).
-- `best_gi: Vec<u64>` and a compact best-point record `best_pt: Vec<PeakPt>` where
-  `PeakPt { pos: [f32;3], flags: u32 }` (16 B) — written **only** on the rare new-max branch.
-- Reconstruct the `GpuPoint` at emit time (the peak-tail loop) from `best_pt` (`weight: 1.0`,
-  `_pad: [NO_CLUSTER, 0]`) — the grid never needs `weight`/`_pad`.
+**Change (SAFE version — no GpuPoint reconstruction):** split only the *hot* intensity out of the
+current `peaks: Vec<(f32, u64, GpuPoint)>` (loader.rs:224):
+- `best_i: Vec<f32>` init **`-1.0`** (exactly today's tuple `.0` default) — the hot per-point read for
+  `intensity > best_i[cell]`. 1M × 4 B = **4 MB**, so the compare stops pulling a 48 B cache line of
+  cold data.
+- `best_gi: Vec<u64>` + `best_gp: Vec<GpuPoint>` — the cold record, written **only** on the new-max
+  branch (same fields stored as today; NO reconstruction).
 
-**Invariants to preserve (claudex will check):**
-- Init `best_i` to a sentinel below any real intensity so cell-0 semantics match today's `> slot.0`
-  with `slot.0` default 0.0 (use `0.0` init and keep the `intensity > best_i[cell]` compare — a point
-  with intensity 0 was never a peak anyway). Confirm against the current default.
-- The peak-tail filter uses `gi % stride != 0` and `i >= 0.0` (occupied) — replace `i >= 0.0` occupancy
-  with an explicit "was this cell ever written" test (e.g. `best_gi` sentinel `u64::MAX` = empty), since
-  `best_i` default 0.0 no longer distinguishes empty from a real 0-intensity peak.
-- `select_nth`/emit order unchanged; `region_estimate_concentrates_budget` still passes.
+**Invariants (codex-flagged — verify all):**
+- `best_i` init `-1.0` (NOT 0.0) — with strict `intensity > best_i[cell]`, a real 0-intensity point
+  still occupies an empty cell (`0.0 > -1.0`), matching today (loader.rs:351).
+- Keep strict `>` (first-wins on ties); `>=` would flip to last-wins (loader.rs:352).
+- Peak-tail (loader.rs:445): gate **occupancy first** — `best_i[cell] >= 0.0` (== today's `i >= 0.0`)
+  **then** `best_gi[cell] % stride != 0`. Never run the modulo on an empty cell.
+- `global_i` still assigned-before-increment, survivor-relative (loader.rs:337-380); emit order + the
+  `region_estimate_concentrates_budget` test unchanged. (Note: that test only guards the systematic
+  count — peak occupancy/flags/zero-intensity/dedup are NOT covered, so review carefully.)
 
-**Gain:** ~1.3–1.8× on the fold phase (48 B RMW → 4 B read per point). **Risk:** medium, local to
-loader.rs, test-covered.
+**Gain:** a fold speedup — treat "~1.3–1.8×" as a **hypothesis to benchmark**, not a given: access is
+slab-local (RT frame order), and the fold also does normalization/binning/histograms/systematic pushes.
+**Risk:** low–med, local to loader.rs.
 
 ## T2.2 — Volume MS-toggle via `VolumeGrid::combine` (volume.rs + web/lib.rs) — SAFE, niche
 **Now:** an MS1/MS2/both toggle sets `vol_needs_grid`, and `ensure_volume` re-deposits **all**

--- a/tims-viewer/PERF_PLAN_TIER2.md
+++ b/tims-viewer/PERF_PLAN_TIER2.md
@@ -1,0 +1,51 @@
+# tims-viewer performance — Tier-2 (post-merge round)
+
+Follow-up to Tier-1 (merged in #429). Source: the 5-agent deep-dive. Same loop: plan → claudex →
+implement. Behavior-preserving unless flagged. Scope this round: the loader peak-grid SoA (primary)
+and the volume MS-toggle `combine` (safe, reuses tested code). Double-buffer is a stretch.
+
+## T2.1 — Peak-grid Struct-of-Arrays (loader.rs) — PRIMARY, biggest remaining win
+**Now:** the peak grid is `peaks: Vec<(f32, u64, GpuPoint)>` — ~1M cells × ~48 B ≈ **48 MB**. Every
+one of the 100M+ surviving points does `let slot = &mut peaks[peak_cell(pos)]` — a *random* index
+into 48 MB (near-guaranteed L2/L3 miss) + a read of `slot.0` (needs only 4 B) and, on a new max, a
+44-byte write. This random RMW over a 48 MB array is the dominant fold cost (memory-bound).
+
+**Change:** split hot/cold (SoA):
+- `best_i: Vec<f32>` — 1M × 4 B = **4 MB**, cache-resident for the per-point `intensity > best_i[cell]`
+  compare (the hot read).
+- `best_gi: Vec<u64>` and a compact best-point record `best_pt: Vec<PeakPt>` where
+  `PeakPt { pos: [f32;3], flags: u32 }` (16 B) — written **only** on the rare new-max branch.
+- Reconstruct the `GpuPoint` at emit time (the peak-tail loop) from `best_pt` (`weight: 1.0`,
+  `_pad: [NO_CLUSTER, 0]`) — the grid never needs `weight`/`_pad`.
+
+**Invariants to preserve (claudex will check):**
+- Init `best_i` to a sentinel below any real intensity so cell-0 semantics match today's `> slot.0`
+  with `slot.0` default 0.0 (use `0.0` init and keep the `intensity > best_i[cell]` compare — a point
+  with intensity 0 was never a peak anyway). Confirm against the current default.
+- The peak-tail filter uses `gi % stride != 0` and `i >= 0.0` (occupied) — replace `i >= 0.0` occupancy
+  with an explicit "was this cell ever written" test (e.g. `best_gi` sentinel `u64::MAX` = empty), since
+  `best_i` default 0.0 no longer distinguishes empty from a real 0-intensity peak.
+- `select_nth`/emit order unchanged; `region_estimate_concentrates_budget` still passes.
+
+**Gain:** ~1.3–1.8× on the fold phase (48 B RMW → 4 B read per point). **Risk:** medium, local to
+loader.rs, test-covered.
+
+## T2.2 — Volume MS-toggle via `VolumeGrid::combine` (volume.rs + web/lib.rs) — SAFE, niche
+**Now:** an MS1/MS2/both toggle sets `vol_needs_grid`, and `ensure_volume` re-deposits **all**
+`cpu_points` (trilinear scatter, ~8 voxel adds/point) — O(8N points) on every toggle.
+
+**Change:** deposit two persistent grids (MS1, MS2) once at load; an MS-toggle calls the
+already-written-and-tested `VolumeGrid::combine(a, b, wa, wb)` (dead in the web path today) — one
+O(voxels) pass with 0/1 weights. Extra cost: ~2× grid RAM (~50 MB f32) + one extra deposit at load.
+
+**Gain:** MS-toggle-in-volume-mode drops from O(8N) scatter to O(voxels). **Niche** (only that path).
+**Risk:** medium; `combine` is tested, but wiring two grids + the toggle path needs care. Skippable if
+the effort/benefit doesn't hold up under claudex.
+
+## Stretch — double-buffer decode/fold (loader.rs)
+Overlap batch N+1 decode (rayon) with batch N fold. ~1.3× load. **Higher risk** (concurrency +
+`global_i` prefix ordering the test pins exactly). Defer unless T2.1 lands cleanly and there's appetite.
+
+## Out of scope this round
+Behavior-changing C3 (raymarch 256→128) / D1 (f32 clustering); rustdf decode slimming + mmap (shared
+crate); `Arc<Vec<u8>>`; WebGPU compaction (blocked on wgpu 23+).

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -226,7 +226,13 @@ fn run_loader(
     // the hundreds of millions of per-point updates. Sentinel intensity -1 = unoccupied;
     // the source index lets us drop peaks the systematic sampler already emitted.
     let n_cells = (PEAK_DIMS[0] * PEAK_DIMS[1] * PEAK_DIMS[2]) as usize;
-    let mut peaks: Vec<(f32, u64, GpuPoint)> = vec![(-1.0, 0, ZERO_POINT); n_cells];
+    // Peak grid, struct-of-arrays. The hot per-point compare reads only `best_i` (1M×4 B = 4 MB,
+    // cache-resident) instead of pulling a cache line of the 48 B (f32,u64,GpuPoint) tuple; the cold
+    // `best_gi`/`best_gp` are written only on a new max. `best_i` sentinel -1.0 (== the old tuple .0)
+    // so a real 0-intensity point still occupies an empty cell via strict `> -1.0`.
+    let mut best_i: Vec<f32> = vec![-1.0; n_cells];
+    let mut best_gi: Vec<u64> = vec![0; n_cells];
+    let mut best_gp: Vec<GpuPoint> = vec![ZERO_POINT; n_cells];
 
     // Subsample intensities into a reservoir for percentile defaults.
     let mut reservoir: Vec<f32> = Vec::with_capacity(RESERVOIR_CAP);
@@ -347,12 +353,14 @@ fn run_loader(
             }
             let pos = bounds.normalize($mz, $im, $rt);
             let flags = if $ms2 { GpuPoint::MS2_FLAG } else { 0 };
-            // Peak: keep the highest-intensity point per coarse cell.
-            let slot = &mut peaks[peak_cell(pos) as usize];
-            if intensity > slot.0 {
-                slot.0 = intensity;
-                slot.1 = global_i;
-                slot.2 = GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [GpuPoint::NO_CLUSTER, 0] };
+            // Peak: keep the highest-intensity point per coarse cell (SoA — the hot read is best_i
+            // only; strict `>` keeps first-wins on ties).
+            let cell = peak_cell(pos) as usize;
+            if intensity > best_i[cell] {
+                best_i[cell] = intensity;
+                best_gi[cell] = global_i;
+                best_gp[cell] =
+                    GpuPoint { pos, intensity, weight: 1.0, flags, _pad: [GpuPoint::NO_CLUSTER, 0] };
             }
             // Systematic density base (every stride-th survivor, via the countdown above).
             if keep_in == 0 {
@@ -444,10 +452,11 @@ fn run_loader(
     // the strongest survive if occupied cells exceed the headroom.
     let peak_room = budget.saturating_sub(systematic_count as usize);
     if peak_room > 0 && stride_u64 > 1 {
-        let mut peak_pts: Vec<GpuPoint> = peaks
-            .into_iter()
-            .filter(|(i, gi, _)| *i >= 0.0 && gi % stride_u64 != 0)
-            .map(|(_, _, gp)| gp)
+        // Occupancy first (best_i >= 0.0, == the old `i >= 0.0`), THEN the systematic-dedup modulo —
+        // never run `% stride` on an empty cell.
+        let mut peak_pts: Vec<GpuPoint> = (0..n_cells)
+            .filter(|&c| best_i[c] >= 0.0 && best_gi[c] % stride_u64 != 0)
+            .map(|c| best_gp[c])
             .collect();
         // Keep the strongest `peak_room` peaks. A partial select (O(n)) suffices — order within the
         // kept set is irrelevant (everything is shuffled downstream). Guard peak_room < len:


### PR DESCRIPTION
Tier-2 perf follow-up to #429. Splits the loader's peak grid from `Vec<(f32,u64,GpuPoint)>` (~48 MB) into struct-of-arrays: a hot `best_i: Vec<f32>` (4 MB, cache-resident) for the per-point `intensity > best_i[cell]` compare, plus cold `best_gi`/`best_gp` written only on a new max — so the hot fold read stops pulling a 48-byte cache line of cold data.

**Behavior-preserving** (claudex/codex-reviewed twice — plan + code): `-1.0` sentinel (a real 0-intensity point still occupies via strict `> -1.0`), strict `>` first-wins on ties, peak-tail gates occupancy (`best_i >= 0.0`) before the systematic-dedup `% stride`. No `GpuPoint` reconstruction (kept the cold point). Codex code review: *"preserves the previous peak selection, occupancy, deduplication, and emission semantics … no introduced correctness issues."*

27 lib tests pass; web + native build. Gain (fold speedup) is a benchmark hypothesis — the cache layout is strictly better regardless. Plan + deferred items (T2.2 volume `combine`, double-buffer) in `tims-viewer/PERF_PLAN_TIER2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)