### PR TITLE
security(connector): upgrade pyo3 & numpy 0.23 → 0.29 (closes 3 Dependabot alerts)

### DIFF
--- a/imspy_connector/Cargo.toml
+++ b/imspy_connector/Cargo.toml
@@ -8,8 +8,8 @@ name = "imspy_connector"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23.3", features = ["extension-module"] }
-numpy = "0.23.0"
+pyo3 = { version = "0.29.0", features = ["extension-module"] }
+numpy = "0.29.0"
 mscore = { path = "../mscore", version = "0.4.1" }
 rustdf = { path = "../rustdf", version = "0.4.1" }
 serde = "1.0.219"

--- a/imspy_connector/src/py_acquisition.rs
+++ b/imspy_connector/src/py_acquisition.rs
@@ -33,7 +33,7 @@ impl PyAcquisitionScheme {
         // I/O errors map to OSError/FileNotFoundError via PyErr::from; release the
         // GIL while reading the .d's SQLite metadata.
         let inner = py
-            .allow_threads(|| AcquisitionScheme::from_bruker_d(path))
+            .detach(|| AcquisitionScheme::from_bruker_d(path))
             .map_err(PyErr::from)?;
         Ok(Self { inner })
     }
@@ -43,7 +43,7 @@ impl PyAcquisitionScheme {
     #[staticmethod]
     pub fn from_thermo_raw(py: Python<'_>, path: &str) -> PyResult<Self> {
         let inner = py
-            .allow_threads(|| AcquisitionScheme::from_thermo_raw(path))
+            .detach(|| AcquisitionScheme::from_thermo_raw(path))
             .map_err(PyErr::from)?;
         Ok(Self { inner })
     }
@@ -61,7 +61,7 @@ impl PyAcquisitionScheme {
         path: &str,
     ) -> PyResult<Vec<(u32, f64, u8, Option<f64>, Option<f64>, Option<f64>)>> {
         let sched = py
-            .allow_threads(|| AcquisitionScheme::thermo_frame_schedule(path))
+            .detach(|| AcquisitionScheme::thermo_frame_schedule(path))
             .map_err(PyErr::from)?;
         Ok(sched
             .into_iter()
@@ -106,7 +106,7 @@ impl PyAcquisitionScheme {
             }
         };
         let inner = py
-            .allow_threads(|| {
+            .detach(|| {
                 AcquisitionScheme::from_sciex_wiff(path, cycle_time_s, gradient_length_s, ce)
             })
             .map_err(PyErr::from)?;
@@ -142,7 +142,7 @@ impl PyAcquisitionScheme {
             }
         };
         let rows = py
-            .allow_threads(|| {
+            .detach(|| {
                 AcquisitionScheme::from_sciex_wiff(path, cycle_time_s, gradient_length_s, ce)
                     .map(|s| s.dia_frame_schedule())
             })
@@ -336,7 +336,7 @@ impl PyThermoRawWriter {
             }
         }
         let mut w = py
-            .allow_threads(|| ThermoRawWriter::from_template(template, out))
+            .detach(|| ThermoRawWriter::from_template(template, out))
             .map_err(PyErr::from)?
             .with_allow_partial(allow_partial);
         if let Some(tol) = overlay_merge_tol_ppm {
@@ -419,7 +419,7 @@ impl PyThermoRawWriter {
         if self.finalized {
             return Err(PyRuntimeError::new_err("writer already finalized"));
         }
-        py.allow_threads(|| self.inner.finalize())
+        py.detach(|| self.inner.finalize())
             .map_err(writer_err)?;
         self.finalized = true;
         Ok(())
@@ -461,7 +461,7 @@ pub fn legacy_frame_projection(
     n_steps: Option<usize>,
     num_threads: usize,
 ) -> Vec<Vec<(u32, f64)>> {
-    py.allow_threads(|| {
+    py.detach(|| {
         rustdf::sim::projector::project_time_legacy(
             &rt_mus, &rt_sigmas, &rt_lambdas, &frame_ids, &frame_times, rt_cycle_length, target_p,
             step_size, n_steps, remove_epsilon, num_threads,
@@ -506,7 +506,7 @@ pub fn legacy_scan_projection_par(
     step_size: f64,
     num_threads: usize,
 ) -> Vec<Vec<(i32, f64)>> {
-    py.allow_threads(|| {
+    py.detach(|| {
         rustdf::sim::projector::project_mobility_legacy_par(
             &means, &sigmas, &scan_ids, &scan_mobilities, im_cycle_length, target_p, step_size,
             num_threads,
@@ -538,7 +538,7 @@ pub fn accurate_frame_projection(
     }
     let intervals: Vec<(f64, f64)> =
         event_starts.into_iter().zip(event_ends).collect();
-    Ok(py.allow_threads(|| {
+    Ok(py.detach(|| {
         mscore::algorithm::utility::project_emg_over_events_par(
             &intervals, rt_mus, rt_sigmas, rt_lambdas, target_p, step_size,
             num_threads.max(1), n_steps,
@@ -562,7 +562,7 @@ pub fn accurate_scan_projection(
     step_size: f64,
     num_threads: usize,
 ) -> Vec<Vec<(i32, f64)>> {
-    py.allow_threads(|| {
+    py.detach(|| {
         rustdf::sim::projector::project_mobility_accurate_par(
             &means, &sigmas, &mobility_grid, target_p, step_size, num_threads,
         )
@@ -687,7 +687,7 @@ pub fn write_astral_raw(
         superimpose_ppm,
     };
     let s = py
-        .allow_threads(|| {
+        .detach(|| {
             run(Path::new(db_path), Path::new(template_path), Path::new(out_path), opts)
         })
         .map_err(PyValueError::new_err)?;
@@ -708,7 +708,7 @@ pub fn rewindow_thermo_template(
 ) -> PyResult<usize> {
     use rustdf::sim::acquisition::rewindow_thermo_template as run;
     use std::path::Path;
-    py.allow_threads(|| run(Path::new(src_path), Path::new(dst_path), isolation_width))
+    py.detach(|| run(Path::new(src_path), Path::new(dst_path), isolation_width))
         .map_err(PyValueError::new_err)
 }
 
@@ -728,7 +728,7 @@ pub fn render_dia_mzml(
 ) -> PyResult<(usize, usize, usize, usize)> {
     use std::path::Path;
     let s = py
-        .allow_threads(|| {
+        .detach(|| {
             rustdf::sim::mzml::render_db_to_mzml(
                 Path::new(db_path),
                 Path::new(out_path),

--- a/imspy_connector/src/py_annotation.rs
+++ b/imspy_connector/src/py_annotation.rs
@@ -5,7 +5,7 @@ use mscore::simulation::annotation::{SourceType, SignalAttributes, ContributionS
 use mscore::data::peptide::FragmentType;
 use numpy::{IntoPyArray, PyArray1, PyArrayMethods};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyTimsSpectrumAnnotated {
     pub inner: TimsSpectrumAnnotated,
@@ -98,7 +98,7 @@ impl PyTimsSpectrumAnnotated {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyTimsFrameAnnotated {
     pub inner: TimsFrameAnnotated,
@@ -279,7 +279,7 @@ impl PyTimsFrameAnnotated {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyMzSpectrumAnnotated {
     pub inner: MzSpectrumAnnotated,
@@ -325,7 +325,7 @@ impl PyMzSpectrumAnnotated {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPeakAnnotation {
     pub inner: Vec<ContributionSource>,
@@ -345,7 +345,7 @@ impl PyPeakAnnotation {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PySourceType {
     inner: SourceType,
@@ -374,7 +374,7 @@ fn fragment_type_from_str(s: &str) -> Option<FragmentType> {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PySignalAttributes {
     inner: SignalAttributes,
@@ -412,7 +412,7 @@ impl PySignalAttributes {
     pub fn description(&self) -> Option<String> { self.inner.description() }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyContributionSource {
     pub inner: ContributionSource,

--- a/imspy_connector/src/py_dda.rs
+++ b/imspy_connector/src/py_dda.rs
@@ -381,7 +381,7 @@ impl PyTimsFragmentDDA {
 }
 
 /// Statistical moments of a signal distribution
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PySignalMoments {
     inner: SignalMoments,
@@ -487,7 +487,7 @@ impl PyPrecursorMS1Signal {
 }
 
 /// Input coordinates for MS1 extraction
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPrecursorCoord {
     inner: PrecursorCoord,

--- a/imspy_connector/src/py_dia.rs
+++ b/imspy_connector/src/py_dia.rs
@@ -55,7 +55,7 @@ where
 /// # Default: adaptive with 3× noise
 /// mode = PyThresholdMode.default()
 /// ```
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyThresholdMode {
     pub inner: ThresholdMode,
@@ -135,7 +135,7 @@ impl From<PyThresholdMode> for ThresholdMode {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyRawPoints {
     pub inner: RawPoints,
@@ -186,7 +186,7 @@ impl PyRawPoints {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyClusterResult1D {
     pub inner: ClusterResult1D,
@@ -494,7 +494,7 @@ impl PyTofScanPlanGroup {
         // --- collect frames/times and discover TOF scale
         let (frame_ids_sorted, frame_times, scale, rows, global_num_scans, views) = {
             let ds_bound = ds.bind(py);
-            let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.downcast()?;
+            let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.cast()?;
             let ds_ref = ds_obj.borrow();
 
             // 1) RT-sort MS2 frames for this group
@@ -645,7 +645,7 @@ impl PyTofScanPlanGroup {
         self.windows_idx.len()
     }
 
-    fn __getitem__(&self, py: Python<'_>, idx: &Bound<PyAny>) -> PyResult<PyObject> {
+    fn __getitem__(&self, py: Python<'_>, idx: &Bound<PyAny>) -> PyResult<Py<PyAny>> {
         // int (supports negative)
         if let Ok(i_signed) = idx.extract::<isize>() {
             let n = self.windows_idx.len() as isize;
@@ -659,7 +659,7 @@ impl PyTofScanPlanGroup {
         }
 
         // slice
-        if let Ok(slice) = idx.downcast::<PySlice>() {
+        if let Ok(slice) = idx.cast::<PySlice>() {
             let indices = slice.indices(self.windows_idx.len() as isize)?;
             let (start, stop, step) = (indices.start, indices.stop, indices.step);
             let out = PyList::empty(py);
@@ -717,25 +717,25 @@ impl PyTofScanPlanGroup {
 
         let indices: Vec<usize> = (start..end).collect();
 
-        // Build all grids without holding the GIL
-        let built: Vec<Result<TofScanWindowGrid, String>> = py.allow_threads(|| {
-            if self.views.is_some() {
-                // Fully GIL-free path when views are precomputed
+        // Build all grids. The views path is fully GIL-free (no dataset access),
+        // so it runs under `detach`. The dataset path borrows the Python dataset
+        // in `build_window`, so it must hold the GIL; `build_window` already
+        // parallelizes internally over frames, so the outer loop stays serial on
+        // the GIL thread. (The previous code released the GIL and re-fabricated a
+        // token via the now-removed `assume_gil_acquired`, which was unsound.)
+        let built: Vec<Result<TofScanWindowGrid, String>> = if self.views.is_some() {
+            py.detach(|| {
                 indices
                     .par_iter()
                     .map(|&i| Ok(self.build_window_from_views(i)))
                     .collect()
-            } else {
-                // Fall back to calling build_window under an assumed GIL.
-                indices
-                    .par_iter()
-                    .map(|&i| {
-                        let py = unsafe { Python::assume_gil_acquired() };
-                        self.build_window(py, i).map_err(|e| format!("{e}"))
-                    })
-                    .collect()
-            }
-        });
+            })
+        } else {
+            indices
+                .iter()
+                .map(|&i| self.build_window(py, i).map_err(|e| format!("{e}")))
+                .collect()
+        };
 
         // Convert to Python objects, preserving order and surfacing any errors
         let mut out = Vec::with_capacity(built.len());
@@ -793,7 +793,7 @@ impl PyTofScanPlanGroup {
             let fids = self.frame_ids_sorted[lo..=hi].to_vec();
             let frames = {
                 let ds_bound = self.ds.bind(py);
-                let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.downcast()?;
+                let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.cast()?;
                 let ds_ref = ds_obj.borrow();
                 ds_ref.inner.get_slice(fids, self.num_threads).frames
             };
@@ -970,7 +970,7 @@ impl PyTofScanPlan {
         // ---- Borrow only inside this block; collect everything we need, then drop the borrow.
         let (frame_ids_sorted, frame_times, scale, rows, global_num_scans, views) = {
             let ds_bound = ds.bind(py);
-            let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.downcast()?;
+            let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.cast()?;
             let ds_ref = ds_obj.borrow();
 
             // 1) RT-sort MS1 frames
@@ -1149,7 +1149,7 @@ impl PyTofScanPlan {
         }
     }
 
-    fn __getitem__(&self, py: Python<'_>, idx: &Bound<PyAny>) -> PyResult<PyObject> {
+    fn __getitem__(&self, py: Python<'_>, idx: &Bound<PyAny>) -> PyResult<Py<PyAny>> {
         // integer first
         if let Ok(i_signed) = idx.extract::<isize>() {
             let n = self.windows_idx.len() as isize;
@@ -1163,7 +1163,7 @@ impl PyTofScanPlan {
         }
 
         // slice
-        if let Ok(slice) = idx.downcast::<PySlice>() {
+        if let Ok(slice) = idx.cast::<PySlice>() {
             let indices = slice.indices(self.windows_idx.len() as isize)?;
             let (start, stop, step) = (indices.start, indices.stop, indices.step);
             let out = PyList::empty(py);
@@ -1221,23 +1221,21 @@ impl PyTofScanPlan {
         let end = (start + count).min(n);
         let indices: Vec<usize> = (start..end).collect();
 
-        let built: Vec<Result<TofScanWindowGrid, String>> = py.allow_threads(|| {
-            if self.views.is_some() {
+        // See get_batch_par above: views path is GIL-free (detach); the dataset
+        // path holds the GIL and relies on build_window's internal parallelism.
+        let built: Vec<Result<TofScanWindowGrid, String>> = if self.views.is_some() {
+            py.detach(|| {
                 indices
                     .par_iter()
                     .map(|&i| Ok(self.build_window_from_views(i)))
                     .collect()
-            } else {
-                indices
-                    .par_iter()
-                    .map(|&i| {
-                        let py = unsafe { Python::assume_gil_acquired() };
-                        // now build_window returns Result, so map_err makes sense
-                        self.build_window(py, i).map_err(|e| format!("{e}"))
-                    })
-                    .collect()
-            }
-        });
+            })
+        } else {
+            indices
+                .iter()
+                .map(|&i| self.build_window(py, i).map_err(|e| format!("{e}")))
+                .collect()
+        };
 
         let mut out = Vec::with_capacity(built.len());
         for item in built {
@@ -1266,7 +1264,7 @@ impl PyTofScanPlan {
             let fids = self.frame_ids_sorted[lo..=hi].to_vec();
             let frames = {
                 let ds_bound = self.ds.bind(py);
-                let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.downcast()?;  // <-- `?` now valid
+                let ds_obj: &Bound<PyTimsDatasetDIA> = ds_bound.cast()?;  // <-- `?` now valid
                 let ds_ref = ds_obj.borrow();
                 ds_ref.inner.get_slice(fids, self.num_threads).frames
             };
@@ -1386,7 +1384,7 @@ impl PyTofScanPlan {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyFit1D {
     pub inner: Fit1D,
@@ -1619,7 +1617,7 @@ impl PyRtPeak1D {
         let min_width = min_width.max(1);
 
         // ---- Heavy work in parallel, GIL released ------------------------
-        let peaks: Vec<RtPeak1D> = py.allow_threads(|| {
+        let peaks: Vec<RtPeak1D> = py.detach(|| {
             (0..n)
                 .into_par_iter()
                 .map(|i| {
@@ -2095,7 +2093,7 @@ impl PyImPeak1D {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyTofScanWindowGrid {
     pub inner: TofScanWindowGrid,
@@ -2406,7 +2404,7 @@ impl PyTimsDatasetDIA {
             };
 
             // ---- Run the core DIA clustering --------------------------------
-            let mut results = py.allow_threads(|| {
+            let mut results = py.detach(|| {
                 self.inner.clusters_for_group(
                     window_group,
                     tof_step,
@@ -2557,7 +2555,7 @@ impl PyTimsDatasetDIA {
             };
 
             // ---- Run the core MS1 clustering --------------------------------
-            let mut results = py.allow_threads(|| {
+            let mut results = py.detach(|| {
                 self.inner.clusters_for_precursor(
                     tof_step,
                     &im_rs,
@@ -3078,7 +3076,7 @@ pub fn save_clusters_bin(
 ) -> PyResult<()> {
     let mut rust_clusters = Vec::with_capacity(clusters.len());
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         for c in clusters {
             let inner = &c.borrow(py).inner;
 
@@ -3137,7 +3135,7 @@ pub fn save_clusters_parquet(
 ) -> PyResult<()> {
     let mut rust_clusters = Vec::with_capacity(clusters.len());
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         for c in clusters {
             let inner = &c.borrow(py).inner;
 
@@ -3214,7 +3212,7 @@ pub fn save_pseudo_spectra_bin(
 ) -> PyResult<()> {
     let mut rust_spectra = Vec::with_capacity(spectra.len());
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         for s in spectra {
             let inner = &s.borrow(py).inner;
             // No heavy fields to strip, just clone the whole thing
@@ -3234,7 +3232,7 @@ pub fn load_pseudo_spectra_bin(
     let spectra = cio::load_pseudo_bincode(path)
         .map_err(|e| exceptions::PyIOError::new_err(e.to_string()))?;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut out = Vec::with_capacity(spectra.len());
         for spec in spectra {
             let obj = Py::new(py, PyPseudoSpectrum { inner: spec })
@@ -3309,7 +3307,7 @@ impl PyTofRtGrid {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyAssignmentResult {
     pub inner: AssignmentResult,
@@ -3342,7 +3340,7 @@ impl PyAssignmentResult {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPseudoBuildResult {
     pub inner: PseudoBuildResult,
@@ -3474,7 +3472,7 @@ impl PyScoredHit {
 }
 
 use std::sync::Arc;
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyCandidateOpts {
     pub(crate) inner: CandidateOpts,

--- a/imspy_connector/src/py_feature.rs
+++ b/imspy_connector/src/py_feature.rs
@@ -18,7 +18,7 @@ use crate::py_dia::PyClusterResult1D;
 // PyAveragineLut – optional, but now used for cosine gating too
 // ---------------------------------------------------------------
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyAveragineLut {
     pub inner: AveragineLut,
@@ -105,7 +105,7 @@ impl PyAveragineLut {
 // PySimpleFeatureParams – controls the greedy builder
 // ---------------------------------------------------------------
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PySimpleFeatureParams {
     pub inner: SimpleFeatureParams,
@@ -197,7 +197,7 @@ impl PySimpleFeatureParams {
 // PySimpleFeature – thin wrapper around SimpleFeature
 // ---------------------------------------------------------------
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PySimpleFeature {
     pub inner: SimpleFeature,

--- a/imspy_connector/src/py_mz_spectrum.rs
+++ b/imspy_connector/src/py_mz_spectrum.rs
@@ -6,7 +6,7 @@ use mscore::timstof::spectrum::{TimsSpectrum};
 use pyo3::types::{PyList, PyTuple};
 use std::sync::OnceLock;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyMsType {
     pub inner: MsType,
@@ -27,7 +27,7 @@ impl PyMsType {
     pub fn ms_type_numeric(&self) -> i32 { self.inner.ms_type_numeric() }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PyMzSpectrum {
     pub inner: MzSpectrum,
     // Cached numpy arrays
@@ -148,7 +148,7 @@ impl PyMzSpectrum {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyMzSpectrumVectorized {
     pub inner: MzSpectrumVectorized,
@@ -188,7 +188,7 @@ impl PyMzSpectrumVectorized {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PyIndexedMzSpectrum {
     pub inner: IndexedMzSpectrum,
     // Cached numpy arrays
@@ -262,7 +262,7 @@ impl PyIndexedMzSpectrum {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PyTimsSpectrum {
     pub inner: TimsSpectrum,
     // Cached numpy arrays

--- a/imspy_connector/src/py_peptide.rs
+++ b/imspy_connector/src/py_peptide.rs
@@ -55,7 +55,7 @@ impl PyPeptideIon {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPeptideProductIonSeries {
     pub inner: PeptideProductIonSeries,
@@ -133,7 +133,7 @@ impl PyPeptideProductIonSeriesCollection {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPeptideSequence {
     pub inner: PeptideSequence,
@@ -276,7 +276,7 @@ impl PyPeptideSequence {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPeptideProductIon {
     pub inner: PeptideProductIon,

--- a/imspy_connector/src/py_pseudo.rs
+++ b/imspy_connector/src/py_pseudo.rs
@@ -4,7 +4,7 @@ use rustdf::cluster::pseudo::{PseudoFragment, PseudoSpectrum};
 use crate::py_dia::PyClusterResult1D;
 use crate::py_feature::PySimpleFeature;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyPseudoFragment {
     mz: f32,
@@ -37,7 +37,7 @@ impl PyPseudoFragment {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyPseudoSpectrum {
     pub inner: PseudoSpectrum,

--- a/imspy_connector/src/py_quadrupole.rs
+++ b/imspy_connector/src/py_quadrupole.rs
@@ -6,7 +6,7 @@ use mscore::timstof::quadrupole::{IonTransmission, PASEFMeta, TimsTransmissionDD
 use crate::py_mz_spectrum::PyMzSpectrum;
 use crate::py_tims_frame::PyTimsFrame;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPasefMeta {
     pub inner : PASEFMeta,

--- a/imspy_connector/src/py_simulation.rs
+++ b/imspy_connector/src/py_simulation.rs
@@ -64,7 +64,7 @@ use crate::py_tims_frame::PyTimsFrame;
 ///     individual fragment ion based on its complementary fragment (more accurate but slower)
 /// * `min_probability` - Minimum probability threshold for isotope transmission (default: 0.5)
 /// * `max_isotopes` - Maximum number of isotope peaks to consider (default: 10)
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyIsotopeTransmissionConfig {
     pub inner: IsotopeTransmissionConfig,
@@ -633,7 +633,7 @@ pub fn write_spectral_library_tsv(
 ) -> PyResult<(usize, usize)> {
     use pyo3::exceptions::PyValueError;
     use std::path::Path;
-    py.allow_threads(|| {
+    py.detach(|| {
         rustdf::sim::library::build_spectral_library_tsv(
             Path::new(out_path),
             &modified_sequences,

--- a/imspy_connector/src/py_spectrum_processing.rs
+++ b/imspy_connector/src/py_spectrum_processing.rs
@@ -6,7 +6,7 @@ use mscore::timstof::spectrum_processing::{
     deisotope_spectrum, filter_top_n, process_spectrum,
 };
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PySpectrumProcessingConfig {
     pub inner: SpectrumProcessingConfig,
@@ -60,7 +60,7 @@ impl PySpectrumProcessingConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPreprocessedSpectrum {
     pub inner: PreprocessedSpectrum,

--- a/imspy_connector/src/py_tims_frame.rs
+++ b/imspy_connector/src/py_tims_frame.rs
@@ -9,7 +9,7 @@ use std::sync::OnceLock;
 
 use crate::py_mz_spectrum::{PyIndexedMzSpectrum, PyTimsSpectrum};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyRawTimsFrame {
     pub inner: RawTimsFrame,
@@ -71,7 +71,7 @@ impl PyRawTimsFrame {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PyTimsFrame {
     pub inner: TimsFrame,
     // Cached numpy arrays - lazily initialized on first access (stored as Py<PyAny> for Clone)
@@ -309,7 +309,7 @@ impl PyTimsFrame {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyTimsFrameVectorized {
     pub inner: TimsFrameVectorized,

--- a/imspy_connector/src/py_tims_slice.rs
+++ b/imspy_connector/src/py_tims_slice.rs
@@ -7,7 +7,7 @@ use crate::py_mz_spectrum::{PyTimsSpectrum};
 
 use crate::py_tims_frame::{PyTimsFrame, PyTimsFrameVectorized};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyTimsSlice {
     pub inner: TimsSlice,
@@ -177,7 +177,7 @@ impl PyTimsSlice {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyTimsSliceVectorized {
     pub inner: TimsSliceVectorized,


### PR DESCRIPTION
## What & why

Closes the three open Dependabot alerts against **pyo3** (all fixed in ≥ 0.29):

| Sev | Advisory | Issue |
|-----|----------|-------|
| High | GHSA-36hh-v3qg-5jq4 | OOB read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators |
| Medium | GHSA-chgr-c6px-7xpp | missing `Sync` bound on `PyCFunction::new_closure` |
| Low | GHSA-pph8-gcv7-4qj5 | buffer overflow in `PyString::from_object` |

None of the vulnerable APIs are called in this crate (verified by grep), so real-world exposure was nil — but the bump clears the alerts and modernizes the binding layer. Bumps `pyo3` **0.23 → 0.29** and `numpy` **0.23 → 0.29** (they version-pair).

## API migration (localized to 3 files: `py_dia`, `py_acquisition`, `py_simulation`)

- `Python::with_gil` → `Python::attach`
- `Python::allow_threads` → `Python::detach`
- `Bound::downcast` → `Bound::cast`
- `PyObject` (dropped from prelude) → `Py<PyAny>`

## Latent unsoundness fixed ⚠️

The removal of `Python::assume_gil_acquired` in 0.29 surfaced a real bug in `get_batch_par` (two sites): it released the GIL via `allow_threads`, then **re-fabricated a `Python` token inside a rayon parallel loop** that borrows the Python dataset (`build_window`) — undefined behavior. Fixed: the views path stays fully GIL-free under `detach`; the dataset path now holds the GIL on the outer loop and relies on `build_window`'s existing internal frame-level parallelism.

## Deprecation cleanup

Every `Clone` `#[pyclass]` is opted into `#[pyclass(from_py_object)]` to **preserve** the current auto-`FromPyObject` behavior (0.29 makes it opt-in). Build is warning-clean (0 warnings).

## Verification

- `cargo check` — clean, **0 errors / 0 warnings**
- `maturin build --release` — wheel builds and **links** cleanly (extension-module)
- Throwaway-venv smoke test: connector imports, all 22 submodules load, a `Clone` pyclass round-trips through construction, getters, `filter_ranged`, and by-value `__add__` (the `FromPyObject` extraction path)

**Not runtime-tested:** the restructured `get_batch_par` dataset path (needs a real DIA `.d` dataset). The change is straightforward and compiles, but a reviewer with a DIA dataset should exercise `get_batch_par` on a no-precomputed-views group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)