### PR TITLE
docs(imspy-simulation): annotated-frame onboarding notebook (#425)

### DIFF
--- a/packages/imspy-simulation/CONFIGURATION.md
+++ b/packages/imspy-simulation/CONFIGURATION.md
@@ -419,6 +419,14 @@ written into the raw output file**; there is no annotated-raw writer. Instead yo
 **stream** annotated frames in Python, on demand, straight from
 `synthetic_data.db`.
 
+> **▶ Start here: the onboarding notebook.** A runnable, end-to-end walkthrough of
+> everything in this section — building annotated precursor **and** fragment frames,
+> reading the per-peak `.df`, assembling m/z–ion-mobility and m/z–retention-time maps,
+> understanding the `to_dense_windows_with_labels` output (what `N` and `Y` are and why
+> `overlapping=True` produces duplicate cells), and a small PyTorch training loop — lives
+> at [`notebooks/AnnotatedFrames_Onboarding.ipynb`](notebooks/AnnotatedFrames_Onboarding.ipynb).
+> Point it at any TimSim run's `synthetic_data.db` and run top-to-bottom.
+
 > **Package layout note (latest `main`).** The monolithic `imspy` package has
 > been split into modular packages, so imports differ from older notebooks/the
 > paper's examples. In particular `from imspy.simulation…` → `from

--- a/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
+++ b/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
@@ -1,0 +1,1364 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ba227d1d",
+   "metadata": {},
+   "source": [
+    "# Working with Annotated Frames\n",
+    "\n",
+    "**Peak-level ground truth from TimSim synthetic timsTOF data — and how to use it for machine learning.**\n",
+    "\n",
+    "TimSim writes two kinds of ground truth for every simulation:\n",
+    "\n",
+    "1. **Molecule-level ground truth** — the complete molecular layout (peptides, ions,\n",
+    "   fragments, proteins) in `synthetic_data.db`.\n",
+    "2. **Peak-level annotations** — for every *peak* in a frame, which peptide / charge\n",
+    "   state / isotope it came from. This is what makes synthetic data useful for\n",
+    "   training and benchmarking ML models directly on raw signal.\n",
+    "\n",
+    "This notebook is a hands-on tour of the **peak-level** side: how to build annotated\n",
+    "frames, read the per-peak labels, turn them into m/z–ion-mobility and m/z–retention-time\n",
+    "maps, understand the model-ready `to_dense_windows_with_labels` output, and feed all of\n",
+    "it into a small PyTorch model.\n",
+    "\n",
+    "> **Prerequisites:** a TimSim simulation output directory containing a\n",
+    "> `synthetic_data.db`. Any DIA/DDA/midia run produces one. If you don't have one yet,\n",
+    "> run a quick simulation (see `CONFIGURATION.md`) or point the config cell below at an\n",
+    "> existing run.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77a9440e",
+   "metadata": {},
+   "source": [
+    "## 0 · Setup\n",
+    "\n",
+    "Point `DATASET_DB` at the `synthetic_data.db` of one of your TimSim runs. You can also\n",
+    "set the `TIMSIM_DB` environment variable instead of editing the cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b9128e3a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:56.170227Z",
+     "iopub.status.busy": "2026-07-02T09:33:56.169961Z",
+     "iopub.status.idle": "2026-07-02T09:33:56.687931Z",
+     "shell.execute_reply": "2026-07-02T09:33:56.687538Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using run: TIMSIM-DIA\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sqlite3\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# --- EDIT ME: path to a synthetic_data.db from a TimSim run --------------------\n",
+    "DATASET_DB = os.environ.get(\n",
+    "    \"TIMSIM_DB\",\n",
+    "    \"/path/to/your/timsim_run/synthetic_data.db\",   # <- replace with your own\n",
+    ")\n",
+    "\n",
+    "assert os.path.exists(DATASET_DB), (\n",
+    "    f\"synthetic_data.db not found at {DATASET_DB!r}.\\n\"\n",
+    "    \"Set TIMSIM_DB or edit DATASET_DB to point at a TimSim run.\"\n",
+    ")\n",
+    "# Show the run name only (keeps local paths out of committed notebook output).\n",
+    "print(\"Using run:\", os.path.basename(os.path.dirname(os.path.abspath(DATASET_DB))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3759689f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:56.689112Z",
+     "iopub.status.busy": "2026-07-02T09:33:56.689002Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.433568Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.433172Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Builder ready: TimsTofSyntheticPrecursorFrameBuilder\n"
+     ]
+    }
+   ],
+   "source": [
+    "from imspy_simulation.experiment import TimsTofSyntheticPrecursorFrameBuilder\n",
+    "\n",
+    "# The builder reads the molecular ground truth and reconstructs frames on demand.\n",
+    "builder = TimsTofSyntheticPrecursorFrameBuilder(DATASET_DB)\n",
+    "print(\"Builder ready:\", type(builder).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86473feb",
+   "metadata": {},
+   "source": [
+    "## 1 · Enumerate precursor (MS1) frames\n",
+    "\n",
+    "Annotated **precursor** frames are built one MS1 frame at a time. The `frames` table in\n",
+    "`synthetic_data.db` lists every frame with its `ms_type` (`0` = precursor/MS1) and\n",
+    "retention `time`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "aa407da3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.434866Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.434750Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.455177Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.454786Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2135 precursor frames (of 34155 total; ms_type counts: {9: 32020, 0: 2135})\n",
+      "first precursor frame_ids: [1, 17, 33, 49, 65, 81, 97, 113]\n"
+     ]
+    }
+   ],
+   "source": [
+    "with sqlite3.connect(DATASET_DB) as con:\n",
+    "    frames = pd.read_sql_query(\n",
+    "        \"SELECT frame_id, time, ms_type FROM frames ORDER BY frame_id\", con\n",
+    "    )\n",
+    "\n",
+    "precursor_ids = frames.loc[frames.ms_type == 0, \"frame_id\"].astype(int).tolist()\n",
+    "print(f\"{len(precursor_ids)} precursor frames \"\n",
+    "      f\"(of {len(frames)} total; ms_type counts: {frames.ms_type.value_counts().to_dict()})\")\n",
+    "print(\"first precursor frame_ids:\", precursor_ids[:8])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "848ba553",
+   "metadata": {},
+   "source": [
+    "## 2 · Build a single annotated frame\n",
+    "\n",
+    "`build_precursor_frame_annotated(frame_id)` returns a `TimsFrameAnnotated`: the same\n",
+    "peaks a real MS1 frame would have, but every peak carries its ground-truth origin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2344a071",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.456245Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.456186Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.470653Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.470319Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "frame_id       = 17073\n",
+      "retention_time = 1800.3 s  (30.00 min)\n",
+      "num peaks      = 10,849\n",
+      "m/z range      = 380.2 – 1220.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "frame = builder.build_precursor_frame_annotated(precursor_ids[len(precursor_ids) // 2])\n",
+    "print(f\"frame_id       = {frame.frame_id}\")\n",
+    "print(f\"retention_time = {frame.retention_time:.1f} s  ({frame.retention_time/60:.2f} min)\")\n",
+    "print(f\"num peaks      = {len(frame.mz):,}\")\n",
+    "print(f\"m/z range      = {min(frame.mz):.1f} – {max(frame.mz):.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa016644",
+   "metadata": {},
+   "source": [
+    "## 3 · The `.df` view — the easy entry point\n",
+    "\n",
+    "`frame.df` is a tidy per-peak table. **One row = one peak**, with its label columns:\n",
+    "\n",
+    "| column | meaning |\n",
+    "|---|---|\n",
+    "| `mz`, `scan`, `inv_mobility`, `intensity`, `tof` | the peak itself |\n",
+    "| `peptide_id` | which peptide it belongs to (`-2` = random noise) |\n",
+    "| `charge_state` | charge of the contributing ion |\n",
+    "| `isotope_peak` | which isotope in the envelope (0 = monoisotopic) |\n",
+    "\n",
+    "For most analysis and visualization, this is all you need — no windowing required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c65cf2cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.471667Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.471607Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.477703Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.477351Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "columns: ['tof', 'mz', 'scan', 'inv_mobility', 'intensity', 'peptide_id', 'charge_state', 'isotope_peak']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tof</th>\n",
+       "      <th>mz</th>\n",
+       "      <th>scan</th>\n",
+       "      <th>inv_mobility</th>\n",
+       "      <th>intensity</th>\n",
+       "      <th>peptide_id</th>\n",
+       "      <th>charge_state</th>\n",
+       "      <th>isotope_peak</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1217.611130</td>\n",
+       "      <td>200</td>\n",
+       "      <td>1.384250</td>\n",
+       "      <td>3.813788</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1218.113239</td>\n",
+       "      <td>200</td>\n",
+       "      <td>1.384250</td>\n",
+       "      <td>4.585320</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1218.614485</td>\n",
+       "      <td>200</td>\n",
+       "      <td>1.384250</td>\n",
+       "      <td>2.674591</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1219.116391</td>\n",
+       "      <td>200</td>\n",
+       "      <td>1.384250</td>\n",
+       "      <td>1.079969</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1217.611130</td>\n",
+       "      <td>201</td>\n",
+       "      <td>1.383172</td>\n",
+       "      <td>5.720683</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1218.113239</td>\n",
+       "      <td>201</td>\n",
+       "      <td>1.383172</td>\n",
+       "      <td>6.877981</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1218.614485</td>\n",
+       "      <td>201</td>\n",
+       "      <td>1.383172</td>\n",
+       "      <td>4.011886</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1219.116391</td>\n",
+       "      <td>201</td>\n",
+       "      <td>1.383172</td>\n",
+       "      <td>1.619954</td>\n",
+       "      <td>289</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   tof           mz  scan  inv_mobility  intensity  peptide_id  charge_state  \\\n",
+       "0    0  1217.611130   200      1.384250   3.813788         289             2   \n",
+       "1    0  1218.113239   200      1.384250   4.585320         289             2   \n",
+       "2    0  1218.614485   200      1.384250   2.674591         289             2   \n",
+       "3    0  1219.116391   200      1.384250   1.079969         289             2   \n",
+       "4    0  1217.611130   201      1.383172   5.720683         289             2   \n",
+       "5    0  1218.113239   201      1.383172   6.877981         289             2   \n",
+       "6    0  1218.614485   201      1.383172   4.011886         289             2   \n",
+       "7    0  1219.116391   201      1.383172   1.619954         289             2   \n",
+       "\n",
+       "   isotope_peak  \n",
+       "0             0  \n",
+       "1             1  \n",
+       "2             2  \n",
+       "3             3  \n",
+       "4             0  \n",
+       "5             1  \n",
+       "6             2  \n",
+       "7             3  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = frame.df\n",
+    "print(\"columns:\", list(df.columns))\n",
+    "df.head(8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "49a1918c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.478626Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.478570Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.480894Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.480578Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "signal peaks: 10,849   noise peaks: 0   distinct peptides: 7\n"
+     ]
+    }
+   ],
+   "source": [
+    "# label composition of this frame\n",
+    "n_signal = int((df.peptide_id >= 0).sum())\n",
+    "n_noise  = int((df.peptide_id == -2).sum())\n",
+    "print(f\"signal peaks: {n_signal:,}   noise peaks: {n_noise:,}   \"\n",
+    "      f\"distinct peptides: {df.loc[df.peptide_id >= 0, 'peptide_id'].nunique()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "484a95d9",
+   "metadata": {},
+   "source": [
+    "## 4 · Build an m/z–ion-mobility map (with a label overlay)\n",
+    "\n",
+    "The classic single-frame view: intensity as a function of **m/z** (x) and\n",
+    "**ion mobility / scan** (y). We build it straight from `.df` by histogramming the peaks\n",
+    "onto a grid. The same binning gives us an aligned **label map** (the dominant peptide id\n",
+    "per cell) that we can overlay."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "767315aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.481942Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.481881Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.484711Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.484381Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def grid_peaks(mz, keys, values, labels, mz_min, mz_max, mz_bin,\n",
+    "               key_min, key_max, key_bin):\n",
+    "    \"\"\"Bin peaks onto a (key-axis x m/z) grid.\n",
+    "\n",
+    "    Returns (intensity_image, label_image, mz_edges, key_edges).\n",
+    "    - intensity accumulates (sum) per cell\n",
+    "    - label = the id of the highest-intensity peak in that cell (dominant contributor)\n",
+    "    \"\"\"\n",
+    "    n_mz  = int(np.ceil((mz_max  - mz_min ) / mz_bin )) + 1\n",
+    "    n_key = int(np.ceil((key_max - key_min) / key_bin)) + 1\n",
+    "    col = np.round((mz   - mz_min ) / mz_bin ).astype(int)\n",
+    "    row = np.round((keys - key_min) / key_bin).astype(int)\n",
+    "    ok  = (col >= 0) & (col < n_mz) & (row >= 0) & (row < n_key)\n",
+    "    row, col, values, labels = row[ok], col[ok], values[ok], labels[ok]\n",
+    "\n",
+    "    img = np.zeros((n_key, n_mz), np.float32)\n",
+    "    np.add.at(img, (row, col), values)                    # intensity accumulates\n",
+    "\n",
+    "    lbl = np.full((n_key, n_mz), -1, np.int32)\n",
+    "    order = np.argsort(values, kind=\"stable\")             # highest intensity wins the cell\n",
+    "    lbl[row[order], col[order]] = labels[order]\n",
+    "\n",
+    "    mz_edges  = mz_min  + np.arange(n_mz ) * mz_bin\n",
+    "    key_edges = key_min + np.arange(n_key) * key_bin\n",
+    "    return img, lbl, mz_edges, key_edges"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "15584a36",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.485723Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.485659Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.739795Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.734408Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABQoAAAHvCAYAAAAcm+J6AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWJ5JREFUeJzt3QeYXFXZAOCzm0YoCS30QGiKCIRIM0hVIBTpigJKBBGQIoINEAggEBGkCEEQBQQEKUIAaSqCoQmEZqH8IpFQEnoSEkLa3v/5DsxmdrKbbJLdnS3v+zyTnblzZ+bce6d8+e75zqkpiqJIAAAAAECXVlvtBgAAAAAA1SdRCAAAAABIFAIAAAAAEoUAAAAAgEQhAAAAACBRCAAAAABkJjMBAAAAACQKAQAAAACJQgAAAABAohAA5t+VV16Zampq0v/+979OvftiG4888sgF2h/bbLNNvpTEfbFOrMv8+89//pN22GGH1Ldv37wfR44caTdCO1f6bhw9enS1mwIAzWaMQgA6vb333jvtvPPO1W4GFe688850yimn2C/NMHTo0PTPf/4znXHGGenqq69OG2+8cafYby+88EI65phj0uabb54WWWSRJhPw999/f76vqUvsl3ITJkxIhxxySOrXr19abLHF0rbbbpuefPLJBX7OUaNGpd122y31798/t3OFFVZIO+64Y3rooYdaJbHU1OV3v/tdg/Vfe+21tM8++6Qll1wy9enTJ+2+++7ppZdeavS5f/Ob36RPfepTuf1rr712uvDCC5vdrmnTpqUf/ehHaaWVVkq9e/dOm222Wfrzn//crMfO77ELf/nLX9LnP//5nBhfYokl0kYbbZSuv/76Oda77bbb0mc+85m8TauuumoaNmxYmjlzZrPaVVdXl372s5+l1VdfPT9+gw02SNddd91cH1M64dGcS2c/kQRA59W92g0AgNY0Y8aM/B/a4cOHt9hzfv3rX09f/epXU69evVrsOTuy5uyP1VZbLU2dOjX16NGjQaJwxIgRkoXzEPvtkUceST/+8Y+b1cOzI4nt+sUvfpHWXXfdnMR6+umnG10v7osEaaVY9qc//Sn3tixPAO2yyy7pmWeeST/4wQ/Ssssumy6++OLcw/WJJ57ISbL5fc7/+7//S7W1temwww7LScL33nsvXXPNNWmrrbZKd9xxR04atoR4vsbadN555+Xt+cIXvlC/bPLkyTkBOnHixHTCCSfkz1ast/XWW+f9uMwyy9Sve+mll+a2x0mTY489Nj3wwAPpO9/5Tvrggw9yAnBevvGNb6Sbbropffe73837LxKacfLlvvvuS1tsscVcHzs/+zlcccUV6Zvf/Gbafvvt05lnnpm6deuWE8qvvPJKg/XuuuuutMcee+TjGknPSKSffvrp6c0330y//OUv57lN8Xn66U9/mr71rW+lTTbZJN16661pv/32y0m++D5rTCSeK7fl5z//eXr11Vfzvq9cFwA6pAIAOrF77723iJ+7MWPGVLspHU7styOOOGKBHrv11lvny9zEcwtF5u3ll1/O++nss8+e57qTJ08uOpJ33nmnmDRpUr4e2ze/n9W11lqrWHvttRssu/766/Pz3HjjjfXL3nzzzWLJJZcs9t133wV6zsZMmTKlWH755YshQ4YUremDDz4ollhiiWL77bdvsPyss87K2/nYY4/VL3vuueeKbt26Fccff3yDxy+zzDLFLrvs0uDx+++/f7HYYosV77777lxf/9FHH53j/Td16tRizTXXLAYPHrzA29XYfo5j37t37+I73/nOPB+/7rrrFgMHDixmzJhRv+zHP/5xUVNTk/fD3Lz66qtFjx49Gny/1dXVFVtuuWWxyiqrFDNnzmz2dsR+XW211Rq974orrsj77vHHH2/28wFAtSk9BqBdipLU6NkRPXm+9rWv5RK06KFx0kknxUmu3Lskyuyi3C56+ESvjsZEb5/orTRgwIC5lsDF/Qs7RmH0Wvr0pz+de9ZFid4RRxyRSyDLRe+X9dZbLz377LO5N9Ciiy6aVl555VwCNz+v/eCDD+YeQbFPouzw0EMPTdOnT8+vd8ABB6SllloqX374wx/m/VVuypQp6Xvf+14uo4y2fvKTn0znnHPOHOuVRLljrBPleVECGGWYzdkf5SrHKIweStGbMJQfh2hDHIs4tpU+/PDD/D6IbW3O2Io33nhjPvZRKjl48ODc46jUu2qttdbK2xPHo7Ld0dvqy1/+ci5ljP0T+ynKY6NnX7nYhsUXXzyXeg4ZMiSXuMZxP+2005rclwvyOYjemCF6x5W/V0ufkXgvRU+oON6l3l3/+Mc/cvvWWGON+lLZgw46KL3zzjst/jmLstQo+Yx9Wtpf8b6L5fOy9NJL59LSBfHYY4+lF198Me2///4NlkfPt+WXXz7ttdde9ctim6JEN3qNza1dTT1nY+KzG89b+Rlvabfffnt6//33G93O6AkXl5J11lkn9zq84YYb6pdFr7847ocffniDx8f3U3wXxHfk3MTrRK++KOUuifdU9PqLHqGVPf2ao6n9fMkll6RZs2blz1Cp12Rjn6V4z8cl2tS9++wCqdjGWD/aPDfxPoje5uX7JD4H3/72t3PvwNiulhTvuejJWSqF33PPPdNbb73Voq8BAC1FohCAdu0rX/lKLiWMErEYFytKy84///xclhYJtrPOOisnKL7//e/PkcAqlbeWxicslcCVX6JkLUr2lltuuYVqZyRc4j/ekSiKZEqU+EVCKsrq4j+k5aJsMUoVBw4cmNeN/9xH+V+U0jXXUUcdlSe4OPXUU/PYab/61a9ycmfXXXfN/9GOkr1IGp199tkNSuXiP9GxfpTJRRvOPffcnASMJFT8R7bS3/72t1xuGEmk+M97JBzicf/6178Wan9Fsi+OYSg/HvGf9Xit2BfvvvvuHAmTSZMm5fvnJZJ9kQyNsf3i2Dz33HPpi1/8Yk5ORqlrJAhimyMhEAm0cpFgjJLMSBrE+yOSgPE3ErCVYl/H/ojEVCR7I5EaSbO4tIRIdpVKGvfdd9+8j+L9Xy6SmtHeOOZRRhmi3D4SmAceeGBue5RS/v73v8+fhcYSLwv6OYvHxPspEs3x3ovXinLQaHM8Z2sqjddXmWx66qmn8rh1USpcbtNNN837KZKi8/ucJfH+e/vtt9Pzzz+fy33jc1BeDtwaok2R7C5PfMZ+j2RwY2NVxnb+97//zcnF0v4IlevGezX2Uen+psT9n/jEJ3KyuPJ1QlPl4vPapsb2c4xNGN+H8b29yiqr5CRylFDHd1tsc3mbGtum+P6NxzVnmyJhF78JjW3TvB4/v+L7OkrH43shvlfiu6yzDSMAQCdS7S6NANCYYcOG5ZKtQw45pH5ZlINFWViUlv30pz+tX/7ee+/lcrWhQ4c2eI6XXnopP8d9993X6GtEqdkXv/jFYvHFFy/+/e9/N/tAlMrJSiWSUdbYs2fPYocddihmzZpVv95FF12U17v88svrl0U5biy76qqr6pdNmzatWGGFFYq999672a8d5Y7R/pIoAYz9cthhh82xv8pLgEeOHJkff/rppzd43i996Uv58S+++GL9slgvLqNHj25QBrvIIosUe+65Z5P7o7Sd5a8b98U6se68So9feOGFvPyXv/xlg+W77bZbMWDAgAbb3Zh4bK9evRq059JLL83LYz+XSl1DlGhWtj1KNSsNHz4875/Y/pJ4v8VjjzrqqPpl0bYoRYz3w1tvvTXXdr7++uu5RHL69OlzXa+07ypLj0ufkcbKaRvbhuuuuy6vP2rUqBb7nF199dVFbW1t8cADDzR4rUsuuSQ/70MPPVQ01/yUHkcbo+x30003neO+KKc96KCD5lh+xx135Oe/++675/s5S+JzV/pcxDE+9NBDcxnuvMR7IY51lCvPb2l2vM4+++wzx/NFG0477bQ5HjNixIh83/PPP1//OYty5Mb069ev+OpXvzrXNnz6058uPv/5z8+xPL4z43XiWM+Pue3nPn36FEsttVT+/J500knFTTfdVOy33375dY477rg53itjx46d4zk22WST4rOf/exc2xCf0TXWWGOO5XF8Kl+rJUqPt9tuuwbfW8ccc0w+JhMmTGj26wBAW9GjEIB27eCDD66/HuVv0YMkckFR9lYSpbfRK65yts8oqYtSyqYG2//JT36S/vjHP+Zy2ChRXVDRCybKfqPnXXkvpujdFb1wKkv7oly1vFdcz549c0+WpmYrbUxsf/S+K4leYJX7pbS/yp83eurE8ihbLhe97+Lxlb0ao2Q3eh6VRDlulKLec889uTdda4jeS7E95TO8Ru/CaFv0QCrf7qZEL6/ycvJ4vhA9PctLXUvLy/dR9N4qidLM6EEWs/LG/mmsp1F5z6BS2XO8H+J9MTfHH3987tEUM9cujJikolL5NkTJdmzDZz/72Xy7cvbfhfmcRe/L2IboBRavUbrEjLWlstfWcO+996Y33nij0Z5/USLe2MQ6US5bun9+n7MkelzGBBwxg3DszzjOzZll96KLLsr7KUpu50eU0MZrVLaptA3N2c74G98xjYl1m9ofC7s/mzK3/RylxtHjOnpKRw/m+LzG90D02r3gggvqe0nOa/vbepvmJUqky7+3ttxyy/z9+fLLL7fo6wBASzDrMQDtWiSmykXiL/4zFzOZVi6vHH8tEnRR+ls+hlXJ3Xffnf8zGsma+M9oScwg2tR/EmN8qUiiVCr9Zy+SKOXiP+cxRlzlfwajNK4y2RXjy0UpYcn48ePn2L7y5E9j+yXE+HCVy+M/3uVtjfK8ynHhSiV4lW0tzRBbmciLEs4YYyvGrWsNUeYbCbdoT4zRFwmpKOGOGZabY372TyjfR2PHjk0nn3xyuu222xosL70/ykViOI5x5f4JcxuzsSWtvvrqcyyLxGq8v6PcOGaBnds2LMznLMrfo6y7qRleK1+7pUTyKD6LjZU3x+eksXEII2Faun9+n7Nkww03rL8eyf4ocS7NCNwaok0xjuNOO+3UYHlpG5qznfE3ko2NiXWb2h/lr9Wc14n3XPnrxPLS52t+jl0k56PMvlzcju/sSNTHzNDz2v6W2qaWUvn5iu/7UPn9AgDtgR6FALRrjSXmGlsWysdei0RWTF5SGp+w3JgxY3Jvlhh/LcZiK3f00UenFVdcsdHLggza39xtqmx/5Wtff/31zXqOxpa31MQabSnG1IuxI0u9Cq+55prcy60yGduU+dk/5fsoevnE+yKSzDFu5MiRI/N4f6VJWMrHSVtY8ZylyVsWRmNJjZi447LLLsu9DW+++ebcCy4SLU1tw4J+zuK51l9//byPGrtUTqDREiKRf8stt6Ttttsujw1ZKT4v48aNm2N5aVkkyuf3ORsTJwJifMbYv/PqgRbjZMZ+i8lzmisS1qWJdeKzUC6Sh9EjrjnbGfsj3teVSdtI6kXSt7H9sSD7M8ZQLP/Oiu/S+d3PpeeqvK80hmwpsRbPX96GynY1Z5viZEzld+Pc3iMLozmfJQBoL/QoBKBT+utf/5p7jFT2xIn/qMZ/aKOM8rrrrptjwoOYrbWpyTKa6j1XmpX2hRdeaNC7LP4jHknJ+E/x/IokS7mYTbklRFujJDZK+Mp7FcbkDKX7y0WPsUoxGURpxteFMbcS4kiE7LLLLjlRGEndhx56aI5JPFpDzIwc2/fb3/62weQllcejPFEWpbilXoShNFnGwiYAF1QkU6K8M3oURs/IuR3LhbXmmmvmSRqi1Ls5JeEtIXp6NjYLcHmvv0iwxbEp/3w/+uij+X1bfqya+5xNie+TSPbEY1u6F1p8P8VzN9am2K5I0I4ePXqO+2I743uo9Pku9YKMdctPnMTt2EflvSQbE/dHCXlM5FI+oUm8Tvnzx8RM5T3kGku2zWs/xzAH8T6Ncvzy79LXX389/y1955RvU2kCktJ6MWtx+QzNTW3Tr3/969wbtnzYicptAoCuSI9CADqlGIsveqBV9kyJHlaRyIleLaXyr3Lxn8ZI7DV2KY1fVSnui95FMZtueQ+RGMcsyjwj4TW/Kl+71INmYUWiIHoXxZhp5WKW2kj0VCZWY1bg8jHtolflrbfemku6m+ol01wx62iYMGFCo/dHmfGzzz6bZyeO14pehq2ttE3lxzGux/hoTSnfl7Fu3I4eYK09G+78bENojURr9FyMpE70XmwsiRZlpC3t2muvzQm/Pffcs9H7v/SlL+Ux8KKnX0mMmxjl6zEzc2Nj083rORsroY737R/+8Idczr6ws6Y3JtoUJatNjbEa2/n44483SBbGyYo4SRK9EEtivMhIvP/yl79s8Pi4Hdtc/v1UmtE5emSXv058Z8TM6iVxEuaKK67IY3yWyvkjyVf+ndXYuK/z2s+lcuT47iyJZGa8VmxDabzUOHES42JGm8rHSo1tiu+xaHNJfAfHNpWX3Mc4q/EZvfjii+uXxeflkksuybN8x5ikANBV6VEIQKdNFB544IENlkU56VVXXZXHJIzxAMvHBIwJRvbYY48Feq3o5RJjHUYPrhh0P8oR4z/s8Z/QTTbZpMkeitUQiZJtt902/fjHP85j6A0cODCXpUbyLyZjiR5i5dZbb700ZMiQPPlJJFhK/7GObV1Ypf/0x3PHa1QmAyOBscwyy+QETyQwWyMZUymSD7EPvv/97+cEWPSgimRQU2OJRfI4SnqHDh2akyYx4Uq8z0444YSF7nG5oKLNMY7bz372szyuYyQ+4hhH79aWFsncG264ISfgo9fZ5z73uZy4icRMLI9JbyJh35RI3lx44YX5evQaDZFojR6/cSmfKKZ8Upv4DMdntjGRJIqJRuLzH4nmGGcx3rfRrsbet815znj/xdiicYzjfRhlwZG8ih5slcMCtIR//etf+fvpuOOOa7KnZpR1R4I2Pifxfo3E17nnnptPjsTkRCXR0zEmbjriiCNyAjE+a9HjMsr5zzjjjJyAK4l9H/sojmWpTDq2OR4X33GRMF1rrbVyj9v4/ihP6M1Lc/ZzJPAiwT58+PCctIzvpyj/f/DBB9Oll17aIMl79tln5+/aOGkR3xuxz6L9MTFPaczVECeF4r0QxyvGkwxxLOP7Lp4jPiPxPR2vE/ulNIYiAHRVEoUAdDr//ve/8yQYleMTxuQbIRI/cSkXJbcLmigsjUEWiaH4j+oxxxyT//Md5W9nnnnmHOOLVVOULEb5X5SkRoIj/vMcJbLxH+by5ELJ1ltvnWc+juRBJEeil1CMrbfBBhssdFuiBPyoo47KE25E0iJ69JQnCqOXZvQwiiRPcycxWVhxrG6//facvIxkRSQCo/dTJKwiaVEpEgqRKPz2t7+dez5GueewYcMalPxWQ/Tcin07YsSIvF8jmRJJmpYeey3eT5FgiR6pkYSPpEz0GIuy0RijrrEy33KRgD3ppJMaLIsS1tJnsjJRWJrUZr/99mvyOeOYxImCOB7Ryzd6NkYiKN63jY1x2ZznPOigg/L7NLYzehJGb+RIRsZ+jhlsW1ppbM65tSneazEOa3zfxFir0fMuknvRxsokdSQV470d+zY+/9ELMNZrbBzBxsSxjeN09dVX52MWn/+YMT4S0s3VnP0cSdF4P5144on5+6l0zOL7obJc+Ytf/GLuNRrfTfFej22OBH1zP3sxg3Ucx0hAxuvExE3xOnNrHwB0BTWFUXQB6GSiJ1X0rImB6dtq3DRaRyRBotdSTDwQCaj2pDTb7eTJk6vdFAAAaBHGKASg04kecqUx9+i4Pvzww9zDJ0oV21uSEAAAOiOlxwB0OjHBAh1XjIMWMzNHb7133nmn2eWRAADAwpEoBADalZiAIsYji0kjYoy5DTfcsNpNAgCALsEYhQAAAACAMQoBAAAAAIlCAAAAAECiEAAAAACQKAQAAAAAstqP/gAAAAAAXZlEIQAAAAAgUQgAAAAASBQCAAAAABKFAAAAAIBEIQAAAACQmcwEAAAAAJAoBAAAAAAkCgEAAAAAiUIAAAAAQKIQAAAAAMhMZgIAAAAASBQCAAAAABKFAAAAAIBEIQAAAAAgUQi0iSuvvDLV1NSk//3vfx1+j99///15W+JvtdTV1aX11lsvnXHGGR1+H7/zzjtpscUWS3feeWe1mwIALKBvfOMbacCAAfNcL+KUiFcibmkp8xMDRRujrfMSz3fKKacscFtGjx6dWkq0I56zI+rIbYeuzGQmQLv27LPP5iCjPSfArr322nT++ee32etdd9116ZVXXklHHnlkamu//OUv05e//OW06qqr5sCvOcH23CyzzDLp4IMPTieddFKLtREAaHmvv/56jsmefvppuxegE5MoBFrd17/+9TR16tS02mqrLVCi8NRTT203icKtttoqb0v8rVai8Oyzz05f/epXU9++fVNbO+uss9Jf//rX9OlPfzp17969RZ7zsMMOS08++WR+XgCg/SYKIyZrLFF42WWXpRdeeKHDxZkAzEmiEGh13bp1S4ssskinKD2ora3N2xJ/q+Gpp55KzzzzTNpnn32q8vp/+9vf0ttvv53uuuuu1KtXrxZ5zk996lO5lLoly5AAgLbTo0ePFosLunKc2VlMmTKl2k0AFoJEIdDqGhs7JsaI+eIXv5gefPDBtOmmm+YAb4011khXXXVVg8dFmWvYdttt83NUjg8YCastt9wyj3O3xBJLpF122SX9+9//bvD6UR67+OKLp9deey3tscce+Xq/fv3S97///TRr1qwG6/7+979PG220UX6uPn36pPXXXz9dcMEFTY5RuM0226Q77rgjvfzyy/Xti22bPHlybtPRRx89x/549dVXc1A7fPjw+d6XI0eOTD179mzQo3FuLr744tz7L4L3lVZaKR1xxBFpwoQJc6w3YsSIvP979+6dj8cDDzyQty0u5eJsfXMC8dI+f+mll9KQIUPyvojXP+2001JRFHOsv/3226fbb7+90fsAgIZjvj3//PP5pGHEKjGMR8QbH3744Ry76ZprrslxTfy+L7300rkiIYYvKRe/9XHC7oknnkibb755Xnf11VdPl1xySf06Efdssskm+fqBBx5YH/OUTvI1NkZhxBuxPCogllxyyTR06NBGY5AQ2/OlL30ptzFiwo033jjddtttCxxnRjxx+umnp1VWWSUtuuiiOY6sjA/nR8R5hx9+ePrkJz+Z90/s84hRm6p4+eCDD9Khhx6a14tjdMABB6T33ntvjvWaE8fOjxtvvLH+eC+77LLpa1/7Wo5/S84555y8r2J7Kh1//PE5xixv56OPPpp23HHHfAxjP2699dbpoYceavQ9GVVA++23X1pqqaXSFlts0WQbr7jiivT5z38+Lbfccjk+XXfddfPQNuXivRLtnzFjxhyP32GHHfJxAFqPRCFQNS+++GIOCiNJ9POf/zwHFhFQlgKkSIZ95zvfyddPOOGEdPXVV+dL9EALcT0CqkhIRUlsjHMXQUoEJ5WBWyQEI2EVAVsESRHoxGv+6le/ql/nz3/+c9p3331zO+L5fvrTn+bguTIgKvfjH/84bbjhhjmYKbUvypCjTXvuuWe6/vrr50hGxhiDEcDuv//+873PHn744RzMx5n7eYnALRKDkaCLbd17773TpZdemgOs8sArgrMY7zCC6Z/97Gc5YI2EaiQ0F0ZsdwSXyy+/fH7eCFyHDRuWL5XivvjPw8IExwDQVUSSMBKDcdJx5513Tr/4xS/SIYcc0mCdmPQsElRrr712Ovfcc9N3v/vddO+99+b4qjJhF8mheJ74PY7f7IgJvv3tb6fLL7883x+xV5zsC/E6pZinqROXEefsvvvueZ1IVkXSLuKKSABVit/+z372s+m5555Lxx13XI5ZInEWscgtt9yyQPvn5JNPznHhwIED85AtcTI04p8F7en2+OOP5xgsEq2xr2PYlNiXESdGUrBSxFWxPRGLxTH43e9+l7en/ITo/MSxzU2YxvuidDL6W9/6Vrr55pvz85WOd9wfSb0bbrhhjsfHsthHEQeHGBImju+kSZNy7HbmmWfm54kk32OPPTbH4yNxGvsi1ovXbkrEnXHiOWL7ONb9+/fPSdg4aV1eTh4T3t1zzz0NHjt+/PjcrnhPAa2oAGhlV1xxRURFxZgxY+qXrbbaannZqFGj6pe9+eabRa9evYrvfe979ctuvPHGvN59993X4Dnff//9Yskllyy+9a1vNVg+fvz4om/fvg2WDx06ND/Haaed1mDdQYMGFRtttFH97aOPPrro06dPMXPmzCa3JdpR2Z5ddtklb0+le+65J6971113NVi+wQYbFFtvvXWxIFZZZZVi7733nuc+jn3Zs2fPYocddihmzZpVv95FF12U17v88svz7WnTphXLLLNMsckmmxQzZsyoX+/KK6/M682tnYsttljet40p7fOjjjqqflldXV3eV9Gut956q8H6Dz/8cF7/+uuvn6/9AQBdybBhw/Lv5W677dZg+eGHH56XP/PMM/n2//73v6Jbt27FGWec0WC9f/7zn0X37t0bLI/f+njsz3/+8/plER9suOGGxXLLLVdMnz49L3v88cfzehFzNPa7Xx4LjRw5Mq/7s5/9rH5ZxFdbbrnlHM/xhS98oVh//fWLDz/8sEHMsPnmmxdrr732PPdJUzFQxBzxPCUnnHBCXq+p2KVcrBf7uuSDDz6YY51HHnkkr3fVVVfN0ZaIL0v7LcR+iOW33nrrfMexpWM+N/FacazWW2+9YurUqfXL//jHP+bHnnzyyfXLBg8e3CD+DY899liDbYn9Fvt+yJAhDfZh7IfVV1+92H777edo37777jtHuxpre2P7Ml5njTXWqL8dsWvEvF/5ylcarHfuuecWNTU1xUsvvTTX/QEsHD0KgaqJUoPovVYS5cBRShDlqvMSvf/irGb0AIwx80qXOIu62Wabpfvuu2+Ox8TZ33Lx2uWvFWUxcaY5nrslbLfddrk3X5xFLvnXv/6V/vGPfyzwmdA4u1o60zs3f/nLX9L06dNz74Hy8RTjDG+UwES5dBg9enR+zlhePjlJ9HZszuvMS/nMzHEGO25Hu6J95UqvFccQAJi7qBgod9RRR+W/d955Z/4bPcnq6upyD7LyOGmFFVbIPQwr46SIAaJUtiRKUOP2m2++mUuS51e0I54zeiWWRIxWamfJu+++m3uIRTvff//9+nZGbBKVIP/5z38alM42RykGitcqHy4lYqIFFaW8JVGVEe1ba621cuwYE7JVil6X5dUfsR9if5SOz4LEsXMT8Vwcq+iZF6XbJdFjcZ111qmP+8JXvvKVfEz/+9//1i+LCpgoA45eoCEmrIl9H6XEsa2l9kWc/IUvfCGNGjUqv7/mFmc3Z19OnDgxP29U+kRMHrdDxK4Ri0b5ebwvSiKmjvL4KI0HWk/LTFkJsABWXXXVOZZFwqixMVwqRfASovyhMZEMKxdBUyQi5/ZaEVxF2cVOO+2UVl555Vx+EYFrlM8uiFKQEyUWUYoRY7tEgBNtKY29uCCaM45faeyZyjFcIvCP8pvS/aW/EeyWi2C2cqyhBdn+eK1yn/jEJ/LfypKa0jYZiBwA5i2SfeXWXHPN/Ltb+n2NOCl+WyvXK6kcwiRObEa5b1O/2VEaPD8ivlhxxRVzWW25yrgkhqGJdkbZbVwaEwmwSHC+9dZbDZbHeIYR1zT22qFy2yMOXNCToDGrcpTzxvh6kbgsj8VKya1yla8d+yH2R/nxmZ84dkHjvhCJwhgTvCRi0GOPPTYnB6P8N7YlxjaM+Lf0uqX2NVYqXr7d5fuzucm7GNInSpkfeeSROcq24zljPMQQJdtRkh3l53E9ZtWOBGf52JlA65AoBKomzpouaCKsdBYzxneJ4LFSee+4ub1WuRhUOc6gxngoMbh0XCIgjODkt7/9bVoQ8dgYGycmIYmzxtdee22exKUUBM2vGGOxOYnUjqa0TTHWIwAwfypPtEWcFMsilmksBqpM4FVLKZ6LCeaiB2Fj4mRmTMBSmYiKXneVk661luidGDFh9EocPHhwjuNi/8aYhZU965pjfuPYlhRJ4aiqiZPjkSj8+9//nsaOHZuTcpXtixg2xuJuTOV7qLynYFOiF2P0SIzkZYybGeMTRrI3elqed955DfZlVB7FmJkxIU/E0/E31o2T+EDrkigE2rWmepjFmfNSci9KfFtKBCC77rprvkSwEr0MYwKQOMtd2etuXm0MMfHIoEGDck/CGBg8ArELL7xwgdsXgdWYMWPmuV4MEh3i7Gt5r74oxYnHl/ZZab04ox8zApbMnDkzn/XeYIMNFritsf+ijKTUIyH83//9X/5b2VuxtE2liWoAgKZFj6/yxFn8jsfvbun3NeKkOPEa65T/Djfl9ddfz2Wl5b0KK3+z56fXf8QXMdnH5MmTGySUIi4pV4pRoofj3OK5uL9yaJiYqKSp1y7to/IYKHokLujJ1ptuuin3rovJN0piMpmmZnGO1y6Pq2I/jBs3Lk8Y0xpxbHncV9lLMZaV7i8vP44YN+6LnoVR9RKxb0mpfdHDsCXj7Ntvvz1NmzYtlxSXVxY1VWodCcLo/Rj7Lk62Ryl1SwyNA8ydMQqBdq0UsFYGYnHWOYKXmFmtfAbfksrylOaIMVjKRQlPKVEWQc3c2thY2Un5zG1/+tOf8mzI0SMwSjsWVJzFjnEO59aeEEFdJD1jZr7yHpq/+c1vclsj0Aobb7xxbtNll12Wk4MlkdhsiZ6LF110Uf31aEfcjmA/ziaXi1KSODv/6U9/eqFfEwA6u/IZYkPpJGQpxthrr71yT8JTTz11jkqNuF0Z80QMECdGy08sxu0o141eXXOLyRoTCbF4zhh+pWTWrFlznCyNRFn0CozXimRQU/FcDNsSsU35pamEUdwXsUa8Vvm2Rxy2oGJfVu7HeP7Ypsb86le/ahCfxn6I/VE6Pi0dx0Y8F/syynLLY8ToURqzL5fivpK99947b9N1112Xy46j2qU8SRzHPJKF55xzTk5yLmz7Skq9WytLt6O3ZmOiGicS1EcffXQ++Wy2Y2gbehQC7VqUO0RQEeUQEUjEQMtxpjSCoQi6Ign3mc98Jpd+RDAbPfZiwObPfe5zDZJUzXHwwQfnQbXj+aP3X4z3EkFgtGFuPd0imIqzsXHGc5NNNslnzsvPysZA0D/84Q/zGCsxmHXluEDzIwaZ/slPfpL+9re/5TEUmxL74vjjj8//QYgxFnfbbbd81vjiiy/ObSwFWpFMPOWUU3JJTWx3lHNET8Irr7wyB4iVvQfiTPAzzzyTr0dgGxOznH766fl2vEZ5D8QI6u++++58Bj4G5o5gNY5NlLlUjhcZvQRinxmjEADmLXrix+9u/MbHWG9RlhnxRqmXXfyGx+9zxALxu77HHnukJZZYIj8u4pGYbCPKfcvLUSPWinWjB2LENTEcSyS8SnFLPGdM3hHJqHiuSCzF73tjY9PFb3rEYscdd1x+zigjjQlWGjuxGknPLbbYIq2//vp5crXoBfjGG2/k7Xr11Vfr447mihgjti3GFIwEWCQtn3rqqRyHLOgQJ/E8USYcJzVjW6JtMWlKnGxtTCRa46RoxFWl+Cu2MY5ZiCRhS8axcYzi+B144IF5YpBIsMU+vOCCC3KP0GOOOabB+hFHR4/HKP+NyUKih2HlyfJf//rXObEZJ3HjeWP87hifMXr/RfsjJpxfEbuWqndispxIQsbJ6mhPY4ni2CfxHo9kZrz3KhOeQCtZyFmTAebpiiuuiNOGxZgxY+qXrbbaasUuu+wyx7pbb711vpS77LLLijXWWKPo1q1bfp777ruv/r64PmTIkKJv377FIossUqy55prFN77xjWL06NH16wwdOrRYbLHF5nitYcOG5ecruemmm4oddtihWG655YqePXsWq666anHooYcW48aNa/B6lW2YPHlysd9++xVLLrlkvi+2rdLOO++c73v44YcX+h2zwQYbFN/85jfnuY/DRRddVKyzzjpFjx49iuWXX7749re/Xbz33ntzPOcvfvGL3O5evXoVm266afHQQw8VG220UbHjjjs2WC/2ZbxOY5doQ+U+/+9//5v36aKLLppfP/b5rFmzGjznc889lx//l7/8ZaH3DQB0ZqXY5dlnny2+9KUvFUsssUSx1FJLFUceeWQxderUOdb/wx/+UGyxxRb5NzkuERMcccQRxQsvvFC/TsRdn/70p3PsNHjw4BxPRUwQMUSlW2+9tVh33XWL7t27N/jtj9/9yvjnnXfeKb7+9a8Xffr0yXFaXH/qqafmiBlCxAsHHHBAscIKK+SYZeWVVy6++MUv5thsXhqLgSLWOPXUU4sVV1yx6N27d7HNNtsU//rXv3Ibo63zEs8X+7okYqcDDzywWHbZZYvFF188x57PP//8HM9Xasvf/va34pBDDsnHJtbff//98/6o1Jw4tjJenZvrr7++GDRoUI7nll566fy6r776aqPrRnwdzxvvocbeOyGO11577VUss8wy+Tlje/fZZ5/i3nvvnaN9b7311hyPb6ztt912W45lY3sHDBhQnHXWWcXll1/eaBwbbrjhhnxf7E+gbdTEP62VhATgI3vuuWf65z//mccQWlhxRvuII47IZ53j7GpriHGO4ixulC7Fmd759Y1vfCOP59NYuUqlGBh81KhRufxYj0IAaFpUAUS1QJR+ttQEYFH6+/bbb+ehTaC9ufXWW3OP2IgVYxIWoPUZoxCglUUpRZSRRHlJS9h///3zANCV4xMtqBiMu/Kc0VVXXZXLsFt7NsEYIylKW6I8SpIQAIByccI6ytGjdBtoG8YoBGglMQ7QQw89lBNhMXZMjMXSEmLcmJY86//3v/89j13z5S9/OY+18+STT+ZJT2LG5ljWmuL1mtPrEACAruP3v/99Hgs7TrbHWItOKEPbkSgEaCUx4UgM/hy9/37729+mFVZYoV3u6xjkun///nmG5OhFuPTSS6cDDjgg/fSnP80DTgMAQFuKCVligsBvfvOb6fDDD7fzoQ0ZoxAAAAAAMEYhAAAAACBRCAAAAAB0xTEK6+rq0uuvv56WWGIJA6ICAF1azHj+/vvvp5VWWilPlNReid8AANomfutyicJIEsag/QAAfOSVV15Jq6yySrvdHeI3AIC2id+6XKIwehKGLdLOqXvqUe3mAABUzcw0Iz2Y7qyPj9qrUvsiIO7Tp0+1mwMAUDWTJk3KHeBaK37rconCmpqa/DeShN1rJAoBgC6saBgftVel9kWSUKIQACC1WvzWfgejAQAAAADajEQhAAAAACBRCAAAAABIFAIAAAAAEoUAAAAAgEQhAAAAAJCZzAQAAAAAkCgEAAAAACQKAQAAAACJQgAAAABAohAAAAAAyExmAgAAAABIFAIAAAAAEoUAAAAAgEQhAAAAACBRCAAAAABkJjMBAAAAACQKAQAAAACJQgAAAABAohAAAAAAkCgEAAAAADKTmQAAAAAAEoUAAAAAgEQhAAAAACBRCAAAAABIFAIAAAAAmclMAAAAAACJQgAAAABAohAAAAAAkCgEAAAAACQKAQAAAIDMZCYAAAAAgEQhAAAAACBRCAAAAABIFAIAAAAAEoUAAAAAQGYyEwAAAABAohAAAAAAkCgEAAAAACQKAQAAAACJQgAAAAAgM5kJAAAAANA+EoUjRoxIAwYMSIssskjabLPN0mOPPTbX9c8///z0yU9+MvXu3Tv1798/HXPMMenDDz9ss/YCAAAAQGdT9UTh9ddfn4499tg0bNiw9OSTT6aBAwemIUOGpDfffLPR9a+99tp03HHH5fWfe+659Jvf/CY/xwknnNDmbQcAAACAzqLqicJzzz03fetb30oHHnhgWnfdddMll1ySFl100XT55Zc3uv7DDz+cPve5z6X99tsv90LcYYcd0r777jvPXogAAAAAQDtNFE6fPj098cQTabvttpvdoNrafPuRRx5p9DGbb755fkwpMfjSSy+lO++8M+28885t1m4AAAAA6Gy6V/PF33777TRr1qy0/PLLN1get59//vlGHxM9CeNxW2yxRSqKIs2cOTMddthhTZYeT5s2LV9KJk2a1MJbAQBASxK/AQB00dLj+XX//fenM888M1188cV5TMObb7453XHHHeknP/lJo+sPHz489e3bt/4Sk58AANB+id8AAKqjpohueVUsPY7xCG+66aa0xx571C8fOnRomjBhQrr11lvneMyWW26ZPvvZz6azzz67ftk111yTDjnkkDR58uRcujyvM9KRLNwm7Z661/RotW0DAGjvZhYz0v3p1jRx4sTUp0+f1F40Fb+1t3YCALS1iIuiI1xrxUVV7VHYs2fPtNFGG6V77723flldXV2+PXjw4EYf88EHH8yRDOzWrVv+21jOs1evXnnHlV8AAGi/xG8AAF1wjMJw7LHH5h6EG2+8cdp0003T+eefn6ZMmZJnQQ4HHHBAWnnllXMJSth1113zTMmDBg1Km222WXrxxRfTSSedlJeXEoYAAAAAQAdLFH7lK19Jb731Vjr55JPT+PHj04Ybbpjuvvvu+glOxo4d26AH4Yknnphqamry39deey3169cvJwnPOOOMKm4FAAAAAHRsVR2jsJq13MYoBAC6uvY6RmFbj8UDANBRTOrMYxQCAAAAAO2DRCEAAAAAIFEIAAAAAEgUAgAAAAAShQAAAACARCEAAAAAkJnMBAAAAACQKAQAAAAAJAoBAAAAAIlCAAAAAECiEAAAAADITGbSVmra7JUAAGgBs2bNqr9eV1eXiqLI1+Nv3AYA6GwkCttI0bPH7Ovdu6Wi28e7vqYmpVpZRACA9mb8G2/WJwcnTpyYPvjgg3x9ypQp6f33369y6wAAWp5EYVvp2X329e7dZicHI1FY4zAAALQ377w3of765CkfpA8//DBfnzr1w3wbAKCzkaFqI0UkBEviaul2TcVR0LsQAKBdKMqvf9yzsDGlBCIAQEcnUdhG6npEsvDj691SKj7e81GCXFcqQw49ZpcoAwDQvsVYhePGv1HtZgAAtAiJwjZSdCu7Hnu9pux6eS/C8qQhAADt3vvKkAGATkJWqhqJwl7d6nsUxhGo711Yk1Jd95oGk54AANA+koF1dU2XH5dMmjSpTdoDANAaJArbSo+6+qt1S3RP6eMcYCQJi+6zg85Zi5QlCnsrQwYAaA/eeve9NKtu1jzXG/fGW7kcGQCgI5IorMaejl6DteUTm8y+q76nYX5Mbf24hgAAVM+06TPnOqFJyYfTp9dfb876AADtiURhG+nZbWZ9PrBb97pUW/NR4FhbW6Ta2rKzzt2KBhOglBQ9ujVIKAIA0L69++67adasefdCBABoLyQK20ivbrODxG49Z6VuHycHa2vqUrfaj5ODkQjs3niiMPXonooamUIAgI7i7XcnSBQCAB2KRGGb7ehIDH6UBIx8X33KL1+fnRys+binYWhQdlw+MzIAAO1ejGmo/BgA6EgkCttIj9qyHoW1s3JPwnw9Fanbx8nBSAWWehp+dHTKeheWzYYMAAAAAC1NorCNdM89Cj/e6bV19b0IowdhKWkYSknDj+6cfbWIWZLlCgEAAABoJRKFbaQ0eUkpGVgabjAShuWlx+Xr1ZT1ImxQhpxnSpY1BABob6ZO/bDR5TNnzkwzZsxo8/YAAMwPicI20qtmVn2HwJ61s3LJceiW6lL3sh6FPWpmlyjXLtK9/noRR+rjJyhqa1PRPboYAgDQnox7e0Kjy6dMmZImTJjY5u0BAJgfEoVtJBKC9ddro9z4o0Rh/K2t71EY4xXOXq+mR03jRyomNjG5CQBAuzNl2vRGl8+YMTNNm974fQAA7YVEYRupKRtgsKxz4Mf3lV0vLz0unx254tmMVwgAAABAS5IobCO1ZWMKRmfAmvLhBsvHKCy7nsomMDFGIQAAAACtSaKwjdQ0saQ8STjHeg1uNFyv4S0AAAAAWDizZ8ugVdUVs1N7dUUk+j663XDO45TqyrKDRV1NfUawpkGXQpXHAAAAALQsPQrbyKyydOCsnCj8SPxtkCgsSwhGbrFoqguhLoUAAAAAtCCJwippKlEYPQwbdD1s6sFlPRQBAGgfenaLQaYBADompcdtpLykuK5BprBh6XGD6x/ObPSOmqYSiAAAVNVyS/dxBACADkuisI00SACWJQcrpzJp0FFw+swmnqz4ONsIAEB7slTfJardBACABSZR2EZmFbOrvGflROFHPQzjb3kHwY/W+zgLWDZeYU0sKh+wUKdCAIAOo0eP7qmuzpleAKB9kyhsIx8WPepze9Nn9kg1xUeB4syiNtWUJf2m13WL1GG+XjerLFE4q+zJIrNY/iAAANq1xRZbLPXu3bvazQAAmCuJwjYSCcHyXoORDiz1KCwvQ45Zj+uHwG6yR6FZjwEAOpLu3YXdAED7Z9bjNvJRSfFHib+6uig3/vh6EddnH4a4r0FysHR9xkzlxgAAHciSfZZI3cyCDAB0IBKFbSRKiktmzexWkSj8ODkYc5TU1TZablwzdWaqaTDTCQAA7dly/frpSQgAdCgShW0kZjqefWP27Vx6XHFfvfIehZKEAADtXrfa2eG1cmMAoKORKGwjM2d1mz0W4fTaVJRKjOtqZl/PJcazr9d+MEO5MQBAB7LcMkunmpqyk8AAAB2IRGEbmTlzdulxMX12cjAmPy5PFNbOLDs4U2d8PKohAAAdQb9+y0oUAgAdVrtIFI4YMSINGDAgLbLIImmzzTZLjz32WJPrzpgxI5122mlpzTXXzOsPHDgw3X333am9q5k5u464ZkZdDE740Y0ixiIsqzcuu15jSEIAgKrp1bNH/fVFe/dK3Wo/OvHbrVtt6l42SUnPHrPX05sQAOjIqp4ovP7669Oxxx6bhg0blp588smc+BsyZEh68803G13/xBNPTJdeemm68MIL07PPPpsOO+ywtOeee6annnoqtWfdJs4uI+424cNUO+2jmUrib83H1yMxWPvB9Go2EwCAj624XL/6xN8nBqya+vRZIl9fbLHF6q/X1tamFZfvZ58BAJ1CTVFUd5aM6EG4ySabpIsuuijfrqurS/37909HHXVUOu644+ZYf6WVVko//vGP0xFHHFG/bO+99069e/dO11xzzTxfb9KkSalv375pm7R76l4z++wvAEBXM7OYke5Pt6aJEyemPn36pPaqFL+193YCAHT0uKiqPQqnT5+ennjiibTddtvNblBtbb79yCOPNPqYadOm5ZLjcpEkfPDBB1u9vQAAAADQWXWv5ou//fbbadasWWn55ZdvsDxuP//8840+JsqSzz333LTVVlvlcQrvvffedPPNN+fnaSqxGJfyzCsAAO2X+A0AoIuOUTi/LrjggrT22munddZZJ/Xs2TMdeeSR6cADD8w9ERszfPjw3CWzdImyZgAA2i/xGwBAF0wULrvssqlbt27pjTfeaLA8bq+wwgqNPqZfv35p5MiRacqUKenll1/OPQ8XX3zxtMYaazS6/vHHH5/rtkuXV155pVW2BQCAliF+AwDogonC6BG40UYb5fLhkpjMJG4PHjx4ro+NcQpXXnnlNHPmzPSHP/wh7b777o2u16tXrzy4Y/kFAID2S/wGANAFxygMxx57bBo6dGjaeOON06abbprOP//83FswyonDAQcckBOCUYISHn300fTaa6+lDTfcMP895ZRTcnLxhz/8YZW3BAAAAAA6rqonCr/yla+kt956K5188slp/PjxOQF49913109wMnbs2AbjD3744YfpxBNPTC+99FIuOd55553T1VdfnZZccskqbgUAAAAAdGw1RVEUqQuJWY9jUpNt0u6pe02PajcHAKBqZhYz0v3p1jyOc3senqUUv7X3dgIAdPS4qMPNegwAAAAAtDyJQgAAAABAohAAAAAAkCgEAAAAACQKAQAAAACJQgAAAAAgM5kJAAAAACBRCAAAAABIFAIAAAAAEoUAAAAAgEQhAAAAAJCZzAQAAAAAkCgEAAAAACQKAQAAAACJQgAAAABAohAAAAAAyExmAgAAAABIFAIAAAAAEoUAAAAAgEQhAAAAACBRCAAAAABkJjMBAAAAACQKAQAAAACJQgAAAABAohAAAAAAkCgEAAAAADKTmQAAAAAAEoUAAAAAgEQhAAAAACBRCAAAAABIFAIAAAAAmclMAAAAAACJQgAAAABAohAAAAAAkCgEAAAAACQKAQAAAIDMZCYAAAAAgEQhAAAAACBRCAAAAABIFAIAAAAAEoUAAAAAQGYyEwAAAABAohAAAAAAkCgEAAAAAKqdKBw1alTadddd00orrZRqamrSyJEj5/mY+++/P33mM59JvXr1SmuttVa68sor26StAAAAANCZVTVROGXKlDRw4MA0YsSIZq0/ZsyYtMsuu6Rtt902Pf300+m73/1uOvjgg9M999zT6m0FAAAAgM6sezVffKeddsqX5rrkkkvS6quvnn7+85/n25/61KfSgw8+mM4777w0ZMiQVmwpAAAAAHRuHWrW40ceeSRtt912DZZFgjCWAwAAAAAdtEfh/Bo/fnxafvnlGyyL25MmTUpTp05NvXv3nuMx06ZNy5eSWBcAgPZL/AYAUB0dqkfhghg+fHjq27dv/aV///7VbhIAAHMhfgMAqI4OlShcYYUV0htvvNFgWdzu06dPo70Jw/HHH58mTpxYf3nllVfaqLUAACwI8RsAQHV0qNLjwYMHpzvvvLPBsj//+c95eVN69eqVLwAAdAziNwCALtijcPLkyenpp5/OlzBmzJh8fezYsfVnkw844ID69Q877LD00ksvpR/+8Ifp+eefTxdffHG64YYb0jHHHFO1bQAAAACAzqCqicLRo0enQYMG5Us49thj8/WTTz453x43blx90jCsvvrq6Y477si9CAcOHJh+/vOfp1//+td55mMAAAAAoIOWHm+zzTapKIom77/yyisbfcxTTz3Vyi0DAAAAgK6lQ01mAgAAAAC0DolCAAAAAECiEAAAAACQKAQAAAAAJAoBAAAAAIlCAAAAACAzmQkAAAAAIFEIAAAAAKTUfUF3wsyZM9O///3vNH78+Hx7hRVWSOuuu27q0aOH/QoAAAAAnT1RWFdXl04++eQ0YsSINHHixAb39e3bNx155JHp1FNPTbW1qpoBAAAAoNMmCo877rh05ZVXpp/+9KdpyJAhafnll8/L33jjjfSnP/0pnXTSSWn69OnprLPOao32AgAAAADtIVF41VVXpauvvjonCcsNGDAgHXLIIWm11VZLBxxwgEQhAAAAAHQg810f/P7776eVVlqpyftXXHHFNGXKlIVtFwAAAADQnhOF22yzTfr+97+f3n777Tnui2U/+tGP8joAAAAAQCcuPb7kkkvSzjvvnHsOrr/++g3GKPznP/+ZZz7+4x//2BptBQAAAADaS6Kwf//+6Zlnnkn33HNP+vvf/57Gjx+fl2+66abpzDPPTDvssIMZjwEAAACgsycKX3/99TxG4U477ZQvjfn973+fvvrVr7ZE+wAAAACA9jhGYfQYnDBhQpP3R5IwZj0GAAAAADpxorBfv365J+EHH3wwx3033HBD+vrXv57OOOOMlmofAAAAANAeE4W33357mjFjRtpjjz3y35Ibb7wxJwlPP/309IMf/KCl2wkAAAAAtKdE4eKLL57uuuuu9Morr6T99tsvFUWRbrrpprT//vunYcOGpR/96Eet01IAAAAAoP1MZlIqP/7Tn/6Utthii7T99tunBx54IJ188snphBNOaPkWAgAAAADtL1H4j3/8o/762WefnScuiTLk3XbbrcF9G2ywQcu1EgAAAABoX4nCDTfcMNXU1OSS49LfGJ8wyo/jeojls2bNao32AgAAAADtIVE4ZsyY1mgHAAAAANCREoX33ntvLjNedtllW6dFAAAAAED7n/X4mmuuSausskrafPPN01lnnZWee+651mkZAAAAANB+E4V//etf07hx49Lhhx+ennjiibTZZpultddeO33ve99Lo0aNSnV1da3TUgAAAACg/SQKw1JLLZW+9rWvpRtuuCG9/fbb6cILL0xTp05N+++/f1puueXyTMgxucmUKVNavsUAAAAAQPtIFJbr2bNn2nHHHdPFF1+cXnnllXTPPfekAQMGpJ/85Cfp3HPPbZlWAgAAAADtazKTeYkeha+++mp65pln0owZM1r66QEAAACA9tijsNK7776bfvvb3+brPXr0aOmnBwAAAADaQ4/C2267ba73v/TSSwvTHgAAAACgIyQK99hjj1RTU5OKomhynbgfAAAAAOjEpccrrrhiuvnmm1NdXV2jlyeffLJ1WgoAAAAAtJ9E4UYbbZSeeOKJJu+fV29DAAAAAKATlB7/4Ac/SFOmTGny/rXWWivdd999C9suAAAAAKA9Jwq33HLLud6/2GKLpa233nph2gQAAAAAtPfSYwAAAACg85EoBAAAAAAkCgEAAAAAiUIAAAAAQKIQAAAAAJAoBAAAAACqP5nJqFGj0q677ppWWmmlVFNTk0aOHDnX9ceNG5f222+/9IlPfCLV1tam7373u23WVgAAAADozKqaKJwyZUoaOHBgGjFiRLPWnzZtWurXr1868cQT8+MAAAAAgJbRPVXRTjvtlC/NNWDAgHTBBRfk65dffnkrtgwAAAAAqmvmzJmpe/fuXaNHIQAAbah7N7sbAKADeeONNxrcrqur67w9CttClCvHpWTSpElVbQ8AQNV065bSzFnt/gCI3wAAPjJh0vtp5ZU/vpFSKooitaZO36Nw+PDhqW/fvvWX/v37V7tJAABVUdTWdIg9L34DAPhIkVo3MdjlEoXHH398mjhxYv3llVdeqXaTAACqom6RhqXHRTvNG4rfAACqo9OXHvfq1StfAAC6urruNakjjFIofgMA6IKJwsmTJ6cXX3yx/vaYMWPS008/nZZeeum06qqr5rPJr732Wrrqqqvq14n7S49966238u2ePXumddddtyrbAADQYXT6WhIAADpsonD06NFp2223rb997LHH5r9Dhw5NV155ZRo3blwaO3Zsg8cMGjSo/voTTzyRrr322rTaaqul//3vf23YcgCAjqeusjthlB637bA3AAC0Y1VNFG6zzTZzna0lkoWVWnt2FwCATqudjkkIAED7oAAFAKCrqHHCFQCApkkUAgB0EYXIDwCAuRAuAgB0ESqPAQCYG4lCAIAuoqZW6TEAAE2TKAQA6CIkCgEAmBuJQgCALkOPQgAAmiZRCADQRdSa9RgAgLmQKAQA6CJqzGYCAMBcSBQCAHQRhcpjAADmQqIQAKCLKJIuhQAANE2iEAAAAACQKAQAAAAAJAoBAAAAAIlCAIAuxGQmAADMhTEKAQC6iLpC6AcAQNNEiwAAXURRV+0WAADQnkkUAgB0EUWqqXYTAABoxyQKAQC6Cj0KAQCYC4lCAAAAAECiEACgq6jRoxAAgLnQoxAAoIuomVUxRmFRrZYAANAeSRQCAHQRNRKDAADMhUQhAEAXUTNDphAAgKZJFAIAdBG1sxrerihEBgCgi5MoBADoKmaZzQQAoCPp1aNHg9s1Na17qleiEACgi6j5cEbDBSqRAQDateX69WtwW6IQAIAWUTOzovYYAIB2rW/fvg1uSxQCAAAAAK1O6TEAAAAAIFEIAAAAAEgUAgAAAAAShQAAAACARCEAAAAAkJnMBAAAAACQKAQAAAAAJAoBAAAAAIlCAAAAAECiEAAAAADITGYCAAAAAEgUAgAAAAAShQAAAACARCEAAAAAIFEIAAAAAGQmMwEAAAAAqpsoHDVqVNp1113TSiutlGpqatLIkSPnuv7NN9+ctt9++9SvX7/Up0+fNHjw4HTPPfe0WXsBAAAAoLOqaqJwypQpaeDAgWnEiBHNTixGovDOO+9MTzzxRNp2221zovGpp55q9bYCAAAAQGfWvZovvtNOO+VLc51//vkNbp955pnp1ltvTbfffnsaNGhQK7QQAAAAALqGDj1GYV1dXXr//ffT0ksvXe2mAAAAAECHVtUehQvrnHPOSZMnT0777LNPk+tMmzYtX0omTZrURq0DAGBBiN8AAKqjw/YovPbaa9Opp56abrjhhrTccss1ud7w4cNT37596y/9+/dv03YCADB/xG8AANXRIROFv//979PBBx+ck4TbbbfdXNc9/vjj08SJE+svr7zySpu1EwCA+Sd+AwCojg5Xenzdddelgw46KCcLd9lll3mu36tXr3wBAKBjEL8BAHTBRGGML/jiiy/W3x4zZkx6+umn8+Qkq666aj6b/Nprr6Wrrrqqvtx46NCh6YILLkibbbZZGj9+fF7eu3fvXFYMAAAAAHTA0uPRo0enQYMG5Us49thj8/WTTz453x43blwaO3Zs/fq/+tWv0syZM9MRRxyRVlxxxfrL0UcfXbVtAAAAAIDOoKo9CrfZZptUFEWT91955ZUNbt9///1t0CoAAAAA6Ho65GQmAAAAAEDLkigEAAAAACQKAQAAAACJQgAAAABAohAAAAAAkCgEAAAAADKTmQAAAAAAEoUAAAAAgEQhAAAAACBRCAAAAABIFAIAAAAAmclMAAAAAACJQgAAAABAohAAAAAAkCgEAAAAACQKAQAAAIDMZCYAAAAAgEQhAAAAACBRCAAAAABIFAIAAAAAEoUAAAAAQGYyEwAAAABAohAAAAAAkCgEAAAAACQKAQAAAACJQgAAAAAgM5kJAAAAACBRCAAAAABIFAIAAAAAEoUAAAAAgEQhAAAAAJCZzAQAAAAAkCgEAAAAACQKAQAAAACJQgAAAABAohAAAAAAyExmAgAAAABIFAIAAAAAEoUAAAAAgEQhAAAAACBRCAAAAABkJjMBAAAAACQKAQAAAACJQgAAAACg2onCUaNGpV133TWttNJKqaamJo0cOXKu6z/44IPpc5/7XFpmmWVS79690zrrrJPOO++8NmsvAAAAAHRW3av54lOmTEkDBw5MBx10UNprr73muf5iiy2WjjzyyLTBBhvk65E4PPTQQ/P1Qw45pE3aDAAAAACdUVUThTvttFO+NNegQYPypWTAgAHp5ptvTg888IBEIQAAAAB01VmPn3rqqfTwww+nrbfeutpNAQAAAIAOrao9ChfUKquskt566600c+bMdMopp6SDDz64yXWnTZuWLyWTJk1qo1YCALAgxG8AANXRIXsURqnx6NGj0yWXXJLOP//8dN111zW57vDhw1Pfvn3rL/3792/TtgIAMH/EbwAA1VFTFEWR2oGY9fiWW25Je+yxx3w97vTTT09XX311euGFF5p9RjqShduk3VP3mh4L3W4AgI5qZjEj3Z9uTRMnTkx9+vRJ7UVT8Vt7aycAQFuLuCg6wrVWXNQhS4/L1dXVNQgkK/Xq1StfAADoGMRvAADVUdVE4eTJk9OLL75Yf3vMmDHp6aefTksvvXRaddVV0/HHH59ee+21dNVVV+X7R4wYkZevs846+faoUaPSOeeck77zne9UbRsAAAAAoDOoaqIwxhncdttt628fe+yx+e/QoUPTlVdemcaNG5fGjh3boPdgJA8jodi9e/e05pprprPOOisdeuihVWk/AAAAAHQW7WaMwrau5TZGIQDQ1bXXMQrbeiweAICOYlIrx0UdctZjAAAAAKBlSRQCAAAAABKFAAAAAIBEIQAAAAAgUQgAAAAASBQCAAAAAJnJTAAAAAAAiUIAAAAAQKIQAAAAAJAoBAAAAAAkCgEAAACAzGQmAAAAAIBEIQAAAAAgUQgAAAAASBQCAAAAABKFAAAAAEBmMhMAAAAAQKIQAAAAAJAoBAAAAAAkCgEAAAAAiUIAAAAAIDOZCQAAAAAgUQgAAAAASBQCAAAAABKFAAAAAIBEIQAAAACQmcwEAAAAAJAoBAAAAAAkCgEAAAAAiUIAAAAAQKIQAAAAAMhMZgIAAAAASBQCAAAAABKFAAAAAIBEIQAAAAAgUQgAAAAAZCYzAQAAAAAkCgEAAAAAiUIAAAAAQKIQAAAAAAjdu9puKIoi/52ZZqT00VUAgC4px0Nl8VF7VWrfpEmTqt0UAICqKsVDrRW/dblE4TvvvJP/PpjurHZTAADaTXzUt2/f1N7jt/79+1e7KQAAnTp+63KJwqWXXjr/HTt2bLsOiDt79jsC/VdeeSX16dOn2s3pkhyD6nMMqs8xqD7HoPomTpyYVl111fr4qL0Sv1Wfz2v1OQbV5xhUn2NQfY5B54/fulyisLa2Nv+NJKEkVXXF/ncMHIOuzueg+hyD6nMM2k981F6J39oPn9fqcwyqzzGoPseg+hyDzhu/te+oEAAAAABoExKFAAAAAEDXSxT26tUrDRs2LP/FMeiqfA6qzzGoPseg+hyD6usox6CjtLMzcwyqzzGoPseg+hyD6nMMOv8xqClaaz5lAAAAAKDD6HI9CgEAAACAOUkUAgAAAAAShQAAAABAJ0kUDhgwINXU1MxxOeKII/L9H374Yb6+zDLLpMUXXzztvffe6Y033mjwHGPHjk277LJLWnTRRdNyyy2XfvCDH6SZM2dWaYs63zH41a9+lbbZZpvUp0+fvHzChAlzPMe7776b9t9//7zOkksumb75zW+myZMnV2FrOt8xiH171FFHpU9+8pOpd+/eadVVV03f+c530sSJExs8h89B6x2DcOihh6Y111wzH4N+/fql3XffPT3//POOQRseg5IYnnennXbK940cOdIxaMNjEL8FlfcddthhjkEbHoPwyCOPpM9//vNpscUWy7+7W221VZo6dWqb/iaL36pP/FZ94rfqE79Vn/it+sRv1TegHcVv3VMn8Pjjj6dZs2bV3/7Xv/6Vtt9++/TlL3853z7mmGPSHXfckW688cbUt2/fdOSRR6a99torPfTQQ/n+eGwkCVdYYYX08MMPp3HjxqUDDjgg9ejRI5155plV267OdAw++OCDtOOOO+bL8ccf3+hzxBs69v2f//znNGPGjHTggQemQw45JF177bVtth2d9Ri8/vrr+XLOOeekddddN7388sv5P+ax7Kabbsrr+xy07jEIG220UX6fR6I2vsRPOeWUtMMOO6QxY8akbt26OQZtcAxKzj///PzDW8nnoG2Owbe+9a102mmn1d+Ok3SOQdsdgwgyS7/HF154YerevXt65plnUm1tbZv+Jovfqk/8Vn3it+oTv1Wf+K36xG/V93h7it+KTujoo48u1lxzzaKurq6YMGFC0aNHj+LGG2+sv/+5556LmZ6LRx55JN++8847i9ra2mL8+PH16/zyl78s+vTpU0ybNq0q29CZjkG5++67L+/79957r8HyZ599Ni9//PHH65fdddddRU1NTfHaa6+1Wbu7wjEoueGGG4qePXsWM2bMyLd9Dtr+GDzzzDP5ff/iiy86Bm14DJ566qli5ZVXLsaNG5f3/y233FJ/n89B6x+DrbfeOi9rimPQ+sdgs802K0488cQm16/Wb7L4rfrEb9Unfqs+8Vv1id+qT/zWteO3TlF6XG769OnpmmuuSQcddFDuLfLEE0/kTOp2221Xv84666yTe/RERjbE3/XXXz8tv/zy9esMGTIkTZo0Kf373/+uynZ0pmPQHHEMomvsxhtvXL8sjllkxx999NFWbG3XPQZRdhxdkuNMRPA5aNtjMGXKlHTFFVek1VdfPfXv398xaKNjEL2b99tvvzRixIjci7ySz0HrH4Pwu9/9Li277LJpvfXWy2dF47g4Bm1zDN588838uxrDrGy++eY59tl6663Tgw8+WNXfZPFb9Ynfqk/8Vn3it+oTv1Wf+K36qh2/dbpEYYw1FePffeMb38i3x48fn3r27Jl3WLnYsXFfaZ3yJGHp/tJ9LNwxaI7Yz/GmLxcJrKWXXtoxaIVj8Pbbb6ef/OQnuRty+THwOWj9Y3DxxRfnsVLjctddd+Vu4fEd5Ri0zTGIoSjixzXGh2yMz0HrH4NI1Ebgc9999+Uk4dVXX52+9rWvOQZtdAxeeuml/DeGPogS8Lvvvjt95jOfSV/4whfSf/7zn6r9Jovfqk/8Vn3it+oTv1Wf+K36xG/VV+34rVOMUVjuN7/5TR6gfqWVVqp2U7osx6B9H4PoKRtjcsZYhfFFQ9segxg3IsaaiLEjYszIffbZJ4+XusgiizgUrXwMbrvttvTXv/41PfXUU/Z1FT8H5Scoojf/iiuumIOc//73v3myH1r3GNTV1dVPrhTj1oRBgwale++9N11++eVp+PDhVTkEYofqcwyqT/xWfeK36hO/VZ/4rfqqHb91qh6FMUHDX/7yl3TwwQfXL4vSsui2WTnLbsx6XCo7i7+VsyCXbjdWmsb8HYPmiP0c3WnLxazTMeGDY9Byx+D999/PA6AuscQS6ZZbbskT9pQfA5+D1j8GMaHS2muvnWeoiolkYtbjOBaOQesfg0gSRjIqepjH2bVS2f3ee++dZ+J1DFr/GDRms802y39ffPFFx6ANjkEkZkOcLCr3qU99Ks98X43fZPFb9Ynfqk/8Vn3it+oTv1Wf+K362kP81qkShTHeV3S1jN5SJTHLaCRDItNa8sILL+SdOXjw4Hw7/v7zn/9ssFOjHDDGb6s8EMz/MWiOOAaRzI0xJcv/Ux+Z89J/Ilm4YxA9CWOG3ShzjZ5VlT3YfA7a/nNQFEW+TJs2zTFog2Nw3HHHpX/84x/p6aefrr+E8847L68ffA5a9xg0pnQcSgGQY9C6x2DAgAH57HTEQuX+7//+L6222mpV+U0Wv1Wf+K36xG/VJ36rPvFb9Ynfqq9dxG9FJzFr1qxi1VVXLX70ox/Ncd9hhx2W7/vrX/9ajB49uhg8eHC+lMycObNYb731ih122KF4+umni7vvvrvo169fcfzxx7fxVnTeYxCzi8ZMo5dddlmeiWfUqFH59jvvvFO/zo477lgMGjSoePTRR4sHH3ywWHvttYt99923jbeicx6DiRMn5lmS1l9//TzDbhyP0iXe/8HnoHWPwX//+9/izDPPzN9BL7/8cvHQQw8Vu+66a7H00ksXb7zxhmPQRt9FlSpnPfY5aN1jEN8/p512Wv4cjBkzprj11luLNdZYo9hqq60cgzb8HJx33nlFnz59ihtvvLH4z3/+k2fQW2SRRepnYG/L32TxW/WJ36pP/FZ94rfqE79Vn/it+ma1k/it0yQK77nnnvwfvhdeeGGO+6ZOnVocfvjhxVJLLVUsuuiixZ577pkTJOX+97//FTvttFPRu3fvYtllly2+973vFTNmzGjDLejcx2DYsGH5vsrLFVdcUb9OJA3jTbz44ovnD8CBBx5YvP/++228FZ3zGNx3332N7v+4xH/WS3wOWu8YxJT08R2z3HLLFT169ChWWWWVYr/99iuef/75Bus5Bq13DJqTKHQMWvcYjB07NicFI0Heq1evYq211ip+8IMf5JMZjkHbfg6GDx+ev4ciLoqTpw888ECD+9vqN1n8Vn3it+oTv1Wf+K36xG/VJ36rvnvaSfxWE/8sbNdIAAAAAKBj61RjFAIAAAAAC0aiEAAAAACQKAQAAAAAJAoBAAAAAIlCAAAAAECiEAAAAADITGYCAAAAAEgUAgAAAAAShQAAAACARCEAAAAAIFEI0E68/PLLqXfv3mny5MnVbgoAAPMgdgM6K5OZALQDt956a9p2223T4osvXu2mAAAwD2I3oLOSKARoQdtss0066qij0ne/+9201FJLpeWXXz5ddtllacqUKenAAw9MSyyxRFprrbXSXXfdNUewudtuu+XrNTU1c1wGDBjgOAEAtDCxG0BDEoUALey3v/1tWnbZZdNjjz2Wk4bf/va305e//OW0+eabpyeffDLtsMMO6etf/3r64IMP8voTJkxIDz74YH2icNy4cfWXF198MScWt9pqK8cJAKAViN0AZqspiqIouw3AQp6VnjVrVnrggQfy7bjet2/ftNdee6WrrroqLxs/fnxaccUV0yOPPJI++9nPpmuvvTadd9556fHHH2/wXPH1vPfee6exY8fm54sxDAEAaDliN4CGulfcBmAhbbDBBvXXu3XrlpZZZpm0/vrr1y+LcuTw5ptvzlF2XO6EE07IycTRo0dLEgIAtBKxG8BsSo8BWliPHj0a3I4xBsuXxe1QV1eXpk+fnu6+++45EoXXXHNN7mV4yy23pJVXXtkxAgBoJWI3gNkkCgGq6P7778+TngwcOLB+WfQiPPjgg9Oll16aS5MBAGgfxG5AZ6f0GKCKbrvttga9CWP8wj333DN99atfTUOGDMm3SyXM/fr1q2JLAQAQuwGdnR6FAO0o2Hz++efTG2+8kWffiwlPSpdNNtnEcQIAqDKxG9DZmfUYoEqefPLJ9PnPfz699dZbc4yNAwBA+yJ2A7oCPQoBqmTmzJnpwgsvlCQEAOgAxG5AV6BHIQAAAACgRyEAAAAAIFEIAAAAAEgUAgAAAAAShQAAAABAZtZjAAAAAECiEAAAAACQKAQAAAAAJAoBAAAAAIlCAAAAACCF/wdViv6qKrEnwwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1300x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Zoom to a populated m/z window so the isotope/charge structure is visible.\n",
+    "mz   = df.mz.to_numpy();  im = df.inv_mobility.to_numpy()\n",
+    "inten = df.intensity.to_numpy(); pep = df.peptide_id.to_numpy()\n",
+    "\n",
+    "mz_lo, mz_hi = 700.0, 760.0\n",
+    "img, lbl, mz_e, im_e = grid_peaks(\n",
+    "    mz, im, inten, pep,\n",
+    "    mz_min=mz_lo, mz_max=mz_hi, mz_bin=0.02,\n",
+    "    key_min=im.min(), key_max=im.max(), key_bin=0.005,\n",
+    ")\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 2, figsize=(13, 5), sharex=True, sharey=True)\n",
+    "ext = [mz_e[0], mz_e[-1], im_e[-1], im_e[0]]\n",
+    "ax[0].imshow(np.log1p(img), aspect=\"auto\", extent=ext, cmap=\"viridis\")\n",
+    "ax[0].set_title(\"intensity  (log1p)\"); ax[0].set_xlabel(\"m/z\"); ax[0].set_ylabel(\"1/K0\")\n",
+    "lab_show = np.where(lbl >= 0, lbl % 20, np.nan)           # mod for a repeating colour cycle\n",
+    "ax[1].imshow(lab_show, aspect=\"auto\", extent=ext, cmap=\"tab20\")\n",
+    "ax[1].set_title(\"peptide-id label overlay\"); ax[1].set_xlabel(\"m/z\")\n",
+    "fig.suptitle(f\"m/z–ion-mobility map · frame {frame.frame_id} · {mz_lo}-{mz_hi} Th\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d6aed7c",
+   "metadata": {},
+   "source": [
+    "## 5 · `to_dense_windows_with_labels` — demystified\n",
+    "\n",
+    "This is the **model-ready** representation, and its output shapes trip people up, so\n",
+    "here is exactly what it returns.\n",
+    "\n",
+    "It slices the frame into fixed-width **windows** and returns a *stack of tiles* — **not**\n",
+    "a single dense image. Each tile is one ion-mobility scan restricted to one m/z window.\n",
+    "\n",
+    "```\n",
+    "scan_idx, window_idx, mz, mobility,   X, iso_labels, charge_labels, pep_labels\n",
+    "   (N,)      (N,)     (N,)   (N,)   (N,Y)   (N,Y)        (N,Y)          (N,Y)\n",
+    "```\n",
+    "\n",
+    "- **Y (columns)** is fixed = `round(window_length · 10^resolution) + 1`.\n",
+    "  With `window_length=10, resolution=1` that's **101 bins of 0.1 Th**.\n",
+    "- **N (rows)** = number of `(scan × m/z-window)` tiles that passed the\n",
+    "  `min_num_peaks` / `min_intensity` filter.\n",
+    "- The per-row 1-D arrays are metadata **for each tile**: its scan, its window key\n",
+    "  (negative keys are the half-shifted overlap windows), the m/z of its first peak, and\n",
+    "  its 1/K0.\n",
+    "- The `(N, Y)` arrays are per-bin: `X` = intensity, and three label planes giving the\n",
+    "  **dominant contributor per bin** (`-1` = empty, `-2` = noise, `≥0` = signal → isotope\n",
+    "  index / charge / *per-window re-indexed* peptide id 0–5).\n",
+    "\n",
+    "**Why you see duplicate `scan`/`mz`/`mobility` values:** with `overlapping=True` each\n",
+    "m/z region is covered by two windows (aligned + half-shifted), and every scan yields one\n",
+    "tile per window it has peaks in. That's expected — it's a patch representation for a CNN,\n",
+    "not a single frame image. Use `.df` (Section 4) when you want an image; use this when you\n",
+    "want fixed-size labelled training patches."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9e1cb7f3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.742522Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.742345Z",
+     "iopub.status.idle": "2026-07-02T09:33:57.777964Z",
+     "shell.execute_reply": "2026-07-02T09:33:57.777567Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N (tiles)         = 1403\n",
+      "Y (m/z bins/tile) = 101   (= round(10 * 10^1) + 1 = 101)\n",
+      "per-tile metadata : scan_idx(1403,), win_idx(1403,), mz(1403,), mobility(1403,)\n",
+      "per-bin planes    : X(1403, 101), iso(1403, 101), charge(1403, 101), pep(1403, 101)\n"
+     ]
+    }
+   ],
+   "source": [
+    "scan_idx, win_idx, mz_w, mob_w, X, iso, chg, pep = frame.to_dense_windows_with_labels(\n",
+    "    window_length=10.0, resolution=1, min_num_peaks=3, min_intensity=5.0, overlapping=True,\n",
+    ")\n",
+    "print(f\"N (tiles)         = {X.shape[0]}\")\n",
+    "print(f\"Y (m/z bins/tile) = {X.shape[1]}   (= round(10 * 10^1) + 1 = 101)\")\n",
+    "print(f\"per-tile metadata : scan_idx{scan_idx.shape}, win_idx{win_idx.shape}, \"\n",
+    "      f\"mz{mz_w.shape}, mobility{mob_w.shape}\")\n",
+    "print(f\"per-bin planes    : X{X.shape}, iso{iso.shape}, charge{chg.shape}, pep{pep.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "10538647",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:57.778984Z",
+     "iopub.status.busy": "2026-07-02T09:33:57.778913Z",
+     "iopub.status.idle": "2026-07-02T09:33:58.003402Z",
+     "shell.execute_reply": "2026-07-02T09:33:58.003019Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEEAAAJQCAYAAABhO3rQAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAkZhJREFUeJzt3Qd8U+X+x/FfaUsBoZRZwAIioLJXpVZEUMuQIUOUdVkKTpAhKKCIil4Rr4CCgsoVvAhXXKCIgCzhIkPLXmIZAhWhgOzRljT/1++5/5ObjrTpTJt83q9XTHNycvLk5CRyvvk9z+Nnt9vtAgAAAAAA4OUKeboBAAAAAAAAeYEQBAAAAAAA+ARCEAAAAAAA4BMIQQAAAAAAgE8gBAEAAAAAAD6BEAQAAAAAAPgEQhAAAAAAAOATCEEAAAAAAIBPIAQBAAAAAAA+gRAEAPKRm266Sfr37y++ys/PT15++eV8v83cfM9//PFH02a99jRtl7bPG+gxoPsVmdOyZUupW7duhuv9/vvvZv/OmTMnT3dxfvp8u/vZ1X2k6+k+y633IzN8/f87AHwPIQgAr2L94zKty+jRoz3dPPioDRs2mBO1c+fOia/4/vvv883JqSt///vfZdGiRZ5uBgAAyEMBeflkAJBXXn31ValWrVqyZTn96xly3tWrVyUgIMArQ5BXXnnF/NoaEhKS7L79+/dLoUL58zeJjz76SJKSkrIcgrz33nv5Jgh58cUXUwWhGoJ069ZNOnfu7LF2eYuqVauaz29gYGCePq+3fmcAAHIP/9cA4JXuv/9+CQ8P99jz64ljQkKCFClSxGNtKIh8cX8FBQVJfpXXJ7S5SU+UPXWyrOGXdn3ID12c0nL58mW54YYbsrUNrbbzxOfXF78zAADZkz9/egKAXLZ69Wpp3ry5+Ye//jLfqVMn2bdvn1vjIaQ1toDeHjx4sMybN0/q1KljTmyXLVvm8vntdru89tprEhYWJsWKFZN77rlH9uzZk+a62oVi2LBhUrlyZbPdGjVqyJtvvpnsF3qrP/4//vEP+fDDD6V69epm3dtvv11++eWXZNs7ceKEDBgwwDy3rlOxYkXz+lP2T1+6dKljH5UoUULat2/vso3O3n33XfH390/W9ePtt9827RsxYoRjmc1mM9t9/vnnk+1H58oBa18fOHDAUUVRsmRJ0/4rV64ke974+HgZPny4lCtXzmz3gQcekNjY2DTbuG3bNhOUBQcHS/HixeW+++6TTZs2Jdvn+hr0tVhOnz5tKjbKlClj3j/Lk08+KRUqVHC5P/Q1jBo1yvyt1UlW9yxrf7vbH3/z5s3Stm1b8/r1mGnRooX89NNPyda5ePGiOVZ0m/reli9fXlq1aiVbt251rKP77ddffzWvJyMpPwPuHmf6OK0CUc5d0ix67E6dOtV8VvQkNjQ0VB5//HE5e/ZssufX5+7QoYOsX79emjZtata9+eab5V//+ley9RITE02lTc2aNc06+h7dddddsmLFimTvg3Mb9G89+f/kk08c7dN2r1mzxvy9cOHCVPtj/vz55r6NGzdKXo4xsWDBAhk7dqw5zvTzqMf2sWPHsnSMWPth79690qtXLylVqpTZVxnZsmWL3HnnnVK0aFFzHM+cOTPDMUF0f+rn648//jDVNvq3fj5HjhxpPv8ZiY6OljZt2kjZsmUdz/vII49kOCaI7jcNwfVY0GP0gw8+SPd7W7tEaaWgHst6TKb87j5y5Ig89dRTcuutt5p26PH10EMPZWlMD1e++eYb8x1bqVIl0w5t94QJE1zup4zeD+s7cfz48eb/GbpN/X/Ic889Z5anx53PEwAUZFSCAPBK58+fT3WSp/+QVitXrjQnwHoypf8w1nLqadOmSbNmzczJYlYHgtRg5fPPPzf/qNbnSm87L730kglB2rVrZy76vK1btzbVI870hFVPZPQkQk8Sq1SpYrpWjBkzRv78809zIpnyJE1PhHVd/Qf+pEmTpGvXrnLo0CHHr/oPPvigCTOGDBli2hgXF2f+cXv06FFHm+fOnSv9+vUzJyAauGg7ZsyYYf4hrAFCeq9NgxM9ydUTVz2BVf/5z39MgKDXFt3OpUuX5O67785w3z788MPmH/pvvPGG2VezZs0yJ/jaNsvAgQPl008/NSd2enKg74eeVKSkr13bqAGInhDoftGTJB1wcO3atRIREWHCFj0pWrdunTzzzDPmcfp6dJ/+9ddf5gRST5as16bbc0X3/2+//Sb//ve/ZcqUKY7jUE8G3aWvRY/ZJk2amJMa3ZezZ8+We++91zy/BgTqiSeekC+//NIcg7Vr15YzZ86YdmvA17hxY7POzz//bEI33U5Wu6pkdJzp8uPHj5vjSo+llPR+PVnWMEv37+HDh2X69OnmmNCTducKFA3AtMvKo48+ao7Jjz/+2Jxc676w3gN9HXps6DGg++LChQvmBFqPFQ2B0qLtstZ/7LHHzDI98bzjjjvMyaIGml26dEn2GF2m60RGRkpeev31181+1sBQP6/6uY+KipLt27ebk+DMHCMWPYnXk1ztEuQc6qVFwyn9ntLPYc+ePc33nIZ/hQsXThVKpKQn8fo9op8rDc/0+1dDUd2Pug1X9HXqd6J+TrQbk34mNXT4+uuv030+PYY0CNJwV0/k9fm1e6Srz5t+PnSbGnJoeKrBp35H6vehnvwrDfj0e7dHjx4mPNZ26Pehfmfod4EGTtmlnwcNiTQo1mt9P/X/E3osv/XWW5l+P/Q7WMMyfX16fNeqVUt27dplvoP0+yi9sXCy8nkCgALFDgBeZPbs2fqv+TQvloYNG9rLly9vP3PmjGPZjh077IUKFbL37dvXsaxfv372qlWrpnqO8ePHJ9ue0tv6+D179mTYxri4OHvhwoXt7du3tyclJTmWjx071mxHn9cyYcIE+w033GD/7bffkm1j9OjRdn9/f/vRo0fN7cOHD5vHlilTxv7XX3851vvmm2/M8sWLF5vbZ8+eNbffeustl+27ePGiPSQkxD5o0KBky0+cOGEvWbJkquUp2Ww2e3BwsP25554zt/U1arseeugh02bdvpo8ebLZZ9omi7ZN92/Kff3II48ke44uXbqYbVq2b99u1nvqqaeSrderV69U2+zcubPZ/wcPHnQsO378uL1EiRL2u+++27Hs6aeftoeGhjpujxgxwtyvx86MGTPMMj2G/Pz87O+88066+0T3t7ZD36eU9Bhzfs/XrFlj1tVra//VrFnT3qZNm2THy5UrV+zVqlWzt2rVyrFM3x9td3qs7TvvE1dSfgbcPc6UtiOtf2b85z//McvnzZuXbPmyZctSLdfn1mXr1q1L9vkJCgqyP/vss45lDRo0MJ+n9KT1udXPlvO+t4wZM8Y8x7lz55I9b0BAgFv7LSV9jhYtWmT6cdZ7deONN9ovXLjgWP7555+b5dZxl5ljxNoPPXv2dKsN2m5d/+2333Ysi4+Pd3yPJiQkJDs29DvY+XXrsldffTXZNhs1amRv0qRJus+7cOFC89hffvkl3fVSHssdO3a0FytWzP7HH384lsXExJj3Lq3vbf0uOHDgQLL/F+jyadOmJduPKW3cuNGs969//cvlZzej/085fx+k9RyPP/64eS3Xrl3L9Psxd+5c8/2qnzdnM2fONI//6aefXH4HufN5AoCCjO4wALySluLrr9DOF6XVE/rrqf6SXLp0acf69evXN79w6WCOWaUVG/rre0b0l1Ct+NBKDOfybO3GkNIXX3xhqgy0ZF0rW6yL/gqsv3BqpYKz7t27m3UtVoWC/kKv9Fdj/bVQy8VTdj2w6L7S7iD6C6Pzc2r3EP01V7sLpEd/gdZKDKttWoWgFQn6a66ed1hdCfTXaa22SDlQaFq0wsGZvi7dpv5Cqaz3zaracLVPdZ/98MMPpjRfK4Es+quxVpDor6bWNvU5Tp48aQYutdqrVSu63Kpo0fX1NaVXCZJderzGxMSY9ulrtt4P7cqh3Xh0P1tdo3RfapcIrcJwRX+91jZnZ8DSjI6z9Ogxrd019PPmfHxpBYP+Ap7y+NLPlPP+1V/0tVuC83Pp69YKH91POaFv376my4BW1Vi0S8r169flb3/7W7qP1ffC+XXpRbelXQxSLtdl7rZHqxQsWhmjx6x13GfmGHH1mUqPjqWi1TsW/Q7R21qtod0ysvL5zehYsb4XvvvuO7f3k36+9ftVP9/arcSi3UG0SiYt+l2qVSnO/y/QKjHn9lnVNkrbovtYt6ltdO5qlh3Oz6FVVvr+6X6yuq9l9v3Qz5lWf9x2223JjjmtDFLpfY/n9OcJAPIbusMA8EpawpvWwKjat1vpSVRK+g/G5cuXZ3mQwJSz0bhitUFL0Z3pyZ3ziaXSf4Tu3LnTZSm3/qPXmXaXcWZtzwo8tF+4diF59tlnzTgMWvqvXVb0JMsa18L6h6/1j+WU9ARBaTci7XbkzNqG/uPd6mqkgYGesGl3jAYNGpjbegKsAYKWc7sjvdel7dF9quGL88lMWu/zqVOnzEmFq/dfTxR1rAXtZmGdeGt7tQRey+y1C5O+F1rWb92nz6+vK7dY74d2BXFF3wfdJ9otRdfT7hwaKmjJvL63zoFPTsjoOMvo9Wh7tTtTVo5p6/mcn0u7O+i4NrfccosJ1rQ7RJ8+fcwJbVboiaOOc6LdX7QbjtK/9fOiJ7/p0W4Urr4LUn6O9URUQ6mMpPyu0PBU22GNSZGZY8Ti3Mb0PstKA4WU34m6r5W2QfeLKzqmRMrXnfL9cxUqa7cU7dKiXTh0P2m4oUGPq8GE9djR15LWe+TqfXPn+NJtavcQ7V6kXROduw+l3G9ZpaGDzmCk3WCsINbVc7jzfugxoQG0u//vcJbTnycAyG8IQQDAhZSD6FlcDVTn/EteTtGTcg0MdOyKtFj/8LVotUZanP/RrtURHTt2NH3CNfQZN26c+Qe+/uO7UaNGjl+MdcyEtAb8tGbY0F/GdUyHtJ5Hxw7RX0y16sN5zAyrikJ/2dRAwt0KCndeV07TEw09UdRf0XUMFH0uHQtCTyqGDh1qghd9LVr1kptT3Frvh44L0LBhwzTX0QoKpaGS7lMd1FMrXvQxGnrpmAeufgnPiuy8H/p6NADRUCEtKU/a3HkurdA5ePCgGVxSX7eOGaMnzjpYpI5rkBUaHun7rIPraiWHDpyr45ZkRD8zKQeQ1PdBByTWsTCc5VR4lpljJK3vq/Q+y9nl6v1z5/tXK3F0vy9evNh8V+l4F7oPdVnK15PT7XN+/Vq1pwGIfnfqd4BWMmn7dIyQrE4h7Uwr7zT00UBVAwgNczU80ioTHQcmK8+hj6lXr55Mnjw5zfs1KHUlNz5PAJCfEIIA8ClVq1Y111YXB2d6Yq6DVlq/sOmvgc4znKSs5MhuG/SXOudf6DUUSPnrqP5jWAcP1ZLtnKTb1WoQvWg79MRJTy50YFGrmkJPVNN7Xh3s0NVsAVqJoyXaGhLoxZodRf9x/dFHH8mqVasct3OC7lP9R7/+w925yiPl+6wn2DqIoav3X8MM55MDDRQ0BNEwRPeRdknQE1c9CdIZJPQkRX+pzmqg5g7r/dATJHeOA6260UEe9aK/9moFjg6smZMhiDtcvWZ9PdplQQcizsngULu36Ym8XqwBd7UaKb2TtvTeFz3B1UEqdUBbrQTQwVq1G1BG9OQ15fuknysNUrL6OU7ZLUFP0HXAWOuX+cweI5n5LCvtXpWyQk4H11RZHUjaXVrVoBc9hnVA3t69e8tnn32W5vuq31m6/3XfpJTWMndpGKNVNs4h1rVr19L8/0NWaPdE7WKjYaXzd6IOGJzV90OPiR07dpjuUFn5/snK5wkACgrGBAHgU/QEUU9mdVpM53/A7t692/zipd0HLPqPSC1D1u4oFh1TJK2pMzNDT1L0hEpnpHH+tTHlTC/WL/taTaG/gqak7dcxCjJDu4LoP96d6evUk3tr2kQ9IdKTKZ01Iq2++BrWWPtSX4vzxaInItqdQE8gtXuAcyWInlDqDAz6vLqNnGCd4DtPaZvWPtVffXXGCf2F03l6Sx37Q0+wtILF6u5jtVfX01/KrddgjXmiv7Dq/nGnmsU6WcnKSZN2a9F9pV1w9GTE1fuhFUopy+b1pFArWpynxMzMFLnZ4eo16zGtbdXpP1PS4zkr+0hPIJ1plYB2f8hoKlBto6vn00BUjysNMLRqRbsEWDP75DWdEljHiXA+KdfvIuu4d/cYcSW9z7L1vugMShYd00hva6ioz50bNBBOWY1iVbm4el/1861t1yo353FxNADRKb+zSrebsi36/e3ONL/ubl85P4fu4/fffz/N9d15P/Rzpl13NHROSb+DNUTJ6c8TABQUVIIA8DlaMq4nD1rWrP39rSly9dd958Ei9ZdgLUXWaTJ1wE1rmljtgpKdwfD0H6ojR440XVB0PA4NXnS8Cf1HesqTLK2g+Pbbb8161rSg+o9XnepQT4T0BD0zJ2b6a6H+Mqj/QNYBJ7Vri4Y6GgLo61UaAujr1D7gWkWgy7XNGmYsWbLE/ILvTrcADQcmTpxo9quWZVsn5VqpoZUY+npyip4c6UCuetKgQYCGFFptktavvzquh/7qrYGHVkvoPtATCP0Hvo6pkfI1KG2vhkIW/VVU3y8dm0DDnoxYJyYvvPCC2Z8agmmXJHfGntHQRcvR9ZjVsUr0l9kbb7zRnODomBL6fml3AT1J1rFLdNBMrVbRExetuNDpPZ1/wc6JKXLdYb1m/exosKYnevratexfB3HU418H9NRQSveHVjvoYI7vvPOOeQ2Zoceyjhmhz6m/YOt0ntZUwRm1UfeRBlpW9ycd/Ne5S4zVlrRCm7yir0mPV33v9bOq4Z6elA4aNChTx0hW6b7RblX6faPffxoK6nv34YcfJpvOOCdpUK2fZ/3+1YBHj289odfX4hxWp6THtAba+j2l08ZqUKHfVzq2hbY5K/T7V7sH6neZHmsaTOtxY02hm136faWVh1ptop8XrdzQ53PVJcmd90O/v3XqXB2UVo8B3R+6LzQA1eUarKc1blZ2Pk8AUGB4enoaAMhJ1tSDGU2ruHLlSnuzZs3sRYsWNdO56rSKe/fuTbXeDz/8YK9bt66ZRvHWW2+1f/rppy6nyM1oatKU08i+8sor9ooVK5o2tGzZ0r579+5UUxUqnVJWp+ysUaOGaUfZsmXtd955p/0f//hHqukp05r61nkKydOnT5t23nbbbWZ6UJ1SNSIiwky5mZJO86hTbuo6RYoUsVevXt3ev39/e3R0tFuvccmSJea577///mTLBw4caJb/85//TLetytrXp06dynCKyatXr9qfeeYZM32rvjZ9T48dO5bmdLBbt241r6148eJmCsp77rnHvmHDhjRfh047qds4efKkY9n69evNsubNm9vdpdMd61SnOm2lc9szmiLXsm3bNnvXrl3N69PpW/VxDz/8sH3VqlWOaTJHjRplprfU6X51H+jf77//fo5PkZvRcaauX79uHzJkiL1cuXJmGuGUn5kPP/zQTJOqx7+2t169emZaZZ2u2KLPndZUnTpNqPOUs6+99pq9adOmZmpn3Z4e36+//rrj86HS+tz++uuvZtpjfUzK6amtfVqqVCnzGdDjK6uyO0Xuv//9b/MdoMeitlX3yZEjR1Ktn9Exkt5nyhVtd506dcznPjIy0nwX6HanT5+ebD1XU+TqcZhSWu9FSvoZ1Wl8q1SpYl6LvvYOHTqk+v5J61jW16vT8Or3pX5vzZo1y0yprG1353s75WdSp/EeMGCA+e7V7wz97tBjx93PbkppfX/plLV33HGHeX8rVapkPgvLly9PtT133w+lx/+bb75p1td9qMeyfub0/z3nz593+Xrd+TwBQEHmp//xdBADAACQ32i3A/3VXat2/vnPf+b58+tYEVq1oxUyma2OQXI6swzTvgIAFGOCAAAApEHHltDxNLRbDAoO7eLoTLtaff/9925NRwwA8H6MCQIAAOBk8+bNZkBkHQdEp43WcUxQcOisWzrmkF7rbF46xpHOVuVqqnEAgG8hBAEAAHCiJ806K4wOuDtnzhz2TQGjM/nozFQnTpwwgxfrINg6sHHNmjU93TQAQD7AmCAAAAAAAMAnMCYIAAAAAADwCYQgAAAAAADAJxCCAAAAAAAAn0AIAgAAAAAAfAIhCAAAAAAA8AmEIAAAAAAAwCcQggAAAAAAAJ9ACAIAAAAAAHwCIQgAAAAAAPAJhCAAAAAAAMAnEIIAAAAAAACfQAgCAAAAAAB8AiEIAAAAAADwCYQgAAAAAADAJxCCAAAAAAAAnxDg6QZ4g6SkJDl+/LiUKFFC/Pz8PN0cAAAAAAB8it1ul4sXL0qlSpWkUCHX9R6EIDlAA5DKlSvnxKYAAAAAAEAWHTt2TMLCwlzeTwiSA7QCxNrZwcHBObFJAAAAAADgpgsXLpjiBOv83BVCkBxgdYHRAIQQBAAAIGsSDhyVc9PnS/yuGAmqV1NCBveSwjWqsDsBAG7LaIgKQhAAAADkiwAkNmqg2K8liNhskrDnoFxatFrCVs4iCAEA5BhCEAAAAHicVoBYAYhhs5nburz81NGebh6AAsJms0liYqKnm4FcFhgYKP7+/ll6LCEIAAAAPKbNhCXm+vkfoqWqFYBYbDbZvSJa7vVM0wAUMJcuXZLY2FgzSwi8v8tLWFiYFC9ePNOPJQQBAACAx8WWC5Ww03Hi73TyYvPzk9iyoR5tF4CCUwGiAUixYsWkXLlyGY4LgYJLQ65Tp06Z97tmzZqZrgghBAEAAIDHrWgSIU1i9olcv26CEA1AEgMCzPK+nm4cgHxPu8DoybEGIEWLFvV0c5DL9H3+/fffzftOCAIAAIACJ65UGZnYo7+02rJZwk6fNBUgGoDocgBwFxUgvsEvG5U+VIIAAAAgX9DAY15UO083AwDgxQp5ugEAAADw3LS0ccMmyrH7HjXXehsAkHnaNSM8PDzddebMmSMjR47M0jaz89iMREdHy6hRo9zednae/8cff5Ru3bql+Zh77rlH8gKVIAAAAD5IA4/YqIGOaWkT9hyUS4tWS9jKWVK4RhVPNw8A8uR7UKfhjt8VI0H1akrI4F4++f0XHh7udmCSm9asWZMnz0MlCAAAgA/Sf/hbAYhhs5nbuhwAfCUIvvjZMknY+Zu51ts5URF38OBBad68uTRu3FiaNm0q27dvd9x3+PBhufvuu+WWW26RqVOnOpbPnTtXbr/9dmnQoIGMGDEi3e3rzChdu3Y1wUVkZKRs27bNLD9w4IDZRv369eXdd99N87G7du0y7WrYsKG5xMXFJavOOHnypKnIqFu3rowZM0bKli3rqER5+OGHpVWrVlKjRg15++23Hdvs0KGDNGnSxDxm3rx5Ge6fs2fPStu2beXWW29NVoFiPZe2R5+nc+fOZj9ltD8yixAEAADAh7SZsMRcdv8Q/b8AxGKzye4V0Z5qGgB4RRBcsWJFWblypWzdulVmzZqV7ET/l19+kW+//dbcN3PmTBOY7Nu3T7755hvZuHGj7NixQ06fPi1Llixxuf1hw4aZgEK7sfzrX/+SJ554ItnynTt3SmBgYJqP/fDDD+XJJ580wYw+X0hISLL7X3nlFenUqZPs3r1bqlevnuw+3e7ChQvN806aNEkSEhLMcm3Dli1bZPPmzfL6669LfHx8uvtn06ZNph179uwxj9HQIyXdPx988IFpx+LFi+Xo0Zzrrkl3GAAAAB8UWy5Uwk7HmeloLTotrc7KAgDeTrvApBUEx+8+kP1tx8fL4MGDTWig07dq5YZFKyCs4KFdu3YmiDh37pwJBqwuKVeuXDGVFXXq1Elz+xqwaIDgXFlhBSwaGKjevXvLqlWrUj02MjJSXn31VTlz5oyp7Lj55puT3b9hwwYZN26c+bt79+4yevRox31anVG8eHHzd6VKlUzVSOXKlWXKlCkm2FEaVujFVQijmjVrJlWq/LfbkVagrF+/Xlq2bJlsnTvvvFNCQ//7/yOtMDly5IjjMdlFCAIAAOCDdPrZJjH7RK5fN0GIBiCJAQFmeV9PNw4AcpmOAaJjISULQvz9JahujWxvW7u53HTTTfLpp5/K5cuXzd9pTe2qf+slKSlJBg0aJOPHj081uKgrWo0REBCQ6Wlje/XqZbroaFiiocYXX3yR7H67UzCeUlBQkONvDXdsNpsZx+Onn34yFR1FihQxQY6GQOmFIGntA3eeK6fQHQYAAMBHp6Od2KO/bKpVT46UDzXXeluXA4C300FQ/YoUNsGH4e9vbuvy7Lpw4YKplNCTex1Lw9myZcvk/PnzJhxZunSp3HHHHXLffffJggULTHWG0nE6/vzzT5fb1zE7ZsyY4bitXWiUBhDarUbNn592t55Dhw6Zbi7Dhw+X1q1by969e1NVYFjBSMqAxNVrLVOmjAlAtIuN1Zb0aGgSGxsr169fl6+++kruuusuyUuEIAAAAD5KA495Ue3kzR4DzDUBCABfobPA6GxYJXq0lcINbjXXOTU71lNPPWXGs9CBR61gw6IDl3bs2FEaNWokjz32mAkktNvLCy+8YMIQHdS0ffv28tdff7nc/rRp08w4GjqIaq1atRyBh1ag6JgcutwaryOlBQsWmO4l2rbjx49Lly5dkt2v1SgaTNSrV890uQkODk73tWr3nosXL0rt2rXNc2s3noxERETIwIEDzevW/dGiRQvJS3729Opd4BZNv0qWLGkSvYwOEgAAAE/SQVEzsnxce/HV9gAomK5du2ZmXqlWrZqpSkDW92NgYKDpgqKVIBqafPnllwXi/Xb3vJwxQQAAAAAAgOg4JD179jRjcGigMHv2bK/bK4QgAAAAAABAbrvtNtm2bZtX7wnGBAEAAAAAeAVGe/AN9myM6kElCAAAAACgQNNxLHQ2llOnTkm5cuXcmi4WBTcA0fdZ3+P0puJ1hRAEAAAAAFCg6UCeYWFhZupVHdcC3s3Pz8+83/q+ZxYhCAAAAACgwCtevLjUrFlTEhMTPd0U5DJrBpusIAQBAAAAAHgFPTHO6skxfAMDowIAAAAAAJ9ACAIAAAAAAHwCIQgAAAAAAPAJhCAAAAAAAMAnuB2CfPPNN/Ltt9+av9evXy9Dhw6Vf/7zn7nZNgAAAAAAgBzj1uww48aNkx9++EESEhJk7dq1Eh0dLe3atZNPPvlEjh8/bu4HAAAAAAAo8CHIwoULZfv27XLlyhWpUKGCHDt2TMqUKSNPPfWUNGvWjBAEAAAAAAB4R3eYwoULS0BAgAQHB0uNGjVMAKJKlCjBHMwAAAAAAMB7QhCbzeb4+4MPPnD8bbfbTRcZAAAAAAAArwhBXnnlFbl8+bL5OzIy0rH8t99+k+7du+de6wAAAAAAAPJyTJDOnTunufzWW2+Vl156KafaAgAAAAAA4NlKkPj4eJk5c6Z899135vbHH38sffr0kTfffDPN7jBly5Y1U+ju3Lkz51sMAAAAAACQW5UgTzzxhJw4ccLMDrNkyRLZv3+/dOvWTZYvXy4HDhyQjz76KNn6OmBqUlKStGzZUqpXry6PPvqo9OrVywysCgAAAAAAkG9DkJ9//ll2794t165dM1PkHj9+XG644QYZNGiQNGrUKNX6pUqVkmnTpsk//vEP+eqrr0zlyKhRo6RLly4ycOBAufvuu3PjtQAAAAAAAGSvO4xOj+vn5ydFihQxFw1AVGBgYLpT5AYFBZkKkJUrV8quXbukatWqphsNAAAAAABAvgxBNLwYOXKk6RZTp04dGTJkiGzatElefvllqVixYqr1derclG666SaZMGGC/P777241TLetwYvz5bbbbnPcr1UpTz/9tJQpU0aKFy8uDz74oJw8eTLZNo4ePSrt27eXYsWKSfny5U01yvXr15Ot8+OPP0rjxo1NYFOjRg2ZM2eOW+0DAAAAAABeGIJodxabzWYqQLR7S61atUxXmO3bt5sBU1OaO3euy21pmOEuDVz+/PNPx2X9+vWO+4YPHy6LFy+WL774QtauXWu66HTt2tVxv7ZXAxAduHXDhg3yySefmIDDeTabw4cPm3Xuuece81qGDRtmuuvoWCcAAAAAAMC7+NnTKtvIYRpIHDlyRCpXrmy60LhbCbJo0SITTqR0/vx5KVeunMyfP98M0Kp+/fVXE85s3LhR7rjjDlm6dKl06NDBhCOhoaFmHQ1snn/+eTl16pQULlzY/K0Dvep4J5YePXrIuXPnZNmyZW6/vgsXLkjJkiVNuxj8FQAA5GdtJizJcJ3l49qLt7cn4cBROTd9vsTvipGgejUlZHAvKVyjSo4/DwAgb7h7Xu5WJYh2K9HuJ0ozk/fff1/69u0rkydPTtW9RI0dO1bi4uLM3xpiaHcaDSZuvPHGZNUcGYmJiZFKlSrJzTffLL179zbtUFu2bJHExESJiopyrKtdZapUqWJCEKXX9erVcwQgqk2bNmbH7Nmzx7GO8zasdaxtpDdlsG7H+QIAAICCQQOQ2KiBcvGzZZKw8zdzrbd1OQDAu7kVgmhFhVZzqPHjx8vXX39tQo1169bJ0KFDU62v3VR0DA41evRomTVrlglFvvvuO3n22WfdalhERITpvqIVGTNmzDBdV5o3by4XL1400/VqJUdISEiyx2jgofcpvXYOQKz7rfvSW0dDjatXr7ps2xtvvGESJuuiFS4AAAAoGLQCxH4tQcuV/7vAZjO3dTkAwLu5NUWuVn9YM8Jo95H//Oc/ZrDRxx57zAwqmpKOw2E5ffq0tG3b1vzdtGlTU0Xhjvvvv9/xd/369U0oohUln3/+uRQtWlQ8acyYMTJixAjHbQ1NCEIAAADyN6vrzfM/REtVKwCx2Gyye0W03OuZpgEA8lMliA5mas28UqJECTNlrtLpcdPqDnP77bfLlClTzN/h4eGmYkTpNLk6xW5WaNXHLbfcIgcOHJAKFSqYoEXH7nCmbdT7lF6nnC3Gup3ROtp/KL2gRWeS0XWcLwAAACgYYsuFii3FYP16O7Zs8gphAICPhiDaBUZnUNFuLdolRaej1a4qOk6Hzq6S0vTp0021iFZu7Ny5U+69914zRa6ur11bsuLSpUty8OBBMyVvkyZNzACrq1atcty/f/9+M2ZIZGSkua3XGrpYY5OoFStWmMCidu3ajnWct2GtY20DAAAA3mdFkwhJDAhwBCF6rbd1OQDAu7nVHUZDDx2cVAdC3bt3r6n+0Klye/XqZWZTSatqQ8cN0dDCWl8HLdXwwl0jR46Ujh07miBFZ3jRIEYrT3r27GnG4Xj00UdNl5TSpUubYGPIkCEmvNCxSlTr1q1N2NGnTx+ZNGmSGf/jxRdflKefftpUcqgnnnjCBDbPPfecPPLII7J69WrT3Ua7/AAAAMA7xZUqIxN79JdWWzZL2OmTpgJEAxBdDgDwbm6FIKpRo0Yyd+7cTG28evXq5pIVsbGxJvA4c+aMmQ73rrvukk2bNpm/lXa3KVSokAlodJwRndVFZ62xaGCiA7E++eSTJhzRMU369esnr776qmOdatWqmcBj+PDh8s4770hYWJipdtFtAQAAwHtp4DEvqp2nmwEAyK8hSF777LPP0r1fxxZ57733zMUVrSL5/vvv091Oy5YtZdu2bVluJwAAAAAA8KIxQQAAAAAAAAo6QhAAAAAAAOATcr07zObNm80Aqc5T6fbt2ze3nxYAAAAAACDrIcjWrVtl7NixcujQoWShht5Oiw5Kunz5cmnYsKEZqFT5+fkRggAAAAAAgPwdgujsKoMHDzazrVihRnpWrlxppsjVQUwBAAAAAAAKTAiiwcfjjz/u9voVK1aUoKCgrLQLAAAAAADAcyFIs2bNJDo6WsLDw91aPyIiQrp16ybdu3dPVg3ywAMPZL6lAAAAAAAAeRWCrFu3Tj766COpUaNGslBDxwpJiwYmasaMGY5lOiYIIQgAAAAAAMjXIcj06dMztfE1a9Zktj0AAAAAAACeD0FatGjh1noxMTFSs2ZN2blzZ5r3169fPzNPCwAAAAAAkLchyNWrV2XatGmyfft2uXbtmmP5119/nWy94cOHy3fffSedOnVKtQ3tDuNqSl0AAAAAAIB8EYIMGjRIgoODZcOGDfLss8/KnDlz5O677061ngYg6vDhwznXUgAAAAAAgGwolJmVd+zYIe+//74JQoYMGSI//vijbNmyxeX6r732mmzevFmSkpKy00YAAAAAAIC8DUGKFi1qrgMCAuTy5ctSokQJOXXqlMv17Xa7jBo1SsqXL29mhHn33Xdlz5492W81AAAAAABAboYgpUuXlrNnz0q7du2kTZs20rlzZwkLC3O5/rhx48y0ukeOHJFu3brJlClTGBQVAAAAAADk/zFBlixZIv7+/jJhwgSZP3++CUT69u3rcv2VK1eay+rVq02XmIceekhatWqVE+0GAAAAAADIvRDkjz/+MF1bihQpIr179zazxZw+fdqMEZKW1q1by5133ilvv/22NG/ePHMtAwAAAAAA8FR3GO3S4s4yy+7du+Xhhx+Wt956S2rXri39+/eXefPmZa2lAAAAAAAAeRWCJCQkmCoQ54FS4+PjXa6vwcczzzwj77zzjgwePFjWrl0r/fr1y057AQAAAAAAcj8E8fPzk7i4OMftEydOmBlgXHn88celRo0aZhyQnTt3yqRJk5I9HgAAAAAAIF+OCaJVHZGRkdKnTx9z+9NPP5Xx48e7XD88PFxGjx4t1apVy35LAQAAAAAA8ioEGTBggAk0vv/+e3N79uzZ6Q54OmjQoOy0DQAAAAAAwDMhiGrZsqW5nD9/Xo4dO5ZzLQEAAAAAAMgvY4K0bdtWzp07J5cuXZIGDRpIhw4d5KWXXsq91gEAAAAAAHgiBDl58qSEhISY7jCdOnWSmJgYWbhwYU61BQAAAAAAIH+EIImJieZ63bp1ZsaXwMBACQjIdI8aAAAAAACAPJepBKNu3bpy//33y759+8x0t1euXMm9lgEAAABeIOHAUTk3fb7E74qRoHo1JWRwLylco4qnmwUAPilTIcicOXNk2bJlZjyQYsWKyR9//CFvvPFG7rUOAAAAKOABSGzUQLFfSxCx2SRhz0G5tGi1hK2cRRACAPm9O0yRIkWkc+fOZppcdeONN5rBUgEAAACkphUgVgBi2Gzmti4HAOQ9BvQAAAAAclibCUvM9fM/REtVKwCx2Gyye0W03MteB4D8XQkCAAAAwH2x5ULF5ueXbJneji0bym4EAA8gBAEAAAByyYomEZIYEOAIQvRab+tyAEDeozsMAAAAkEviSpWRiT36S6stmyXs9ElTAaIBiC4HAOQ9QhAAAAAgF2ngMS+qHfsYAPIBusMAAAAAAACfQAgCAAAAAAB8AiEIAAAAAADwCYQgAAAAAADAJxCCAAAAAAAAn0AIAgAAAAAAfAIhCAAAAAAA8AmEIAAAAAAAwCcQggAAAAAAAJ8Q4OkGAAAAAMg7CQeOyrnp8yV+V4wE1aspIYN7SeEaVXgLAPgEQhAAAADAhwKQ2KiBYr+WIGKzScKeg3Jp0WoJWzmLIASAT6A7DAAAAOAjtALECkAMm83c1uUA4AuoBAEAAAC8XJsJS8z18z9ES1UrALHYbLJ7RbTc65mmAUCeohIEAAAA8BGx5ULF5ueXbJneji0b6rE2AUBeIgQBAAAAfMSKJhGSGBDgCEL0Wm/rcgDwBXSHAQAAAHxEXKkyMrFHf2m1ZbOEnT5pKkA0ANHluYGZaADkN4Qg/++9996Tt956S06cOCENGjSQadOmSdOmTT377gAAAAA5TAOPeVHtvG4mGgIXAO6gO4yILFiwQEaMGCHjx4+XrVu3mhCkTZs2EhcX59ZOBAAAAOC5mWiswOXiZ8skYedv5lpv63JP0OeNGzZRjt33qLn2VDsApEYIIiKTJ0+WQYMGyYABA6R27doyc+ZMKVasmHz88cdp7DIAAAAA6c1Eo5fdP0T/LwBJMRONN0/9m98CGQDJ+Xx3mISEBNmyZYuMGTPGsVMKFSokUVFRsnHjRklLfHy8uVjOnz9vri9cuJDm+gAAAPnF9WtXMlwnL/9Nk5ft8dbnyq+v/WjpMhJ2Ok787XbHfToQ69FSZXLsubq8udxcv7D857Sn/l3+i4Tn8b/RL0z+ROzX4kVsSY526O24yZ9I8MShedoWwJdc+P/Put3pOyctfvaM1vByx48flxtvvFE2bNggkZGRjuXPPfecrF27VjZv3pzqMS+//LK88soredxSAAAAoOCo5l9UFoU0lCDxkwC/QnLdniTxYpfO57bLYdvVHH2uvxevIV2DypvnsejzfR0fJ2MvHZC8tLBkA6kXWCLV8l2JF6XL+R152hbAFx07dkzCwsJc3u/zlSBZoVUjOoaIJSkpSf766y8pU6aM+KWYd72gJWeVK1c2B01wcLCnmwNkGccyvAnHM7wJxzPU9jzcDU///yU/HMv3agV5LrQFyK4LXnIeqPUdFy9elEqVKqW7ns+HIGXLlhV/f385efJksh2jtytUqJDmTgsKCjIXZyEhIeIt9MAvyAc/YOFYhjfheIY34XiGt+BYhjcJ9oLzwJIlS2a4js8PjFq4cGFp0qSJrFq1Klllh9527h4DAAAAAAAKNp+vBFHataVfv34SHh4uTZs2lalTp8rly5fNbDEAAAAAAMA7EIKISPfu3eXUqVPy0ksvyYkTJ6Rhw4aybNkyCQ0NFV+iXXzGjx+fqqsPUNBwLMObcDzDm3A8w1twLMObBPnYeaDPzw4DAAAAAAB8g8+PCQIAAAAAAHwDIQgAAAAAAPAJhCAAAAAAAMAnEIIAAAAAAACfQAgCAAAAAAB8AiEIAAAAAADwCYQgAAAAAADAJxCCAAAAAAAAn0AIAgAAAAAAfAIhCAAAAAAA8AmEIAAAAAAAwCcQggAAAAAAAJ9ACAIAAAAAAHwCIQgAAAAAAPAJhCAAAAAAAMAnBHi6Ad4gKSlJjh8/LiVKlBA/Pz9PNwcAAAAAAJ9it9vl4sWLUqlSJSlUyHW9ByFIDtAApHLlyjmxKQAAAAAAkEXHjh2TsLAwl/cTguQArQCxdnZwcHBObBIAAAAAALjpwoULpjjBOj93hRAkB1hdYDQAIQRBdiUcOCrnps+X+F0xElSvpoQM7iWFa1RhxwIAAABABjIaooIQBMhnAUhs1ECxX0sQsdkkYc9BubRotYStnEUQAgAAAADZRAgC5CNaAWIFIIbNZm7r8vJTR3u6eQAAAEC+ZrPZJDEx0dPNQC4LDAwUf3//LD2WEATIB9pMWGKun/8hWqpaAYjFZpPdK6LlXs80DQAAACgQLl26JLGxsWaWEHh/l5ewsDApXrx4ph9LCALkI7HlQiXsdJz4O31x2/z8JLZsqEfbBQAAAOT3ChANQIoVKyblypXLcFwIFFwacp06dcq83zVr1sx0RQghCJCPrGgSIU1i9olcv26CEA1AEgMCzPK+nm4cAAAAkE9pFxg9OdYApGjRop5uDnKZvs+///67ed8JQYACLK5UGZnYo7+02rJZwk6fNBUgGoDocgAAAADpowLEN/hlo9KHShAgn9HAY15UO083AwAAAAC8TiFPNwDID9PSxg2bKMfue9Rc620AAAAAcJd2zQgPD093nTlz5sjIkSOztM3sPDYj0dHRMmrUKLe3nZ3n//HHH6Vbt25pPuaee+6RvEAlCHyaBh6xUQMd09Im7DkolxatlrCVs6RwjSqebh4AAAAA5Krw8HC3A5PctGbNmjx5HipB4NPOTZ/vCEAMm83c1uUAAAAAvFduVYQfPHhQmjdvLo0bN5amTZvK9u3bHfcdPnxY7r77brnllltk6tSpjuVz586V22+/XRo0aCAjRoxId/s6M0rXrl1NcBEZGSnbtm0zyw8cOGC2Ub9+fXn33XfTfOyuXbtMuxo2bGgucXFxyaozTp48aSoy6tatK2PGjJGyZcs6KlEefvhhadWqldSoUUPefvttxzY7dOggTZo0MY+ZN29ehvvn7Nmz0rZtW7n11luTVaBYz6Xt0efp3Lmz2U8Z7Y/MohIEPqnNhCXm+vkfoqWqFYBYbDbZvSJa7vVM0wAAAAAU4IrwihUrysqVKyUoKEh27twpzz77rKxYscLc98svv5hlAQEBJsTo2LGjJCQkyDfffCMbN240y/v27StLliyROnXqpLn9YcOGmYBCA4+YmBj529/+Jps3b3Ys14Dk+eefT/OxH374oTz55JMyaNAguXr1aqqZVV555RXp1KmT2dasWbOS3aft1q4z169fNwHGkCFDpHDhwvKvf/1LSpcuLZcvXzZtctXdxbJp0ybZt2+fVKpUSe69914TerRs2TLZOlu3bpW9e/dKqVKlzH7Q9lSpkjOV+lSCwKfFlgs109A609s6KwsAAAAA75SbFeHx8fHyyCOPSL169UygoSfzFq2ACAkJkeLFi0u7du1M8LFq1SoTDGgootUZ+rdWdbiiAYuGGLruQw89JCdOnHAELF26dDF/9+7dO83HRkZGmiqOiRMnyp9//mlCDGcbNmyQ7t27m7+ta4tWZ2i7tf0aYGjViJoyZYqpYLnzzjvl6NGj5pKeZs2amUBDAx8NTNavX59qHd1WaGioaZ9WmBw5ckRyCpUg8Gk6/WyTmH0i16+Lv91uApDEgACzvK+nGwcAAAAgV8TvivlfAGKx2SR+t+vwwV3azeWmm26STz/91FRH6N9pTe2qf+slKSnJhBrjx49PNbioK1qRoSFCZqeN7dWrl+mis3jxYhNqfPHFF8nut9vtLh+rlS0WrSCx2WxmHI+ffvrJVKIUKVLEBDkaAgUGBrrcTlr7wJ3nyilUgkB8fTraiT36y6Za9eRI+VBzrbd1OQAAAADvFFSvpp5dJ1/o7y9BdWtke9sXLlwwlRJ6cq9jaThbtmyZnD9/3oQjS5culTvuuEPuu+8+WbBggZw5c8aso+N0aJWGKzpmx4wZMxy3d+zYYa41gNBuNWr+/LQrWg4dOiTVq1eX4cOHS+vWrZNVqVgVGFYwkjIgcfVay5QpYwIQHfvEakt6NDSJjY013Wq++uorueuuuyQvEYLA52ngMS+qnbzZY4C5JgABAAAAvFvI4F7iV6Tw/4IQf39zW5dn11NPPSUffPCB6a5iBRsWHTNDxwFp1KiRPPbYYyaQ0DEvXnjhBROG6KCm7du3l7/++svl9qdNm2bG0dAuKLVq1XIEHlqB8vrrr5vlOs5IWhYsWGC6l2jbjh8/7ug+Y9FqFA0mtCvPnj17JDg4ON3Xqt17Ll68KLVr1zbPrQOkZiQiIkIGDhxoXrfujxYtWkhe8rOnV+8Ct2j6VbJkSZPoZXSQIH8NjJqe5ePai6+2BwAAAChIrl27ZmZeqVatmqlKcHdwVB0DRLvAaAWIBiDZHRTVG/ZjYGCg6YKilSAamnz55ZdSEN5vd8/LGRMEAAAAAOBzNPAoP3W0p5uRr/z+++/Ss2dPMwaHBgqzZ88Wb0MIAgAAAAAA5LbbbpNt27Z59Z5gTBAAAAAAgFdgtAffYM/GqB5UggAAAAAACjQdx0JnYzl16pSUK1fOreliUXADEH2f9T1ObypeVwhBAAAAAAAFmg7kGRYWZqZe1XEt4N38/PzM+63ve2YRggAAAAAACrzixYtLzZo1JTEx0dNNQS6zZrDJCkIQAAAAAIBX0BPjrJ4cwzcwMCoAAAAAAPAJhCAAAAAAAMAnEIIAAAAAAACfQAgCAAAAAAB8gtshyDfffCPffvut+Xv9+vUydOhQ+ec//5mbbQMAAAAAAMgxbs0OM27cOPnhhx8kISFB1q5dK9HR0dKuXTv55JNP5Pjx4+Z+AAAAAACAAh+CLFy4ULZv3y5XrlyRChUqyLFjx6RMmTLy1FNPSbNmzQhBAAAAAACAd3SHKVy4sAQEBEhwcLDUqFHDBCCqRIkSzMEMAAAAAAC8JwSx2WyOvz/44APH33a73XSRAQAAAAAA8IoQ5JVXXpHLly+bvyMjIx3Lf/vtN+nevXuGj79+/bocPHiQwAQAAAAAAOTvEKRz585yww03pFp+6623yksvvZRq+dKlSyU0NFTCw8Nl9+7dctttt5nwpGLFirJ69eqcaTkAAAAAAEBOD4waHx8vs2fPlrCwMOnQoYN8/PHHsmbNGqlbt64MHz7cjBni7MUXX5Svv/5azp49K1FRUTJr1izzuI0bN8ozzzwjv/zyS2baCAAAAAAAkDchyBNPPCEnTpwws8MsWbJE9u/fL926dZPly5fLgQMH5KOPPkq2flJSkpk1RhUtWtQEIEqrQbRrDAAAAAAAQL4MQX7++WfTreXatWtmitzjx4+b7jGDBg2SRo0apTmQ6qlTp+T8+fNy5swZM3bILbfcIidPnmRcEAAAAAAAkH9DEJ0e18/PT4oUKWIu1vgggYGBaU6R++yzz5qpdNXMmTOlT58+UqpUKdm+fbu88MILOf0aAAAAAAAAcmZg1KpVq8rIkSNNt5g6derIkCFDZNOmTfLyyy+bwU5T6tevn/z+++9y6NAh6dWrl6xYscJUjeiAqfpYd+i2NXhxvugAqxatSnn66aelTJkyUrx4cXnwwQdNpYmzo0ePSvv27aVYsWJSvnx5GTVqVKruOD/++KM0btxYgoKCTHAzZ84ct9oHAAAAAAC8MATRgVC1i4tWgHz11VdSq1YtE2poZYdWeqRFKz80oFD6OO02owOpZoYGLn/++afjsn79esd9OiDr4sWL5YsvvpC1a9eaLjpdu3Z13K/t1QAkISFBNmzYIJ988okJOJxnszl8+LBZ55577jGvZdiwYTJw4EAz1gkAAAAAAPAufna73Z7TGx07dqwJFLT6QsMFHRhVwwils8bcddddblWCLFq0yDw+JR1rpFy5cjJ//nwzQKv69ddfTTijM9DccccdpupEn1fDEZ2uV2lg8/zzz5vxSnRGG/1bB3rV8U4sPXr0kHPnzsmyZcvcfr0XLlyQkiVLmnYFBwe7/Th4TpsJSzJcZ/m49uKr7QEAAACAgsTd83K3KkG0W4l2P1Gambz//vvSt29fmTx5cpqzvWiFhgYgavTo0WaK3Li4OPnuu+/MeCHuiomJkUqVKsnNN98svXv3Nu1QW7ZskcTERDP9rkW7ylSpUsWEIEqv69Wr5whAVJs2bcyO2bNnj2Md521Y61jbSG/KYN2O8wUoiBIOHJW4YRPl2H2Pmmu9DQAAAADeyq0QRCsqtHuJGj9+vKnm0GqLdevWydChQ1Otb1V9qNOnT0vbtm3N302bNjUBgjsiIiJM9xWtyJgxY4bputK8eXO5ePGima5XKzlCQkKSPUYDD71P6bVzAGLdb92X3joaaly9etVl29544w2TMFmXypUru/WagPxEA4/YqIFy8bNlkrDzN3OttwlCAAAAAPh0CKLVH9aMMNp95Ntvv5WnnnpKvvzyS/nPf/6Tav3bb79dpkyZYv4ODw83YYnatWuXmV3GHffff7889NBDUr9+fVOd8f3335tuKp9//rl42pgxY0yJjXU5duyYp5sEZNq56fPFfi1BB9D57wKbzdzW5QAAAADgsyGIzsxizbxSokQJM2Wu0ulx0+oOM336dBOO6KwyO3fulHvvvVduuukm06VFqzqyQqs+brnlFjlw4IBUqFDBVJtoKOJM26j3Kb1OOVuMdTujdbT/UNGiRV22RWeS0XWcL0BBoeOP6GX3D9H/C0AsNpvsXhHtqaYBAAAAQK76b5qRAe0CozOojBgxwnRJ0elo9fLDDz+Y2VXSCiy0y8zBgwdl7969JijR8TqaNGmS5YZeunTJbK9Pnz5mO4GBgbJq1SrTDrV//34zZkhkZKS5rdevv/66GYvEGp9Ep+rVwKJ27dqOdbTCxJmuY20D8Gax5UIl7HSc+DuNjWzz85PYssm7iAEAAACAT4UgGjTo4KQ6EKoVauhUub169TKzqbhSvXp1c7HChcwYOXKkdOzY0VST6AwvGsRo5UnPnj3NOByPPvqoCWVKly5tgo0hQ4aY8ELHKlGtW7c2YYeGJpMmTTLjf7z44ovy9NNPm0oO9cQTT5iqleeee04eeeQRWb16teluo11+AG+3okmENInZJ3L9uglCNABJDAgwy/t6unEAAAAA4KkQRDVq1Ejmzp2b5SfS6WhbtWrl9vqxsbEm8Dhz5oyZDlen1d20aZP5W+mYI4UKFTIBjQ62quOG6Kw1Fg1MdDaaJ5980oQjOqZJv3795NVXX3WsU61aNRN4DB8+XN555x0JCwszM9notgBvF1eqjEzs0V9abdksYadPmgoQDUB0OQAAAAD4dAiSXTq4amZ89tln6d6vA6y+99575uKKVpGk7O6SUsuWLWXbtm2ZahvgLTTwmBfVztPNAAAAAID8MzBqTkiv2wwAAAAAAIDXhCDaHQYAAAAAAMDrQxAAAAAAAIACMybI1q1bZezYsXLo0CEzQ4xFbwMAAAAAAHhNCKKzqwwePNjMtqKzrwAAAAAAAHhlCKLBx+OPP56pJ9i8ebMcPHgwWeVI3759M7UNAAAAAACAPA1BmjVrJtHR0RIeHu7W+k8++aQsX75cGjZs6Kgc8fPzIwQBAAAAAAD5OwRZt26dfPTRR1KjRg0pUqRIsrFC0rJy5UrZu3dvsnUBAAAAAADyfQgyffr0TG28YsWKEhQUlNk2AQAAAAAAeDYEadGiRaY2HhERId26dZPu3bsnqwZ54IEHMrUdAAAAAACAPA1Brl69KtOmTZPt27fLtWvXHMu//vrrNNfX8UPUjBkzHMt0TBBCEAAAAAAAkK9DkEGDBklwcLBs2LBBnn32WZkzZ47cfffdLtdfs2ZNTrQRAAAAAAAgb0OQHTt2yK5du6R+/foyZMgQ6d+/v7Rv3z7VejExMVKzZk3ZuXNnmtvRxwMAAAAAAOTbEKRo0aL/fVBAgFy+fFlKlCghp06dSrXe8OHD5bvvvpNOnTqluk+7wxw6dCg7bQYAAAAAAMjdEKR06dJy9uxZadeunbRp00bKli0rYWFhqdbTAEQdPnw48y0CAAAAAADwdAiyZMkS8ff3lwkTJsj8+fNNINK3b1+X67/22mvSqlUruf3226VQoUI50V4AAAAAAIDcD0H++OMPKV++vJnutnfv3ma2mNOnT5vBUtNit9tl1KhRsnfvXrnzzjslKipK7rvvPqlTp07WWgsAAAAAAJBFmSrP6Natm1vLLOPGjZN169bJkSNHzHpTpkxhUFQAAAAAAJD/K0ESEhJMFYjzQKnx8fEu11+5cqW5rF69WpKSkuShhx4y3WMAAAAAAADydQiiM7vExcWZLjHqxIkTpsuLK61btzbdYN5++21p3rx59lsLAAAAAACQFyHIM888I5GRkdKnTx9z+9NPP5Xx48e7XH/37t2mEuStt96Sxx9/XJo2bWoqQXQ8EQAAAAAAgHwbggwYMECqVasm33//vbk9e/bsdCs8ateubS4dO3aUpUuXmjBEgxNCEAAAAAAAkK9DENWyZUtzOX/+vBw7dizddbX6Y9WqVeZvnRlm0qRJZnYYAAAAAACAfB2CtG3bVj777DMJCAiQBg0amGV9+/aVV199Nc31w8PDZfTo0aZ6BAAAAAAAoMBMkXvy5EkJCQkx3WE6deokMTExsnDhQpfrDxo0iAAEAAAAAAAUvBAkMTHRXK9bt84McBoYGGiqQgAAAAAAAPK7TCUYdevWlfvvv1/27dtnxve4cuVK7rUMgNdIOHBUzk2fL/G7YiSoXk0JGdxLCteo4ulmAQAAAPAxmQpB5syZI8uWLTPjgRQrVkz++OMPeeONN3KvdQC8IgCJjRoo9msJIjabJOw5KJcWrZawlbMIQgAAAADk3+4wRYoUkc6dOzvG+bjxxhvNYKkA4IpWgFgBiGGzmdu6HAAAAADybQgCAJnRZsIS2f1D9P8CEIvNJrtXRJv7AQAAACCvEIIAyFWx5ULF5ueXbJneji0byp4HAAAAkKcIQQDkqhVNIiQxIMARhOi13tblAAAAAJCXmN8WQK6KK1VGJvboL622bJaw0ydNBYgGILocAAAAAPISIQiAXKeBx7yoduxpAAAAAB5FdxgAAAAAAOATCEEAAAAAAIBPIAQBAAAAAAA+gRAEAAAAAAD4BEIQAAAAAADgEwhBAAAAAACATyAEAQAAAAAAPoEQBAAAAAAA+ARCEAAAAAAA4BMCPN0AAMhrCQeOyrnp8yV+V4wE1aspIYN7SeEaVXgjAAAAAC9HCALA5wKQ2KiBYr+WIGKzScKeg3Jp0WoJWzmLIAQAAADwcnSHAeBTtALECkAMm83c1uUAAAAAvBshCACf0WbCEtn9Q/T/AhCLzSa7V0Sb+wEAAAB4L0IQAD4ltlyo2Pz8ki3T27FlQz3WJgAAAAB5gxAEgE9Z0SRCEgMCHEGIXuttXQ4AAADAuzEwKgCfEleqjEzs0V9abdksYadPmgoQDUB0eW5gJhoAAAAg/yAEAeBzNPCYF9Uu15+HmWgAAACA/IXuMP/vvffek5tuukmKFCkiERER8vPPP3v2nQFQ4OX1TDQausQNmyjH7nvUXOttT8pv7QEAAAAIQURkwYIFMmLECBk/frxs3bpVGjRoIG3atJG4uDiOEAAFYiYaq+rk4mfLJGHnb+Zab3sqeMhv7QEAAAAU3WFEZPLkyTJo0CAZMGCA2SkzZ86UJUuWyMcffyyjR49OdaTEx8ebi+X8+fPm+sKFCxxVBcT1a1cyXCcv38+8bI+3Pld+fO1HS5eRsNNx4m+3O5brQKxHS5Ux9+fka78w+ROxX4sXsSU5VZ3ES9zkTyR44tAce56C2h4AAAB4N+vf1nanf3unxc+e0RpeLiEhQYoVKyZffvmldO7c2bG8X79+cu7cOfnmm29SPebll1+WV155JY9bCqCgqeZfVBaFNJQg8ZMAv0Jy3Z4k8WKXzue2y2Hb1Rx9roUlG0i9wBKplu9KvChdzu/I0ecqiO0BAACAbzh27JiEhYW5vN/nK0FOnz4tNptNQkNDk+0Yvf3rr7+mudPGjBljus9YkpKS5K+//pIyZcqI3/9Pu1lQk7PKlSubgyY4ONjTzQG89ljenofPda9Wq0n+kd/aUxDk9+MZyAyOZ3gLjmV4kwte8m8Nre+4ePGiVKpUKd31fD4EyYqgoCBzcRYSEiLeQg/8gnzwAxaOZXgTjmd4E45neAuOZXiTYC84DyxZsmSG6/j8wKhly5YVf39/OXnyZLIdo7crVKiQi28PAAAAAADISz4fghQuXFiaNGkiq1atSta9RW9HRkbm6ZsBAAAAAAByD91hRMz4HjoQanh4uDRt2lSmTp0qly9fdswW4yu0i49OE5yyqw9Q0HAsw5twPMObcDzDW3Asw5sE+dh5oM/PDmOZPn26vPXWW3LixAlp2LChvPvuuxIREeHRNwcAAAAAAOQcQhAAAAAAAOATfH5MEAAAAAAA4BsIQQAAAAAAgE8gBAEAAAAAAD6BEAQAAAAAAPgEQhAAAAAAAOATCEEAAAAAAIBPIAQBAAAAAAA+gRAEAAAAAAD4BEIQAAAAAADgEwhBAAAAAACATyAEAQAAAAAAPoEQBAAAAAAA+ARCEAAAAAAA4BMIQQAAAAAAgE8gBAEAAAAAAD4hwNMN8AZJSUly/PhxKVGihPj5+Xm6OQAAAAAA+BS73S4XL16USpUqSaFCrus9CEFygAYglStXzolNAQAAAACALDp27JiEhYW5vJ8QJAdoBYi1s4ODg3NikwAAAAAAwE0XLlwwxQnW+bkrhCA5wOoCowEIIQiyK+HAUTk3fb7E74qRoHo1JWRwLylcowo7FgAAAAAykNEQFYQgQD4LQGKjBor9WoKIzSYJew7KpUWrJWzlLIIQAAAAIAM2m00SExPZT14uMDBQ/P39s/RYQhAgH9EKECsAMWw2c1uXl5862tPNAwAAAPKtS5cuSWxsrBkgE95f7REWFibFixfP9GMJQYB8oM2EJeb6+R+ipaoVgFhsNtm9Ilru9UzTAAAAgAJRAaIBSLFixaRcuXLM2unF7Ha7nDp1yrzfNWvWzHRFCCEIkI/ElguVsNNx4u+UXtv8/CS2bKhH2wUAAADkZ9oFRk+ONQApWrSop5uDXKbv8++//27e98yGIK4nzwWQ51Y0iZDEgAATfCi91tu6HAAAAED2BsWEd8jO+0wlCJCPxJUqIxN79JdWWzZL2OmTpgJEAxBdDgAAAADIHipB4PN0Rpa4YRPl2H2Pmmu97UkaeMyLaidv9hhgrglAAAAAgPxNu2aEh4enu86cOXNk5MiRWdpmdh6bkejoaBk1apTb287O8//444/SrVu3NB9zzz33SF6gEgQ+jSlpAQAAAPiy8PBwtwOT3LRmzZo8eR4qQeDT0puSFgAAAID3yq2K8IMHD0rz5s2lcePG0rRpU9m+fbvjvsOHD8vdd98tt9xyi0ydOtWxfO7cuXL77bdLgwYNZMSIEeluX2dG6dq1qwkuIiMjZdu2bWb5gQMHzDbq168v7777bpqP3bVrl2lXw4YNzSUuLi5ZdcbJkydNRUbdunVlzJgxUrZsWUclysMPPyytWrWSGjVqyNtvv+3YZocOHaRJkybmMfPmzctw/5w9e1batm0rt956a7IKFOu5tD36PJ07dzb7KaP9kVlUgsAnMSUtAAAA4LtysyK8YsWKsnLlSgkKCpKdO3fKs88+KytWrDD3/fLLL2ZZQECACTE6duwoCQkJ8s0338jGjRvN8r59+8qSJUukTp06aW5/2LBhJqDQwCMmJkb+9re/yebNmx3LNSB5/vnn03zshx9+KE8++aQMGjRIrl69mmpmlVdeeUU6depktjVr1qxk92m7tevM9evXTYAxZMgQKVy4sPzrX/+S0qVLy+XLl02bXHV3sWzatEn27dsnlSpVknvvvdeEHi1btky2ztatW2Xv3r1SqlQpsx+0PVWqZO99sVAJAvH1KWmtmVgsTEkLAAAAeLfcrAiPj4+XRx55ROrVq2cCDT2Zt2gFREhIiBQvXlzatWtngo9Vq1aZYEBDEa3O0L+1qsMVDVg0xNB1H3roITlx4oQjYOnSpYv5u3fv3mk+NjIy0lRxTJw4Uf78808TYjjbsGGDdO/e3fxtXVu0OkPbre3XAEOrRtSUKVNMBcudd94pR48eNZf0NGvWzAQaGvhoYLJ+/fpU6+i2QkNDTfu0wuTIkSOSU6gEgU/TmVeaxOwTuX5d/O32ZFPS9vV04wAAAADkivhdMf8LQCw2m8Tvdh0+uEu7udx0003y6aefmuoI/TutqV31b70kJSWZUGP8+PGpBhd1RSsyNETI7LSxvXr1Ml10Fi9ebEKNL774Itn9drvd5WO1ssWiFSQ2m82M4/HTTz+ZSpQiRYqYIEdDoMDAQJfbSWsfuPNcOYVKEPg0a0raTbXqyZHyoeZabzMjCwAAAOC9gurV1LPr5Av9/SWobo1sb/vChQumUkJP7nUsDWfLli2T8+fPm3Bk6dKlcscdd8h9990nCxYskDNnzph1dJwOrdJwRcfsmDFjhuP2jh07zLUGENqtRs2fn3ZFy6FDh6R69eoyfPhwad26dbIqFasCwwpGUgYkrl5rmTJlTACiY59YbUmPhiaxsbGmW81XX30ld911l+QlQhD4PKakBQAAAHxLyOBe4lek8P+CEH9/c1uXZ9dTTz0lH3zwgemuYgUbFh0zQ8cBadSokTz22GMmkNAxL1544QUThuigpu3bt5e//vrL5fanTZtmxtHQLii1atVyBB5agfL666+b5TrOSFoWLFhgupdo244fP+7oPmPRahQNJrQrz549eyQ4ODjd16rdey5evCi1a9c2z60DpGYkIiJCBg4caF637o8WLVpIXvKzp1fvArdo+lWyZEmT6GV0kCB/DYyanuXj2ouvtgcAAAAoSK5du2ZmXqlWrZqpSnB3cFQdA0S7wGgFiAYg2R0U1Rv2Y2BgoOmCopUgGpp8+eWXUhDeb3fPyxkTBAAAAADgczTwKD91tKebka/8/vvv0rNnTzMGhwYKs2fPFm9DCAIAAAAAAOS2226Tbdu2efWeYEwQAAAAAIBXYLQH32DPxqgeVIIAAAAAAAo0HcdCZ2M5deqUlCtXzq3pYlFwAxB9n/U9Tm8qXlcIQQAAAAAABZoO5BkWFmamXtVxLeDd/Pz8zPut73tmEYIAAAAAAAq84sWLS82aNSUxMdHTTUEus2awyQpCEAAAAACAV9AT46yeHMM3MDAqAAAAAADwCYQgAAAAAADAJxCCAAAAAAAAn0AIAgAAAAAAfAIhCAAAAAAA8AlZDkFq1aqVsy0BAAAAAADIRW5Nkdu4ceNUyw4dOuRYvnXr1pxvGQAAAAAAQF6HINeuXZPmzZtLr169zG273S49e/aUKVOm5GRbAAAAAAAAPNsdRis9ihQpItOnT5e6detKy5YtpWjRotKiRQtzAQAAAAAA8IoQRAOQd955Rx5//HFp06aNfP3115l6kuvXr8vBgwclISEhq+0EAAAAAADIu4FRo6KiZNWqVbJw4ULTJcaVpUuXSmhoqISHh8vu3bvltttuk8jISKlYsaKsXr06ey0GAAAAAADIrTFBnJUsWVLmzp2b7jovvviiqRY5e/asCU5mzZolHTp0kI0bN8ozzzwjv/zyS1baCgAAAAAAkLshSHx8vMyePVvCwsJMmPHxxx/LmjVrzPggw4cPl8KFCydbPykpSZo1a2b+1rFD9DFKq0G0awwAAAAAAEC+DEGeeOIJOXHihFy5ckWWLFki+/fvl27dusny5cvlwIED8tFHHyVb32azyalTp+T8+fNy5swZ+e233+SWW26RkydPMi4IAAAAAADIvyHIzz//bMb20KlyK1SoIMePH5cbbrhBBg0aJI0aNUq1/rPPPis1atQwf8+cOVP69OkjpUqVku3bt8sLL7yQ868CAAAAAAAgJ0KQgIAA8fPzM7PE6EUDEBUYGCj+/v6p1u/Xr5888MADpltMmTJlTHeYFStWyM0335xmaAIAAAAAAJAvZoepWrWqjBw50nSLqVOnjgwZMkQ2bdokL7/8spnxJS1a+aEBiNLQRMMPHUPEXbptDV6cLzrLjEWrUp5++mnzHMWLF5cHH3zQdLdxdvToUWnfvr0UK1ZMypcvL6NGjUo1JsmPP/4ojRs3lqCgIFO9MmfOHLfbCAAAAAAAvCwE0YFQdZwPDTO++uorqVWrlukKo91btLtLSmPHjpW4uDjzt66jIcodd9whN954o6xfv97txmng8ueffzouzo/VAVkXL14sX3zxhaxdu9Z00enatavjfm2vBiAJCQmyYcMG+eSTT0zA8dJLLznWOXz4sFnnnnvuMe0cNmyYDBw40Ix1AgAAAAAAvIuf3W635/RG69WrJ7t27TJ/t23b1oQLeq1ji2gVyebNm92qBFm0aJEJJ1LSAVfLlSsn8+fPNwO0ql9//dWEMzoNrwYuS5cuNd1wNBwJDQ0162hg8/zzz5tBW3VGG/1bB3rV8U4sPXr0kHPnzsmyZcvSnS1HL5YLFy5I5cqVTbuCg4MzubfgCW0mLMlwneXj2ou3tyfhwFE5N32+xO+KkaB6NSVkcC8pXKNKjj8PAAAAAOQmPS8vWbJkhuflblWCaLcS7X6iNDN5//33pW/fvjJ58uQ0p7zV6gvL6dOnTQCimjZtmiw8yEhMTIxUqlTJjCXSu3dv0w61ZcsWSUxMlKioKMe62lWmSpUqJgRReq1hjBWAqDZt2pgds2fPHsc6ztuw1rG24cobb7xhdq510QAEKGg0AImNGigXP1smCTt/M9d6W5cDAAAAgDdyKwTRigrtXqLGjx8vX3/9tam2WLdunQwdOjTV+rfffrtMmTLF/B0eHm7WU1odogOruiMiIsJ0X9GKjBkzZpiuK82bN5eLFy+a6Xq1kiMkJCTZYzTw0PuUXjsHINb91n3praNBydWrV122bcyYMSZdsi7Hjh1z6zUB+YlWgNivJWjfsf8usNnMbV0OAAAAAD47O4xWf1gzwmj3kf/85z9msNHHHnvMDCqa0vTp0+WRRx6RqVOnmnFAZs2aJWFhYaYkRcfmcMf999/v+Lt+/fomFNGxRT7//HMpWrSoeJIOoqoXoCCyut48/0O0VLUCEIvNJrtXRMu9nmkaAAAAAHg+BNGZWXTmFa2SKFGihJkyV+n0uGl1h9EKDa0WOXjwoOzdu9eso11VmjRpkuWG6jZvueUWOXDggLRq1cp0udGxO5yrQbSNFSpUMH/rtY5B4syaPcZ5nZQzyuhtDWs8HbQAuS22XKiEnY4Tf6dhgWx+fhJbNnl1FAAAAAD4VHcY7QKjM6hoRYd2SdHpaLWrio7TobOruFK9enXp2LGjdOnSRf76669sNfTSpUsmVNEpeTVMCQwMlFWrVjnu379/vxkzJDIy0tzWa+1+Y81So1asWGECjtq1azvWcd6GtY61DcCbrWgSIYkBASb4UHqtt3U5AAAAAPhsJYiGHjo4qQ6EalV26FS5vXr1MrOpuENnYtEKDneNHDnSBCjaBUZneNEgRitPevbsaQYjffTRR2XEiBFSunRpE2zorDMaXuhYJap169Ym7OjTp49MmjTJjP/x4osvytNPP+3oyvLEE0+YrjvPPfec6b6zevVq091Gu/wA3i6uVBmZ2KO/tNqyWcJOnzQVIBqA6HIAAAAA8NkQRDVq1Ejmzp2b5SfK7Ey8sbGxJvA4c+aMmQ73rrvukk2bNpm/lQ68WqhQIRPQ6IwzOquLzlpj0cDku+++kyeffNKEIzqmSb9+/eTVV191rFOtWjUTeAwfPlzeeecdM26JVrvotgBfoIHHvKh2nm4GAAAAAOSvECS73K0YsXz22Wfp3q+zzLz33nvm4opWkXz//ffpbqdly5aybdu2TLUNAAAAAAB46ZggOUG7wwAAAAAAAHh9CAIAAAAAAOBJhCAAAAAAAMAnZGpMkK1bt8rYsWPl0KFDZoYYi94GAAAAAADwmhBEZ1cZPHiwmW1FZ19xx+bNm+XgwYPJQpO+fftmvqUAAAAAAAB5FYJo8PH444+7vb5OT7t8+XJp2LChIzTx8/MjBAEAAAAAAPk7BGnWrJlER0dLeHi4W+uvXLlS9u7da6azBQAAAAAAKDAhyLp16+Sjjz6SGjVqJAs2dKyQtFSsWFGCgoKy30oAAAAAAIC8DEGmT5+eqY1HRERIt27dpHv37slCkwceeCBT2wEAAAAAAMjTEKRFixaZ2rh2nVEzZsxwLNMxQQhBAAAAAABAvg5Brl69KtOmTZPt27fLtWvXHMu//vrrNNdfs2ZN9lsIAAAAAACQ1yHIoEGDJDg4WDZs2CDPPvuszJkzR+6+++5U68XExEjNmjVl586daW6nfv36WW8xAAAAAABAbocgO3bskF27dpkQY8iQIdK/f39p3759qvWGDx8u3333nXTq1CnVfdod5tChQ1lpKwAAAAAAQN6EIEWLFv3vgwIC5PLly1KiRAk5depUqvU0AFGHDx/OessAAAAAAAByUKHMrFy6dGk5e/astGvXTtq0aSOdO3eWsLAwl+u/9tprsnnzZklKSsqJtgIAAAAAAORNJciSJUvE399fJkyYIPPnzzeBSN++fV2ub7fbZdSoUbJ371658847JSoqSu677z6pU6dO1lsMAAAAAACQ25Ugf/zxh5kVRsf16N27tzz66KNy/vx5l+uPGzdO1q1bJ0eOHJFu3brJlClTGBQVAAAAAADk/0oQDTI01Ei5TLu8pGXlypXmsnr1atMl5qGHHpJWrVplr8UAAAAAAAC5HYIkJCRIkSJFkg2UGh8f73L91q1bm24wb7/9tjRv3jwr7QMAAAAAAMj77jDaDSYuLs5x+8SJE2bcD1d2794tDz/8sLz11ltSu3ZtM6XuvHnzstdiAAAAAACA3K4EeeaZZyQyMlL69Oljbn/66acyfvx4l+tr8KGXjh07ytKlS00Yoo/R8UQAAAAAAADybQgyYMAAqVatmnz//ffm9uzZs9Pt5vL444/LqlWrzN86M8ykSZPM7DAAAAAAAAD5OgRRLVu2NBedFebYsWPprhseHi6jR482wQkAAAAAAECBGROkbdu2cu7cObl06ZI0aNBAOnToIC+99JLL9QcNGkQAAgAAAAAACl4IcvLkSQkJCTHdYTp16iQxMTGycOHC3GsdAAAAAACAJ7rDJCYmmut169aZqpDAwEAJCMh0jxoAPibhwFE5N32+xO+KkaB6NSVkcC8pXKOKp5sFAAAAwMdkKsGoW7eu3H///bJv3z4zyOmVK1dyr2UAvCYAiY0aKPZrCSI2myTsOSiXFq2WsJWzCEIAAAAA5N/uMHPmzDEzvqxZs0aKFSsmZ8+elTfeeCP3WgegwNMKECsAMWw2c1uXAwAAAEC+DUGKFCkinTt3dgx2euONN5puMQCQljYTlsjuH6L/F4BYbDbZvSLa3A8AAAAA+TIEAYDMii0XKjY/v2TL9HZs2VB2JgAAAIA8RQgCIFetaBIhiQEBjiBEr/W2LgcAAACAvMTULgByVVypMjKxR39ptWWzhJ0+aSpANADR5QAAAACQlwhBAOQ6DTzmRbVjTwMAAADwKLrDAAAAAAAAn0AIAgAAAAAAfAIhCAAAAAAA8AmEIAAAAAAAwCcQggAAAAAAAJ9ACAIAAAAAAHwCIQgAAAAAAPAJhCAAAAAAAMAnEIIAAAAAAACfEODpBgBAXks4cFTOTZ8v8btiJKheTQkZ3EsK16jCGwEAAAB4OUIQAD4XgMRGDRT7tQQRm00S9hyUS4tWS9jKWQQhAAAAgJejOwwAn6IVIFYAYths5rYuBwAAAODdCEEA+Iw2E5bI7h+i/xeAWGw22b0i2twPAAAAwHsRggDwKbHlQsXm55dsmd6OLRvqsTYBAAAAyBuEIAB8yoomEZIYEOAIQvRab+tyAAAAAN6NgVEB+JS4UmVkYo/+0mrLZgk7fdJUgGgAostzAzPRAAAAAPkHIQgAn6OBx7yodrn+PMxEAwAAAOQvdIf5f++9957cdNNNUqRIEYmIiJCff/7Zs+8MgAIvr2ei0dAlbthEOXbfo+Zab3tSfmsPAAAAQAgiIgsWLJARI0bI+PHjZevWrdKgQQNp06aNxMXFcYQAKBAz0VhVJxc/WyYJO38z13rbU8FDfmsPAAAAoOgOIyKTJ0+WQYMGyYABA8xOmTlzpixZskQ+/vhjGT16dKojJT4+3lws58+fN9cXLlzgqCogrl+7kuE6efl+5mV7vPW58uNrP1q6jISdjhN/u92xXAdiPVqqjLk/J1/7hcmfiP1avIgtyanqJF7iJn8iwROH5tjzFNT2AAAAwLtZ/7a2O/3bOy1+9ozW8HIJCQlSrFgx+fLLL6Vz586O5f369ZNz587JN998k+oxL7/8srzyyit53FIABU01/6KyKKShBImfBPgVkuv2JIkXu3Q+t10O267m6HMtLNlA6gWWSLV8V+JF6XJ+R44+V0FsDwAAAHzDsWPHJCwszOX9Pl8Jcvr0abHZbBIaGppsx+jtX3/9Nc2dNmbMGNN9xpKUlCR//fWXlClTRvz+f9rNgpqcVa5c2Rw0wcHBnm4O4LXH8vY8fK57tVpN8o/81p6CIL8fz0BmcDzDW3Asw5tc8JJ/a2h9x8WLF6VSpUrprufzIUhWBAUFmYuzkJAQ8RZ64Bfkgx+wcCzDm3A8w5twPMNbcCzDmwR7wXlgyZIlM1zH5wdGLVu2rPj7+8vJkyeT7Ri9XaFChVx8ewAAAAAAQF7y+RCkcOHC0qRJE1m1alWy7i16OzIyMk/fDAAAAAAAkHvoDiNixvfQgVDDw8OladOmMnXqVLl8+bJjthhfoV18dJrglF19gIKGYxnehOMZ3oTjGd6CYxneJMjHzgN9fnYYy/Tp0+Wtt96SEydOSMOGDeXdd9+ViIgIj745AAAAAAAg5xCCAAAAAAAAn+DzY4IAAAAAAADfQAgCAAAAAAB8AiEIAAAAAADwCYQgAAAAAADAJxCCAAAAAAAAn0AIAgAAAAAAfAIhCAAAAAAA8AmEIAAAAAAAwCcQggAAAAAAAJ9ACAIAAAAAAHwCIQgAAAAAAPAJhCAAAAAAAMAnEIIAAAAAAACfQAgCAAAAAAB8AiEIAAAAAADwCQGeboA3SEpKkuPHj0uJEiXEz8/P080BAAAAAMCn2O12uXjxolSqVEkKFXJd70EIkgM0AKlcuXJObAoAAAAAAGTRsWPHJCwszOX9hCA5QCtArJ0dHBycE5sEAAAAAABuunDhgilOsM7PXSEEyQFWFxgNQAhBAAAAsibhwFE5N32+xO+KkaB6NSVkcC8pXKMKuxMA4LaMhqggBAEAAEC+CEBiowaK/VqCiM0mCXsOyqVFqyVs5SyCEABAjiEEAQAAgMdpBYgVgBg2m7mty8tPHe3p5gEoIGw2myQmJnq6GchlgYGB4u/vn6XHEoIAAADAY9pMWGKun/8hWqpaAYjFZpPdK6LlXs80DUABc+nSJYmNjTWzhMD7u7yEhYVJ8eLFM/1YQhAAAAB4XGy5UAk7HSf+TicvNj8/iS0b6tF2ASg4FSAagBQrVkzKlSuX4bgQKLg05Dp16pR5v2vWrJnpihBCEAAAAHjciiYR0iRmn8j16yYI0QAkMSDALO/r6cYByPe0C4yeHGsAUrRoUU83B7lM3+fff//dvO+EIAAAAChw4kqVkYk9+kurLZsl7PRJUwGiAYguBwB3UQHiG/yyUelDJQgAAADyBQ085kW183QzAABerJCnGwAAAADPTUsbN2yiHLvvUXOttwEAmaddM8LDw9NdZ86cOTJy5MgsbTM7j81IdHS0jBo1yu1tZ+f5f/zxR+nWrVuaj7nnnnskL1AJAgAA4IM08IiNGuiYljZhz0G5tGi1hK2cJYVrVPF08wAgT74HdRru+F0xElSvpoQM7uWT33/h4eFuBya5ac2aNXnyPFSCAAAA+CD9h78VgBg2m7mtywHAV4Lgi58tk4Sdv5lrvZ0TFXEHDx6U5s2bS+PGjaVp06ayfft2x32HDx+Wu+++W2655RaZOnWqY/ncuXPl9ttvlwYNGsiIESPS3b7OjNK1a1cTXERGRsq2bdvM8gMHDpht1K9fX9599900H7tr1y7TroYNG5pLXFxcsuqMkydPmoqMunXrypgxY6Rs2bKOSpSHH35YWrVqJTVq1JC3337bsc0OHTpIkyZNzGPmzZuX4f45e/astG3bVm699dZkFSjWc2l79Hk6d+5s9lNG+yOzCEEAAAB8SJsJS8xl9w/R/wtALDab7F4R7ammAYBXBMEVK1aUlStXytatW2XWrFnJTvR/+eUX+fbbb819M2fONIHJvn375JtvvpGNGzfKjh075PTp07JkyRKX2x82bJgJKLQby7/+9S954oknki3fuXOnBAYGpvnYDz/8UJ588kkTzOjzhYSEJLv/lVdekU6dOsnu3bulevXqye7T7S5cuNA876RJkyQhIcEs1zZs2bJFNm/eLK+//rrEx8enu382bdpk2rFnzx7zGA09UtL988EHH5h2LF68WI4ezbnumnSHAQAA8EGx5UIl7HScmY7WotPS6qwsAODttAtMWkFw/O4D2d92fLwMHjzYhAY6fatWbli0AsIKHtq1a2eCiHPnzplgwOqScuXKFVNZUadOnTS3rwGLBgjOlRVWwKKBgerdu7esWrUq1WMjIyPl1VdflTNnzpjKjptvvjnZ/Rs2bJBx48aZv7t37y6jR4923KfVGcWLFzd/V6pUyVSNVK5cWaZMmWKCHaVhhV5chTCqWbNmUqXKf7sdaQXK+vXrpWXLlsnWufPOOyU09L//P9IKkyNHjjgek12EIAAAAD5Ip59tErNP5Pp1E4RoAJIYEGCW9/V04wAgl+kYIDoWUrIgxN9fgurWyPa2tZvLTTfdJJ9++qlcvnzZ/J3W1K76t16SkpJk0KBBMn78+FSDi7qi1RgBAQGZnja2V69epouOhiUaanzxxRfJ7rc7BeMpBQUFOf7WcMdms5lxPH766SdT0VGkSBET5GgIlF4IktY+cOe5cgrdYQAAAHx0OtqJPfrLplr15Ej5UHOtt3U5AHg7HQTVr0hhE3wY/v7mti7PrgsXLphKCT2517E0nC1btkzOnz9vwpGlS5fKHXfcIffdd58sWLDAVGcoHafjzz//dLl9HbNjxowZjtvahUZpAKHdatT8+Wl36zl06JDp5jJ8+HBp3bq17N27N1UFhhWMpAxIXL3WMmXKmABEu9hYbUmPhiaxsbFy/fp1+eqrr+Suu+6SvEQIAgAA4KM08JgX1U7e7DHAXBOAAPAVOguMzoZVokdbKdzgVnOdU7NjPfXUU2Y8Cx141Ao2LDpwaceOHaVRo0by2GOPmUBCu7288MILJgzRQU3bt28vf/31l8vtT5s2zYyjoYOo1qpVyxF4aAWKjsmhy63xOlJasGCB6V6ibTt+/Lh06dIl2f1ajaLBRL169UyXm+Dg4HRfq3bvuXjxotSuXds8t3bjyUhERIQMHDjQvG7dHy1atJC85GdPr94FbtH0q2TJkibRy+ggAQAA8CQdFDUjy8e1F19tD4CC6dq1a2bmlWrVqpmqBGR9PwYGBpouKFoJoqHJl19+WSDeb3fPyxkTBAAAAAAAiI5D0rNnTzMGhwYKs2fP9rq9QggCAAAAAADktttuk23btnn1nmBMEAAAAACAV2C0B99gz8aoHlSCAAAAAAAKNB3HQmdjOXXqlJQrV86t6WJRcAMQfZ/1PU5vKl5XCEEAAAAAAAWaDuQZFhZmpl7VcS3g3fz8/Mz7re97ZhGCAAAAAAAKvOLFi0vNmjUlMTHR001BLrNmsMkKQhAAAAAAgFfQE+OsnhzDNzAwKgAAAAAA8AmEIAAAAAAAwCcQggAAAAAAAJ9ACAIAAAAAAHxClkOQWrVq5WxLAAAAAAAAcpFbs8M0btw41bJDhw45lm/dujXnWwYAAAAAAJDXIci1a9ekefPm0qtXL3PbbrdLz549ZcqUKTnZFgAAAAAAAM92h9FKjyJFisj06dOlbt260rJlSylatKi0aNHCXAAAAAAAALwiBNEA5J133pHHH39c2rRpI19//XXutwwAAAAAAMBTA6NGRUXJqlWrZOHChaZLDAAAAAAAgFeNCeKsZMmSMnfu3NxpDQAAAAAAgCcrQeLj42XmzJny3Xffmdsff/yx9OnTR958801JSEhItX7ZsmVl6NChsnPnzpxvMQAAAAAAQG5VgjzxxBNy4sQJuXLliixZskT2798v3bp1k+XLl8uBAwfko48+SrZ+iRIlJCkpyQygWr16dXn00UfNzDLBwcFZaSMAAAAAAEDehCA///yz7N6920yVW6FCBTl+/LjccMMNMmjQIGnUqFGq9UuVKiXTpk2Tf/zjH/LVV1+ZypFRo0ZJly5dZODAgXL33Xdnv+UAAAAAAAA53R0mICBA/Pz8zCwxetEARAUGBoq/v7/LxwUFBZkKkJUrV8quXbukatWqphsNAAAAAABAvgxBNLwYOXKk6RZTp04dGTJkiGzatElefvllqVixYqr105o55qabbpIJEybI77//7lbDdNsavDhfbrvtNsf9WpXy9NNPS5kyZaR48eLy4IMPysmTJ5Nt4+jRo9K+fXspVqyYlC9f3lSjXL9+Pdk6P/74ozRu3NgENjVq1JA5c+a41T4AAAAAAOCFIYh2Z7HZbKYCRLu31KpVy3SF2b59uxkwNaX0Zo/RMMNdGrj8+eefjsv69esd9w0fPlwWL14sX3zxhaxdu9Z00enatavjfm2vBiA6cOuGDRvkk08+MQHHSy+95Fjn8OHDZp177rnHvJZhw4aZ7jo61gkAAAAAAPAufva0yjZymAYSR44ckcqVK5suNO5WgixatMiEEymdP39eypUrJ/PnzzcDtKpff/3VhDMbN26UO+64Q5YuXSodOnQw4UhoaKhZRwOb559/Xk6dOiWFCxc2f+tArzreiaVHjx5y7tw5WbZsWbqz5ejFcuHCBfPatF0M/goAAPKzNhOWZLjO8nHtxdvbk3DgqJybPl/id8VIUL2aEjK4lxSuUSXHnwcAkDf0vLxkyZIZnpe7VQmi3Uq0+4nSzOT999+Xvn37yuTJk1N1L1Fjx46VuLg487eGGNqdRoOJG2+8MVk1R0ZiYmKkUqVKcvPNN0vv3r1NO9SWLVskMTFRoqKiHOtqV5kqVaqYEETpdb169RwBiGrTpo3ZMXv27HGs47wNax1rG6688cYbZudaFw1AAAAAUDBoABIbNVAufrZMEnb+Zq71ti4HAHg3t0IQrajQag41fvx4+frrr02osW7dOhk6dGiq9bWbio7BoUaPHi2zZs0yoch3330nzz77rFsNi4iIMN1XtCJjxowZputK8+bN5eLFi2a6Xq3kCAkJSfYYDTz0PqXXzgGIdb91X3rraFBy9epVl20bM2aMSZesy7Fjx9x6TQAAAPA8rQCxX0vQcuX/LrDZzG1dDgDwbm5NkavVH9aMMNp95D//+Y8ZbPSxxx4zg4qmpONwWE6fPi1t27Y1fzdt2jRZN5L03H///Y6/69evb0IRrSj5/PPPpWjRouJJOoiqXgAAAFBwWF1vnv8hWqpaAYjFZpPdK6LlXs80DQCQnypBdDBTa+aVEiVKmClzlU6Pm1Z3mNtvv12mTJli/g4PDzcVI0qnydUpdrNCqz5uueUWOXDggFSoUMEELTp2hzNto96n9DrlbDHW7YzW0f5Dng5aAAAAkDtiy4WKLcVg/Xo7tmzyCmEAgI+GINoFRmdQ0W4t2iVFp6PVrio6TofOrpLS9OnTTbWIVm7s3LlT7r33XjNFrq6vXVuy4tKlS3Lw4EEzJW+TJk3MAKurVq1y3L9//34zZkhkZKS5rdcaulhjk6gVK1aYgKN27dqOdZy3Ya1jbQMAAADeZ0WTCEkMCHAEIXqtt3U5AMC7udUdRkMPHZxUB0Ldu3evqf7QqXJ79eplZlNJq2pDxw3R0MJaXwct1fDCXSNHjpSOHTuaIEVneNEgRitPevbsaQYjffTRR2XEiBFSunRpE2wMGTLEhBc6Volq3bq1CTv69OkjkyZNMuN/vPjii/L00087urI88cQTJrB57rnn5JFHHpHVq1eb7jba5QcAAADeKa5UGZnYo7+02rJZwk6fNBUgGoDocgCAd3MrBFGNGjWSuXPnZmrj1atXN5esiI2NNYHHmTNnzHS4d911l2zatMn8rbS7TaFChUxAo+OM6KwuOmuNRQMTHYj1ySefNOGIjmnSr18/efXVVx3rVKtWzQQew4cPl3feeUfCwsJMtYtuCwAAAN5LA495Ue083QwAQH4NQfLaZ599lu79OrbIe++9Zy6uaBXJ999/n+52WrZsKdu2bctyOwEAAAAAgBeNCQIAAAAAAFDQEYIAAAAAAACfkOvdYTZv3mwGSHWeSrdv3765/bQAAAAAAABZD0G2bt0qY8eOlUOHDiULNfR2WnRQ0uXLl0vDhg3NQKXKz8+PEAQAAAAAAOTvEERnVxk8eLCZbcUKNdKzcuVKM0WuDmIKAAAAAABQYEIQDT4ef/xxt9evWLGiBAUFZaVdAAAAAAAAngtBmjVrJtHR0RIeHu7W+hEREdKtWzfp3r17smqQBx54IPMtBQAAAAAAyKsQZN26dfLRRx9JjRo1koUaOlZIWjQwUTNmzHAs0zFBCEEAAAAAAEC+DkGmT5+eqY2vWbMms+0BAAAAAADwfAjSokULt9aLiYmRmjVrys6dO9O8v379+pl5WgAAAAAAgLwNQa5evSrTpk2T7du3y7Vr1xzLv/7662TrDR8+XL777jvp1KlTqm1odxhXU+oCAAAAAADkixBk0KBBEhwcLBs2bJBnn31W5syZI3fffXeq9TQAUYcPH865lgIAAAAAAGRDocysvGPHDnn//fdNEDJkyBD58ccfZcuWLS7Xf+2112Tz5s2SlJSUnTYCAAAAAADkbQhStGhRcx0QECCXL1+WEiVKyKlTp1yub7fbZdSoUVK+fHkzI8y7774re/bsyX6rAQAAAAAAcjMEKV26tJw9e1batWsnbdq0kc6dO0tYWJjL9ceNG2em1T1y5Ih069ZNpkyZwqCoAAAAAAAg/48JsmTJEvH395cJEybI/PnzTSDSt29fl+uvXLnSXFavXm26xDz00EPSqlWrnGg3AAAAAABA7oUgf/zxh+naUqRIEendu7eZLeb06dNmjJC0tG7dWu688055++23pXnz5plrGQAAAAAAgKe6w2iXFneWWXbv3i0PP/ywvPXWW1K7dm3p37+/zJs3L2stBQAAAAAAyKsQJCEhwVSBOA+UGh8f73J9DT6eeeYZeeedd2Tw4MGydu1a6devX3baCwAAAAAAkPshiJ+fn8TFxTlunzhxwswA48rjjz8uNWrUMOOA7Ny5UyZNmpTs8QAAAAAAAPlyTBCt6oiMjJQ+ffqY259++qmMHz/e5frh4eEyevRoqVatWvZbCgAAAAAAkFchyIABA0yg8f3335vbs2fPTnfA00GDBmWnbQAAAAAAAJ4JQVTLli3N5fz583Ls2LGcawkAAAAAAEB+GROkbdu2cu7cObl06ZI0aNBAOnToIC+99FLutQ4AAAAAAMATIcjJkyclJCTEdIfp1KmTxMTEyMKFC3OqLQAAAAAAAPkjBElMTDTX69atMzO+BAYGSkBApnvUAAAAAAAA5LlMJRh169aV+++/X/bt22emu71y5UrutQwAAADwAgkHjsq56fMlfleMBNWrKSGDe0nhGlU83SwA8EmZCkHmzJkjy5YtM+OBFCtWTP744w954403cq91AAAAQAEPQGKjBor9WoKIzSYJew7KpUWrJWzlLIIQAMjv3WGKFCkinTt3NtPkqhtvvNEMlgoAAAAgNa0AsQIQw2Yzt3U5ACDvMaAHAAAAkMPaTFhirp//IVqqWgGIxWaT3Sui5V72OgDk70oQAAAAAO6LLRcqNj+/ZMv0dmzZUHYjAHgAIQgAAACQS1Y0iZDEgABHEKLXeluXAwDyHt1hAAAAgFwSV6qMTOzRX1pt2Sxhp0+aChANQHQ5ACDvEYIAAAAAuUgDj3lR7djHAJAP0B0GAAAAAAD4BEIQAAAAAADgEwhBAAAAAACATyAEAQAAAAAAPoEQBAAAAAAA+ARCEAAAAAAA4BMIQQAAAAAAgE8gBAEAAAAAAD4hwNMNAAAAAJB3Eg4clXPT50v8rhgJqldTQgb3ksI1qvAWAPAJhCAAAACADwUgsVEDxX4tQcRmk4Q9B+XSotUStnIWQQgAn0B3GAAAAMBHaAWIFYAYNpu5rcsBwBdQCQIAAAB4uTYTlpjr53+IlqpWAGKx2WT3imi51zNNA4A8RSUIAAAA4CNiy4WKzc8v2TK9HVs21GNtAoC8RAgCAAAA+IgVTSIkMSDAEYTotd7W5QDgC+gOAwAAAPiIuFJlZGKP/tJqy2YJO33SVIBoAKLLcwMz0QDIbwhBAAAAAB+igce8qHa5/jzMRAMgP6I7zP9777335KabbpIiRYpIRESE/Pzzz559ZwAAAIACLK9notHQJW7YRDl236PmWm8DQEpUgojIggULZMSIETJz5kwTgEydOlXatGkj+/fvl/Lly6faaQAAAADyz0w0+a3qhG5AQP5FJYiITJ48WQYNGiQDBgyQ2rVrmzCkWLFi8vHHH3v6/QEAAAAKpLyciSavq07cCWQufrZMEnb+Zq71NpUpQP7g85UgCQkJsmXLFhkzZoxjpxQqVEiioqJk48aNae60+Ph4c7GcP3/eXF+4cCEP3jIAAICsu37tSobr5OW/afKyPd76XPn1tS+r20Ca/LZPxHZd/O32/85E4x9glnfOoefq8uZyc/3C8p/TrjpZ/ouE5/G/0S9M/kTs1+JFbEmOdujtuMmfSPDEoXnaFsCXXPj/z7rdbk93PT97Rmt4uePHj8uNN94oGzZskMjISMfy5557TtauXSubN29O9ZiXX35ZXnnllTxuKQAAAFCwVPMvKoOK3ii1/G+QfbbL8tHVP+Sw7WqOP8/fi9eQrkHlJcDvf4Xu1+1J8nV8nIy9dEDy0sKSDaReYIlUy3clXpQu53fkaVsAX3Ts2DEJCwtzeb/PV4JkhVaN6BgilqSkJPnrr7+kTJky4pei5K+gJWeVK1c2B01wcLCnmwNkGccyvAnHM7wJx7Nv03FAns7j53w6l54zK8eyvv7/1o8D+csFLzkP1PqOixcvSqVKldJdz+dDkLJly4q/v7+cPHky2Y7R2xUqVEhzpwUFBZmLs5CQEPEWeuAX5IMfsHAsw5twPMObcDzDW3Asw5sEe8F5YMmSJTNcx+cHRi1cuLA0adJEVq1alayyQ287d48BAAAAAAAFm89Xgijt2tKvXz8JDw+Xpk2bmilyL1++bGaLAQAAAAAA3oEQRES6d+8up06dkpdeeklOnDghDRs2lGXLlkloaM5P35WfaRef8ePHp+rqAxQ0HMvwJhzP8CYcz/AWHMvwJkE+dh7o87PDAAAAAAAA3+DzY4IAAAAAAADfQAgCAAAAAAB8AiEIAAAAAADwCYQgAAAAAADAJxCCwHjvvffkpptukiJFikhERIT8/PPP7Bnke2+88YbcfvvtUqJECSlfvrx07txZ9u/fn2yda9euydNPPy1lypSR4sWLy4MPPignT570WJsBd0ycOFH8/Pxk2LBhjmUcyyhI/vjjD/nb3/5mvnuLFi0q9erVk+joaMf9drvdzMpXsWJFc39UVJTExMR4tM1AWmw2m4wbN06qVatmjtXq1avLhAkTzDFs4XhGfrVu3Trp2LGjVKpUyfy7YtGiRcnud+fY/euvv6R3794SHBwsISEh8uijj8qlS5ekICMEgSxYsEBGjBhhpkXaunWrNGjQQNq0aSNxcXHsHeRra9euNQHHpk2bZMWKFZKYmCitW7eWy5cvO9YZPny4LF68WL744guz/vHjx6Vr164ebTeQnl9++UU++OADqV+/frLlHMsoKM6ePSvNmjWTwMBAWbp0qezdu1fefvttKVWqlGOdSZMmybvvviszZ86UzZs3yw033GD+7aFhH5CfvPnmmzJjxgyZPn267Nu3z9zW43fatGmOdTiekV/pv4n13E5/8E7LJDe+izUA2bNnj/m39nfffWeClccee0wKNDt8XtOmTe1PP/20Yz/YbDZ7pUqV7G+88YbP7xsULHFxcfqzjH3t2rXm9rlz5+yBgYH2L774wrHOvn37zDobN270YEuBtF28eNFes2ZN+4oVK+wtWrSwDx061CznWEZB8vzzz9vvuusul/cnJSXZK1SoYH/rrbccy/QYDwoKsv/73//Oo1YC7mnfvr39kUceSbasa9eu9t69e5u/OZ5RUOi/fxcuXOi47c6xu3fvXvO4X375xbHO0qVL7X5+fvY//vjDXlBRCeLjEhISZMuWLab0yVKoUCFze+PGjR5tG5BZ58+fN9elS5c213psa3WI8/F92223SZUqVTi+kS9pZVP79u2THbOKYxkFybfffivh4eHy0EMPma6KjRo1ko8++shx/+HDh+XEiRPJjvOSJUua7rj82wP5zZ133imrVq2S3377zdzesWOHrF+/Xu6//35zm+MZBdVhN76L9Vq7wOh3ukXX1/NFrRwpqAI83QB41unTp01fx9DQ0GTL9favv/7qsXYBmZWUlGTGT9AS7Lp165pl+sVeuHBh8+Wd8vjW+4D85LPPPjNdErU7TEocyyhIDh06ZLoPaFfbsWPHmmP6mWeeMd/H/fr1c3z/pvVvD76bkd+MHj1aLly4YH5E8ff3N/9ufv31100XAcXxjILqhBvfxXqtYbazgIAA84NjQf6+JgQB4DW/oO/evdv8OgMUNMeOHZOhQ4ea/rY6QDVQ0ENp/dXw73//u7mtlSD6/ax9zjUEAQqSzz//XObNmyfz58+XOnXqyPbt282PLjrQJMczUDDRHcbHlS1b1qTaKWfL0NsVKlTwWLuAzBg8eLAZqGnNmjUSFhbmWK7HsHb5OnfuXLL1Ob6R32h3Fx2MunHjxuYXFr3oQL46WJn+rb/KcCyjoNBZBmrXrp1sWa1ateTo0aPmb+vfF/zbAwXBqFGjTDVIjx49zCxHffr0MQNV6wx1iuMZBVUFN76L9TrlZBnXr183M8YU5HNFQhAfp6WpTZo0MX0dnX/B0duRkZEebRuQER3jSQOQhQsXyurVq830dc702NbZCZyPb51CV/8hzvGN/OS+++6TXbt2mV8YrYv+kq7l1tbfHMsoKLRbYsrpynU8hapVq5q/9bta//Hs/N2s3Q20fznfzchvrly5YsY/cKY/IOq/lxXHMwqqam58F+u1/pioP9ZY9N/cevzr2CEFFd1hYPrsajmf/iO7adOmMnXqVDOd0oABA9g7yPddYLQ89ZtvvpESJUo4+ibqoE4617le61zmeoxr30Wd33zIkCHmC/2OO+7wdPMBBz1+rbFsLDpNXZkyZRzLOZZRUOiv5DqYpHaHefjhh+Xnn3+WDz/80FyUn5+f6U7w2muvSc2aNc0/xMeNG2e6F3Tu3NnTzQeS6dixoxkDRAdV1+4w27Ztk8mTJ8sjjzxi7ud4Rn526dIlOXDgQLLBULdv327+XazHdEbfxVrF17ZtWxk0aJDp0qgTDugPkFoZpesVWJ6engb5w7Rp0+xVqlSxFy5c2EyZu2nTJk83CciQfoWldZk9e7ZjnatXr9qfeuope6lSpezFihWzd+nSxf7nn3+yd5HvOU+RqziWUZAsXrzYXrduXTPV4m233Wb/8MMPk92vUzOOGzfOHhoaata577777Pv37/dYewFXLly4YL6L9d/JRYoUsd988832F154wR4fH+9Yh+MZ+dWaNWvS/Ldyv3793D52z5w5Y+/Zs6e9ePHi9uDgYPuAAQPsFy9etBdkfvofTwcxAAAAAAAAuY0xQQAAAAAAgE8gBAEAAAAAAD6BEAQAAAAAAPgEQhAAAAAAAOATCEEAAAAAAIBPIAQBAAAAAAA+gRAEAAAAAAD4BEIQAAAAAADgEwhBAAA+76abbpKpU6emux/8/Pxk0aJFebav+vfvL507d053nR9//NG069y5cy7Xefnll6Vhw4a50MK83yf54TjIjjlz5khISEi2t9OyZUsZNmyY5KWEhASpUaOGbNiwQfIbdz4HnuDO+z169GgZMmRInrUJAEAIAgDwEkeOHJGiRYvKpUuXcmX7f/75p9x///2SV9555x1zEpXdE9+RI0fKqlWrstWW3AxSUrp27ZoJgOrVqycBAQEugyA98W3cuLEEBQWZk3PnfZWSbk9Pkl1dNPzIC927d5fffvtNCqKZM2dKtWrV5M4773Qs++uvv6R3794SHBxsTvYfffTRDD9/H374oTmW9THuBBfpvW960WOzINPP5yeffCKHDh3ydFMAwGdQCQIA8ArffPON3HPPPVK8ePFc2X6FChXMCXdeKVmyZI5UDej+KFOmjBQUNpvNhFnPPPOMREVFpbnO4cOHpX379ub93r59uwmHBg4cKMuXL3cZKGmIZV3U7NmzHbd/+eUXyQv6usqXLy8Fjd1ul+nTp5uQw5kGIHv27JEVK1bId999J+vWrZPHHnss3W1duXJF2rZtK2PHjnXruZ3fN63S0fDEeZmGCAVZ2bJlpU2bNjJjxgxPNwUAfAYhCAAg39BfiLU0XE9qS5UqJaGhofLRRx/J5cuXZcCAAVKiRAnzq//SpUvTDEEeeOAB83dWfu2/ePGi9OzZU2644Qa58cYb5b333nPZ9eP33383t7/++mtzIl6sWDFp0KCBbNy40eX29WStQ4cOjtt6QqfbWLZsmWOZvrZZs2al6g6jf69du9aczFuvR9tg2bJli4SHh5t26C/1+/fvd1nFYW33H//4h1SsWNEEJE8//bQkJiam2W6tsHjllVdkx44djud2rro4ffq0dOnSxTx3zZo15dtvv032+N27d5sKGg1j9P3s06ePeYwruv/1hHDQoEEmeEqvKuHtt9+WWrVqyeDBg6Vbt24yZcoUl4GSbsu6KA2YrNvlypVLdpL+yCOPmGOtSpUqpnLBFT3x1+1ocKM0kNH9o10cLBrO/O1vf3PsS+dgy3pv5s6da45PbWePHj3MsWjRY79v375m/+n7pa85pbNnz5p19DOj74Pu75iYGEeAoa/vyy+/dKyvz6nbsqxfv94EfPra06LH18GDB03wZNm3b585dvV4jYiIkLvuukumTZsmn332mRw/ftzlPtPPtu6fO+64Q9zh/L7p/tH967zMOfRM73OQlmPHjsnDDz9s3pPSpUtLp06dkn2uNBxr1aqVCSr0uVu0aCFbt25Ntg2tZHn88cfNsV2kSBGpW7euOS6caTinx6m2VQMgK4izdOzY0ew3AEDeIAQBAOQrWhquJx0///yzCUSefPJJeeihh8xJjZ6AtG7d2pxIO5+w6YmInshZIYjzL8UHDhww4cLdd9+d7vO+9dZbJsjYtm2bOUkbOnSo+YU7PS+88IIJN/Tk95ZbbjEhyvXr19NcV0+gtI3WCbOGGvo6tVuH+uOPP8yJpgZBKWn4ERkZaYIB63VVrlw5WTv05Dg6Otp0IdGT+PSsWbPGPJde6/7Wk3NX3Um0C8ezzz4rderUcTy3LrNoQKInkjt37pR27dqZ6gDtJmG9L/fee680atTItE1Pmk+ePGnWzw4Nm1JWieiv6emFUO7S/agn0nocPPXUU+b4c3Uy3bx5cxNY6LppvafWsrTeU4u+Dxqu6YmzXnT9iRMnOu4fNWqUWaYh3w8//GC2nfJEXIMt3b8aQOk+0OBD3wsNtjQ00GPfapMGJhpgXL16VX799VdHG2+//XYTHqTlP//5jzm+NRiy6PNoeKD7yqLvSaFChWTz5s3iCZn5HOi+0WNGX5O+vp9++skRUuj4J0rf2379+pnP7aZNm0zIp/vVCqmSkpJM4KSP/fTTT2Xv3r3mvfP393c8j35PaeCoQZdWyhw9ejRV9UrTpk0lNjY2WQADAMhFdgAA8okWLVrY77rrLsft69ev22+44QZ7nz59HMv+/PNPu/7va+PGjY5l8+bNs4eHh6faXlJSkr1Lly72Jk2a2K9cueLyeatWrWpv27ZtsmXdu3e333///Y7b+pwLFy40fx8+fNjcnjVrluP+PXv2mGX79u1L8znOnj1rL1SokP2XX34x7SpdurT9jTfesEdERJj7P/30U/uNN97oWL9fv372Tp06Jds3Q4cOTbbNNWvWmOdcuXKlY9mSJUvMsqtXr5rb48ePtzdo0CDZdvX16r61PPTQQ+b1upJyG8775MUXX3TcvnTpklm2dOlSc3vChAn21q1bJ3vMsWPHzDr79+93+Xyu9oGlZs2a9r///e/JllmvO733Oa330pnul7/97W+O2/o+lS9f3j5jxgyX22rcuLH9rbfeMn937tzZ/vrrr9sLFy5sv3jxoj02NtY812+//Wbunz17tr1kyZLJ9muxYsXsFy5ccCwbNWqU45jQbei2Pv/8c8f9Z86csRctWtRxLOi29Tl++uknxzqnT58261iPe/fdd+116tQxfy9atMhsX/er9bqioqLsY8eOdfka9bnuvffeZMv0dd5yyy2p1i1Xrpz9/ffft2fEOnb1c+GulPsvM5+DlObOnWu/9dZbzXtsiY+PN/tt+fLlaT7GZrPZS5QoYV+8eLG5revpZ9rVsazt1TYcOHDAsey9996zh4aGJlvv/PnzZr0ff/wxw30AAMg+KkEAAPlK/fr1HX/rL6raXUMHybRo2bmKi4tLsyuMMx13QH+x1vt1PIb0aKVFytv6i7m7bbW6Fzi3y5n+aq6VJvqL/K5du6Rw4cJm/AStItDBJPXXeK0WyYrMtENpVYfzr9X6mPTWd/e5tSuLjtlgbUu70Gi1if7Cbl1uu+02RwVEfuT8eqyuF+ntG33P9D3VbEUrCrp27Wq6Pmj1gL6nlSpVMhUErmg3GOcKC+f3QveRViVodxOLdtu49dZbHbf1GNWqB+d19DOj61jHr7ZRqxROnTrlqEzRi7ZbKyJ0xpf0qlW0akS7euR3mfkc6LGpVWK6761jU/etDsxrHZtataTVV/r+aXcYPbb1s6rVHEorwMLCwkyVjCtaXVO9evVk7UrZJuu7yVV3JABAzgrI4e0BAJAtgYGByW7riajzMr1tlaIrPUnUbhYpB1rU8nQdI0JP9HSMj9yQXrvSYp146vgLemKqJ13OJ8za7SQv2pHWPk5vfXefO+W29IRRxzt48803Uz3OeUyKzNJgQk9QneltPUnNKOzKSGb3jb6nH3/8sTmp1sdqyGO9z9r1JKNgKyffC1c0RNRjTY8xvbz++utmH+r7ouNeaBDiPOtLStrFR4M7Z2mFQ9oVTLtCuRrLJbdl5nOgx2aTJk1k3rx5qe6zxojRrjBnzpwx3dGqVq1qPrcajlrdZdw51tJ6f/9bjPQ/Vvcx57FpAAC5h0oQAECBpiebOiCkVllYtPpDB6T84IMP3B6AUfv8p7ytAUVOssYF0SlrrV/e9frf//63mTo1vV/jtXLEGk8kr2X1uXUKW509RKsddFwW54tWjWSVnoimnPZXx29JWc2TF6xxQTRwswIPKwTRS3rvaUa0gkBPop3H2NBgxXmaXT1GNXxwXkdP3HUck9q1aztOvLWdWhGl74cOYqpVE/Hx8eYzouN6pPd+6JguOn6I88m77msd80UHI7WsXr3ahA7OVSn5lR6bOnisztaT8tjUqg+lY33oLEU6DohWT2kI4jyor+5DHcsju9Me6+DB+j7rcwAAch8hCACgQNPBIJ27wpw4ccLMVqKzbOjAh3pbL9oVID16wjNp0iRzQqMzw3zxxRdmcNScpANU6gmzDoDpHILor9FaGZFeWb0GCXqiq4Mn6olYTlcLpEefW6el1fJ/fW49eXaHzjqjv3LrgLFacaDdDHSmDJ3pJ71QRbtu6HPpY8+fP2/+1ovliSeekEOHDslzzz1nTs7ff/99+fzzz2X48OGS1zSA05NhfQ+t91TfZx28VI+lrHZxUtpFQ6el1cFRNWDQk2UdBFUHH7VoVw2d1US7bWjAphUpOhuNVj/pcosVtunMMLpd3Ya2U9udURt1BiStnNAAxTl80UFE9Xl1EGP9/OgsPfq50y5A1mC/Whmj91v0s6jvpXZFUVphYr3XeUkH8NUKF91H2o1Jj28NrTT00GDD2rc6oKl2K9LPnj7GufpD95vuwwcffNCEcLoNnbnKecYnd+jza0iV3SomAIB7CEEAAF4VguhJsXaN0FlPNFiwLjr7RXq0K4rOKqG/er/22msyefJkE6Lk9Amzdk3QsndrbAw9idJAI6MTUZ1RQsfx0F/39fHWuAR5QU/y9IRXT4b1ufVk2h16Mqwnxxp46Kw++tp1ilQdH8X5RD4l/eVd34fFixebE1P9Wy8WnR53yZIl5sRTK4B0RhCdqjWn3y936Xunr9EKQbTrib5P2i3EefyOrNBZi/QEWbsV6ewrWsWh3TiczZ492yzTKZi1QkMrNr7//vtkXTFStlHp3ymXpUXHGNFgMWXXEb2tx/F9991n3jNtm/OUwtrNRitSnMe60OmN9b3U8MQ6/vV2yqmVc5uO1aGzteg0yNY4Lho46Zgg2q1K/fOf/zSVN1o1ojNSaUCilSPOvvrqK/PdokGfvucazGW2akqnx7X2BwAg9/np6Kh58DwAAOQ4/bVdp2DVKo+Ufe8B5BydArlVq1ammkcrSZAztHJEA1jdvzrALQAg91EJAgAosHQshGnTphGAALlMu/zoQKra5QM55/Lly6aShwAEAPIOlSAAAAAAAMAnUAkCAAAAAAB8AiEIAAAAAADwCYQgAAAAAADAJxCCAAAAAAAAn0AIAgAAAAAAfAIhCAAAAAAA8AmEIAAAAAAAwCcQggAAAAAAAJ9ACAIAAAAAAMQX/B/jhX/87GZf3gAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1100x600 with 4 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Visualise a handful of tiles: intensity trace + which bins are labelled signal.\n",
+    "rows = np.argsort(X.sum(axis=1))[-4:][::-1]        # the 4 most intense tiles\n",
+    "fig, axes = plt.subplots(len(rows), 1, figsize=(11, 6), sharex=True)\n",
+    "bins = np.arange(X.shape[1])\n",
+    "for ax, r in zip(axes, rows):\n",
+    "    ax.bar(bins, X[r], width=1.0, color=\"steelblue\")\n",
+    "    sig = np.where(pep[r] >= 0)[0]\n",
+    "    ax.scatter(sig, X[r][sig], color=\"crimson\", s=14, zorder=3, label=\"labelled signal bin\")\n",
+    "    ax.set_ylabel(f\"scan {int(scan_idx[r])}\\nwin {int(win_idx[r])}\", fontsize=8)\n",
+    "    ax.legend(loc=\"upper right\", fontsize=7)\n",
+    "axes[-1].set_xlabel(\"m/z bin within the 10 Th window (0.1 Th each)\")\n",
+    "fig.suptitle(\"Four dense-window tiles: intensity + per-bin signal labels\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acb56ce9",
+   "metadata": {},
+   "source": [
+    "### \"But I expected to build an m/z–ion-mobility image from *these*…\"\n",
+    "\n",
+    "You can — and doing it once makes the duplicates click. Each tile's **window key** gives its\n",
+    "absolute m/z offset, so `absolute_bin = window_start(win_idx) + column`. Placing every tile\n",
+    "cell at `(scan, absolute_bin)` rebuilds the full image. Because `overlapping=True` covers\n",
+    "each m/z region with two tiles, many `(scan, m/z-bin)` cells are written **twice** — those\n",
+    "are exactly the duplicate `scan`/`mz`/`mobility` values you noticed. Collapsing with a\n",
+    "max-per-cell dissolves them, and the result matches the `.df` map from Section 4.\n",
+    "\n",
+    "(This is a good way to *understand* the layout; for real work, the Section-4 `.df` path is\n",
+    "simpler.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8b66c0fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:58.004730Z",
+     "iopub.status.busy": "2026-07-02T09:33:58.004612Z",
+     "iopub.status.idle": "2026-07-02T09:33:58.310003Z",
+     "shell.execute_reply": "2026-07-02T09:33:58.309576Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6591 tile-cells -> 3352 unique (scan, m/z) pixels (3239 overlap duplicates removed)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWSVJREFUeJzt3QecU1X2wPHzkswMdQZBqoIgqBRBVBRRrLAgiqJg/Sug4KqIBezuKq6igrg2LFjWFV1lbasiqCgqqChSrYAIFkCluCKdYTLJ/X/OhZdNhpkhYdLz++pjJsmbl/tKXvJOzj3XMcYYAQAAAAAAAJLIk8wnAwAAAAAAABRBKQAAAAAAACQdQSkAAAAAAAAkHUEpAAAAAAAAJB1BKQAAAAAAACQdQSkAAAAAAAAkHUEpAAAAAAAAJB1BKQAAAAAAACQdQSkAAAAAAAAkHUEpAMgB48ePF8dx5KeffpJsput4+eWX79b2OO644+zk0sd0Hp030Zo3by4XXHBBwp8H6cc9zv7+97/vct6//e1vdt54KnvcV6S0tFSuv/56adq0qXg8HjnttNMkE7nb8L///W9Knz9X6XlOz3fpvkwAQPIQlAKANNSvXz856aSTUt0MlPHWW2/Zi0og1/zzn/+Ue+65R8444wx55plnZPjw4ZLO7rrrLnn99ddT3Qxgt3366af2/WbdunVJ2Yq8ZgCkCkEpAEgzfr9fpk6dKieffHLcltm/f3/ZunWr7LPPPnFbZiaLZnvoYzqPzhselLrtttvi3p7FixfLk08+GfflAvHywQcfyF577SX333+/fU0ce+yxab1xucBOT3qe0/MdogtK6fsNQSkA2c6X6gYAACJ9/PHHsnHjxrgGpbxer50Q/fbQLjbVqlVLyiYrKCiQXBMMBqWkpCRp2xhVs2bNGqlTp05U3fx03+bn57PJsZO8vDy2CgAgAplSABDnWiHfffednH/++VJUVCT169eXW265RYwxsmLFCunTp48UFhZKo0aN5N577y13OW+++aa0bdvW1siYPn26XWZ5Uyw1NCqqKfXoo49Ku3btbFCkSZMmMnTo0J2+ldV6MwceeKAsXLhQjj/+eKlRo4bNmBgzZkxMzz1jxgy58sor7TbRi9tLLrnEBiX0+QYMGCB77LGHnbRujW6vcJs3b5ZrrrnG1rPRth5wwAG2Bk/Z+VzPP/+8nUcDHoceeqh89NFHUW2PcGVrSmndkkceecT+Hr4ftA26L3TfllVcXGyPA13XWGpKxWOb6fY58sgjpV69elK9enW7HV555ZWdnluzwfQ59txzT6ldu7aceuqp8ssvv9jnL9tVUe8fNGiQNGzY0O4HPXa0W1cs9b5037jH3JQpU6Jerq73iBEj7HroNq1Zs6YcffTRMm3atJ2e64UXXrDz6fro6619+/by4IMPRmQjagbCfvvtZ48R3UZdu3a1GYrhvv32W9tdrW7duna+Tp06yRtvvBExTzz2lUuzkDRDT/eXZiJ98803UW3b5557zq6v/p229ZxzzrHnm7KeeOIJadmypZ3v8MMPtwHwXXFfB7qdFyxYEDru9dwUXg/rgQcesMvW/afnCje7SveR7ivdJvoaWbRoUULOm+F0eXrO0G6GbnvL1mzT/aL3abv0OS+88ELZsmXLbm/b8ugxcdhhh9ljR7fN448/XuG80TxPLOfihx56yL6OdB497vTYnTBhQlxez7rtNKg/duzY0H1ao0trjelrKfz4HjJkiN1vFdV/Cj+G3ONT26Lbbc6cOTs9t3bJ1G2g21R/vvbaa+W2MZr3jL59+8ohhxwS8XennHKKbU/463zWrFn2vrfffrvS7RLNc1ZWqzD8nKs/r7vuOvt7ixYtQsex+54Vfj6t7L2uonpbZWubRfOaAYBEIVMKAOLs7LPPljZt2sjo0aNtgOmOO+6wFxl6QXLCCSfI3XffbT9IXnvttfaD9zHHHBPx99pFrHfv3vZ3Xc6//vWvnS4Irr76amnQoEGV2qkfSvXCvHv37vbCQbtUjBs3zl4IfPLJJxHfaP/xxx9y4okn2g/xZ511lg1u3HDDDfZiv1evXlE93xVXXGEvTvQ5P/vsM3sBoheE2kWhWbNmtruNrrvWrdGLDb2QV/qBXgMlelE8ePBg6dixo7zzzjv2A7teVOmFfLgPP/xQXnzxRRsg0AsDDbxp22fPnm2Xu7s0yPDrr7/awEX4PtEP73oxrReGa9eutfvaNWnSJNmwYYN9fHfs7jZTGoTR7XbeeefZ4IgGas4880yZPHlyRBaeXni89NJLtkvWEUccYbdfeVl6q1evto+7F0MaONCLNN0nuo7Dhg3b5fpokEKfS/9eg2B6sRTtcvX3f/zjH3LuuefKn//8Z5tN+NRTT0nPnj3tvtXjQun+0Xm6detmX2tKAyF6TF911VWhY3/UqFFy0UUX2eCMLnvu3Lkyf/58+dOf/mTn0QDMUUcdZS/6b7zxRhtY0bZrge///Oc/cvrpp8dtX6lnn33WrpMGhjWYqftPzxdff/21DRpU5M4777QBHH1d6vr89ttvNiCh55XPP/88lN2k20qPYQ1U6jb94Ycf7PGhx6teRFdE94ce7/o8mzZtstvNPTdpQFM9/fTTts0XX3yxfc3pMt977z17bth3333t9tZ5tV26TXU7l71Qrup5M5y219232ialwY5wur30Yl/XR9ujx5aeU91jJpZtWx7dbz169LDbT9dfM8huvfXWcvdlLM8TzblYu8jp+U8DqnrM67756quvbHDl//7v/6r8etb26DGsARB9HjcAp8vSc6AGzTTApTTwqYHJXdGAmR7/eozqcvR8quuox6n7XvTuu+/aeov6pY3ut99//90GE/fee++IZUX7nqHtmjhxol1fDXrq3+l5QoNr2m5dhrsOep8euxWJ9X1qV3TdNVD773//2/6tni+V7qdEvNdF85oBgIQxAIC4uPXWW/XrUHPxxReH7istLTV77723cRzHjB49OnT/H3/8YapXr24GDhwYsYwffvjBLmPatGnlPkcwGDS9e/c2tWrVMgsWLIi6bU8//bRd7o8//mhvr1mzxuTn55sePXqYQCAQmu/hhx+28/3zn/8M3Xfsscfa+5599tnQfdu2bTONGjUy/fr1i/q5e/bsadvv6tKli90ul1566U7bS5/T9frrr9u/v+OOOyKWe8YZZ9i/X7p0aeg+nU+nuXPnhu5btmyZqVatmjn99NMr3B7ueoY/rz6m8+i8rqFDh9r7ylq8eLG9f9y4cRH3n3rqqaZ58+YR612effbZJ+JYqOo2U1u2bIm4XVJSYg488EBzwgknhO6bN2+efZ5hw4ZFzHvBBRfY+/WYdg0ePNg0btzY/Pe//42Y95xzzjFFRUU7PV9ZujyPx7PTcRvtcnU99bgLp6+jhg0bmkGDBoXuu+qqq0xhYaGdvyIHHXSQOfnkkyttb7du3Uz79u1NcXFx6D7dF0ceeaTZb7/94rav3ONMzwc///xz6P5Zs2bZ+4cPH77TOcb1008/Ga/Xa+68886Itn/99dfG5/OF7td936BBA9OxY8eIbfjEE0/Y5ZU9dsqj87Rr1y7iPrftur31nBJOn0uf8/fffw/d9+WXX9pjYMCAAXE9b5anZs2a5c7nPl/4MaP0/FCvXr2Yt21FTjvtNHve0fOPa+HChXaZu7MPYzkX9+nTZ6d9VVZVX896LtTXnuvqq682xxxzjN3n7nlQ973uwwcffDA0n+4TPd+VPYZ0269duzZ0/8SJE+39kyZNijimtM3r1q0L3ffuu+/a+cKXGe17xpw5c+x8b731lr391Vdf2dtnnnmm6dy5c8R5/OCDD650e0T7nOW9r7jKnnPvueeend6nYn2vK7u9KzqXVPaaAYBEo/seAMSZftvo0i4O2m1CP0Pqt6fh3zRryr1+CxxOMwS0K4l2JSrPyJEjbaaLpv7rt8W7S7MYNHtGvw3Xb4BdmoGi3xhrO8LVqlUrIttH68XoN6pl218ZXf/w7gKdO3feabu42yt8uZpdove738i7tJuE/n3ZLhVdunSx3RhcmqWi3X/0W+tAICCJsP/++9v10UwOl2YMaNs0U2l3h4Df3W2mtBtQeHbF+vXrbWaAZoW43O5zl1122U5ZP+H0OTU7SLu26O/aVcedNFNJlx2+3Ipol7Tw4zaW5ep6unWKtGaRbl/NPtF1D39ufW1pN5SyXfHC6TyaCbVkyZJyH9dla1aXZqJo9obbJs3M0Hbp32n2Q7z2ldIMLM3KcunrS5ehx39FXn31VbsttJ3h204ztrRrotu1UbPAtCbUpZdeGlHrSbPk9HxTVZq9Ep7BsXLlSvniiy/s8sMzBzt06GAz0cpbp6qcN3eHbotw+trQ/atZM7Fs2/LoeUbPN7pP9fzj0kwwPX7Cxfo80ZyLdTv9/PPP5XZ/i9frWbeXZlu5Rcs1m0gzu/R+t1uoZk/p8qPJlNJMOe1mGL585a6Xe0wNHDgw4pjV46nse2G07xkHH3yw3Z5ulzdtt2ZdaRajrr9259T5dT12tQ6xvk/FQyre6wAgEei+BwBxFn4RovQDtNZ7cNPvw+/Xi6BwGgzSLh8+386nZw0gaNegm266yV4EuvQCwu1GU5ZeKJZX0HvZsmX2p17ghdMLHO1u4z7u0g/qZQMregGhXUJcq1at2mn9wgMj5W0XVbbrkN6vQZTwtmq9K60PFE4v8MLXxaUXcuUFjfQCQ7vFhNc3iSe9kNFuMNoerQv08ssv29pF4aP3xWp3t5nS4KV2gdILuW3btoXuD9+P2lYNSmo3pnCtWrWKuK3bTbuNapc0ncqjQY9dKfs8sS5X651oTSGt9aTbtrzlaoBNu9lpVyYN8ujrSS/4tVuL6/bbb7cXb3pcaDcXfUz3kwZN1NKlS+2FpHap0qmidoUHkaqyryo7bnVdKqLBMW1neX+r3G5P7muk7Hz6uL7eq6rsfq3o/OK+bvWiWQOH2iUyHufN3VH2+dyAiO4bDcxHu23Lo8e1npPL+1vdJuFBuVifJ5pzsXbn0y8eNFilr2V9DWi3Pbf7WSyvu4rO626Qxg3kaDdDPd/oe47WUXIf02150EEHSVX2R2XHsLtNw4No0b5n6HujBnbcIJrb1VC/FNKgjnbD1e6WGqTeVVAq1vepeEjVex0AxBtBKQCIs/KCQBWN9BZeAFU/SGrxYK3rVNaPP/5oM270W2H94B9Oa4boxXp59O9iKYhekWja37hx44jHtM5MeKHUipZR3v0VFYJOZ1qYePjw4TZb6i9/+YstXKzZHuVdmEdrd7eZWw9FMxe0zojuG7241X1StthxNDSTQ2mGhmYqlMcN6FQmPEgZ63J1e+rxpNknWqdF6//odtDaMt9//31ofr1fA3Ea+NDsBJ10vTVo6L5OdLvo32g9Ga1To/WEtG7LY489ZjN23HZp/aKymS0VBe5ScXxrO90CzOU9j2aBJEPZ/ZrM82Y8ny982cnatrE+TzTbRAMhmsGkgWn9MkOzovQ8oAMF6BcbsbzuKjqvawBGg5GaZaTvMfr8GuDRoJS+J2kQRs9DWsMsPBu3Ionc15XRAJTW9NK6W9rev/71r6GaWXrbrQEWTbZXNCrKmk1UZlOynw8AdgdBKQBIE9pdSDNayhYO12/cteipflDWoqdlP+DraF4VFdKu6JtSzeRReuESnimhXfo0kKXFz2NVtruUW+i2qrSt+q2/dqMK/xZas2Xcx8OV1yVLC8bqKFThXYx2R2Xd8LSbkhYI16CUBhC1YK6OSJYKehGqWSYamNECuOEXlOF02+kFqu7z8G/dNVMonG433fZ6IbM7x0ZFYlmuFnTWY1W7O4XvBy0eXZZm/GnXJJ10/TR7Sgtma9aTG0zS/aVFknXSAt4aqNKC1BqUcl8TGsiL5/pWpqLjtrKgshYi1ot2DQ5ohkRF3NeIPocWDXdptpnu+2gyWWIRfn4pS1+3mv0UniWVCLvbZTbWbVsePa41UFfePi27TaryPJXR7atd4nTS87q+h2jwRTNtY3ndVXZe10CNBqW07VrYW5epx5JmU2kwTLOXNAgWD+HH8K62aSzvGboOun30vVW75LrBJz0fuEEp3S+VDTYQy3O6GWBlR7ktL5NqV8dwNO91+nxln2t3nw8AEoWaUgCQJrRLh2bWlP3wq7VP9IOmDn0dXnPDpfU09MKivEkDE+XRx/TCXYf0Dv8mWkfo0u6A5Y2+titln7vsN+y766STTrIXTw8//HDE/ZrZoh+iywbxZs6cGdGVQ4dV14wY7cJS0bfx0XIvpMv7kK+0C5iOPKWZPPpcmj2VCvrcum3Cvw3XocR1OPVwbhaQZlGE05G/yi5Pu4xqsOubb77Z6fm0q8jutjPa5br7Lvx41dHEdH+HK9u1S4O4btaH242x7DyajaLBKvdxzbY67rjjbCBLa9nEa30ro/smvE6VjqCl61fZ6JYaaNDtohf+ZTNK9La7nnpe0YtUzQTTC3CX1qar6FiuCn3ta5BCM9PCl6/7WDPT9DWdaPparcq6Rbtty6N/p68t3afLly8P3a+jQGqgOF7PU5Gyf6Pnen2f0OVpIDKW111l53UN4Oh5RUeAc4M5+nrT7Kj77rvPPle8MozCjyl9jwoPmuk5d3ffM7RumwafddRFDVS7QTdtt3bf0xHuolmHaJ9TuzNqUNatY+Uqew6O5v0mmvc6DXrq9grv3qnnNP08Ud7zJeJ8AAC7QqYUAKRRUEqzNsrWmNKh4vUCQj9Uhn+w1Atp7cq0O/QCVb8x1wshraejXb3022b9YKzDrVeUeZUKmu1y/PHH224VegGk38Trha1++NZC7WWHrdZuF3pBGD5MtorHN/ZuUVldtj5H2cCTBvPq1atn60npRYgGN1JB26EXhbpvtZaM1od55JFHbOAl/BjS9dFjSzO69EJWh4jXizANgpb95nz06NG26LJexGlBfL3I1VorelGkGQL6++6Idrm9e/e2WVKnn366XT/N8NEgi86vmU4uzXTSv9GMIK11oxkBGmTTC1q3vov+jQaddP31QlQLgWsmltYEc+n20q497du3t+3S7Ckt7KwXglpE+ssvv5R40n2jzzdkyBAbHNN9oseSZkJWRI997c6rr2V9bej5QLM0dNvoRacO7a5dEPWiW+e75JJL7HbR7BmdRzPn4lFTqjz33HOPfQ1oly4tVq4Zn7ofNItGM9ISTfetHj/6OnC7mukxFq1ot21F9Hyj2UIa0NBMPS3Kr+uvQY/w12BVn6c8GpTQLFmtIaVfcmgwTIMl+rpxs3ji8Xp2gzX63nHXXXeF7tcsI+2OqOdffT+JF+2qq+ugr5NBgwbZNrrbNPwcEMt7hmYV6bGiASj9O/ecp+ugdc90iiYoFctz6jlKt7/+1ICxBqjcc2557ze6TH2f0dexPo8brIrmvU7/TmuM6XlT59MyAVoiQLO/yhazr+prBgB2W8LH9wOAHOEOsfzbb79F3K9DLOtQy5UNsf7NN9/Yv509e3bEPO5w8+VN5Q3zXBF3OWWHln744YdN69atTV5enh3ee8iQIXbY9YraWXa9ommD+9w6/Pbubq+NGzea4cOHmyZNmti27rfffna47GAwGDGfLk+HKn/uuefsPAUFBXYo72nTpu1ye+h66uQqb+huHar+iiuuMPXr17fDfJf3NnrZZZfZ+ydMmGCipdsxfCjueGyzp556KrQNdB/rMssbBnzz5s12m9WtW9fUqlXLDmW/ePFiO9/o0aMj5l29erWdt2nTpnY/6FD03bp1M0888cQu19HdN+WJZrm6r++66y67rdz9Onny5J2Ow1deecX06NHDDk2fn59vmjVrZi655BKzcuXK0Dw6bPvhhx9u6tSpY6pXr263z5133mlKSkoi2vX999+bAQMG2PZou/baay/Tu3dv+xzx2lfucabH87333mu3ga7f0Ucfbb788styl1nWf/7zH9O1a1e7XJ10fXR76n4M9+ijj5oWLVrY5Xfq1Ml89NFHOx33FSnvPBDe9vK899575qijjrLbuLCw0Jxyyilm4cKFu7WdKmtHeb799ltzzDHH2OfW5buvr4qer6JzZLTbtjwffvihOfTQQ+1xuO+++5rHHnusSvsw2nPx448/bte9Xr16dl+3bNnSXHfddWb9+vVxez279HWm66PLcs2YMcPep8fwrtpa2TGk9+v2Krud2rRpY9erbdu25tVXXy33vSja9wyl20af6+677464v1WrVvZ+PQ9EI9rn3LJlixk8eLApKioytWvXNmeddZZZs2ZNues7cuRIe97xeDwRx2e073Xq3XffNQceeKA9Dg844AD7N+UdhxW9ZgAg0Rz9Z/dDWgCAeBgzZoz9dlLT6qnrkNm02Ll2g9RRq/Rb+EykhcJ1uHQtLq71sQAA6UM/JwwdOnSn7oIAkImoKQUAaUCLGbu1J5C5dAQnDeRol7hMCUhpt6qytOuY1obRLiwAAABAolBTCgDSwFlnnZXqJqAKtGaT1uLQukRam0mHRM+kLL158+bZeig+n8/WgtFJa9k0bdo01c0DAABAFiMoBQBAFenoT9rNTQub64iGWlQ7U+hIWTqC1ciRI22x4GbNmtlC1FpcFwAAAEgkakoBAAAAAAAg6agpBQAAAAAAgKQjKAUAAAAAAICko6aUiASDQfn111+ldu3ajHwFAAAAAABQBcYY2bhxozRp0sSO6lwRglIiNiDFCEMAAAAAAADxs2LFCtl7770rfJyglIjNkFJd5STxSV4cNz8AAAAAAED2M/k+CdbMFydgJLhpk8wITg7FWypCUEqHIHScHRsjT3wOQSkAAAAAAIBYBL0+kbx80d56TrWgyJb/xVsqQlAKAAAAAAAAVeOIGK9IULOmvJUHo1wEpQAAAAAAAFAlRietaW4ISgEAAAAAACBZNDlqx0B7xhNdplTF4/IBAAAAAAAA0Xbf8xgxYcGpXaH7HgAAAAAAAKpmRzDKmB2BqSiQKQUAAAAAAIAqMuI4ZntgKspoE0EpAAAAAAAAVI0jNijlaJYUmVIAAAAAAABIBhuL0kwph+57AAAAAAAASCIddI9MKQAAAAAAACTR9iyp7T+j+wtqSgEAAAAAAKBqNEsq+nJSFkEpAAAAAAAAJB1BKQAAAAAAAFSNifgRFYJSAAAAAAAAqCJHjNnRgS/KyBRBKQAAAAAAAFSZLXMeQ6oUQSkAAAAAAADEISDl/G8QvigQlAIAAAAAAEDVGJGg2dGFLxjdnxCUAgAAAAAAQNVpMIpMKQAAAAAAACTNjiwpJ0imFAAAAAAAAJJpR0DKibL7ni/R7QEAAAAAAECWM9uDUTYgFeUQfASlAAAAAAAAUCVOeFAqQFAKAAAAAAAAyaBBqcD2KdqgFKPvAQAAAAAAIC5BKU/AiOOPrqgUQSkAAAAAAABUufueRzOlSo1IqaZL7Ro1pQAAAAAAAFA1gaA4xX5xAkEKnQMAAAAAACA5bDAqULL9RpSj79F9DwAAAAAAAElHUAoAAAAAAABJR1AKAAAAAAAASUdQCgAAAAAAAElHUAoAAAAAAABJR1AKAAAAAAAASUdQCgAAAAAAAElHUAoAAAAAAABJR1AKAAAAAJATjOOIOKluBQAXQSkAAAAAQIjxOGK8jv2ZTYzPI6Z2dZFqBSIanAKQcr5UNwAAAAAAkD4CtfPFFPjEU2LEu7FYJBCUrOA4YvK9YowRRwNuAZPqFgE5j0wpAAAAAECI8YgEfZpZ5IjJy548Bg1BaVAqqBlTHi6FgXTAKxEAAAAAEHGVaLw7pmzqwufsCLR5RSQ/e4JtQCYjKAUAAAAACLtKNHaywZs8r0i2ZBU5mgGmtbI04EbBcyAdZMnZBQAAAAAQD47HiMdrsjJbavv6ZNc6AZkspUGpcePGSYcOHaSwsNBOXbp0kbfffjv0eHFxsQwdOlTq1asntWrVkn79+snq1asjlrF8+XI5+eSTpUaNGtKgQQO57rrrpLS0NAVrAwAAAACZz+MY8XqCNlsqaDOKnOzpvrcjKCUalPJoKhiAnA1K7b333jJ69GiZN2+ezJ07V0444QTp06ePLFiwwD4+fPhwmTRpkrz88svy4Ycfyq+//ip9+/YN/X0gELABqZKSEvn000/lmWeekfHjx8uIESNSuFYAAAAAkLm8nu1BKc2YsgEc7cKXFXZ0SbSZUnZFU90gIOc5RsfDTCN169aVe+65R8444wypX7++TJgwwf6uvv32W2nTpo3MnDlTjjjiCJtV1bt3bxusatiwoZ3nsccekxtuuEF+++03yc/Pj+o5N2zYIEVFRXKc9BGfk5fQ9QMAAACAdObdyxGnlke2luaJ2eKVvA0BcTYXS6YLVvdIcasi8a4rEU+xiG+jX5ziklQ3C8hKpcYv02WirF+/3vaMq0jahIY16+mFF16QzZs32258mj3l9/ule/fuoXlat24tzZo1s0EppT/bt28fCkipnj172iCTm21Vnm3bttl5wicAAAAAgIhXjPg8AfE6wf8VBc8WbuaXdt/LotUCMlXKg1Jff/21rRdVUFAgl156qbz22mvStm1bWbVqlc10qlOnTsT8GoDSx5T+DA9IuY+7j1Vk1KhRNjPKnZo2bZqQdQMAAACATONxgjYgpbWlxNEub9kTvXHcbnv6M1tqZQEZLOVBqQMOOEC++OILmTVrlgwZMkQGDhwoCxcuTOhz3nTTTTaFzJ1WrFiR0OcDAAAAgEzhEWOzpbYHpURMtsVudJ1IkwLSgi/VDdBsqFatWtnfDz30UJkzZ448+OCDcvbZZ9sC5uvWrYvIltLR9xo1amR/15+zZ8+OWJ47Op87T3k0K0snAAAAAEAkDUa5k43d2CBOlvR2C1un7FghILOlPFOqrGAwaGs+aYAqLy9P3n///dBjixcvluXLl9uaU0p/ave/NWvWhOaZOnWqLaKlXQABAAAAALFxNEvK5hKFBXCyUFqN+AXkqJRmSmk3ul69etni5Rs3brQj7U2fPl3eeecdW+tp8ODBcvXVV9sR+TTQdMUVV9hAlI68p3r06GGDT/3795cxY8bYOlI333yzDB06lEwoAAAAANgN2+NQZkfJJQ3deMTROkyBYFZFozRpCkAOB6U0w2nAgAGycuVKG4Tq0KGDDUj96U9/so/ff//94vF4pF+/fjZ7SkfWe/TRR0N/7/V6ZfLkybYWlQaratasaWtS3X777SlcKwAAAADIZG60JqzyUrYUBbcFsow4hogUkA4cY3g1btiwwQbFjpM+4nPyUr1PAAAAACBlCpv6Ja8wKBsD1WXT1gLxbPaIb12xSGkgo/dKsLpHig8oEu8mI55NpeJb7xdn67ZUNwvISqXGL9Nloh1cTnu+ZUxNKQAAAABA6mgOka0oZdxcKSMSyOyAVIj2QPSXigR15ciWAlKNoBQAAAAAIGR7ifPt044IVXbEb8yOoFRQu+9RUwqQXK8pBQAAAABIL8Y4NpEoaOsvbQ/mZEdFKUckqNOO4FRWRNqAzEZQCgAAAAAQEhRHAuLYnzYglUWxGycg4gR1Mtu78QFIKYJSAAAAAICQgGZIabaUzSpytgdwsoEG2AI7fgbDRxkEkCoEpQAAAAAAIUHx7OjC52yvvRSwEZys4Cl1s6VsFXcAKUZQCgAAAAAQmSkV9Egw6AkVBs8KNsBmtmdJ+bNkNEEgwxGUAgAAAACEBM32gJQJOuLRAE6WZEpp1pfHb7YHpkoJSgHpgKAUAAAAACAkEHRCWVK2BlOWBKVsppQ/IE6pdt3LkuwvIMMRlAIAAAAAhGg9KWODUs72rKJsCeAEg+JsLrbrlDVdEoEMR1AKAAAAAPA/QUdMwBGPFgQvDdpgTjawxc2L/aluBoAwnvAbAAAAAIAct6PbnuMGpUgqApAgBKUAAAAAACE6Op0GpGymVLbUkwKQlghKAQAAAAAiglKhrnv+UrYMgIShphQAAAAAIMR22/Mb8ZSQJQUgsQhKAQAAAAAiC4JnUYFzAOmLoBQAAAAAIMTZWsLWAJAU1JQCAAAAAABA0hGUAgAAAAAAQNIRlAIAAAAAAEDSEZQCAAAAAABA0hGUAgAAAAAAQNIRlAIAAACQeh5HxEl1IwAAyURQCgAAAEBKGZ9HTM3qInl57AkAyCEEpQAAAACk2I4sKTKlACCnEJQCAAAAkHLGBqSISgFALiEoBQAAAAAAgKQjKAUAAAAgPZAoBQA5haAUAAAAAAAAko6gFAAAAID0YFLdAABAMhGUAgAAAAAAQNIRlAIAAACQco7NkiJVCgByCUEpAAAAAKlljIg/IBIIsicAIIf4Ut0AAAAAALnN0WDU1m2pbgYAIJ2DUosWLZIXXnhBPv74Y1m2bJls2bJF6tevLwcffLD07NlT+vXrJwUFBYlrLQAAAAAAAHKn+978+fOle/fuNvg0Y8YM6dy5swwbNkxGjhwp559/vhhj5K9//as0adJE7r77btm2jW85AAAAAAAAUMVMKc2Auu666+SVV16ROnXqVDjfzJkz5cEHH5R7771X/vKXv0SzaAAAAAAAAOSgqIJS3333neTl5e1yvi5dutjJ7/fHo20AAAAAAADI5e574QGpH374Iab5ozV69GhxHMd2C3QVFxfL0KFDpV69elKrVi2bsbV69eqIv1u+fLmcfPLJUqNGDWnQoIHN6CotLY35+QEAAAAAAJBmQalwrVq1kuOPP16ee+45GzSKhzlz5sjjjz8uHTp0iLh/+PDhMmnSJHn55Zflww8/lF9//VX69u0bejwQCNiAVElJiXz66afyzDPPyPjx42XEiBFxaRcAAAAAAADSJCilRc81eHT11VdLo0aN5JJLLpHZs2fvdgM2bdok5513njz55JOyxx57hO5fv369PPXUU3LffffJCSecIIceeqg8/fTTNvj02Wef2XneffddWbhwoQ2QdezYUXr16mWLrz/yyCM2UAUAAAAAAIAsCUpp8EeLmWvW0j//+U9ZuXKldO3aVQ488EAbQPrtt99iWp52z9NsJx3dL9y8efNsbarw+1u3bi3NmjWzBdWV/mzfvr00bNgwNE/Pnj1lw4YNsmDBggqfU0cH1HnCJwAAAAAAAKRxUMrl8/lsVzrtWnf33XfL0qVL5dprr5WmTZvKgAEDbLBqV1544QWbeTVq1KidHlu1apXk5+fvNNqfBqD0MXee8ICU+7j7WEX0+YqKikKTthkAAAAAAAAZEJSaO3euXHbZZdK4cWObIaUBqe+//16mTp1qs6j69OlT6d+vWLFCrrrqKnn++eelWrVqkkw33XST7R7oTtoWAAAAAAAAJI8v1j/QAJTWdlq8eLGcdNJJ8uyzz9qfHs/2+FaLFi1ssfHmzZtXuhztnrdmzRo55JBDIgqXf/TRR/Lwww/LO++8Y+tCrVu3LiJbSkff01pWSn+WrWfljs7nzlOegoICOwEAAAAAACBDMqXGjRsn//d//yfLli2T119/XXr37h0KSLkaNGhgi5RXplu3bvL111/LF198EZo6depki567v+fl5cn7778f+hsNhC1fvly6dOlib+tPXYYGt1yaqVVYWCht27aNddUAAAAAAACQrplSGvTRYuNlA1HGGNsNTh/TWlADBw6sdDm1a9e2xdHD1axZU+rVqxe6f/DgwXaUv7p169pA0xVXXGEDUUcccYR9vEePHjb41L9/fxkzZoytI3XzzTfb4ulkQgEAAAAAAGRRUKply5a2iLlmQ4Vbu3at7bqnXfDi5f7777fBr379+tkR83RkvUcffTT0uNfrlcmTJ8uQIUNssEqDWhoMu/322+PWBgAAAAAAAMSfYzTFKQYaJNKMpLJBKe3Op1lLmzdvlkyzYcMGOwrfcdJHfE5eqpsDAAAAAACQsUqNX6bLRDu4nPZ8q3KmlHajU47jyIgRI6RGjRqhxzQ7atasWdKxY8eqthsAAAAAAAA5IOqg1Oeff25/amKVFhfXulEu/f2ggw6Sa6+9NjGtBAAAiJXj6CcX+z8AAAAyOCg1bdo0+/PCCy+UBx98sNL0KwAAgFQyXo9IjWrilPhFtvnZGQAAANlQ6Pzpp59OTEsAAADiyHgdcZzI0YIBAACQYUGpvn37yvjx4212lP5emVdffTVebQMAANg9jojxuIEpvUEfPgAAgIwMSunIdPYD3Y7fAQAA0p0GpcTjbJ8CBKUAAADSjWO0cnmO27Bhgw22HSd9xOfkpbo5AACgikyeR0rrVBdviRHPpm06VDDbFAAAIElKjV+my0RZv359pTXJKbQAAACyjv3GTXvtaaL39mRvAAAAZGL3vYMPPjjUfW9X5s+fX9U2AQAAVFkoIEVQCgAAIHODUqeddlriWwIAABBPNiDliBGHuBQAAECmBqVuvfXWxLcEAAAAAAAAOYOaUgAAILu78AEAACBzM6Xq1q0r3333ney5556yxx57VFpfau3atfFsHwAAwG5zcn6MYQAAgAwPSt1///1Su3Zt+/sDDzyQ6DYBAAAAAAAgyznGmJz/DnHDhg1SVFQkx0kf8Tl5qd4nAACgioJ5HimtW128JUa8m0pE/KVsUwAAgCQpNX6ZLhNl/fr1UlhYWLVMqbICgYC89tprsmjRInu7bdu20qdPH/H5dmtxAAAAiem6Z6ec//4NAAAgLcUcRVqwYIGceuqpsmrVKjnggAPsfXfffbfUr19fJk2aJAceeGAi2gkAABA1W/3ShAWmAAAAkPmj71100UXSrl07+fnnn2X+/Pl2WrFihXTo0EEuvvjixLQSAAAgFm5AKkhUCgAAIGsypb744guZO3euHYXPpb/feeedcthhh8W7fQAAALvFCepk6L4HAACQLZlS+++/v6xevXqn+9esWSOtWrWKV7sAAACqHpQKmB3ZUgAAAMjIoJSOTudOo0aNkiuvvFJeeeUV24VPJ/192LBhtrYUAABAWnTfI0sKAAAgrTnG7HpIGo/HI45jS4Za7p+494Xf1pH5Mo0G24qKiuQ46SM+Jy/VzQEAAHFgPI5+0KHQOQAAQJKVGr9Ml4myfv16KSwsrFpNqWnTpsWzbQAAAAlnM6UAAACQtqIKSh177LGJbwkAAAAAAAByRsyj76l169bJU089JYsWLbK327VrJ4MGDbJd4AAAAAAAAIC4j743d+5cadmypdx///2ydu1aO9133332vvnz58e6OAAAAAAAAOSgqAqdhzv66KOlVatW8uSTT4rPtz3RqrS0VC666CL54Ycf5KOPPpJMQ6FzAAAAAACANCx0XjZTKjwgZRfi88n1118vnTp12v0WAwAAAAAAIGfE3H1PI1zLly/f6f4VK1ZI7dq149UuAAAAAAAAZLGYg1Jnn322DB48WF588UUbiNLphRdesN33zj333MS0EgAAAAAAAFkl5u57f//738VxHBkwYICtJaXy8vJkyJAhMnr06ES0EQAAoGocEYmpiiYAAADSrtC5a8uWLfL999/b33XkvRo1akimotA5AADZyxTkifi84hSXiASCqW4OAABA1itNVKFzlwah2rdvv7t/DgAAkBTG44jj9Yg4mi4FAACAdBFzUKq4uFgeeughmTZtmqxZs0aCwchvHOfPnx/P9gEAAFSNI2IcjUkRlAIAAMjooJQWOX/33XfljDPOkMMPP5wPeAAAIP2DUh5HxOsV8W+vhwkAAIAMDEpNnjxZ3nrrLTnqqKMS0yIAAIA40iwp49nRjY8tCwAAkDY8sf7BXnvtJbVr105MawAAABJBo1FEpAAAADI7KHXvvffKDTfcIMuWLUtMiwAAABIRkNIufASmAAAAMjco1alTJ1vsfN9997UZU3Xr1o2YYvG3v/3N1qQKn1q3bh16XJ9n6NChUq9ePalVq5b069dPVq9eHbGM5cuXy8knn2xHA2zQoIFcd911UlpKvQgAAPA/ho0BAACQ+TWlzj33XPnll1/krrvukoYNG1a50Hm7du3kvffe+1+DfP9r0vDhw+XNN9+Ul19+WYqKiuTyyy+Xvn37yieffGIfDwQCNiDVqFEj+fTTT2XlypUyYMAAycvLs+0DAABwGf0CjM0BAACQuUEpDf7MnDlTDjrooPg0wOezQaWy1q9fL0899ZRMmDBBTjjhBHvf008/LW3atJHPPvtMjjjiCDsK4MKFC21QSwNkHTt2lJEjR9ruhZqFlZ+fH5c2AgAAAAAAIMXd97R73datW+PWgCVLlkiTJk1sd8DzzjvPdsdT8+bNE7/fL927d4947mbNmtmgmNKf7du3twEpV8+ePWXDhg2yYMGCuLURAABkPsfQiQ8AACCjg1KjR4+Wa665RqZPny6///67DQCFT7Ho3LmzjB8/XqZMmSLjxo2TH3/8UY4++mjZuHGjrFq1ymY61alTJ+JvNACljyn9GR6Qch93H6vItm3bqtRuAACQWei2BwAAkAXd90488UT7s1u3bhH3G2NsfSmt8xStXr16hX7v0KGDDVLts88+8tJLL0n16tUlUUaNGiW33XZbwpYPAADSiNkxBQ0VzwEAADI5KDVt2rTEtETEZkXtv//+snTpUvnTn/4kJSUlsm7duohsKR19z61BpT9nz54dsQx3dL7y6lS5brrpJrn66qtDtzVTqmnTpglYIwAAkFaBKQAAAGRuUOrYY49NTEtEZNOmTfL9999L//795dBDD7Wj6L3//vvSr18/+/jixYttzakuXbrY2/rzzjvvlDVr1kiDBg3sfVOnTpXCwkJp27Zthc9TUFBgJwAAkP0cmyUl4mimFAAAADI3KBVP1157rZxyyim2y96vv/4qt956q3i9Xjn33HOlqKhIBg8ebDOa6tatawNNV1xxhQ1E6ch7qkePHjb4pEGsMWPG2DpSN998swwdOpSgEwAA2M7sCEjFUGIAAAAAWR6U+vnnn20ASgum169fX7p27SqfffaZ/V3df//94vF4bKaUFifXkfUeffTR0N9rAGvy5MkyZMgQG6yqWbOmDBw4UG6//fYUrhUAAEi7oJTtvkemFAAAQDpxjFYoz3FaU0ozs46TPuJz8lLdHAAAEEemWr6IzyvO1hKypQAAAJKg1PhlukyU9evX255vaZkpBQAAkHAlfnFKSkWCQTY2AABAGiEoBQAAstr2Auc5nxgOAACQdjyx/sHq1attYfEmTZqIz+ezdZ3CJwAAAAAAACDumVIXXHCBLF++XG655RZp3LixOI4T6yIAAAAAAACQ42IOSs2YMUM+/vhj6dixY2JaBAAAAAAAgKwXc/e9pk2bCgP2AQAAAAAAIKlBqQceeEBuvPFG+emnn6r0xAAAAAAAAMhdMXffO/vss2XLli3SsmVLqVGjhuTl5UU8vnbt2ni2DwAAAAAAAFnItzuZUgAAAAAAAEBSg1IDBw6s0hMCAAAAAAAAMQelVCAQkNdff10WLVpkb7dr105OPfVU8Xq9bFEAAAAAAADEPyi1dOlSOemkk+SXX36RAw44wN43atQoOyrfm2++aWtNAQAAAAAAAHEdfe/KK6+0gacVK1bI/Pnz7bR8+XJp0aKFfQwAAAAAAACIe6bUhx9+KJ999pnUrVs3dF+9evVk9OjRctRRR8W6OAAAAAAAAOSgmDOlCgoKZOPGjTvdv2nTJsnPz49XuwAAAAAAAJDFYg5K9e7dWy6++GKZNWuWGGPspJlTl156qS12DgAAAAAAAMQ9KDV27FhbU6pLly5SrVo1O2m3vVatWsmDDz4Y6+IAAAAAAACQg2KuKVWnTh2ZOHGiLFmyRL799lt7X5s2bWxQCgAAAAAAAEhIUMq133772QkAAAAAAABISFDq6quvlpEjR0rNmjXt75W57777Ym4EAAAAAAAAcktUQanPP/9c/H5/6PeKOI4Tv5YBAAAAAAAgt4NS06ZNK/d3AAAAAAAAICmj7wEAAAAAAABJCUpdeuml8vPPP0e1wBdffFGef/75qrYLAAAAAAAAud59r379+tKuXTs56qij5JRTTpFOnTpJkyZNpFq1avLHH3/IwoULZcaMGfLCCy/Y+5944onEtxwAAAAAAAAZyzHGmGhmXL16tfzjH/+wgScNQoWrXbu2dO/eXS666CI58cQTJdNs2LBBioqK5DjpIz4nL9XNAQAAAAAAyFilxi/TZaKsX79eCgsLqx6UCqfZUcuXL5etW7fKnnvuKS1btszokfcISgEAAAAAACQ3KBVV972y9thjDzsBAAAAAAAAu4PR9wAAAAAAAJB0BKUAAAAAAACQdASlAAAAAAAAkHQEpQAAAAAAAJB0BKUAAAAAAACQ/kGp1atXS//+/aVJkybi8/nE6/VGTAAAAAAAAMCu+CRGF1xwgSxfvlxuueUWady4sTiOE+siAAAAAAAAkONiDkrNmDFDPv74Y+nYsWNiWgQAAAAAAICsF3P3vaZNm4oxJjGtAQAAAAAAQE6IOSj1wAMPyI033ig//fRTYloEAAAAAACArBdzUOrss8+W6dOnS8uWLaV27dpSt27diClWv/zyi5x//vlSr149qV69urRv317mzp0belyzskaMGGHrV+nj3bt3lyVLlkQsY+3atXLeeedJYWGh1KlTRwYPHiybNm2KuS0AAAAAAABI05pSmikVL3/88YccddRRcvzxx8vbb78t9evXtwGnPfbYIzTPmDFjZOzYsfLMM89IixYtbIH1nj17ysKFC6VatWp2Hg1IrVy5UqZOnSp+v18uvPBCufjii2XChAlxaysAAAAAAADixzEpLBCl3QA/+eQTWzi9PNq0Jk2ayDXXXCPXXnutvW/9+vXSsGFDGT9+vJxzzjmyaNEiadu2rcyZM0c6depk55kyZYqcdNJJ8vPPP9u/35UNGzZIUVGRHCd9xOfkxXktAQAAAAAAckep8ct0mWhjONqrLW7d98IVFxfbgE74FIs33njDBpLOPPNMadCggRx88MHy5JNPhh7/8ccfZdWqVbbLnkuDR507d5aZM2fa2/pTu+y5ASml83s8Hpk1a1ZVVg8AAAAAAAAJEnNQavPmzXL55ZfbIFLNmjVtV7vwKRY//PCDjBs3Tvbbbz955513ZMiQIXLllVfarnpKA1JKM6PC6W33Mf2pbQnn8/lsfSt3nrK2bdtWpWAaAAAAAAAAkhyUuv766+WDDz6wwaSCggL5xz/+IbfddpvtJvfss8/GtKxgMCiHHHKI3HXXXTZLSutA/fnPf5bHHntMEmnUqFE248qdmjZtmtDnAwAAAAAAQBWDUpMmTZJHH31U+vXrZzOSjj76aLn55pttYOn555+PaVk6op7WgwrXpk0bWb58uf29UaNG9ufq1asj5tHb7mP6c82aNRGPl5aW2hH53HnKuummm2y/RndasWJFTO0GAADIRMbnkWC9QpF8amgCAIAMDEppsGffffe1v2uxKr2tunbtKh999FFMy9KR9xYvXhxx33fffSf77LOP/V1H29PA0vvvvx96XLvaaa2oLl262Nv6c926dTJv3rzQPJrJpVlYWnuqPJrhpW0PnwAAALKex5FAda+Y/JgHYAYAAEh9UEoDUlqAXLVu3VpeeumlUAaVFhyPxfDhw+Wzzz6zWVZLly6VCRMmyBNPPCFDhw61jzuOI8OGDZM77rjDFkX/+uuvZcCAAbar4GmnnRbKrDrxxBNtt7/Zs2fb0fy05pWOzBfNyHsAAAC5wjgiwXxHTDWfiJPq1gAAgFwX89dkF154oXz55Zdy7LHHyo033iinnHKKPPzww+L3++W+++6LaVmHHXaYvPbaa7Y73e23324zox544AE577zzImpYaXF1rTelGVGakTVlyhSpVq1aaB7tNqiBqG7dutlR97Rr4dixY2NdNQAAgOymQak8nTzi2P9MqlsEAABymGOMqdKnkWXLltmuc61atZIOHTpIJtIugVrw/DjpIz6HGgsAACA7ade94n0LJW+jkbxVm8QpKU11kwAAQBYqNX6ZLhNtHe/KSiZVuaCA1n9ya0ABAAAgvRmfkWCeY+tLAQAAZFRNqSuvvLLcrnHahU/rPwEAACBNOSKOz4jxaXDKm+rWAACAHBdzUOo///mPHTWvrCOPPFJeeeWVeLULAAAAceY4RjzeoBivESEoBQAAMi0o9fvvv9v6S2VpH8H//ve/8WoXACAKWhTQeGM+lQPIYV5P0H4CNF667wEAgNSK+UpGC5rr6Hdlvf3227LvvvvGq10AgCiYAq/496krplo+2wvALjmOiM8GpYztygcAAJBKMRc6v/rqq+Xyyy+X3377TU444QR73/vvvy/33nuvPPDAA4loIwCgIh5HSmt6xFc9T5ziErYTgF0w4nG2B6QMhc4BAECmBaUGDRok27ZtkzvvvFNGjhxp72vevLmMGzdOBgwYkIg2AgAqYByRQDUjwRp54vmDzQSgcpocpUEprS1FphQAAMi4oJQaMmSInTRbqnr16lKrVq34twwAsGuOEVNgJFDgEZ/2yzFaZQoAdnXu2B7U1knjUwAAABlRU2rr1q2yZcsW+3v9+vVt4XPttvfuu+8mon0AgEpoHMqbF5BgNa9WL2ZbAYhhlAQCUgAAILVivoLp06ePPPvss/b3devWyeGHH27rSen92oUPAJA82gUnP69UTP72jAcA2BVjTxYOvfcAAEDmBaXmz58vRx99tP39lVdekUaNGsmyZctsoGrs2LGJaCMAoLKglDcgxrcjbQoAKmHEkYBxtvf0DdJvDwAAZFhQSrvu1a5d2/6uXfb69u0rHo9HjjjiCBucAgAkj4ah8j0BEa/Rcd7Z9AAqpcGogPGIBB1xgmwsAACQWjFfwbRq1Upef/11WbFihbzzzjvSo0cPe/+aNWuksLAwEW0EAFTAESNeJyCOns3tPwBQuUDAEQmKOGRKAQCAFIv5CmbEiBFy7bXXSvPmzaVz587SpUuXUNbUwQcfnIg2AgAqoiNn2fIwDO8OILp6UsGgRxwNTJWSKgUAAFJLq5DE5IwzzpCuXbvKypUr5aCDDgrd361bNzn99NPj3T4AQGVM5EhaALArwYBHfKUijj/AxgIAAJkVlFJa3FyncDoKHwAg+UWLS4Oe7aNp2crFAFDpSUOcUkec0h0FpgAAAFKIAiQAkMH0ktIf9IpowkOArAcAlbM9ff0iHn9QhEwpAACQYgSlACCDaYZUScBrMx8Y3h3Ark8aIp5SRzx+I46hphQAAEgtglIAkOHd90pKfTbzgZpSAKI4aYinxIhnW4BzBgAASDmCUgCQwTTRodTvFc/WgDgBsh4A7Lr7nnebEadYI9kAAAAZWOgcAJAmtMD5No94SmzV4lS3BkCac0oD4vl9owhBbAAAkAbIlAKATKZZD8WOeDb7iUnlAi0dVlhDpFp+qluCjB59T7vuEcQGAACpR1AKADKYExTxFRvxlDDyXiIYj0igVp4Eq+fZgFCqaRghWM0rpjpBKQAAAGQ+glIAIgSLapKFkUGcoBHfpoA4xSWpbkpWMvke2dashvgb1hRTkB6BoKDPkUCBV8RJgygZAAAAUAUEpQBECNTwSrBGAVslk+rDrF4not1xkJhtnBeUYJ6I8aXHW6bxiQTzHRGfN9VNAQAAAKokPT5hA0gberEbqJkeXZUQZX0YChYnjOMYyfeViuQZMfne9Kgp5TM2W8p4eJECAAAgsxGUAhBBM0IC1T1i6BoEiMcxUs3nt9lSaRGUUt7t2VKSzwC6AAAAyGwEpQBEMJqFUUDXIEA5YqSa1y8+b0CCeU56ZBB6jH2dpkt3QgAAAGB38YkWQATHG5SglpTycnoANFOqumd7UMrkaYgq9VEpx2vsuzfd9wAAAJDpuOoEEMHrDYr4uOAFlIahChy/5GlQSge8S4NgrdcJiniNGG/qA2QAAABAVaT+0zWAtOL1BMXxGZG8NKmfA6T4TbLACUieE7C1nCQNiot7PMYWYDcaIKP2GwAAADIYQSkAEbx6wesxaXHxDaRDplSeE5Q8T9DWckqHolIakLLv3ryDAwAAIMPxkRbAThfholkYaXDxDaSeo71Zt3eZc0RMil8WTmjS12laxMgAAACA3UZQCgCACmjMxyOOeNwgUBqwASkAAAAgCxCUAhDBZkgZhwtfYAct22S7zKVJUIosRgAAAGQLglIAIgSCjpigiATJxgBCTPo0wxidNHicPu0CAAAAdgdBKQARAkGPmFKPiD/AlgHcIJDNIEyPzRE0jg1KOQGiUgAAAMhsBKUA7BSUklIRh0wpwMahAmIkkFZBKY+IZjMGgmnTJgAAAGB36KBCABCiWVKekh0XvECO03EoS/XloIGg7QNTplwwuH3YPR0QEAAAAMhkKc2Uat68uTiOs9M0dOhQ+3hxcbH9vV69elKrVi3p16+frF69OmIZy5cvl5NPPllq1KghDRo0kOuuu05KS/USAsDucEod8RQbkVK67wHabc9vPOIPekU0GKR9+VLMaDsCbvc9AAAAIHOlNCg1Z84cWblyZWiaOnWqvf/MM8+0P4cPHy6TJk2Sl19+WT788EP59ddfpW/fvqG/DwQCNiBVUlIin376qTzzzDMyfvx4GTFiRMrWCch0Hr+ItzgoThpcfAPpEJTaZnzbg1Iap02H14UNSIk4JXwBAwAAgMzmGJMOn7C3GzZsmEyePFmWLFkiGzZskPr168uECRPkjDPOsI9/++230qZNG5k5c6YcccQR8vbbb0vv3r1tsKphw4Z2nscee0xuuOEG+e233yQ/Pz+q59XnKioqkuOkj/icvISuI5Du/I2LxFsSFM/vG1PdFCDlfDWDUqdjQH4rqS0l/60m+T+tS2kXPu1FuG2fQnHEK/m/bBKnxJ+6xgAAAAAVKDV+mS4TZf369VJYWJj+hc412+m5556TQYMG2S588+bNE7/fL927dw/N07p1a2nWrJkNSin92b59+1BASvXs2dMGmRYsWFDhc23bts3OEz4B2M67pVQ8m7exOYAdRcWLg3lSGvCKx2/H4EstrWtVqhmNhmxGAAAAZLy0CUq9/vrrsm7dOrngggvs7VWrVtlMpzp16kTMpwEofcydJzwg5T7uPlaRUaNG2cwod2ratGkC1gjITJ71m0WKtdI5AK0lvjWQJ4FSjzj+9BjtzqNBqW1B6r4BAAAg46VNUOqpp56SXr16SZMmTRL+XDfddJNNIXOnFStWJPw5AQCZxxhHikvzxPg94pSkR/F/zZLybAukR30rAAAAoAp8kgaWLVsm7733nrz66quh+xo1amS79Gn2VHi2lI6+p4+588yePTtiWe7ofO485SkoKLATAAC7Ckr5S73i+B3xlGjeVGppPSvP+q103QMAAEBWSItMqaeffloaNGhgR9JzHXrooZKXlyfvv/9+6L7FixfL8uXLpUuXLva2/vz6669lzZo1oXl0BD8totW2bdskrwUAIOtoMpLfY0ellDQZ7c7xl9J1DwAAAFkh5ZlSwWDQBqUGDhwoPt//mqO1ngYPHixXX3211K1b1waarrjiChuI0pH3VI8ePWzwqX///jJmzBhbR+rmm2+WoUOHkgkFAKg6zUwqccS7LShOIPWZUgAAAEA2SXlQSrvtafaTjrpX1v333y8ej0f69etnR8zTkfUeffTR0ONer1cmT54sQ4YMscGqmjVr2uDW7bffnuS1AABkI+0u5y02dlRKCRKUAgAAAOLJMYZKqRs2bLCZWcdJH/E5eXHdwACQiYzHI44jIjmeHWR8HgnUqSHezSXibGVUSgAAACAapcYv02WiHVxOe76lbaYUACAN1cgX43jE2bhFcplTGhTffzeluhkAAABAVkqLQucAgPRiNE3KpkoBAAAAQGIQlAIA7EzjUV4PgSkAAAAACUNQCgBQPjKlAAAAACQQQSkAQPnovQcAAAAggQhKAQDKZ9gwAAAAABKHoBQAoHyGqBQAAACAxCEoBQDYmcajgkECUwAAAAAShqAUAGAnjmZJBcmUAgAAAJA4vgQuO/N4HGqoAIDyB8SRINsCAAAAQMIQlArn9YqUJm5jA0CmcLb5U90EAAAAAFmO7nthjMP45wAAAAAAAMlAUIqtAQAAAAAAkHQEpcL5vMnfAwAAAAAAADmIoFQY46X7HgAAAAAAQDIQlApHTSkAAAAAAICkICgFAAAAAACApCMoFS5okr8HgGjQsxQAAAAAkGUISoVxAsHU7QmgAqZ6vpjaNdk+AAAAAICsQlAqHEEppCHjccT4PGRLAQAAAACyCkGpcHTfQxoyHhGT5xHx8HIFAAAAAGQPrnLDOASlkI4cEeN1GB0SAAAAAJBVCEqFC1JTCunHEJQCAAAAAGQhglLhyJRCOrJBqe3BKQAAAAAAsgVBKSAD2IAUQSkAAAAAQBYhKAWkOwJSAAAAAIAsRFAKyADG/kuqFAAAAAAgexCUAjKAExaaAgAAAAAgGxCUAtKdxqKIRwEAAAAAsgxBKSADOASmAAAAAABZhqAUkO40IBXcEZgCAAAAACBLEJQC0pwGo5yAETFEpQAAAAAA2YOgFJDujIjHBqVS3RAAAAAAAOLHF8dlAUgAJygi/qBIUH8BAAAAACA7EJQC0pytJVVK9z0AAAAAQHYhKAWku+IScbb5U90KAAAAAADiiqAUkOacoKZKUVAKAAAAAJBdKHQOAAAAAACA3ApKBQIBueWWW6RFixZSvXp1admypYwcOVKM+V9WiP4+YsQIady4sZ2ne/fusmTJkojlrF27Vs477zwpLCyUOnXqyODBg2XTpk0pWCMAAAAAAACkfVDq7rvvlnHjxsnDDz8sixYtsrfHjBkjDz30UGgevT127Fh57LHHZNasWVKzZk3p2bOnFBcXh+bRgNSCBQtk6tSpMnnyZPnoo4/k4osvTtFaAYlhalYTKchn8wIAAAAAsoJjwtOSkqx3797SsGFDeeqpp0L39evXz2ZEPffcczZLqkmTJnLNNdfItddeax9fv369/Zvx48fLOeecY4NZbdu2lTlz5kinTp3sPFOmTJGTTjpJfv75Z/v3u7JhwwYpKiqS46SP+Jy8BK4xsPuCRTXE4w+KbPlfQBYAAAAAgHRTavwyXSbaGI72akvLTKkjjzxS3n//ffnuu+/s7S+//FJmzJghvXr1srd//PFHWbVqle2y59LgUefOnWXmzJn2tv7ULntuQErp/B6Px2ZWlWfbtm02EBU+AenOeBw7AQAAAACQDVI6+t6NN95oA0KtW7cWr9dra0zdeeedtjue0oCU0syocHrbfUx/NmjQIOJxn88ndevWDc1T1qhRo+S2225L0FoBCaIBKQ9jEwAAAAAAskNKr3Bfeuklef7552XChAkyf/58eeaZZ+Tvf/+7/ZlIN910k00hc6cVK1Yk9PmAuPB6RHxeEZKlAAAAAABZIKWZUtddd53NltLaUKp9+/aybNkym8k0cOBAadSokb1/9erVdvQ9l97u2LGj/V3nWbNmTcRyS0tL7Yh87t+XVVBQYCcgk9jibwSkAAAAAABZIqWZUlu2bLG1n8JpN75gMGh/b9GihQ0sad0pl3b301pRXbp0sbf157p162TevHmheT744AO7DK09BWQNAlIAAAAAgCyS0kypU045xdaQatasmbRr104+//xzue+++2TQoEH2ccdxZNiwYXLHHXfIfvvtZ4NUt9xyix1R77TTTrPztGnTRk488UT585//LI899pj4/X65/PLLbfZVNCPvARkjZeNkAgAAAACQZUGphx56yAaZLrvsMtsFT4NIl1xyiYwYMSI0z/XXXy+bN2+Wiy++2GZEde3aVaZMmSLVqlULzaN1qTQQ1a1bN5t51a9fPxk7dmyK1gpIYKIUgSkAAAAAQJZwjDE5f5mrXQKLiorkOOkjPicv1fsEKFdgz1ri8Ys46zexhQAAAAAAaavU+GW6TLSDyxUWFqZnphSAGASMSGB7vTUAAAAAADJdSgudA4ieEzR2AgAAAAAgG5AppWV6dvRgLBU/NXuQtkywZPvIlMaf6qYAAAAAAFAhG18Ji7dUhKCUiGzcuNFujBnyVqUbC0ipDWx/AAAAAEBmxVu0hndFKHQuYrNPfv31V6ldu7Y4jh3jLGEF1Zs2bSorVqyotNAXcgfHBDgewDkCvGeAzxHgcyW41kC2XX9qhpQGpJo0aSIeT8WVo8iU0sJaHo/svffekiy68wlKgWMCnCPA+wb4HAE+W4JrDXD9iWRLVkyisgwpF4XOAQAAAAAAkHQEpQAAAAAAAJB0BKWSqKCgQG699Vb7E+CYAOcI8L4BPkeAz5bgWgNcfyKXYxIUOgcAAAAAAEDSkSkFAAAAAACApCMoBQAAAAAAgKQjKAUAAAAAAICkIygVR6NHjxbHcWTYsGGh+4qLi2Xo0KFSr149qVWrlvTr109Wr14d8XfLly+Xk08+WWrUqCENGjSQ6667TkpLS+PZNCTJ3/72N3sMhE+tW7cOPc7xkJt++eUXOf/88+15oHr16tK+fXuZO3du6HFjjIwYMUIaN25sH+/evbssWbIkYhlr166V8847TwoLC6VOnToyePBg2bRpUwrWBlXVvHnznc4TOul7heI8kVsCgYDccsst0qJFC/v6b9mypYwcOdKeF1ycI3LPxo0b7efJffbZxx4XRx55pMyZMyf0OMdE9vroo4/klFNOkSZNmtj3htdffz3i8Xjt+6+++kqOPvpoqVatmjRt2lTGjBmTlPVD/I+JV199VXr06GE/Z+rjX3zxxU7L4LNF7hwTfr9fbrjhBnu9UbNmTTvPgAED5Ndff03b8wRBqTjRDwqPP/64dOjQIeL+4cOHy6RJk+Tll1+WDz/80B4Mffv2jfgwqgGpkpIS+fTTT+WZZ56R8ePH2zcbZKZ27drJypUrQ9OMGTNCj3E85J4//vhDjjrqKMnLy5O3335bFi5cKPfee6/sscceoXn0BD927Fh57LHHZNasWfYNpGfPnvYDhEvfNBYsWCBTp06VyZMn2zejiy++OEVrhaq+X4SfI3SfqjPPPNP+5DyRW+6++24ZN26cPPzww7Jo0SJ7W88JDz30UGgezhG556KLLrLnhn/961/y9ddf2wtODT7olxyKYyJ7bd68WQ466CB55JFHyn08Hvt+w4YN9pjSoOe8efPknnvusV+sPvHEE0lZR8T3mNDHu3btat8/KsJni9w5JrZs2SLz58+3X3jpTw1aLl68WE499dSI+dLqPGFQZRs3bjT77befmTp1qjn22GPNVVddZe9ft26dycvLMy+//HJo3kWLFulXn2bmzJn29ltvvWU8Ho9ZtWpVaJ5x48aZwsJCs23bNvZOhrn11lvNQQcdVO5jHA+56YYbbjBdu3at8PFgMGgaNWpk7rnnnohjpaCgwPz73/+2txcuXGjPG3PmzAnN8/bbbxvHccwvv/yS4DVAoul7RsuWLe2xwHki95x88slm0KBBEff17dvXnHfeefZ3zhG5Z8uWLcbr9ZrJkydH3H/IIYeYv/71rxwTOUTf+1977bXQ7XidDx599FGzxx57RFxr6OeVAw44IElrhngdE+F+/PFH+/jnn38ecT+fLXL3mHDNnj3bzrds2bK0PE+QKRUH2uVCs530G6xwGlHU9Lnw+7UrV7NmzWTmzJn2tv7U1LqGDRuG5tFvOzQyqZFLZB5NodY0yX333ddGoLV7puJ4yE1vvPGGdOrUyWbBaPfcgw8+WJ588snQ4z/++KOsWrUq4jxRVFQknTt3jjhPaFqtLsel83s8HvstKTKXZsk+99xzMmjQIJt+zXki92i3rPfff1++++47e/vLL7+0Gba9evWytzlH5B4t4aCZ9NpdIpx21dJjg2Mid8Vr3+s8xxxzjOTn50dcf2g2hWZ4I7vw2QLr16+3nzP13JCO5wmCUlX0wgsv2LS4UaNG7fSYvmnoTnR3vksDUPqYO094QMp93H0MmUU/FGj3yylTptjuGPrhQfvham0Ijofc9MMPP9hjYb/99pN33nlHhgwZIldeeaXtqhv+Oi/vPBB+ntCAVjifzyd169blPJHhtAbAunXr5IILLrC3OU/knhtvvFHOOecc+6WVdvPVwLXWEtIvNRTniNxTu3Zt6dKli60tpmUfNEClwWu9QNAuvxwTuSte+57rj9zCZ4vcVlxcbGtMnXvuubZ+VDqeJ3xxXVqOWbFihVx11VW2H2bZb7OQm9xvtpXWF9MglfbDfemll+w3nMg9wWDQfgtx11132dt6wfnNN9/YWhADBw5MdfOQYk899ZQ9b2h2JXKTvj88//zzMmHCBFuTUAvUalBKjwnOEblLa0lpBuVee+0lXq9XDjnkEHtBoRkPAABEQ3ttnXXWWXaABP2SPF2RKVUF+sFgzZo19oOCRhZ10mLmWnxQf9dIonbN0G/Bw+noe40aNbK/68+yo/G5t915kLk0S27//feXpUuX2v3J8ZB7dHSctm3bRtzXpk2bULdO93Ve3nkg/Dyh55qy3Tt01AzOE5lr2bJl8t5779mCxi7OE7lHR9x1s6W0O3///v1tQVo3A5tzRG7SURj1M6WOhKRfgs6ePdteXGhpAI6J3BWvfc/1R27hs0VuB6SWLVtmk2jcLKl0PE8QlKqCbt262RFR9FtNd9KMCE25d3/XVHytFeHSPph6Mapp2Up/6jLCDwr3oCl7IYvMox8mv//+exuYOPTQQzkecpCOvKev+3BaO0Yz6JQOA68n9vDzhNaU0/7c4ecJDW6Hf0P+wQcf2CwszcZDZnr66adt6rTWJHRxnsg9OkqO1nAIp5kx+vpWnCNym46spp8htH6HdgHv06cPx0QOi9f5QOfRkbb0ojX8+uOAAw6IGB0Y2YHPFrkbkFqyZIn9ArRevXoRj6fdeSLupdNzXPjoe+rSSy81zZo1Mx988IGZO3eu6dKli51cpaWl5sADDzQ9evQwX3zxhZkyZYqpX7++uemmm1K0BqiKa665xkyfPt2OfvHJJ5+Y7t27mz333NOsWbPGPs7xkHt0tAufz2fuvPNOs2TJEvP888+bGjVqmOeeey40z+jRo02dOnXMxIkTzVdffWX69OljWrRoYbZu3Rqa58QTTzQHH3ywmTVrlpkxY4Yd8fPcc89N0VqhqgKBgH1v0FFMyuI8kVsGDhxo9tprLzvSmr53vPrqq/Z94/rrrw/Nwzki9+jnQR0J6YcffjDvvvuuHdm3c+fOpqSkxD7OMZHdo3rr6Gk66aXafffdZ393R82Kx77X0dgaNmxo+vfvb7755hvzwgsv2M8mjz/+eErWGVU7Jn7//Xd7+80337SP6/7U2ytXrgwtg88WuXNMlJSUmFNPPdXsvffeNr6gx4E7hY+kl07nCYJSCQ5K6RvEZZddZodT1J14+umnR5wg1E8//WR69eplqlevbj+IamDD7/fHu2lIgrPPPts0btzY5Ofn24sMvb106dLQ4xwPuWnSpEk2+KxDNrdu3do88cQTEY/rEM+33HKLPfHrPN26dTOLFy+OmEc/cOgbRa1atUxhYaG58MIL7RsSMtM777xjP0SU3c+K80Ru2bBhg/3coEHKatWqmX333df89a9/jfjgyDki97z44ov2WNDPE40aNTJDhw61FwgujonsNW3aNPv+UHbSAHY89/2XX35punbtapehn1k12IXMPCaefvrpch+/9dZbQ8vgs0XuHBM//vhjuY/ppH+XjucJR/+Jb+4VAAAAAAAAUDlqSgEAAAAAACDpCEoBAAAAAAAg6QhKAQAAAAAAIOkISgEAAAAAACDpCEoBAAAAAAAg6QhKAQAAAAAAIOkISgEAAAAAACDpCEoBAAAAAAAg6QhKAQAAAAAAIOkISgEAAGSgZcuWSfXq1WXTpk2pbgoAAMBuISgFAACQgSZOnCjHH3+81KpVK9VNAQAA2C0EpQAAAFLouOOOkyuuuEKGDRsme+yxhzRs2FCefPJJ2bx5s1x44YVSu3ZtadWqlbz99ts7BaVOPfVU+7vjODtNzZs3T9EaAQAARIegFAAAQIo988wzsueee8rs2bNtgGrIkCFy5plnypFHHinz58+XHj16SP/+/WXLli12/nXr1smMGTNCQamVK1eGpqVLl9og1jHHHJPitQIAAKicY4wxu5gHAAAACcyUCgQC8vHHH9vb+ntRUZH07dtXnn32WXvfqlWrpHHjxjJz5kw54ogjZMKECXL//ffLnDlzIpalH+v69esny5cvt8vTmlMAAADpypfqBgAAAOS6Dh06hH73er1Sr149ad++feg+7dKn1qxZs1PXvXB/+ctfbOBq7ty5BKQAAEDao/seAABAiuXl5UXc1ppQ4ffpbRUMBqWkpESmTJmyU1Dqueees9lTr732muy1115JajkAAMDuIygFAACQQaZPn24Loh900EGh+zQ76qKLLpLHH3/cdu8DAADIBHTfAwAAyCBvvPFGRJaU1ps6/fTT5ZxzzpGePXva2243wPr166ewpQAAAJUjUwoAACCDg1LffvutrF692o7gp8XQ3emwww5LaTsBAAB2hdH3AAAAMsT8+fPlhBNOkN9++22nOlQAAACZhkwpAACADFFaWioPPfQQASkAAJAVyJQCAAAAAABA0pEpBQAAAAAAgKQjKAUAAAAAAICkIygFAAAAAACApCMoBQAAAAAAgKQjKAUAAAAAAICkIygFAAAAAACApCMoBQAAAAAAgKQjKAUAAAAAAICkIygFAAAAAACApCMoBQAAAAAAAEm2/wccTCCuNgUjqQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "FACTOR = 10 ** 1                      # 10^resolution (resolution=1 above); bins are 0.1 Th\n",
+    "\n",
+    "def window_start_bin(w, window_length=10.0, factor=FACTOR):\n",
+    "    \"\"\"Absolute m/z bin index where a tile's window begins (mirrors the Rust layout).\"\"\"\n",
+    "    w = float(w)\n",
+    "    return round(w * window_length * factor) if w >= 0 \\\n",
+    "        else round((-w * window_length - 0.5 * window_length) * factor)\n",
+    "\n",
+    "rows_i, cols_c = np.nonzero(X > 0)                       # every populated tile-cell\n",
+    "abs_bin  = np.array([window_start_bin(win_idx[i]) for i in rows_i]) + cols_c\n",
+    "scan_of  = scan_idx[rows_i].astype(int)\n",
+    "inten_of = X[rows_i, cols_c]\n",
+    "\n",
+    "b0, b1 = abs_bin.min(), abs_bin.max()\n",
+    "s0, s1 = scan_of.min(), scan_of.max()\n",
+    "img2 = np.zeros((s1 - s0 + 1, b1 - b0 + 1), np.float32)\n",
+    "np.maximum.at(img2, (scan_of - s0, abs_bin - b0), inten_of)   # max collapses overlap dups\n",
+    "\n",
+    "n_unique = len(set(zip(scan_of.tolist(), abs_bin.tolist())))\n",
+    "print(f\"{len(abs_bin)} tile-cells -> {n_unique} unique (scan, m/z) pixels \"\n",
+    "      f\"({len(abs_bin) - n_unique} overlap duplicates removed)\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "ax.imshow(np.log1p(img2), aspect=\"auto\",\n",
+    "          extent=[b0 / FACTOR, b1 / FACTOR, s1, s0], cmap=\"viridis\")\n",
+    "ax.set_xlabel(\"m/z\"); ax.set_ylabel(\"scan (ion mobility)\")\n",
+    "ax.set_title(\"m/z–ion-mobility image reassembled from the dense-window output\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b9729a5",
+   "metadata": {},
+   "source": [
+    "## 6 · Build an m/z–retention-time map\n",
+    "\n",
+    "For feature-detection-style views you want **m/z vs retention time**. There is no\n",
+    "built-in helper yet, so we stack frames along RT ourselves: build many precursor frames,\n",
+    "collapse each over the ion-mobility axis, and index the rows by `retention_time`. The\n",
+    "dominant-label logic gives us an aligned peptide-id map on the same grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d9839076",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:58.311041Z",
+     "iopub.status.busy": "2026-07-02T09:33:58.310979Z",
+     "iopub.status.idle": "2026-07-02T09:33:58.405251Z",
+     "shell.execute_reply": "2026-07-02T09:33:58.404901Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "built 153 annotated frames (RT 0.0–59.8 min)\n",
+      "m/z–RT map shape: (153, 8001) (RT rows x m/z bins)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Sub-sample precursor frames across the gradient to keep this quick.\n",
+    "step = max(1, len(precursor_ids) // 150)\n",
+    "sample_ids = precursor_ids[::step]\n",
+    "frames = builder.build_precursor_frames_annotated(sample_ids, num_threads=8)\n",
+    "print(f\"built {len(frames)} annotated frames \"\n",
+    "      f\"(RT {frames[0].retention_time/60:.1f}–{frames[-1].retention_time/60:.1f} min)\")\n",
+    "\n",
+    "MZ_LO, MZ_HI, MZ_BIN = 400.0, 1200.0, 0.1\n",
+    "mz_axis = np.arange(MZ_LO, MZ_HI + MZ_BIN, MZ_BIN)\n",
+    "rt      = np.array([f.retention_time for f in frames]) / 60.0     # minutes\n",
+    "mzrt    = np.zeros((len(frames), mz_axis.size), np.float32)\n",
+    "lblrt   = np.full((len(frames), mz_axis.size), -1, np.int32)\n",
+    "\n",
+    "for r, f in enumerate(frames):\n",
+    "    d = f.df\n",
+    "    if len(d) == 0:\n",
+    "        continue\n",
+    "    col = np.round((d.mz.to_numpy() - MZ_LO) / MZ_BIN).astype(int)\n",
+    "    ok  = (col >= 0) & (col < mz_axis.size)\n",
+    "    col, iv, pv = col[ok], d.intensity.to_numpy()[ok], d.peptide_id.to_numpy()[ok]\n",
+    "    np.add.at(mzrt[r], col, iv)                       # collapse the ion-mobility axis\n",
+    "    o = np.argsort(iv, kind=\"stable\")\n",
+    "    lblrt[r, col[o]] = pv[o]\n",
+    "\n",
+    "print(\"m/z–RT map shape:\", mzrt.shape, \"(RT rows x m/z bins)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "fb8953f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:58.406325Z",
+     "iopub.status.busy": "2026-07-02T09:33:58.406258Z",
+     "iopub.status.idle": "2026-07-02T09:33:58.553837Z",
+     "shell.execute_reply": "2026-07-02T09:33:58.553540Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEAAAAHqCAYAAAAEQDtgAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAnHpJREFUeJzs3QmcHGW1NvCnqnqfNZM9kpCAKPsiKCKIIAgiIggqeBEjouiVHbwC18smKosfiCiCeBX0KqIooqCyiCCCyL6Iyh6SQPbM2mtt7/c776THmclMMtNT3V1d/fyxzEz3THVNbd116rznGEopBSIiIiIiIiKiCDPrvQBERERERERERNXGAAgRERERERERRR4DIEREREREREQUeQyAEBEREREREVHkMQBCRERERERERJHHAAgRERERERERRR4DIEREREREREQUeQyAEBEREREREVHkMQBCRERERERERJHHAAgREYXOwoUL8alPfQphcv/998MwDP0vTZ7v+9hxxx3xta99beixG2+8Ua/T1157reFXab33Dzle5LhpNHfeeSdaW1uxdu3aei8KERE1AQZAiIjq5KijjsIHPvCBUK3/m266CVdddVVNXuuvf/0rLrzwQvT29iJMvvvd7+oLcwrWz372Myxfvhwnn3xyIPP75z//qfefMAdPank81UI2m8UFF1yA97///ejq6tIBn6keKzKvN7/5zbjkkksCW04iIqLxMABCRFQHjuPgnnvuwaGHHtrUAZCLLrpozADICy+8gO9///sIUwBk3333RaFQ0P/S5H3jG9/AMcccg46OjqHHjjvuOL1Ot9xyy4oCILL/hCUAMtb+EbUAyLp16/CVr3wF//rXv7DLLrsENt/Pfe5z+N73voeBgYHA5klERDQWBkCIiOrgL3/5i/6wX+0ASC6XQyNKJpOIx+MIE9M0kUql9L80OU899RSeeeYZfOxjHxvxuGVZep1KJkGja4b9Y+7cuVi5ciWWLl2qA1pBZsOVSiXccsstgc2TiIhoLNF9lyYiqgJJuZeLtRdffBGf+MQn9N3smTNn4rzzzoNSSqf4H3744Whvb8ecOXNwxRVXjDmf3/3ud9h+++31mP1y7YCxpsmM6S8vm9wZ/4//+A9MmzYN++yzz9DzP/nJT7D77rsjnU7r9HW5Gy/LW7bffvvp5ZKLm7FeXy5QJP1d0tUlQDF//nx86Utf0o8PJ78nwxxuu+02XfNBfnaHHXbQY/2HL+t//dd/6a8XLVo09Hrlu/lj1QB59dVX8dGPflQveyaTwTvf+U69vMOV1+UvfvELXWtiiy220BelBxxwAF5++eXNrkN53X/84x/485//PLRMsl7Gq/Egz8nf+Oyzz+I973mPXi5ZP7/85S/18zKfPffcU6/zt771rfjjH/+40Wu+8cYb+PSnP43Zs2cPrasf/vCHm13W4etaLhxlf5LX2WuvvfD3v/9dPy931WV5ZB3Iso7OlpBAnKzTBQsWDG3TM844Q2cyDCfbQuo0yDY4+OCD0dLSgnnz5ulsANnvN0f2hUQisVH2zFg1QGQbfPCDH8SDDz6Id7zjHXrZt9pqK/z4xz8e8Xuy3GL//fcf2lbDt80f/vAHvPvd79bL2tbWpoONsm3H+rtkGxxxxBH6azmev/jFL8LzvBE/e/PNN+vjR+Ylx/dOO+2Eb33rW0PPj94/xjueZBiJLNNpp5220Xp6/fXXdVAoqOEgEgA966yz9HaV7Sv74P/7f/9vo20m2/vUU0/FjBkz9N/3oQ99SK8TWWY5VstkHnJem4jydrz77rux66676u0o++itt9660c/OmjULO++8M37zm98E8FcTERGNL7aJ54iIaBxHH300tttuO1x66aX6IuerX/2qvjCXC873vve9uOyyy/DTn/5UX0i9/e1v3+jC7/e//72+OBAyn//7v/8b8bwMCznzzDP1hcFkyYXhNttsg69//etDFzoSDJAgjdyB/8xnPqMLDn7729/WyyV35zs7O/HlL38ZfX19+iLsm9/8pv49uSAsF7CUiyK5KD3xxBP1MstFtvycBIPkAnc4+Tm50PnCF76gL6iuvvpqfZd32bJlmD59Oo488kj9e1IXQuYhF15CLj7Hsnr1arzrXe9CPp/XF2oyjx/96Ed6mSTY8OEPf3jEz8t2kTvxsv7lb7r88stx7LHH4pFHHtnkupPhCqeccor+u2V9CAlMbEpPT4/elhJQknV/7bXX6q9l+59++un4/Oc/rwNScsf8Ix/5iA46yTop/10SyCkHMuTvlwv3E044Af39/fr3N0eCGL/97W9x0kkn6e/l4lmWR4JTMpxHtoEso6wDCbT86U9/GvpdCZzIOv3P//xPvU4fffRRvV/IPjD6brwEBKRegyyvzEsCWhIQc11XB0I2N9xJAkUTzeqRYJWsK1kPixcv1gEhCVZIAEICRLLfyn4g+9V///d/6/1RlP+V40l+T4I1cizK3yjbRQKCsr8PD+zJ3yU/J4EqCQ5IkEoCl1tvvbVeL0KGq3384x/XgTSZn5BhIA899NCYgQwx3vEkk+yvP//5z3HllVfqgEeZHA9yzMq+OlUyHzk+7rvvPr0eJQhx11136cCjBDfKyyRk3UrQUIYkyfaVwF0Q2WkvvfSSPlfKMSDb44YbbtDHiOw773vf+0b8rGzb0ecRIiKiwCkiIpqwCy64QCIK6sQTTxx6zHVdtcUWWyjDMNSll1469HhPT49Kp9Nq8eLFI+bx6quv6nncd999Y76G7/vqgx/8oGptbVX/+Mc/Jr1sH//4x0c8/tprrynLstTXvva1EY///e9/V7FYbMTjhx56qNpyyy03mvf//d//KdM01V/+8pcRj1933XX6NR966KGhx+T7RCKhXn755aHHnnnmGf34t7/97aHHvvGNb+jHlixZstHryTIMX2+nn366/tnhrz8wMKAWLVqkFi5cqDzP04/JOpWf22677VSpVBr62W9961v6cfmbN2eHHXZQ73nPezZ6vDzv4dtNfk4eu+mmm4Yee/755/Vjsr7+9re/DT1+11136cdvuOGGocdOOOEENXfuXLVu3boRr3XMMceojo4Olc/nN7msMr9kMjliHX7ve9/Tj8+ZM0f19/cPPX7uuedutL7Hmv8ll1yi9+WlS5cOPSbbQn73lFNOGbGfyv4i23rt2rWbXE45Po466qiNHpd1MXqZZNvLYw888MDQY2vWrNF/51lnnTX02C233DLmcST7RWdnp/rsZz874vFVq1bpdTr88fLf9ZWvfGXEz+62225q9913H/r+tNNOU+3t7fpYH89Y+8d4x1N5X/jDH/4w4vGdd955zH1vIuRvGf5at912m36Nr371qyN+7iMf+YjevuXj84knntA/J8fYcJ/61Kf043JeGctjjz220f48XHk7/upXvxp6rK+vT+/vsn5H+/rXv65/fvXq1ZP8y4mIiCaOQ2CIiCogWRRlcgd3jz320Hdc5U5rmWRVSMq5DBsYTjJGZOjM8OEpw1188cW44447dJq/pIxPltxtHU4yMSSDQ7I/pIhheZJUdskUkTvEmyPZAHJ3fdtttx0xD8l2EaPnceCBB+o76GWS3i7DBkavi4mSjBkZDjF8ncmddMlGkeETMuxnuOOPP14PuSiToRCi0tffFFkOyfgok20u217Wl2QVlJW/Li+D7C+/+tWvcNhhh+mvh69XyUiQ7IEnn3xys68vWQnDMxrKryMZN+VMk7FeX8iQmeHDJeS1JdNGlkcyJUYb3sGlnLVi2/aYQ3uGW79+vR6SNVGy35e3mZDMmLGOpbFItoZkUEnGxvB1KseprIOx9vfRx4y89vDXku0p60fmHQQ5PmQIkWQJlT333HN6KJUMrQuCHDPyN0umzHAyJEa2r2QaifLQNMkUGk4yoaZK/sbh2VlyDvjkJz+p961Vq1aN+Nny/iHbioiIqFo4BIaIqAJSM2E4CWjIGPfyUI7hj8vF3+gAyEEHHYRYbONTsFyMSGeLc889V1/AlsnF8Oi6DMMvDoen0UtNjdFp6HLBI8GOsUxkWILMQ1L+xxuismbNmk2un/IFjgzFqITUURgeTCgrD3mQ52WIxXivX764Kr++1GGQqUzW33h/2+ZInZHRRTxlu0vdhdGPDV8GGYYkF+rXX3+9niayXie6L4rNvb6QIUnnn3++HkIzetvIPjecDCmSWhzDveUtb9H/TqQTy0RqhQSx/8i+KsrBudHkInw4OW5Hb/vRryXBARkicsghh+BNb3qTPn4loChDgioh61KGuciwHBmeI7VjJBgiy1KubTJVckxIAGJ4EGz0MVP+V5Zn9HlDasdMlcxj9LExfJ8ZXk+kvH9EoSAuERGFFwMgREQVGB5w2NRjoy/85GJHiiTKhc9oS5Ys0RdFMjZeaooMJ3UGpObFWOT3hmcADL+rLyT7Qy4q5I7vWMtYrvOxKTIPKfooNQvGMvpieyLropo29/pS60ECTWXShrXSdqrjvdbmlkHWqZA7/lIfYSySOVOt15faF7KvdXd34+yzz9bZPVKcU+pDSE2I8vIFQeqLTCb4NZX9p7zcUgdkrIKdowOP473WcFKL5+mnn9Y1NOQ4kknqWUg2w3jH5ebI70pdGKl7Idkq0jJXarcMbxPcTMr7x+ggMhERUZAYACEiqiEpQCldU+RO8nCS3SGFQSXVXgohjm6lKQUtx0uN31xXBhmKIheOcoe3fPd1POPdfZV5SBtTGW4R1B3aycxHAhQvvPDCRo8///zzQ89P9uJz+HCa4UGjWt2BlqwDuTsvgQgZElFrUsRWCtHKBbysj7LxhnlIYEGGhQzfh+T3xea6FUlwRQJ1QdrUvloOWgS5XmVIlQxXkknWhWSFSNFjKS48XrbEpvYlyVjabbfddOaHZBFJNo4UoA2KHBMyNEnabQ/PAhl9zMi/8vfI9hmeJTaRrkmbI/OQc8/w9TDePiOvL8GPSjOxiIiIJoI1QIiIakjG5Uu9kNGdRaQGgVwY/PrXvx6zVoLURJCLubEmSZvfFAmsyF1uyXgYfQddvh8+REcyAEYPfRCS7i+ZAd///vc3ek6CN1IfYbLktYQMA9mcD3zgA7pDycMPPzz0mLymDB2RC6nJ1kqRoRzD1+Hee+89YrkmskxTJdtEhjlJHRCp/zCaDJGp9uuL4fuEfD28teto3/nOd0b8rHwvQ6gkMLYp0ppX/sbRLZOnYrz9R+qnyDAX6YLkOE4g63X0MDYJUJazczb1N413PJVJ1xVpEyvdhyRLZnRgdCrkmJHg2vBtJqT7iwQkyq8l60tIx6DhggjGrFixQp/TyqSzkbQzlo40owO3TzzxhN5PiIiIqokZIERENQ6ASIHO0TVB5KJALoalCKJMw4enHHHEEVN6TbkjLkNqpK6IDPOQ+ckdYbnjKhcnUkhU2sWWW1FKe05pwSvte+X15Y63XKhJDQQJ1EgRSQkYyMWV3E2Wx2VogAR2JkNeq9wuVIqIyoW0vFb5wna4c845R2fGyEWbFHWUlsOSuSB/gwQQRmfMTIUslwxRknUmd/Ylk2C8ehJTJe16ZX1KfZPPfvazOpAjQ1Kk+KncvZevq0WyMmTfkG0vwS0JGsi6HG+oigTapEaNDNeR5ZVhILLvShvazd21P/zww3VxX2mvKvUzgiAX0RLEkba0EmRIJpN6O8n2ku0n++zb3vY2vW/J8kmGhSyv7LujgwITKXos20LmL9kaUjdDAgSyDOWaGmMZ73gqk/bIkt0lx6G03B2rHk85U2KyQ7Tkdfbff399fMnv7rLLLjrY8pvf/Ea3Vy5nysgyyrlHgjAS6Cm3wS1naozOYpF1J0EnCW6I22+/Xbf6LRdOHT6ER7KFpDD0Y489poO+0s5YWj/L8KHRtW7kvFdu5UxERFQ1k+gYQ0TU9MqtZke3/ZQWlC0tLRutH2lpKW1VxXPPPad/99FHHx2zFehY01gtNCe7bGXSjnKfffbRyynTtttuq0466ST1wgsvDP1MNptV//Ef/6HbiI5+fdu21WWXXab/HmlJOm3aNN0q9KKLLtLtLcvk92S+m2ttKy6++GL1pje9SbeMHd4OdayffeWVV3QLT1m2VCql3vGOd6g77rhjzFak0iJ1OJnvplp2jm6XKu1L29ra9O+U25KO1wa3vH1H/60yj9HGWjfS9lMemz9/vorH47p97QEHHKCuv/76zS7rWPMr/63SZnhz6+af//ynOvDAA3XL5RkzZugWseWWxcPXVXn/lm1w0EEHqUwmo2bPnq33uXIL4s2RFq/S9ncibXDHWneyrke3iP3+97+vttpqK93mefS2ka8PPvhg3fpW9pett95at3Z9/PHHN/q7xjuWyn75y1/qv3vWrFm67e+CBQvU5z73ObVy5cqN1u/wZdjU8VT2gQ98QD/317/+dcz1Jtvlne98p5psG9xyS+AzzjhDzZs3T+9b22yzjd4vpIXxcLlcTu9HXV1del844ogj9HlBlmt4a+/h7W3HmsbajtLyV7a9nDPknDP62BTXXnut3qeGt20mIiKqBkP+r3rhFSIiKrv88st1EdGVK1ey0wE1FCmK+stf/nJE55zJkqKkcodfMjGk1g0NkjaxUo9lrJob0t55hx120G2xDz300JquMin6KjVKfvKTn+jizJMlmStS50SWfXPkdfbbbz89PIeIiKiaWAOEiKhG5IKgPP6eqNnIRbS0t73mmmvqvSihIcFQGZYjw3XGIsOjpC5GtYMfY7XYliExMrRs3333repry7AqaV0sQ/SIiIiqjTVAiIhqRAqJEjUruZgeq9hrM5LaNQ899BD+93//V9f9+NznPjfmz0nGTC3qYkh2mhQhlZoh0ia43OpX6gONbnEdtPe///1TyiwiIiKaDAZAiIiIiGpIioxKMWTJiJFivptrZV1t73rXu3T7YylUK8EIWa4LL7xQF1AlIiKKEtYAISIiIiIiIqLIYw0QIiIiIiIiIoo8BkCIiIiIiIiIKPIiXwPE932sWLECbW1t7LxARERERETUBJRSGBgYwLx583Qh7qgqFouwbTuw+SUSCaRSKURV5AMgEvyodgVzIiIiIiIiCp/ly5djiy22QFSDH4sWvQmrVnUHNs85c+bobmVRDYJEPgAimR+DjA0TERERERERRZvS07+vB6NHMj8k+PHa0l+gvT0z5fn19+excMuP6fkyANKgDKMc9GAAhIiIiIiIqHmopiiD0N6aQntreuoz8n1EXeQzQIiIiIiIiIgiSwIXQQQv/OgHQKJbDabBWLBgNNnmMGHC4LAkivT+3VzHdP3Imua6JiIiIqJN4yfGkOiItyFpRrPQzHgyVgssg0lIFE2tsRakzZZ6L0ZTsAwLaau13otBREREVN8MkCCmiGMAJCQyVhpxI4lmIgEf3rWlqEqZScSbLKhZL3IeSRpc10RERES0abz9HhIl34anHDSLuJGAq1woXZ2ZNmdwKIWsLa6vRuH4DlxurqqLGYnB9a3s6r8YERERURgpNTgFMZ+IYwAkJHqdfngq+ilHZS1WO/LeANwmCvpMhYkYFHwouPVeFJqgAS/XDO8hdWYgY7Yi7w8g72frvTBERERE9eGrgIqgKkQdAyABkEKeU70z7zRZIEBqf3jKY0bDBEn7LqWi38IrSiTDiWpzLpFAk8fgIBERERFtBgMgU5QwY0iaSeTcInx4U51d0yh6OfhonoyXqfIZLCIag0LRz+vsKCIiIqKmxTa4E8YAyBQlzRg6Yq0oeq6+SKWJkXR11rOYOJ93t4nGVPRzPJcQERFRc2MAZMIYAJkqGW6lB/o37ngp0zSRsCz4ng/Pl1Ty6gdyGPwgIp5LiIiIiKiWGACZoqLvwHOlgGnjjvdvySQxf1onSv0FrM/56HUHGjqgQ0RERERE1DSYATJh0luTpsBRHvKe1P9o3DHoyUQMM9tb0ZVKIW2lwFKbREREREREtCkPPPAADjvsMMybN083bbjtttuGnnMcB2effTZ22mkntLS06J/55Cc/iRUrVqCeGAAh2I6H7mwefaUSir7N3I8akUBTWyqOtngCSTPBPZGIiIiIiCZP+f/OApnKpCZ3Uz+Xy2GXXXbBNddcs9Fz+XweTz75JM477zz976233ooXXngBH/rQh+q6hTkEhpDLF/GKvRa+68PV+zyHv9SCaRp4U0cLVBHoLgBrbZt7IxERERERTYqhfD1NlTHJeRxyyCF6GktHRwfuueeeEY995zvfwTve8Q4sW7YMCxYsQD0wANIkDBjjFh71PB95jxff9dgmiZgJZRmIGc33tw9iOVwiIiIiojDp7+8f8X0ymdTTVPX19emhMp2dnagXDoFpAgnDwrR4BnEjXu9FoWGke9CagSLWFgrIeoXQrRsDJiwEv88kLBOz21KYqWvOTP1ESkRERETU1IIY/uJvmADMnz9fZ3CUp0suuWTKi1gsFnVNkI9//ONob29HvTADpAnETQtdiRaUfAXHc+q9ODQiAFLQI45USLM0TCMGTwW7z8RjFua0ZeDkFTzfQd4rBTp/IiIiIqKm4qvBKYj5AFi+fPmIIMVUsz+kIOrHPvYxKKVw7bXXop4YAJkiEzH4CHcLXBlk4CpfX3BTuMg2GRyetHlxQxK2DLhKtmitug4Fv8/Iic/xfDi+quk+OTjsRtZ143ZsIiIiIiKqtvb29sCyNMrBj6VLl+JPf/pTXbM/BAMgUxwikDZbkfN7EWYl38O60gBsFe5ATTMH0QZDGpvePtMTaRiIo9spouQXq75cskRBZ3+Ikuvj9b4clAcUvdoFIywjDsOw4PjhG25ERERERFSxYcNXpsQP9rN5Ofjx0ksv4b777sP06dNRbwyATPGOctxMIew3lD3lI8thBqFlGhZ8iQZsRkssDkMl0e86qMWgEQnKKGx+uSbL8330FWtfdNeECcPgKY+IiIiIIqZOAZBsNouXX3556PslS5bg6aefRldXF+bOnYuPfOQjugXuHXfcAc/zsGrVKv1z8nwikUA98GpgCuTy0KnBnXiKNgl+TKQXSs4dzMZwJxAsoTHWM6Q9GLOgiIiIiIiC8Pjjj2P//fcf+v7MM8/U/y5evBgXXnghfvvb3+rvd9111xG/J9kg++23H+qBAZApDhEo+APBbQ1qSjL0ZSKVMNbbMnSjqGuA0OTp4TwMgBARERFR1Mj1gQogA0RN7jpDghhS32/82YXvuoUBkCnyqzBEoJEMFpYczIYJ07wayUT/XieIk1oTG1zPzbVvhU2zHuNEREREFA4MgNCUtFgZeAoo+Lkpr8nWWApKWch6Mi9eIBFFTdpKA8pEXp8veIwTERERRbkIahgxAEJTkrHScHwjkABIiyUBkDhyXo6XRkQRlDblGI/p8wXDH0REREQB8dXgFMR8Io4BEJoSKcjpq8G09qny9LxMbhGiiJJjXG0YBkNEREREVGsMgNCUZN3g7uT2uwUoVWR9AKKIynl5XQmENUCIiIiIAsQhMBPGAAhNia3swNZgyR9s80pE0eRIJx4iIiIiCpY0SwiifoeKfg0QjjegmnaAyFgpxI0E1zoRERERERHVFDNAqGZk5P+0eCv6HAeOF1zmCBERERERUbMyfF9PQcwn6hgACQnLMnU6juxzXoRTj4wN/238+OBzUk+E9QEamwFzwzaMfhXpTbHMDQl2Ssn/4Df5+iAiIiIiqjcGQEJi7tzp6DCB/nUOXs/3RTIIIH9Rn5tDaYzIYsK00BlPI+8aGPCyTX/x3KhihoUWqwVZtwgPzZvlI8G8WbM6EVM+VMFBvmCgx8lF8rgmIiIiojqTu20yBTGfiGMAJCRmzejA3LiBldkC3sj3R/JCSf6mAVe6QGwsbproSqQBZSDrZSP41zcHyzDRYmVQ8Fx4ARbIbTgGML2rDQnfg28U0OOY6HXykTyuiYiIiKjO2AVmwhgACYlCsYR+x0DBa84uCZ5SKPkuXLXx8BhqHL5ScJTLC30AxZIDTwIgrgdbMkEY/CAiIiIiqisGQEJi+evrsNoA7ILflLUCbN/DqmIWri91QJrv748KT3noc/rhKg/NTCmFlSu7B6vauD5cl7VtiIiIiKhKmAEyYQyAhEQ2W0AzkwyQfJNmv0SJBO/sZh76MkwuX6z3IhARERFRM/Cl4n4AN5H96N+I3tCmgIiIiIiIiIgoupgBQkRERERERNSoOARmwhgAIRqHlGM1DVN3g5LKLEREREREROEcAhPA9YrPITBETStmmJiZaEGL1QpDh0OIiIiIiIioUTEDhGgclmGiM56Grwxkvaz09uC6IiIiIiKicJGUdZmCmE/EMQBCtImOJgXP0a15iYiIiIiIqLExAEI0Dtf3saaUhSsBVWZ/EBERERFRGLEI6oQxAEK0qQwQ3+H6ISIiIiKi8NJdGzgEZiLMCf0UEREREREREVEDYwYIERERERERUaPiEJgJYwCEGrI7iwULrvLhw6v34hAREREREdUPAyATxiEw1HCmxdNYkJ6DjNVR70UhIiIiIiKiBsEMEGo4LbEEZia70OMoZL3uei8OERERERFR/fgBFUH1A5hHyDEAQg2n6Lnod7Jw/FK9F4WIiIiIiKi+lD84BTGfiGMAhBpOj5NH1l2Bku/We1GIiIiIiIioQTAAQpNibPhX6a/qkyJl+x5sFOry2kRERERERKHCITATxgAITUpXOgnDN5F3DOT9PNceRUrciMM0LJT8Yr0XhYiIiIiIAsYACE3KjEwSlhvHWt9EwS9A1SkLhKgaEmYCMSPOAAgRERERNQ62wZ0wBkBoUnylACVhj+gXyKHmI3s2g3pERERE1FA4BGbCGAChSVmdK8LwbZS8wYtFoiixfRsOWFyXiIiIiCiKGAChSekvOVxjFFmuYvCDiIiIiBoxA8QPZj4RxwAINbRWKwlPGSiwaCURVVnaTMBVCo5iIJiIiIhChENgJsyc+I8Shc+cVDu6Eh31XgwiijgDBjrjbWixWuq9KERERERUIWaAUENLGDE4BuN40WDoMqREYRUzTFgG91EiIiIKGx9QQTSp8BF1db1yfOCBB3DYYYdh3rx5MAwDt91224jnlVI4//zzMXfuXKTTaRx44IF46aWX6ra8FD7r7Cz63YF6LwZNkQkTaTPD9Uih1u/mUfCK9V4MIiIiImrEAEgul8Muu+yCa665ZsznL7/8clx99dW47rrr8Mgjj6ClpQUHH3wwikV+AKV/B0B6HQZAGp1pmMhYLXqYAVEYSdcrHQDxC/VeFCIiIqKxa4AEMUVcXYfAHHLIIXoai2R/XHXVVfif//kfHH744fqxH//4x5g9e7bOFDnmmGNqvLThZhkmDJhwlddUwwj8Jvpbo87X+y5ReLH1NxEREYUSi6BOWGiLJyxZsgSrVq3Sw17KOjo6sOeee+Lhhx+u67KFtRtKR6wNEgYhajSe8pDzsrzAJCIiIiKi5iuCKsEPIRkfw8n35efGUiqV9FTW39+PZpA044gbSQ4hoIa9s26rfx+3REREREQ0Qb4/OE2VzyKoDeeSSy7RmSLlaf78+WgGJd9BwS9WdAd9WjyDlJmsynIRUWNJmYmang+k7kvciCFmhDYeT0RERBRurAHS+ENg5syZo/9dvXr1iMfl+/JzYzn33HPR19c3NC1fvhzNIOuVdDcUf5Kti2TIzPx0J1pjLVVbNiJqHO2xDNpirTXLJpP6RWmrtkEXIiIiImpOoQ2ALFq0SAc67r333hHDWaQbzF577TXu7yWTSbS3t4+YmoGn/A0FUCcvbliwwrsr1JRc9LETCTUzy5ByyrU9H0ggVlqhExEREVEFmAEyYXXNOc5ms3j55ZdHFD59+umn0dXVhQULFuD000/HV7/6VWyzzTY6IHLeeedh3rx5OOKII+q52JEiA2ZWFPuQ9dx6L0po0v8tI4Gcl4OaZDYNURQMuDKUzqxZQVpf+Sj6Dvs5EREREVX8gYo1QBoiAPL4449j//33H/r+zDPP1P8uXrwYN954I770pS8hl8vhxBNPRG9vL/bZZx/ceeedSKVSdVzqaJGLnFWlgXovRmikrAQSRgvyXoEBEGpKOa9Y81bWRd+u6WsSERERUXMylFK1uc1XJzJsRoqhDo72YYr15liGBV+pps1+6Ii1IG6k0e30wEdlQ4qIiIiIiKje5DLX13Uho1oWoXyt23vDyWjPTL2eWn++hM7jvxPpdcay+zRCi5VB0bObtiVp3ivBgNu0ASAiIiIiIqKoYgCERogbcTiGNxgwbUKOkloorIdCREREREQNVgQ1iPlEHAMgNILt2/Aq7CZDRERERERENcYAyIQxAEIj5Lx8zbo/EBEREREREdWKVAZtSlIONWaYMFkYdQRf92SIdgDEmMI2N5r3kKkqy5A1K1uGhYqJpobHERERUdNRG9rgTnVSk6uD+MADD+Cwww7DvHnzYBgGbrvttpGLpRTOP/98zJ07F+l0GgceeCBeeukl1FPTXs1l4jFs3dGOtlhLvReFaspA2mypKJAhlxUZs7UqS9XM4qaJOS1pzEi2IGWyxTXRVMSMmO5kRURERE04BCaIaRJyuRx22WUXXHPNNWM+f/nll+Pqq6/Gddddh0ceeQQtLS04+OCDUSwWUS9NOwQmFbMwv7UV2aKNPjdb78WhGpH8gqSZQdEvVtDpxUDKakHO76/S0jWnmGlgZiaFQsGC7Tko+IV6LxJRwzIhAZAUbJWv96IQERFRxB1yyCF6Gotkf1x11VX4n//5Hxx++OH6sR//+MeYPXu2zhQ55phjUA9NmwHiKYWs48Dx2fGj2Xi604uawu9SkGRLFFwXJc9lAV6iKR9PMpCR5ykiIqKmIvd1A8kAQWCWLFmCVatW6WEvZR0dHdhzzz3x8MMPo16aNgMkZ7t4obcXeTfArUyhJ/VN8v6AvkSY/O/6yHl9VVmuZmZ7Pt4YyMP3DdhN0HqLqJpc5cBnJy8iIqLmEnAXmP7+kRnvyWRST5MhwQ8hGR/Dyffl5+qhaTNAHN9HT6mEku/Ue1GoDhcIlWaAOMoOfHmana+zsVzkPQcuM2yIpkQCtR4zQIiIiGgK5s+fr7M1ytMll1wSmfXZtBkgRERERERERI1O+UpPQcxHLF++HO3t7SibbPaHmDNnjv539erVugtMmXy/6667ol6aNgOEiIiIiIiIiEaS4MfwqZIAyKJFi3QQ5N577x16TIbWSDeYvfbaC/XCDBBqOiZMPQBm8l1giIiCYWz4T234j4iIiKhiSg1OU6UmN49sNouXX355ROHTp59+Gl1dXViwYAFOP/10fPWrX8U222yjAyLnnXce5s2bhyOOOAL1wgAINZ3WWAtcX4qhsv0xEdVHzLDQFmvBgFtgbSEiIiIKVRHUiXr88cex//77D31/5pln6n8XL16MG2+8EV/60peQy+Vw4oknore3F/vssw/uvPNOpFIp1AsDINR00mYaJXgMgBBRXQMgLVYGBc9hAISIiIga0n777Qe1iawRwzDwla98RU9hwQBIQzL0MA6p9U+T5ygHnuLwFyKqHx8Ktm/zPE5EREQNmwHSiBgAaUAybjxmJGCrQr0XpSENuFl98UFEVC+O76LHHYDru9wIRERENDUMgEwYAyANGgAxDVOqeFKFGSBERPXkw9cZIERERERUOwyANCDpGOAp3jUkomiJmyY64gm4voG868FWDBAQERERbRYzQCaMAZAGJO1bXV4YEFHEJE0Ls1MZFF0Lnl+A7TEAQkRERETBYQCkgbNAiIiieG7bVDVxIiIiIhr1+UkpqAAKmKom+AzGAAgREYVCyfewspCH5xso+uxyRURERDQhHAIzYQyAEBFRKDi+jx67VO/FICIiIqKIYgCkwVmGibgRg+27uqsAEVVX3LAQMyy4SrGjEBERERHVHzNAJsyc+I9SGKXMOKbF22EZjGUR1ULGimNmsg0tVgtXOBERERGFJwASxBRxvGpucKZh6AwQA0a9F4UodOSoUFXIukoYMcR4yBERERERNRQGQBqc7XsY8PLwwIKBRKO1xdLwlIGclw9s5RR9F71uHgWfQ86IiIiIKASke0sQHVwUM0Ao5KT2h+MPwGdbXKKNdMTScJQZaACk4Dkoeg6POCIiIiIKBeUPTkHMJ+qYAdLglP6PiMYigUE/4Eg2j7ngyWiieDw2eNfBVzprx1PMaiMiIiKiYDEAQkSR1ePkm6GWU8OzLBPzZnXAcFz4BR8DRQPdTn+9F4uIiIioMbALzIQxAEJEkZX3SvVeBJoA0zTR2Z6BWbLhybA+xwAcrjoiIiIiChYDIEREVFe+rzCQLcJwHPi2j5LHFjtEREREE/8wFVALWz/6qdMMgBARUV15no83VvfqGiBKaoA0QQEuIiIioqCwCOrEMQBCU2LC0EVYWYqVosQwNmQgSEex8hc09fWqy51ufL6Q74s2x7wQERERUXUxAEJTupiZm2pF0bOw3unjRSJFRldbCnEYcEvAgOOh5LOWyFQlDAvt8RQc30DOs+EqO5BtRURERNT0NnTSmzIV/Zt+DIBQxUxDAiBt6LMT6Hb6eI+cImN6WxoZGCgqA7ZnMwASgLhpYkYig7xnouSDARAiIiKioMjw4SCGEPuIPAZAApJOJmAqhZLjwZVBWE1BwVE+XOXWe0GIJi2ZiA1GuT3A8X34w0J4rufDgQFHGVBNEAmvBVmLcm70pM4H1ykRERER1QEDIAFZOH8G0iUXS1fnsN7OoRlIltWyfJ9OaWcNEGq0Gh9zZ3XCcl24WR9r8iUUhg1zWdOXhyWZhC5QbIJq2LVQ8j2sLmV1gVNXefVeHCIiIqLIkCLyMgUxn6hjACQg06e1oi1nY/Xa5qkVIEGPHqdQ78UgmjSpcdremkLcdmGXXHSbzoiUv2yB9SmC5ikfA1JUhYiIiIiCxSEwE8YASEDW9WSRK7ooyC3jCBY7bYulUfBcOCxcOGmWaaAtGR/MJnAVbMVuF/UmIzD6BgqIuR5cx4frMyNhKizDRNqMw1GS6cEgBxERERGFEwMgAXlt+VqYPmC70buQsmS4QHIaVhbzcDzeGZ+shGXhTR0tkJFRawoubJcBkHqTGhQr1/TBkHoUMiTDb5a6PdXr8DIz2YYBB7B9m0PiiIiIiGpJRq4EMXpFIfIYAAlIseQ0RNcW+U93SZpUiV8DMcPSdRNo8mS1SQcM3xjcBhQOthO9bK16kXODZIGY3L2JiIiIKMQYAGmijhcz21vQ7iSxruBhnd0LX9pfTICvfKyx+1Dymf1RCcfzsWogD9c2UPCilyFE5Pgeuu2cbm/bBDcOiIiIiEKFRVAnjgGQJpGIxzCnqxVzC+1QnoP1dr+UJZzQ70p70HV2Py9sphAAWT1Q1F+zWw5FkaM89Dj5Dd8xBEJERERUUyyCOmEMgDQJ31co2S5yrg1bF2qd3EUKL9ynhuuPoo77OBERERGFHQMgTaJkO1i2pg+r/RzyjlQA4VAMIiIiIiKiRidF/WUKYj5RxwBIk3A9H335wWEYREREREREFBEcAjNh5sR/NPpMxoMmZWaiDRkrU63NQU0oFbMwLZlAeywFy7A2HJPVbS3SFkuhjfsxEVHdxQ0LrVYKSTNZ70UhIqKIYgBkGMtI1G9LNBhpp7tVZjo6Y531XhSKkLZkHPPaMpiVbEXciCFmJKoc/hgM5M1IdOp9moiI6idlJTAj0YZWq4WbgYiogiEwQUxRxyEwI/ACaDIsw4RZ4TozjcHLTV9NvnhizDD170klE4oWwzBgGcbQ/lGLoIS8luKxT6PIfogKz1FEVBl93jfkkwXf34mIqDoYABnGU3aVVnP0yAXB0kI3+t3KiqlOTydh+RayjoGcl5vwBUbMNPHm9jb0FoBVpb6KXpvCK1tysNJX8BxTt1ZVSpowV9d6OwulLF7i0hC5/JqVSQGeibwL9Lk5rh2iGij5DnrsLEo+AyBERJMiH5iDOHWq6K93BkCG8eHUb0s0oBXFvoqPkc5kAnE/Ac83kfPyEz7aYoaBBW0tMDwGQKIo77goOG5Nz7+9Tn7DfccmOOPThEjyx4xUEr4bg6EUAyBENVLyXdi+y7MxEdEkKclYDeCjrGqCj8MMgFDFppIWXvI8+L4LV02uDI3kAww4LkpeExydTUrV5fW4P9HIfaLgeZBu4Q53DaI6nJOJiIiqgwEQqou1+SIMZcORYjuT+Ljj+grP9/Sh5PIjEhFVh1IKK7MFQBkMgBAREVHoBVXAVDXBCEQGQKguCrp2yOTrh/hKoadUqsoyEREJCa/m3MGhWEREREShJ4GLIIIXPiKvqdvgdsVbkTHT9V4MimiHnK54O2JGvGqv0Wa1ImYwhklEwZHOS61WGmkzDSMkHxGSZhwZS5aHndqIiIhoasLx6aZO5iQ70R5rq/diUATFDQtzkl1IGKmqvUZXohNxI1G1+RNRcwZvp8Vb0WK1hSYAkjZT+r1aGq8TERHR+ENggpiirq6fJi655BK8/e1vR1tbG2bNmoUjjjgCL7zwwoifKRaLOOmkkzB9+nS0trbiqKOOwurVqwOr9M8bShQUuTvJjAyiTR8jlmHxxNsA2ylUuRahWhgiIqLwdoEJYoq6ugZA/vznP+vgxt/+9jfcc889cBwHBx10EHK53NDPnHHGGbj99ttxyy236J9fsWIFjjzyyEBef1WxFwNuNpB5EWWsJN6UmgUTFhzlYXWpG46qXr2SHqcPjmLrZmocMpRhVqKLgcIQ85WPHjeLrJeFCslA4IJX0u/VfkiWh4iIiBpXXQsI3HnnnSO+v/HGG3UmyBNPPIF9990XfX19+MEPfoCbbroJ733ve/XP3HDDDdhuu+100OSd73znlF5/vcPgBwUnZcYxM9GF14tr4SkH653+qq7efnegqvMnClrCjGNavB3dThYug3ehpFuNu3mEScm3UYJd78UgIiIKL98YnIKYT8RVHABZtmwZli5dinw+j5kzZ2KHHXZAMpmc0sJIwEN0dXXpfyUQIlkhBx544NDPbLvttliwYAEefvjhMQMgpVJJT2X9/dW9CG1WmXgMLbE4+ooebMUPpsJVHnJeflJtfam+UvEY0nELrg1kXZvbbpSYYSFmmHCVgqum3hXFUx7yXgmqGQaYEhEREVFjD4F57bXXcPbZZ2PLLbfEokWL8J73vAeHHHII9thjD3R0dOB973ufHqri+5P/cCu/c/rpp2PvvffGjjvuqB9btWoVEokEOjs7R/zs7Nmz9XPj1RWRZSlP8+fPn/Sy0ObNaU9j91kz0Rlv5+raIOeVsKywCr6afHtfqo8Z7WnsMGcaFrZ0bahNQcNlrASmJ9qRMVsCWTFF38bq0jpmfxAREREFiEVQqxAAOfXUU7HLLrtgyZIl+OpXv4p//vOfOmPDtm0djPj973+PffbZB+effz523nlnPPbYY5NYDOhaIM899xxuvvlmTMW5556rl6s8LV++HFEThvJ06XgM01MpndJOIzNA0NQZIPXfNycjFbfQkU6gNZYMxXEVNpL9IXU7giru6ykfBb/IWg5EREREAVLKCGyKugl/qm1pacGrr76qu7GMJnU7pEaHTBdccIGu7SGBB+nwMhEnn3wy7rjjDjzwwAPYYosthh6fM2eODrD09vaOyAKRLjDy3FhkGM5Uh+KEWcKw9B3Z1aW+ii8iUmYGJb8wpXT/7nwJL6o+5NxixfOg6GULpM1W9Dr98DD14RK10Je3sdTIIl80mu6iPG7EdZtTexOFeou+g343j6LPrCaioMlHzNZYGr4yUfAkMMjjjIiIKDQBEBlaMlHvf//7J/RzSimccsop+PWvf437779fD6sZbvfdd0c8Hse9996r298KaZMr9Uf22msvNKOEGcP89EystQd0tf5KZMw22H4JagofttYMFNCdK8HxmjnbgYZrtVKYmZipCyh6AdSLqIXugQL6ckXIqD3JTmgmCTMBCzHY3vgBkILnoOi5rI1CVBUGOmMtcJWFku9w+CQREU15CMxUqSb4OFzXLjAy7EU6vPzmN79BW1vbUF0Pqd2RTqf1vyeccALOPPNMXRi1vb1dB0wk+DHVDjCNTAJHld5tilkmYqYB0zCn9GHLUwqex7tVw0n728G2kQox09R9tH2ZmiSzQPbKRisAO7gfN9Yy15JszyC3qWScDM6P65zo38cZERHR1Mh1RyABEBX9LTGpIqjDh6Acd9xxmDdvHmKxGCzLGjFN1LXXXqvrdOy3336YO3fu0PTzn/986Ge++c1v4oMf/KDOAJHWuDL05dZbb0WzKvkulhbWVJT9EbMszOtqRXvKQ4uVqMryNbOM1Y6YkdTBj3ntGcxOZ9ASS6NZZN0iVpbWsMBlgyj5JRT9Qk1fM2W2wqzsbYcociQY2ONk0e/0M/uDiIgozBkgn/rUp/QwlPPOO08HLAzDqFomQyqVwjXXXKMnAhzlYY092C54sizLQFdrGp7v6sKGFKykmYGjXBimg650Ao4yYbseBpBrilVd8G09UWMIoq3tZCWMFGxI0IXZY0Qi67GOFhERTV1QBUwVi6CO7cEHH8Rf/vIX7LrrrlNeyVQ7vq+QLdrwHA9OyAd4Saq8GBxS0hgcqauiXB3YG7BdeK4Bp4KW0ERR5Sqn4YZJEREREVF0VJSLPH/+/IrrUFD9OJ6P19cPYGUujwG3tqnvkxUz4rqmRiPJ+31w1GBh2Df6clhZzCGr2+ISkSj6A1MqvkxEREREY/ANqAAmyDRBUg9SRoRIIxOp37n11lvj4osvDn2coKIhMFdddRXOOeccfO9738PChQuDXyqqCtkZC3ZjdOcw5D8ZWhXu42eju9tlBZcXeUSjNUp7ZCIiIqKGK4IawHWTmsQ8LrvsMl3T80c/+hF22GEHPP744zj++ON1I5NTTz0VkQqAHH300cjn8zrKk8lkdKva4bq7u4NaPmpS0kaVqfJERERERETh89e//hWHH344Dj30UP29JEb87Gc/w6OPPopIZoAQVRPvFBMREREREdW+CGp/f/+Ix5PJpJ6Ge9e73oXrr78eL774It7ylrfgmWee0bVCr7zyyugFQBYvXhz8khA1AdMwEDMM+MqAp3xmuRARERER0ZQM1fCYIrVhHlLzc7gLLrgAF1544YjHpCSGBEq23XZbWJala4J87Wtfw7HHHotIBEDkj2tvbx/6elPKP0dEI2ViMUxPpFBwLHQ7ebiKbWOJiIiIiCg8li9fPuKafnT2h/jFL36Bn/70p7jpppt0DZCnn34ap59+OubNmxfqhIkJB0CmTZuGlStXYtasWejs7BwsUDlGkU15XKI/RLSxpGWiM5GApeLoc2y4YACEiIiIiIjCUwS1vb19s0kN//Vf/6WzQI455hj9/U477YSlS5fikksuiUYA5E9/+hO6urr01/fdd181l4kosmzfR7/joOD58NkOlIiIiIiIQlYDZCKkKYppmiMek6Ewvu8jzCYcAHnPe94z5tdENHF5x8UKN6drgLgq3CcHIiIiIiKisRx22GG65seCBQv0EJinnnpKF0D99Kc/jcgVQRXFYhHPPvss1qxZs1GU50Mf+lAQy0Y0KRKvNGBASouGlacUPMUhYkRRIeecMrbuJiIionrwfUNPQcxnor797W/jvPPOwxe+8AUdE5DaH5/73Odw/vnnIyjSWlcCKp/61Kd0oCUIhpLCHZN055134pOf/CTWrVu38QxDVgNECrZ2dHRI/40Nl8gUVRkrjs54C9bZBdh+qd6LQ0RNYEYyBSgLeRfI+7l6Lw4RERENkctcH319fZFt0lG+1n3+0E+iLZ6Y8vwGHBvb/u7HoVlnV111FW688UY899xz2H///XHCCSfgwx/+8JhFWSdq5KCdCTrllFPw0Y9+VBdFleyP4VOYgh/UfAGQealOxM3KDwgioomSkLp0dZqeyCBjZRhkJyIioroWQQ1iChPpKiPdZR599FFst912Og4xd+5cnHzyyXjyySdrFwBZvXo1zjzzTMyePbuiFyWqBl8p2L6ruxGNJW6aSFtxmJXt9rQJaTOBmGFxHVHTcZSv6/n4uqbP5j81pK0YEqYFi8dLUw+bihsx7gNERBR4EdQgpjB629vehquvvhorVqzABRdcgP/93//F29/+duy666744Q9/OO7131gquhL8yEc+gvvvv7+SXyWqmqxnY3mhG7ZfHPP5rmQSW7VMQ8ZKcSsEyISBrVpmozPexvVKTUXeatcUC1hdyiLrZSd0rCxs7cTcVBvarJaaLCOFjwSLpydkH2gbUUOGiIiIxuY4Dn7xi1/oWqNnnXUW9thjDx0EOeqoo/Df//3fOPbYY1HVIqjf+c539BCYv/zlL7rfbzweH/H8qaeeWslsiabE9j3Yfn7c51tiMUxPZrCiUAI70AZH6v5Mj7eh37EDnCtRY8i6zoR/1jCA6ck0YspG0eVw0WZlGQZarOSGu1USAAlZvjERETWcerTBrQUZ5nLDDTfgZz/7mW65K3VIv/nNb2Lbbbcd+hmpCSLZIFUNgMgC3H333UilUjoTRC6AyuRrBkAojHKui3WlHGx/4hcsURKTlGvEYKtSoN0q5EP8OnsAhQ2ZN5ZpYmZ7Gn5JobfkNO36JhpNrnfXl/LIux5Ko7qnUfOQbmA5r4iS3gX+fS7OJGJIxCwoT8FzDeQ9Fz6j9URENAG+MvQ0VX7IAiAS2Hjf+96Ha6+9FkccccRGiRdi0aJFOOaYY6obAPnyl7+Miy66COecc46OxBA1gu5iCX36grw5LzxSZhIJMwPHcaHgBjZfaTv8an413A3tfRNxC9ttMR3Oehf/XJdDt98X2GsRNTI5VpZk+3S9Io83/ZuWnCvX2wMYrBrz7x2hszWFaekkVNFDLh+DXRyAzbbpRETUxF599VVsueWWm/yZlpYWnSUyURVFL2zbxtFHH83gRwOTsejNVgxUihUWfbmj1pwBEMnOqtY2L/r2UABEXiEZt5CwLI5vJxp9rHiuHq7n8cK2aUnQw1Eb7wOWaSBumYiZg9Pw7FoiIqJNvrf4RmBTmEjr2/Xr12/0eG9vL7baaquK5lnR1dDixYvx85//vKIXpHCYlkijKz4NFjZOI6Josn0beS8LVeUAkO36eHllD5b09w0NiyEiok3ry9tY1ZfD6lwB3XYOrgouU4+IiKItqm1wX3vtNXjexnXTSqUS3njjjYrmWdEQGFmIyy+/HHfddRd23nnnjcbiXHnllRUtDNWGxPWmxVMwVCf63AI8xRoNzaDkS5FS2dbVPbM5nodXV/fpl5GUfyIi2ryBfAkDw7rCBFmriYiIqJH89re/HfpaYg4dHR0jYhH33nsvFi5cWLsAyN///nfstttu+uvnnntuxHNM2Qw/+Ugl6beGcqqeDUBhU5sP1FLjYCwmYvADrD9CRBQVg2dNBj2IiGjyfARUBBXhGAIjBU/LsQUZfTKcJF9I8OOKK66oXQDkvvvuq+jFKDzWlqRdrMPsD6qphNmCkj/AwBsREREREY3J39C0Qjq8PPbYY5gxYwaCUlEAhBpf3pOhEBz6QrVkwDISXOVERERERAFSytBTEPMJkyVLlgQ+zwkHQD7/+c/jf/7nf7DFFlts9melQKrrujj22GOnunxNbV5rGp4bw5qiFK5kWizVl5wOZ2ZSUJ6FHlu6vkw2gKbgqhIaWcqMI2ZYKPk+HCU1VYiI/s0yDLQn4vB9A45noODbkch44/BFIqJwk8CFH5EAyNVXX40TTzwRqVRKf70pp556avUCIDNnzsQOO+yAvffeG4cddhj22GMPzJs3Ty9YT08P/vnPf+LBBx/EzTffrB+//vrrJ70w9G+y6711egecXAbrinl42Lj6LVEtyRi8RR2tQCmN59weuDqLaHJsv/pdaKqpLZZE2kqj2y7B8RgAIaKREpaJea0ZuLaBPjuGUqkHXgOf88oke89nVxoiIqqBb37zmzqRQuIM8vWmrk2qGgC5+OKLcfLJJ+N///d/8d3vflcHPIZra2vDgQceqAMf73//+ye9IDTGxjEN+IY5GA1hAkhomDB1Rk4ts3IMGIibBjwFeKp+H6Yt05CzjV6eSjRy8KN8ojWx+b9/cB9p/L83SkzZdoakh9b3GKLGJMf0YFcrNaEsEH/DuSIqKj3nExFRbURpCMySYcNe6joERsyePRtf/vKX9SRZH8uWLUOhUNBFSbbeemt2gAmQfMR6qXsAnlOEzw/roWHBRHu8FTnXhq2KNXvdTMLCDtM7saYPeC2/DvWglMLSvhzglWD7jT2UpVJZt4SS4aHkbzojqz3WAdv3kPf7a7ZstGkz0kl0JZPIFS2sKPQxq44mFfyYFu9Cv5uDowqb/FnHV1iZK8D3DJQ8A35EgqAeh/wREYWavNsE8Y7jI9ykBa50pN1yyy0xbdq02hZBlRes9EVpYvTFpg6GMP0jLEzDRKuVge2hpgGQdMzCtjM6YJbqGAABsCIr3YOMpt0n83rYy+aHvrTG2pB3HQZAQqQzlcCCthas8xNYVczCUxxWSBPPfmiPdaLgOZsNgLi+j3WFwfeGKJ0lPRZNJyKiOjj99NOx00474YQTTtDBj3333RcPP/wwMpkM7rjjDuy3336TnqdZlSWlQNR6mAVtnmwPRznwa1yTxfUVego28l59My8GE8C5T26O49tsMR0yJc/DgO1uKErJfZgmTvYWyXqb6Hl/YgNliIiIgh8CE8QUJr/85S+xyy676K9vv/12vPbaa3j++edxxhln6FEplWAAhGgSpHZAjzMA269d9ofI2S4eXbkOr+XW1/R1qTK9bg9yHP4SKmtyRTzf3YflhW54LOZIkyC1fNY762p+3iciImp269atw5w5c/TXv//97/HRj34Ub3nLW/DpT39aD4WpBAMgRJMgd45Lcne/xhkgju9jda6AfnfT6dcUDiW/BJdj5kOl4HroKZWQdYvMAKFJn/eLfgE+XK45IiIKJV/JZAQwIVSkBqk0X5HhL3feeSfe97736cfz+Twsy6ptDRCiyZieSMNXMfQ6OXbGaHCWYaHFbMOA189tSTUh3TTa40l4ykDOlaEIYS/RFayMldEpqQV/sC4UERERUVS7wAx3/PHH42Mf+xjmzp2rG65I11nxyCOPYNttt0VNAyCu6+L+++/HK6+8gv/4j//QbXBXrFiB9vZ2tLa2VjpbiiA5jOalW+G4GfQ7RXhNdvESNTEjjumJ2cgWsgyAUE1IW9HZyQyKnqULUTZbZ6yOWDtc32IAhIiIiJrKhRdeiB133BHLly/Xw1+SyaR+XLI/zjnnnNoFQJYuXYr3v//9ug1uqVTSqSgSALnsssv099dddx2iUPVd/mu2O43VEq5YYng04n7GbUn12vGaed9rhL9dzmWDXaIa53xGREQUnSEwwcwnbD7ykY9s9NjixYsrnl9FAZDTTjsNe+yxB5555hlMnz596PEPf/jD+OxnP4soyFhpWIij3+ur96I0PN0+tZCFryZeRb9ZpMwU4kYS/V4vGoV0wel21vAih2rGUwprinl4ymy67A/R7w6ELiV1LAkzoc9neS/Hcz0REVENRXUIjLj33nv1tGbNGvj+yM+BP/zhD1GTAMhf/vIX/PWvf0UikRjx+MKFC/HGG28gClJmEjEjxQBIQNbZUryTBTzHumBImS0NFQDxlIc+t6fei0FNxIdCj9O8HThyXmPU/ogbcaTMDAqenOsZ7CYiIqKpueiii/CVr3xFJ1+U64BMVUUBEIm8SCXW0V5//XU9FCYKXOVCwa73YlDESTtOx+d+RkSNT4KjkiEmXVOIiIiodnw9pH7qwQE/ZINupbTGjTfeiOOOOy6weVbUBveggw7CVVddNfS9RGKy2SwuuOACfOADH0AU5LwCBtz+ei8GRVzBL2KAw6yIKAKkRXjO6+fwFyIiohpTKrgpTGzbxrve9a5A51lRAOSKK67AQw89hO233x7FYlF3gSkPf5FCqFHJAJE7WUTVv2PKDBAianxS48nV75sh+/REREREDekzn/kMbrrppkDnWdEQmC222EIXQL355pvx7LPP6uyPE044AcceeyzS6XSgCxg1UiV/RqIFec/TWSZE1JjaYglYhrRl9fSdbyIiIiKievCVoacg5hMmkmxx/fXX449//CN23nlnxOPxEc9feeWVtQmA6F+MxfCJT3yi0l9vWqZhYF6qHatLkirMAAhRo+pMJJE0klhXKjEAQkREREQUMEm22HXXXfXXzz333IjnKi2IWnEAZMWKFXjwwQfHbEdz6qmnVjrbpiAF4sI2vmoimStx04LjSz+G5mtDSY3PhKEzNlzlBVKkUSkFCZI32KFMRFQ3ljE48tqX8yfPnkREgVEBFUFVISuCet999wU+z4oCIFKJ9XOf+5xugzt9+vQR0Rf5mgGQ8cmb/hvFPuTdxgoixAwTW2dm47V8Lwp+Y7RkJBouYyUwI9GJ14vrdY2fqepxSojB1UNgiIho8zpjGRhGDH1OnvWviIgCFFQBUxXSO3svv/wyXnnlFey777665IbciKxpBsh5552H888/H+eeey5Ms6I6qk1L7nist/NoxLs2s5OdWFEsMABCDSlhxjA90YaVpR64AZzcc64Ue2ShZCKiiWqNpSSfFDnXZgCEiIg2a/369fjYxz6mM0Ek4PHSSy9hq6220vVHp02bppuzTFZF0Yt8Po9jjjmGwY8mIgNfep1cIHfOiepBhr4MuAWdhUVUTy2xGFqsOBLmyEJeRFFX9B0UfVt3QCMiouCLoAYxhckZZ5yhC58uW7YMmUxm6PGjjz4ad955Z0XzrCgAIhGXW265paIXpMbk+B5ezq1C0ePwF2pMOc/G8sI6BvGo7rVo5mbSmJNuRUeslVuDmkqPnUO33b+hXTIREQVFancENYXJ3Xffjcsuu0x3oR1um222wdKlS2s3BOaSSy7BBz/4QR112WmnnQJpR0PhH7qT9YpoHHLw8k4//ZunfBRUqQlWST33fR53E1lFScuSgYXIh+szBlHV2cwiJSKiScjlciMyP8q6u7uRTCZR0wDIXXfdhbe+9a36+9FFUInqyYSFpNmCgt/PDUFNxYCJtNmKgp+tebcmEyZSZgp5X9p7M/g4HhmBtb5YApSDPEcBEBERUQB8NTgFMZ8wefe7340f//jHuPjii4diDdKB9vLLL8f+++9fuwCIFBv54Q9/iE996lMVvShRNVlGDBmrgwEQajoShGixOlD087UPgBgmMpYEXwoMf2wmm25NsahjRCH7jEFEREQNKqj6HX7IaoBIoOOAAw7A448/Dtu28aUvfQn/+Mc/dAbIQw89VLsaIJJusvfee1f0gkS1oFR42wzHDAtpM4mYwQKIFLxaBz7+/bqqKq9twEDSjMGCDBuJBinEK4Wl5b9GJx3CLMPS24mIiIgoSDvuuCNefPFF7LPPPjj88MP1kJgjjzwSTz31FLbeeuvaZYCcdtpp+Pa3v42rr766ohclqiZPuch5PaFdyV3xFsxLzcXKYhar7RUcLkCB8eFhwOupSxDEVz6yXjbwi/q4YWF+ejrWlWz0uuE9rptVeywDAzEMuEU4qpHqRBEREUVHUAVMVchuaEj3l/nz5+PLX/7ymM8tWLCgNgGQRx99FH/6059wxx13YIcddtioCOqtt95ayWyJArsILKl8aNdmayyBucnpGHAMrGH4gwIkwYeSn6/jaxerkmEwPd6KrCO1RRgACZu0mYBpJJF3XbCvBxEREQVp0aJFWLlyJWbNmjXi8fXr1+vnPM+rTQCks7NTp54Q0eTlPQdr7V7kvVwEEuCJqsuHj14nj5Jvc1WHUNF39FhaCTwTERFRfUS1CKpSaswmK9lsFqlUqqJ5VhQAueGGGyp6MSIC1ttZZN0lsH25YAjZWYYoZOQ4WVZYDyfEdX2aWb8rGUeGbjNNRERE9RG1ITBnnnmm/leCH+edd96IVriS9fHII49g1113rV0AhIgq5ygPjifp/MGSIoRRKKpINJzs0wVmf4SWq+qX+TF4zhM87xEREUXJU089NZQB8ve//x2JRGLoOfl6l112wRe/+MXqBkDe9ra34d5778W0adOw2267jZmKUvbkk09WtDBEVHn7045YO/rcAaaiE1ETMNBiZeAqH0U/+IAyERFRI4naEJj77rtP/3v88cfjW9/6Ftrb2wOb94QDINJ2Rtrflr/eVABkoq699lo9vfbaa/p7Kah6/vnn45BDDtHfF4tFnHXWWbj55ptRKpVw8MEH47vf/S5mz5495dcmihLTMNEZ78SAl4NfxzuyRES1IJ9AWmMtKHouAyBERNT0fGXoaar8AOYRpGqU3phwAOSCCy4Y+vrCCy8M5MW32GILXHrppdhmm210esuPfvQjHVyRlBcJhpxxxhn43e9+h1tuuQUdHR04+eSTdfHVhx56KJDXp2hkPsjFf8I04SoF23ebNh3aVeH72xOWiZhhwvFk6I8s3/jkdNuSTsL0FPKON6XUehOWbgVbzSFBSTOm3yQcVfveF5ZpIGVZ8DwDJd+rS9vbZiRDLgb3LQ9xy4RSgOfLd9Fb/3KTI5OMyx+oj9/Bc2u4eMrT7ZejKm7KO5x8oJW/tTEKzRqwdElcDscMhmkYej+Qc43sB/UcckZEVA+5XE7HC2Qkypo1a+D7I9/3X3311drUANlqq63w2GOPYfr06SMe7+3t1UNlJroghx122Ijvv/a1r+mMkL/97W86OPKDH/wAN910E9773vcORYC22247/fw73/nOShadIiZpJpCx2jC/JY6ekoflhXUN8SGxGhcC3U536AoRzmpJYUY8gxUDHtbYm25hapomdnnzHCQGPDz9Ri96nGzFr5s0W2D7BXhVbMw5N9kB249jZWlNzQMQbck43tzVjv4+C6/lemGrUk1fv1klzARSZka32Z7bEofrmOh1fAy4le+rYZWImdhuyxlQAw7W9igsL6wP1UWtLIusd0+uDCOqK5VA2orBdiz0OR5yXvj3s4SRhqtseGDXpiCkYxZmZ1LwHBM5x8R6py9UxyERhYecGYI4OyiEy2c+8xn8+c9/xnHHHYe5c+cGMgqlogCIDFkZq+euDFN5/fXXK1oQmZ9kekiUZ6+99sITTzwBx3Fw4IEHDv3MtttuiwULFuDhhx8eNwAiyyBTWX9/f0XLQ43BMmJImWnMSqbgec7gQRG2I7cG5ANRzpNuDOHSlohjZiqN3vzm7x7Lpps3sx1pw8XzK6f2t8SNBByjVLV9QU697fEUil4KRqlciLF2UvKhuDUNqxDDsnwWYACkJixYSJopeH4JHYkESspC3g1fZkQQLNPEnGmtUKqI4kA4T6pFP9qBv0wshvZYAgUVa5j9zDLi+iaEZKzQ1En2R2cyARsmPN+C4bDYORE1lz/84Q96RMjee+8d2DwnFQD57W9/O/T1XXfdpYelDA9gSGrKokWLJrUAUtVVAh5S76O1tRW//vWvsf322+Ppp5/WFV47OztH/LzU/1i1atW487vkkktw0UUXTWoZqLGHfUgBvDVFF32up4dSUXgM2A7WqALyYwRMR5NN98bafiT6PRSn2PXDUTZUFbNhZC/rcwpw9PCT2u9zRdfDqoE8+u0YvM0MLaLguPBQ8os6Db23ZMN1TdgRTUn3fB8ru7NA1kY/d7G6yDku5DRmu57uHtYIPOWwDlWAHN8fPNc4JgqeyewPItpk+9og6neokLTBLZMGLF1dXYHOc1IBkCOOOEL/K3fZFy9ePOK5eDyOhQsX4oorrpjUArz1rW/VwY6+vj788pe/1POVNJdKnXvuuUN9g8sZIPPnz694fhRutm/DVT0oZA24vow8DtcQkGa3OlvEesOGM4HNImP6nn15JQwPU77bWfJzVd8XVpb6oZTcjav9PjdQcvCvtX26Bshg7ReqBce34fmu3uYrcjK8ytA1QKLIdn38a+laXXhADkem3dded8lGL5zBWjMNspvZSrL3GmRhG0DB9fBGtjBUA4THIRGNRz6NBvGJ1A/ZKr744ot1kxSpFZrJZGofACkXHZEsD6kBMmPGjCkvgGR5vPnNb9Zf77777nq+0urm6KOPhm3buq7I8CyQ1atXY86cOePOTzrVlLvV0OZJgTWJ9DVqEUW5yJUieG5j3ByrqOhiI3/gkbtXzgT3Lfkrs4Vgxo3Xog5MPYtCykV3vgqvL/ubaOR9rppkvXgb9i07ooGPMsmmy5dqX+CX/s0dVeitETTqZ4mw8pVCaQIZlEREUXXFFVfglVde0aNAJNlCki6Ge/LJJ2tTA2TJkiWoFgmySA0PCYbIHyjDao466ij93AsvvIBly5bpITMUjGnxNiiVRLe7lqs0ZKT+vxSUK/KOGtVIZzwNpSxkPRnmwYtfIiIiokags5KDGAKjwjUEpjwCJUgVBUCCIsNVDjnkEF3YdGBgQHd8uf/++4fqi5xwwgl6OIuM+2lvb8cpp5yigx/sABOczngbfL8N3e46pq2GjDTcTJgZFENY3JSiqT2Whq/iKPguAyBEREREDaJeQ2DeeOMNnH322bpYaT6f1yM7pHPrHnvsEcDSABdccAEiFQCRXr6f/OQnsXLlSh3w2HnnnXXw433ve59+/pvf/KZujSkZIJIVcvDBB+O73/1uPRc5chzlQqnqtquzENOp41FuT2sZJiyYulBdkMMHorzO6iVhSW6N1G4w9P5fqZgR1+2Ho5Ty7SgfSv4mFhMmooiQM77cUuD7KRFRsHp6enR3lv33318HQGbOnImXXnpJFy4NM0NF/JOuFEEd7FYz+AZII2WslE55L/i5qq2aNqtDF3DL+32RXf0dsRTSVhrr7H7dISKoegzSUtCtcoCq2WzRnkFCxZCzTawt9VdcLLUrNhMD3gAcVURUpM2Ergkk9U14sUBEUZA00jqjsqiq9zmHiMJKLnN93WxDRhNE+Vr3J7t9ERlr6nUw814Jn3jq/01onZ1zzjl46KGH8Je//AVBktEfL774oq43KsEUacAynu7u7sbKAKH6y3vVv3iLGQldyjPK4qaFtJXUH7IQUNaGZJIw+BG8lkQMKRWH71pTmk/STCMXseFJhSm2HyYiChvTiA1mgUT7YwgRNbnBpha1bYP729/+Vo/Q+OhHP6q7uL7pTW/CF77wBXz2s5+d0jLIKJC2tjb99VVXXYWgxaZSrPTll1/Ww1jK3WHK9t133yCWjaosYcT1B4OiX6jq69iqpCuZT1XCSOqWn2G8M13yXZhugW14G0B/yUFR+ch71pSGK0nWlI9otKA1NmSDucpHqYmDILrwsJnU7bXDeJ4hosnzlPQik5sTREQ0mcySzXVaffXVV3Httdfqmp3//d//rbu5nnrqqbrL6+LFi1Gp4b87lfkEGgD529/+hv/4j//A0qVLNxorLikqHlt2NYSMlUbcyFQ9AFLwsoHMJ2O1IucNwA9oiEmQcq6NguHCU9GpBxFVa3MlfcGvq2VPIQAy4PZGJuAlw62mxeX4cps6ABIzYmi12tCn+kN5niGiyXNUiUOgiSjyfDU4BTEfMX/+fIwuRnrhhReOeEySIKTY6de//nX9/W677YbnnnsO1113XVUCF3UNgHz+85/Xf+zvfvc7zJ07d5PjcijcarHtgrpIlIu0sNZx8aUUJi+YGoI7KmOtUl7EMgSkMOzgMdbcBoexcT0QRcVgoJvjX4iIJmP58uUjaoCMzv4QEgfYfvvtRzy23Xbb4Ve/+lWoV3ZFARCp7vrLX/5St7mhxlX0S7ADuhisBRly4E2hawcRjU0uDXrdXEOdD6pBuvpIlpmkzBMRERE1aw2Q9vb2zRZBlQ4wL7zwwojHpHjplltuiTCraFDknnvuqet/UOMHQPJV7P4SNBmqw3H5RNW5Q9rv5lH0o9PRptKsnnyEarsQERFRcw2BCWKaqDPOOEOXxpAhMBIbuOmmm3D99dfjpJNOQuQyQE455RScddZZWLVqFXbaaSfE4/ERz++8885BLR9VHdNCq6XVSqHoe3Ajdjc5YZpIxWIouQi8XkTCMtEajyNvKxSbuBZFM0mZcfi69a4cJzwfhUnMNJGJWfA8EwVPCkk2d4bQZKUsSw8rc32pQ8GgGhERRcvb3/52/PrXv8a5556Lr3zlK1i0aJHu2nLsscdWbVjOWPVJahIAOeqoo/S/n/70p0fUkpCCqCyCSjRYT2GrzGwsL2TR466P1CrpTCWwsLUdK/qB14trA71o7Uolscv06Xh+rYulhVWBzZfCa3ayE7ZvYlVp7ZSK0lLw2uIxvKWzA/35OF7JdsNWzZ0hNBkS+JibScPwLQw4BtbavfVeJCIiirCgi6BO1Ac/+EE9VYvrurjoootw9dVXI5sdbKzR2tqqEzKkMOvoRIyqBUCWLFlSya8RNRED7fEMEqXoZTEkYyampRLoyQ2WzAzykjUVMzErk8ZSK3rrjcaWsZIwDRYeDSPJyJJjXdmyjSwm6Ey2tXQsBsOPoRSteslERNQENUDCQgIdt956Ky6//HLstdde+rGHH35Yd6RZv369bsNbkwBI2AubENWb3MleXepFwcsjanK2izeyefQ7wV8PZW0Xr/T2o89huniz6HVycJQEQJj9ETYF19PHeq5kswB1Be8BvbYN+B7yDIAQERFVROqK3HzzzTjkkENGlNuQYTAf//jHaxcAEa+88ooe4/Ovf/1Lfy8tcE477TRsvfXWlc6SKFIffl/Lr4Wnojdmvq/kIGv3wdPXq8FetPYUbTxpr9Nj5qk5rLX7NzSp5EYPm6zj4sWefp0O60bwXFZNsk+vzg8OGQoiJZmIiGiT7zsBDYFRIXvPkva7Cxcu3OhxqTeSSCRq1wXmrrvu0gGPRx99VEdgZHrkkUewww474J577qloQYiiRoreRbFooKcUbN/TLUOrMe+iJ4VjK5+3DMyxjIpju6FgGgZS8RgSpoWok21djX2Jps5XCiXfg6O8wOuzGDBhItr7twSNZBrvfUCO80TM0oWlrco+jhEREWl+gFOYnHzyybj44otRKpWGHpOvv/a1r+nnKlHRVcI555yj295ceumlGz1+9tln433ve19FC0NENFVxI46u+Aystlc2bFHNtkwSOy6YgYHVNv7Rs54BAoqcjJVB3Eiiz+1p2uyfllQcC2d1wMu6WDvg6WwoIiIi+rennnoK9957L7bYYgvssssu+rFnnnkGtm3jgAMOwJFHHjn0s1IrpGoBEBn28otf/GKjx6UrjAyLISKql5gZw7T4NKyxVzVsAEQujLbdYjrW5Ar4V083mB9BUZMyU0iZreh3exv0KJ26dCKGLWe1wzFsFAsOAyBERFQxpaQjawBFUFW4iqB2dnYOdaAtq0sb3JkzZ+Lpp5/GNttsM+JxeWzWrFlTWiAioqnwlY+CX2joiyrb9bCmN4ceu9SwQRyiTXGVA9tv7v3bcX30ZEtwSw5KPgs/ExERjXbDDTcgaBUFQD772c/ixBNPxKuvvop3vetd+rGHHnoIl112Gc4888ygl5GIaMJs38bqUuNmf4j+XAmPvLgCTsGPZCFdopyXQwHFhj5OpypbtPHPZevguz6KTvOuByIimrqg6nf4iL6KAiDnnXce2tracMUVV+Dcc8/Vj82bN0/34z311FODXkYiogmTgoMFv7HbD+sMkL7G/huINsVVkvHQ3FkPjuejJzfYKYaIiGgq/IC6wPgNEo+XkhyHHnqoTsioSQDEMAxdBFWmgYEB/ZgERIgofKQrSmssjZLnwVb/rqBMRERERETUaKQI6tKlSyv63Sn3imTggyjcpNViZ6wVvaoI22MAhIiIiIgoSiRxI4jkDYVw2FxZjbVr11Y87wkHQN72trfpFjTTpk3DbrvtprNAxvPkk09WvEBEFLxmHmdPNBUmTH388BgiIiKicA+BMSIzBOZb3/oWdt11V7S3t4/5fDabrX4A5PDDD0cymRz6elMBECIKD18p9DpZlHw2UyWarJSZ0UPHpGsJEREREVXfm9/8Zl1u4xOf+MSYz0v32d133726AZALLrhg6GspdkpEjUHuXGe9Qr0Xg6ghJcwkPM+DCwZAiIiIKJyiNgRmjz32wBNPPDFuAESSMZSqbGnNSn5pq622wvr16zd6vLe3Vz9HREQUlW4l0lmIaHRx6bTZAqOyj1FERJFlwELSSPP8SFMi3WZPP/30cZ/fZZdd4Pt+7Yqgvvbaa/qO2GilUgmvv/56RQtCREQUNgUvxwAIbcSEhRnxuVhRWgqPATIioiExI46O2Eysd1bBg801UyNRa4M7Z86cqs17UgGQ3/72t0Nf33XXXejo6Bj6XgIiUiR10aJFwS4h0STuyLFQITUb7vfVJYNfiDY67gwDCTM1WA8tJB8WKfp4vqdGIJlxMSPB82ONSS5EEPmqPqJvUgGQI444Qv8rb/iLFy8e8Vw8HsfChQt1ugpRrbVZacTNJLqdXq58ahotVhJpM4VuZ4BZCkQ15Csffe56+IrFpak2MlYSMSOGoufqwsxEYeUpB1mvl+dHCoR0oB2r+Yo8lkqldLHUT33qUzj++OOrEwApj7ORLI/HHnsMM2bMmMyvE1VNezyDFqudARBqKq2xFLri09Dr5vQFGRHVhg8P3c4a/S9RLWSslA54K1WE7TEAQuHOnBzwuqGaIpcgPKQeaIU1QUcIYh5BOv/88/G1r30NhxxyCN7xjnfoxx599FHceeedOOmkk7BkyRL853/+J1zXxWc/+9nq1QCRFyIKW6tXjxeA1GS43xPV8fhj8INqSLodSEFmDvWl8JO9NGRX0U1AwYAPI5D5hMmDDz6Ir371q/j85z8/4vHvfe97uPvuu/GrX/0KO++8M66++urqBkCE1PuQac2aNRtVYP3hD39Y6WyJKtLr5JD1WGiJmsuAW4Ttr4fHNHwiokiTdvYF34btM+uIiJqH1B297LLLNnr8gAMOwFlnnaW//sAHPoBzzjlnwvOsqH/bRRddhIMOOkgHQNatW4eenp4RE1GtFfwSBtwsVzw1laJvo8/N8U4LEVHElXwHea8IVzn1XhQiCvEQmCCmMOnq6sLtt9++0ePymDwncrkc2traJjzPijJArrvuOtx444047rjjKvl1IqKGkTYTOh3Q9l2mvBMRERFR6ES1C8x5552na3zcd999QzVApBbp73//ex2TEPfccw/e8573VDcAYts23vWud1Xyq0REDaUrkYGv4lhnD7CiORERERFRjUhdj+233x7f+c53cOutt+rH3vrWt+LPf/7zUDyiPBSmqgGQz3zmM7jpppt0RIYozIwNhXwatRiTseFvkLJnVB9xw4ILa2hfImqW889YTBj6rwnibxpcO9FbR0RERLXmq8EpiPmEzd57762noFQUACkWi7j++uvxxz/+UVddjcfjI56/8sorg1o+oimZnWxDzvUw4OUack1OSyTRYqWxppRHyWeR13rocwvwlQ1PuXV5fWpMMcNEZzwF1zeQ9Vy4qhSJgM7sVCuUimGdnYOrpnZOao8ndYDR9k0MuHm2TCQiIqKNeJ6H2267Df/617/09zvssAM+9KEPwbIs1CwA8uyzz2LXXXfVXz/33HMjnjMM3iWlcJA9cXayHWthN3QAZFaiA32OywBInfQ6Bf0v71DTZFiGgRmJDIqehZJfiEQARKqmz022wlMp9Dr2lAMgHfEEMmYSA66FnFuEF7qRx0RERI1hMDszmPmEycsvv6y7vLzxxht66Iu45JJLMH/+fPzud7/D1ltvXZsAiBQhIWoEju/BU7X5UJ22LChlougHV6HdVUq3vPPDVpK5iYQl8GHARMyIwZniRSfVhuw1rvLhSkX1kF7Yx00TpmFATpFyrvE3s5zyN9nKh++7gRwXnlJwlA9Pzyocx1lYmBi8q+WDLU+JiKh5h8CceuqpOsjxt7/9bajry/r16/GJT3xCPydBkJoEQIZHZF555RXsu+++SKfTUEoxA4RCQ47fN4q9KPl+TbJNFra3wnWSeCW7brMXEhO1rlTEgOPpdqfU3BJmHNNis7DafiO0F9T0b67vY3UpC08ZOhAbRjNakkgZFkq2hV7bQ97fdCtxCXq8XuiDUhacAM5JPXYRlmHrYUJBnTOjIm216CFHWa+v3otCRERUN1LsdHjwQ0yfPh2XXnppxXVBKgqASNTlYx/7mM4EkSEvL730ErbaaiuccMIJmDZtGq644oqKFoaoGvUbakE+qHYlk3CQGQwCBhQ9zbkOcgguo4Qal4UYWqw2va+FLDhPY5DCxQNuuAOXLfEYWq048n4MWWfz5xnZ73qdYmCvn/dYV2c8cSOhs76IiIgmQpLFg0gYVyH7kJlMJjEwMLDR49lsFolEoqJ5VvTuesYZZ+jCp8uWLUMmkxl6/Oijj8add95Z0YIQNTK5M7q+WEKPndeZUERBkyKsOW8gNENyqPFlbRd9JRtZtzTleh4ULMcvwYlA3RgiIqoNP8ApTD74wQ/ixBNPxCOPPKKvsWSSjJDPf/7zuhBqzTJA7r77btx1113YYostRjy+zTbbYOnSpRUtCFEjk0vS1wayUCrHVG6qCls5WO+s5vAXCsz6fEnXAJFRglKPg8Kj4OfrvQhERER1d/XVV2Px4sXYa6+9hjrPuq6rgx/f+ta3ahcAyeVyIzI/yrq7u3WaCgXD2PAfx0Y3hqIXznH+FE6mrhwzOFRiIqTuR1QLoMp5ThfjlMh+iArPRp1Tg/pIVBkWPyUiokm9b0S0CGpnZyd+85vf6JIbzz//vH5su+22w5vf/OaK51lRAOTd7343fvzjH+Piiy/W30vNA9/3cfnll2P//feveGFopNZYAm1WBqtL/fBYCZ4oMiT0MT2Z0sUk+5wiHNXctRA60gnMTrWjr1BA1lHINmjbaiIiIqJ6iGob3OEjTWQKQkUBEAl0HHDAAXj88cdh2za+9KUv4R//+IfOAHnooYcCWTAaDIDMTHRgrZ2Dp5hdQBQdhg6AeF5cF7pt9gBIeyqBRZ3T8Lp0A/F9BkCIiIiImtSZZ5454Z+98soraxMA2XHHHfHiiy/iO9/5Dtra2nQV1iOPPBInnXQS5s6dW8ksaZw2irbvhjgWR/UYKiDtUKWtJlOkG5vt+/D1duTx7Xo+8o4D2/fgKV93vzBhwWMHpKYVNwY/nrjK45AomhQ5dwwOHea5lYiaR5SGwDz11FMT+jndebMCFQVApPvL/Pnz8eUvf3nM5xYsWFDRwtBI/W4JRX+9/gBIJKROwuxEF9bZOeT9jVtCUWOQGheri9IxyICjg5zNrTtfwj+dNShKEMQDYkYCabMd/d6aei8a1YFuK55ogacs9DoDcBVbgdPExc0WOCoPv8kz64iIGtV9991X1flXFABZtGgRVq5ciVmzZo14fP369fo5j8UgA1HyXT0RDb8waIml0eNEsxhmM5GhLzSo6Lp6KksaGSSMFFdPE0ubCbgqBhOsB0OTYcAy4nCVydVGRE1FwdBTEPOJuooCIFKpf6yUExkKk0rxQytRtcix1+/k4Ea0GwiRkKLPJcUL32aW80rwlMMuaDRJCp6yoRQ7HBFRc1EBDV9RiL5YJQVJJPhx3nnnjWiFK1kfjzzyCHbdddfgl5KIBo8z+Fhjd8PlhzuKMLmAyXm99V4MquMQsR4nq+9C+TzX0STZfo51Y4iIKJgASLkgidyF/vvf/45EIjH0nHy9yy674Itf/OJkZklEk1RpxxAZPmMacvxCl4drjhhv9ElAupzsLZF/uXhsdPI3KLb+bmoM8lKl1IZ3OCKiZhKlIqihCoCUC5Icf/zx+Na3voX29vZqLRcRBawtGUNbPA7bttDjFOCyQFwktKXiaE/E4dkGBmwg62XrvUhEREREVEMStwgidqEQfRVVibrhhht08OPll1/GXXfdhUKhMJQZQkThlEnEMDOdQmc8jdiGFpPU+FqSccxsTaErkULGYg0mIiIiIqJAAyDd3d044IAD8Ja3vAUf+MAHdEcYccIJJ+Css86qZJZEVGWur1BwPd1ZyGeKcGS4no+C46Hoe2yZTURERNTEQ2CCmKKuogDI6aefjng8jmXLlo0ohHr00UfjzjvvDHL5iCgg/UUbb2RzWGtn4bK9cmT0FWy83pvDqkIWAy6HvxARERERjaeiPPi7775bD33ZYostRjy+zTbbYOnSpZXMkoiqzPZ8PVG02K4HmwVDiYiIiJrWYAH5qadvqCaoAlJRACSXy43I/Bg+NCaZTAaxXERERERERES0GewCU+UhMO9+97vx4x//eEQbRt/3cfnll2P//fevZJZEREREREREROEKgEig4/rrr8chhxwC27bxpS99CTvuuCMeeOABXHbZZRUtyKWXXqoDKVJfpKxYLOKkk07C9OnT0draiqOOOgqrV6+uaP5EREREREREUW2DG8QUdRUFQCTY8eKLL2KfffbB4YcfrofEHHnkkXjqqaew9dZbT3p+jz32GL73ve9h5513HvH4GWecgdtvvx233HIL/vznP2PFihX6dYiIiIiIiIiIXWCqWgPEcRy8//3vx3XXXYcvf/nLmKpsNotjjz0W3//+9/HVr3516PG+vj784Ac/wE033YT3vve9+rEbbrgB2223Hf72t7/hne9855Rfm4iIiIiIiIiaw6QzQKT97bPPPhvYAsgQl0MPPRQHHnjgiMefeOIJHWwZ/vi2226LBQsW4OGHHw7s9YmqwbJMzOpswbREGkZliVZEkWeZJjrbM5iWSSJjsYA2ERERUSWUCm6KuoquzD7xiU/o7Iypuvnmm/Hkk0/ikksu2ei5VatWIZFIoLOzc8Tjs2fP1s+Np1Qqob+/f8REVGvpZBx7brsFdpg2GzGjomZLRJGXSMSw7VZzsN2cLsxJybneqPciERERETUcP8Ap6iq6MnNdFz/84Q/xxz/+EbvvvjtaWlpGPH/llVdudh7Lly/HaaedhnvuuQepVApBkWDKRRddFNj8iCq9sz2jIwOVMGHwoo5oTKZpoKM1Dcvx0Wc2w1suERERUTRdeumlOPfcc/U1/lVXXYVIBUCee+45vO1tb9NfSzHU4aSTy0TIEJc1a9YMzUd4nqc7yXznO9/BXXfdpTvM9Pb2jsgCkS4wc+bMGXe+stLPPPPMoe8lA2T+/PmT+vuIpsp2XDy/bB0Gsg58eFyhRGNwXQ/LVnbDzNvodiQA0gR5l0REREQB89XgFMR8KjFeU5PIBEDuu+++Kb/wAQccgL///e8jHjv++ON1nY+zzz5bBy2k3si9996r29+KF154AcuWLcNee+017nyTyaSeiOqpaLt48uWVUJ6Cq3hnm2gstu3h5aVr9IBTn4cJERERUcPJjtPUJKzqVpygra1Nt9MdTobSTJ8+fejxE044QWdzdHV1ob29HaeccooOfrADDIWdUgolx633YhCFmoKC4zJDioiIiGiKH6qCKWCqptbUhAGQKfrmN78J0zR1BogUNz344IPx3e9+d6qzJSIiIiIiIoqEoAqY+hv+Hd1IZLxRFuWmJjIEplGEqj3F/fffP+J7KY56zTXX6ImIiIiIiIiIqmv+qBqaF1xwAS688MKaNDVpqgAIRUPCNJG2Esi7Hhzl1HtxiKhBZGIxGMqAowzYvl3vxSEiIiJqCCqgITBK/Tu4ISUoysbK/thcUxMZwWFZFsKGARAKXFssgQWZLryWLaDH7eEaJqIJmZVKwVJx9DsG1tk9ukYIEREREdV2CEx7e/uIAEglTU3CGPwQDIBQ4CzTQMaKwzKieQfXwGCrZ16cVbbuuN6ia6rHRtKyYKkYYu7E2qnT5PH8RURERLVqahJGDIBQ4PKuixWFfhQimsK+RboTrh/HqtJaXsxPggUTc1NdWGfnUPQL1dtAVLcL64UtnfD8GFYV+2Gr0qTn0VMqwYSHvFdREXIaxUIchmHC3bAtTBjoSrSh5AED3kBlpd6JiIgolB0oZQpiPlHHAAgFLue6KHh98CN4AMl96S3TXSh6LVhVWi8j3eq9SA3DMkxsmZ6FnLuKAZAIMg1gm9bpKLkpdNsl2N7kAyDrivI7pQ2X5dE7f9RazJAASHwoACLBkFmJTvS7ClkvywAuERERVbWpSRgxAEKBk/R3rwGDH6ZhIBOPwXEVbN8b9+LAVZ6eaHJkbcp683lhG1mO78Px5dio7PjnvrGxuGXCMAwoX8FXBjzlT3j9yjnMGHEulnOzH8ngNBERUTPz1eAUxHyijgEQog1aknHsPm8m3lhr47XcABy/uNG6kXPCK7l18FUfVCClhpqHpzy8ml+FgsfhL1Ekb5jPD6yF51sojnHsUGVmdLQgZRnwCgrZkoVeZwD+BDPPXOXAgDtsGymsKvXA8VnDiIiIKErkGiWI2IVC9DEAQrRBMm5h0bR2FPsLWJ7LY7wGvmvtLNdZhXf319p9XHcRJdkGK4tSV4KC1JZJoDVmwfU8+G4cfU5uwkPv/GHBj/I26nPl94mIiIiaEwMgVFNtsVbk3QK8GtbOkLodszpbkHITWJUvoDTO3Wnb9fF6fxa9tj3hO6xEImFI16O4rm0Sxi43EtxrTyXg2UC/bXMIVwPJFR34lgfP8VD0JIzIzDOiqYoZFiwjBkeGZaqRgcKoDqXLJGJ6KJ3nGij5Ptwm+LuJmgmHwEwcAyBUM9KB4E3JOXjNXwHPz9fudU0DOy2chdnZLty99HWsHScAkis5eHT5GthOuY4B0cS0xNJoMTuworQSatRd9zDoyCSx7ZxpKKz38a+ePmS92h1/NDVre3O6wKyU/vB8Az4DIERTljSTaLFa0OcWUFLRz+qU4McW09ugSh6KeRNrizYGvOj/3UTNhAGQiWMAhGrIQMKM63aZtWWgJRVHu53Sd3zG4/sKfboLBUXR4F5nVKXDiLT4jZmxmu/ZE2WZG+7+Wb4u9ls+BsfLVtnc81Q7tstgLIXT8PfyiZ4rKvmdapDlsAxLd0ZqBnIjKBmz4LsKnmlW/HfLemOXLiJqdAyAUM3Ih5019npdmK+WpPDfS290Y1WphJw3do2CmBFDV7wLa+11TDFvaAZMWBvVPhBpK4H2WAt6nRKKAWcg5f0SPKcvtHfns0Ubr67tg51TKPkOOmIZGEYMPU7/mMGgjlgbHAXkPHmeiGhj0+IpfSFd8oCsN7HaMh3xlD5HFz2FvF+/ejS2cpB1c3B9G82g6HhY1ZeDchRcx4DtV5apmLEyupOUDPckojAWQZ16YFkh+hgAodoGQErrat7qUimFF97ohqG6x23PGzcszEjMxDp7fVMc+FGlcxsky2eMsc0tVgJzkp0ouP0oItgASMErooBiaDMmsgUHr5T6ILu/pEjKerCQQq/TP+YSd8TbUPAYACGi8XUlJJgRR7+hNgyr2/z5rzOehoU4euGj4Ofrds60fQfyXzjP2MEr2i5WORuyyeR9oML311arRQdPGAAhCh8OgZk4BkCopup1h9zzN/268iHI9WubmULVMvZHWgl+yQe3sfZBqU+TtGJwdGG4yQ85CGvgY/jyecP+bFdJGHL8v1PWwVT7wMcNE3EzjpLn1rTocaNImJKCbuj1XMk+1wzipqmPTVlHcvyGNcOqWcl5xJSjW03uvVgZcn7Z9FlTLrZl+2PDtvcC3/ZhP2tX4c7wODeAJkPO5dU+Do0NN6VkaWXfYlF6IgoaAyBEABzfwarSKg5/aXDykdYfZ4hVzivhjWI3imMEujKxGBZmpmFVwcY6pxdR1+MMwMD4d197nL5JXdSMpSuRxuzkDCzJr8eAy2J7o81KpWGqGAZcjDsUqdnNSCeRMmMoOiZ6bReFOg6ZoI2tLRV0oMLVu+7E9t/1Tl7/juNv+nck+DE3lYHrm+h3XQywfXPdyfuFnMsleFVNpmFiZrIVvjIw4HrIjjN0mYhGHaNqcJoq1QQfRxgAIdJ3NXz0s95BRD6ijX3mLvmunsYid5umJzLotQ2gCRKB8t6mi/3mvamP785YccxItOGNAuuIjKU1Hoel4nD8wbKQTfB5Y9Ja4jG0WHHE/BiyRlhLDDevnPTVnqT8BH9HijW3xxOwPakXwm0fFiW/+oXiJeurNZaA55u6ZhUTCIkoaAyAEFHTc5SHdaU8CpsJDNDG4kYCMlDBMn3EjASKngtbFZHzHKwt9etig7SxAceBqYsJlrsq0GhZx4XrKZRcD+4YdX0ouiTLoN+xdQZIpQU7KXz00CYjqY/nsYqVCxmgmXVL8BS3PdGks6ADKYKqIr/iGQAhoqaXd128muuG0wx5fwFLW2nEkEAm5iBjTcOa0gBst4huu4ABZxUvXsaxpjg4fGBwqBH3u7GsL5QG225uqANBzUPqMa0s5jcUbua2j1KftozVhryXhz1OUNNXPtaUBoe7TXUoJlEz4RCYiWMAhIgiwTJ0Dxh9oTTZ6LVEzAu8y1gRyf4wDQuW4ep20gasoQKJrmqOFpOVXuA14zEq9EXtBI7RZlxHNEjO4bbP4sBRpEsbG4MFbseiNmRlEhFVCwMgRBQJW81oQ8ZP4uXeAnIei27WirRDNKWhpPKQ99ajWIMx4tR4JPQxv7MFcd9Cd15hvS78SkTNRBL0C34WLodGEgVObhkEcdvAR/QxAEJEkbBwWiu6vDasGOhlAKSGBgMeJRj6HbPIwRw0JsMwsEV7Bmk/Ad9hAISoWTN7Cn6ew/6IqnF8SQZ0AEMGVRMMO2QAhIgiIe94iHs2PBZLRNyIw1Vejdo6D75RRv/tkqZCPk8VXA/Kc1lrh6ip8d2CiOqLARAiioTn1/QirrLIeuw60hHrQp/bC0dxOAqF587vq90DsJSJPA9RIiKiQPm6aHQw84k6BkCIKBLW5waHYpCBlJlGP1hjgcKlp8CiuERERNXgB9QG12+CLC2z3gtARERBUsj7Ofhozir6McPC9Hgr0mZ6Ur/XFkui1UrD3NDFhoiIaKISZhwZK424keBKIwo5BkCIiCKmz+mB16RV9pOmhQXp6WiPtU34d6R98vREC6bF2xAzmRhJRESTk7FS6Iy1ITnJ4DtRUNSGeltTnhB9DIBQRYwG3XXMDf8RDV72RnNf8ODqmgvj/dWW/rulMWkUGbAM+Ssn9/eZsjfo3yOiWhs88nj01ZI+50X6vaC29LtOBe89RFR7vNVFkyYn91ZrGga87oar5j0z0Q4fcay119Z7UajOYkYMGbMNA17PuMGCKEqacUyLd2Ct3QM3gh1zbN/F68UeDHgT/9tk+3c7eShlRnKdEIVdwkjBk9CtYp2YWmmLtegwSM4rwG3SjMEgFbwiXN9Dyed7CNUHa4BMXDRvf1LVAyAZq6Mho9zTEq3ojE3jHQ+CZVhosWSYROPtx1MNgExPdMCKaK0LR3lYXepHzstN6vf6nAL63Bw81Zy1U4jqKW6mEEOcG6GGWmNptFotsHgvNBBF38aAl4PN7mtUJ4EMf1GDU9QxA4QmTY4Lt0FP8EXPgd+gy07BUko15d1GT/koeqVIV/muJKMnumuDKPx85cGHX+/FaCqOzlSQsyXPfkTUXBgAoUmTN8sBd31DvmmusXt1mjsvd0hSfvvc5hr+Ur5LtbK0Dh6HehBRSJT8fNOdi+utz83qDEgO+yOKBg6BmTgGQKgCCrYqNuSay3vM/qBBcrexUffjqXCVB9cr1HsxiIhGFG6m2ir5rPtBFCW+UoFk9/pNMAaGNUCImrT6u7RrSxjJei8KEVHdSAWg9lgKbbF0ZOviEBER0b8xAELUhEzDxOxkF1LsV09ETUyKeU9PtKAr3oaYyQAIERE1JhXgf1HHAAhRU2uuDihEYc/MihsWTL411xzPhERE1Ti3GrAMeVeTdzieaSkcWAOEqAn5yscauwdFnzVRiMIiE4tjbrIN622FbqeHxZprQO50dds5KJi6Pg4REQUnacbQEU/D8Q0MuAU4Tdh9r1YkbyOIXloK0ccACFETkiJJPU5/vReDiIZJmzHMSbWj5HnocaRDEVWbrOM+t/mKIRMR1ULctNARS6PkGyh4LgMgVcQuMBPHAAgREW1SJhZD0kig5PsoeKWmGB9aD47yMeAWUfK5fomIqPF5ykfRd2D7Bnxm2VFIMABCRESbNDvdgnmJ6VhVKOG1wip4/BBTFVnXxiu5bpT8waEZREREjazkuVhTGtDvaA4/O1SVUsEUMFVN0AaXARCiEJDCULzgobBKxyx0JtLoswf3VaoOV2eAsC4PERFFgwcfnh9EZQraHA6BmTh2gSGqM6mLPSsxDQkzVe9FoQiSVsctVvuU5tFTKmFprhvddr8uoBsGMcPC9HgH4ka83otCFFomLLRZnTB5v4uoYkkzgVYrg4SR5FokigBmgBDVmWmYeFNqFvL51bB9FuOjYGWsFiSNVuS8yoverinksR5FSI8MP5Aa41MXN2KYlexC0ffgeE69F4colCzDQmdMjpMSfOXWe3GIGlLGSiJjZtDvlmB7zNKjcGIGyMQxAEIUAoOj9qI/5o7qQfarqe1bnlLwdPgjXAbHqfK4IdrkccJjhGiK7zXl44jvNxReakMIJIj5RB0DIER1JkMKlhdXo+QV6r0oFEE5L4cibESNo1ysstej5EfvbyMKihQs7nHXw1PMkiKqVMEv6vcc2w/fjQAimjwGQIjqTOK16+zeei8GRVRJD6uK3tAqV3nodQbqvRhEoebDm9LwNyKS91EHJTCISOHGITATxyKoRERERERERBR5zAAhIiIiIiIialDMAJk4BkCIiIiqwNjw/yxCSUREjff+NfgV38Mag3TpC6JTn88iqERERFSJrkQGCSOObsdGyWeRYyIiagzTEimYMOD4JnKeDZeFlClCmAFCRERUBTOTGbRZrch7/QyAEBFRw2R/TE+mEEcMedeC7WcZAGkAylBQRhBtcBWijgEQIiKiKvCUgqf8pvgwQURE0eHL+5fhw1McAtMo5LOGfOIIYj5RxwAIERFRFawuZtFtlFDw2D6RiIgag1z+rikWYBoGXF+Gwbj1XiSiQDEAQkREVAX9bgmATERERI1jwLXrvQhUQfFSg0VQJ4QBEKIqkeJRnfFWDLglOIpvJETjyVgJxI0Usm4OHjyuKCIiIqJJGBwAE0QNED/y692s9wIQRZVlmHhzyxy0WC31XhSiUJseb8WC1DzEzWS9F4WIiIiIIowZIERVlDbjMA3GGYk2+UZkmkiaCRiMyRMRERFNmm/4MALoAuM3QQYIAyBEVaygvay4DkWvwHVMtAm9TgG2txYuh4oRERERURXV9db0hRdeCMMwRkzbbrvt0PPFYhEnnXQSpk+fjtbWVhx11FFYvXp1PReZaMI8+FiaX4eCzwAI0ab0OnmsLK2Go9gthYiIiKiSzI2g/ou6uufm77DDDli5cuXQ9OCDDw49d8YZZ+D222/HLbfcgj//+c9YsWIFjjzyyLouL9FkyEmkGfppE029d7284fJYISIiIposBkAaKAASi8UwZ86coWnGjBn68b6+PvzgBz/AlVdeife+973YfffdccMNN+Cvf/0r/va3v9V7sYmIiIiIiIia0iWXXIK3v/3taGtrw6xZs3DEEUfghRdeQNjVPQDy0ksvYd68edhqq61w7LHHYtmyZfrxJ554Ao7j4MADDxz6WRkes2DBAjz88MPjzq9UKqG/v3/ERERERERERBTlNrhBTBMlIzSkXIUkJ9xzzz362v2ggw5CLpdDmNW1COqee+6JG2+8EW9961v18JeLLroI7373u/Hcc89h1apVSCQS6OzsHPE7s2fP1s9tKhIl8yEiIiIiIiKKOh8eDHiBzGei7rzzzhHfy3W9ZIJIIsO+++6LsKprAOSQQw4Z+nrnnXfWAZEtt9wSv/jFL5BOpyua57nnnoszzzxz6HvJAJk/f34gy0tEREREREQUZf2jRlEkk0k9bYqUsBBdXV0Is7oPgRlOsj3e8pa34OWXX9b1QGzbRm9v74ifkS4w8tx4ZMO0t7ePmIiIiIiIiIiiWlA+mCEwSs9PEgg6OjqGJhllsSm+7+P000/H3nvvjR133BFhVtcMkNGy2SxeeeUVHHfccbroaTwex7333qvb3wopqiI1Qvbaa696LyoRERERERFR5CxfvnxEIsHmsj+kFoiUsRje0TWs6hoA+eIXv4jDDjtMD3uRFrcXXHABLMvCxz/+cR1pOuGEE/RwFkmjkQ1wyimn6ODHO9/5znouNhEREREREVEo+IYPw/CnPh8MzmMyIylOPvlk3HHHHXjggQewxRZbIOzqGgB5/fXXdbBj/fr1mDlzJvbZZx9dRVa+Ft/85jdhmqbOAJHuLgcffDC++93v1nORiSLBhAVDl0py670oRJETNxJwlTOURkpERBRmBkz9uXAyBTApjEVQp17dwp/EPqCU0gkKv/71r3H//fdj0aJFaASGkiWPeAEXySYZLHdi1HtxiEIhZbYgbqQw4K2v96IQRYoJE13xWeh11+sgCBERUdjFjKQO3hf8AUSLXOb6ujhnVOtClq91t5p2BCwjPuX5ecrBqz23TWidfeELX8BNN92E3/zmN7qra5ksT6UNTZquCCoR1YaFGOLGpsfyEVElDKTMdCB3YYiIiGoVvI8FcPFM9RREAVRfz2eirr32Wh0o2W+//TB37tyh6ec//znCLFRFUImoNuTOtOEXdLrj9EQH+pwCHFXi6ieaIhn2kvez8JWvj6+OeAaeb2DAy224EzVxHS0pWPJRxFEouQYKvhyjkU7aJCKiOpBhD46yRzyWNpMwDRO27294ju8/YeYrGbpiBjSfiWnUgSQMgBA1IVsVdcDDMkxsmZ6Dl7zVcDwGQIimSu6e9Dk98ODpEdXzkp3IexayhdykPzrO7mpFUgFO1kN33kLRtllXhIiIAifDHjw1si5cezyDuBFHn+vCcUcGR4gaGQMgRE1oMM1tsBiqBEEaKV0/bpiQe+veJCLURLVULi4sGSBy90z+q4RlGrCU3JmTOYW/hlXMNPUNQk9JHkxj3hUiImpGg+fskeftwbKojfH+Q+XP9lPvAqMCmEfYMQBC1MR8pbC8sAZFP49GYBoG3tLeiawdx7LC2qY4SVPjko8iq0t9cHyjonDAmp7c4BCYkkLBkw+g4Q0qxE0TW3e0wbYtrCwUUWiQcwoREY2t383DMiwUfX7WagQKHlQANzRVE3QCYgCEqIlJr+9VpfUNc7dW7kYsam3HmnwKy4vr0KBDD6lJyHG1zi5X1J/8ztrd/+8gQth3dcswsGVbC3K5BNaXwAAIEVGDy3nFei8CUVUwAELU5Bol+FHW79jIe1J4qd5LQlTd46uRdnEphDbgOCh4kyugRkRERMHc1JxMB5dNzyfaGAAhoobhKR//6O2G7Zsc/kIUIo6v8K/uPvi+iYLPAAgRERGFEwMgRNQw5I74epspmURhrHfSU2KXACIionoYLD8eRBFUhahjAIQajHRViMMf1aucKJoMxI0UHFWo94IQERERUUgpJUVQjUDmE3WN0/uSaDD8gZiZ5LqgpiCt55JGa70Xg4iIiIgoEpgBQg2I/cipuYIg1Nyk/bNMUvhXpmYoUEZEREQTxyKoE8cACDUUGdvm+awBQc1BxmGWVLbei0F1Ni2TQCYWg2cbyDoK/W6u3otEREREIaIQ0BAYRH8IDAMg1GAUPNb/oKahYKt8vReC6qw1GUdXMgHHMOH7PgMgRERERBViAISIAhE34rpGi61KXKPUNJJmApZhoeAVq1Y5veT6yJkuXNeA7Y98DRMm4mYCtm+zNTRRk0ibKT0QruTL+230OzYQ0eYp5QfTBUZFf5gtAyBEFIhWqw2WkcI6ZwXXKDWNrng7WqxWvJpfXrW00Z58CQMFG/KZxBn1uSRmxDAtPgNr7TXMjiNqkrpQs5JdsD1glb2qKVpWEtHmsQbIxDEAQkSBiJsxWEhwbVJTSZhxpK1UVYvVllwP4+VVGYaJpJHU2VdE1BxS0g1PDQZDGP4gIpocBkCIKBAFrwCzCQonEQ034Obh+nIPtj4po57yMOD1w4fLDUPUBORs0+v0w5GuUAx/EFH53KACKoKqov9ZngEQIgpEzpPOFOxOQc2l1xlAn5GtW2taV7nodbrZGpeoiayze/SFTr0Cr0REjYwBECIKRL0uABtVwoxBKcBRvHPf8Pu9qntz8HouAI1iwkDMMOEq2TY8L1LwPO5XRDSKZIQFUgQV0R9YxwAIEVGNSYLim1u6kHUsLCuuYhV/ogjJWAnMSXVgbSmPPjdb78UhIqKm6QITxBAYH1HHqmlERDVnYG6yHV2JjiqWziSiekhaMcxMtOriuERERBQuzACpsbiR0KlFrnJq/dJEmglT74clJX0lop/mNhVpMw1bOfCqMEylxykg61rjbgGp7p8yUyj5DgtcElWBtBCW7jmOfj8O7lzo+j763SJsn+/z1Xwfk+0nNXAacZiRCQuWYenlZx0PIgqGFEENZj5RxwyQGstYrUiZLbV+WaIhlhFDR7xLf4Ck8UkAYkZiOhJmJvDVJEHQF3Pr8EZxzbgXXvLhePD1eReZqBoyVgYtVlvgLYxzXgmv5deh32VR6GqR4Ed7rAMxI45GlDATaLXadSCEiCiwITABTVHHDJAak4sapZj0TvUjH/Yb9UNjrSXMeNU+oGZdycDZ9HaSD8lyh5qIgmfBgmkE/zHIVT5czw58vvRvpjGYAdKo58fBDJY4DMNgIiYRUY0xAFJjRa8AKVFDVC8ePOS8gaao8jxVfU4/HD1UqPZ85aPX6YOreCFFVA0l39ZBTmo8MnREWq97aMwuWjLsquDn4Kvop5oTUW0MZm6wCOpEMABSY/KGR1RPUs+i3+3luOPNkABRt9NTt0CRBKp6nB4GTImqpOSXYBhprt8GDYBkdSAfDRsAcT2HNyKIiOqAAZAa4113CgMWXZuYehfXq/frE0X9/VjpO/CNehnd3Br781RjLz0RhY98ZgyippVqgs+eDIAQERFR05EPebbK80KUiIgaHofATBwDIERERNR0BlvS16fGDxEREdUHAyBEdZYwEromvK2K9V4UooaRMjOw/SKHCRERUdUMds0zWJCcQm9wSGd45hNmjdk/jChCWqw2tMQ6670YRA1Dxrh2xrpgsZ0zERFVOdieNtsCqa1AVPW6Vrp0/lQnFfkNxQwQojqzDAsweCgSTUbMiPEDKRERVZUJEwbvFxNFCq+6iOqs4EsRPo5DJ5oouTsx4PXpls5ERETVUlJFHQCJ/j1xikYR1PDMJ8wYACGqs7yXq/ciEDWcfre3KdI0iYiofkq+BEAE328o3BgAmTjWACEKxZg9vrESbYqMv04YSf1V+bghIpo4Qxe05HAGquRTGhFFBwMgREQUepYRw8zEHD0em4hosuTc0RmbjoSR5sojosgJpgCqr6eo4ydJIiJqiIuXVqudd2+JqCKGYSJttrB7FBFRk2MNECIiCj0fHga8/qa4M1EWM0y0xGLwfANF34PLoq9EUxofX/Bz8JTDtUhEkcMaIBPHAAgREYWepzystVfCb6IASCpmYV4mg6JjYU2pCNdj1xuiSsm5o9ddr88lRERRwwDIxDEAQkREoSdF6Bxlo5nIGNWYacIyTF0EloimQsFl9gcRUdNjAISIiCiESp6PNYUCHM+E7TNtn4iIiMYTVIasH/lVzAAIERFRCJV8D2uKRf012zASERHReDgEZuIYACEiooZmGgbaMwlIdnvOiVaxUAY+qJ5k+JVMvpLhI81ROyMdjyFmGVCuiaIXrfMJERExAEJERA0uGbfw9jfPhdft4elVA+h2euu9SESR0GIl0BZLI+e66HUH0Azmz2jDtHQCfl8CL/Xl0Ot213uRiIg2K6gueaoJhsBIjTUiIqKGJYVC53W1Ym5LC5Jmot6LQxQZCdPSQZCEGUezaE8nMLMtjRmpFiR4PiEiihwOgSEioobmeD6WrO6D1++h4A3WzCCqt1Yrqe8zFTwbHhpz+EjJdzHgFnU9mmbRnS3Cc32ovI2iz/MJETUGpVQgBUyVnk+0MQBCREQNreR6eOKVVZASBSU3+qmbFH7Stnh6ogVKxbBa9cFr0ABCzrVR8FxdA6RZvN6dxUrDgPIN2B7PJ0TUKOR9xghgPgpRxwAIERE1NLlbkSuxTSyFrzivH8iH0UpDMFMvouvLaPAmKX5aZrvN9fcSETUbBkCIiIiIAqXQbef1EJh6dBGJGwkYMGGrQs1fm4iI6tUGd+pBd9UEGX8MgBAREREFSD4+9ruFuiUSx4w4TFgMgBARNY1gAiDgEBgiIiIiaqSPkL7cCTTqNfyGiIgovJgBQkRERBQhjirBUAyAEBE1jYCGwIBDYIiIiIiokfgN2naXiIgqM9Wi10HPJ8zMei8AERFRo2iPJbAg3YUWK1PvRSEiIiKiSWIAhIiIaIKmJ9PYvm02OmLtXGdEREQUEn6A0+Rcc801WLhwIVKpFPbcc088+uijCDMGQIiIIsKAgbgR0/9SddczUZiYMBEzLO6bRERUUz//+c9x5pln4oILLsCTTz6JXXbZBQcffDDWrFkT2i3BAAgRUUSkzDgWZuYgbsTrvSiR1W0X8a/savS7A/VeFKIhrbE0ZienI24kuVaIiJqSGixgOtUJk6sBcuWVV+Kzn/0sjj/+eGy//fa47rrrkMlk8MMf/hBhxQAIEVFEJMw45spFkMkASLX0OSUsza9H1stV7TWIJitjJdEV70CMwU8ioialAvkPkwiA2LaNJ554AgceeODQY6Zp6u8ffvhhhFXk2+CqoVY+0a9oS0TNTc53nvI2nPd4zqvaeq7anIkq4ysFn8c+EdGY79j/vh6MuuD+zv7+/hHfJ5NJPQ23bt06eJ6H2bNnj3hcvn/++ecRVpEPgKxfv37DV7wgIKJo6/cG8FDPM/VeDCKqsTX2Oj0REdHY14MdHR2RXDWJRAJz5szBqlWrAptna2sr5s+fP+IxqfFx4YUXIgoiHwDp6urS/y5btiyyO36USfRRDsDly5ejvZ1dFxoRt2Fj4/ZrbNx+jY3br/FxGzY2br/G1tfXhwULFgxdD0aRdF5ZsmSJHo4SFKUUDGNkwffR2R9ixowZsCwLq1evHvG4fC9BmbCKfABExiEJCX7wArpxybbj9mts3IaNjduvsXH7NTZuv8bHbdjYuP2icT0Y5SCITPXIPtl9991x77334ogjjtCP+b6vvz/55JMRVpEPgBARERERERFRsKQF7uLFi7HHHnvgHe94B6666irkcjndFSasGAAhIiIiIiIiokk5+uijsXbtWpx//vm6Dsmuu+6KO++8c6PCqGES+QCIjFeSoi1jjVui8OP2a3zcho2N26+xcfs1Nm6/xsdt2Ni4/Robt19tnHzyyaEe8jKaoZqnLxARERERERERNaloV4QhIiIiIiIiImIAhIiIiIiIiIiaATNAiIiIiIiIiCjyGj4Acumll8IwDJx++ulDjxWLRZx00kmYPn06WltbcdRRR2H16tUjfm/ZsmU49NBDkclkMGvWLPzXf/0XXNetw1/QfC688EK9zYZP22677dDz3H7h98Ybb+ATn/iEPsbS6TR22mknPP7440PPS2khqQY9d+5c/fyBBx6Il156acQ8uru7ceyxx6K9vR2dnZ044YQTkM1m6/DXNJ+FCxdudAzKJOdNwWMw3DzPw3nnnYdFixbp42vrrbfGxRdfrI+7Mh6D4TYwMKA/t2y55ZZ6G77rXe/CY489NvQ8t1+4PPDAAzjssMMwb948fa687bbbRjwf1PZ69tln8e53vxupVArz58/H5ZdfXpO/r9m336233oqDDjpIf6aR559++umN5sH3xXBuP8dxcPbZZ+vPoS0tLfpnPvnJT2LFihUj5sHjjyITAJEPC9/73vew8847j3j8jDPOwO23345bbrkFf/7zn/VBcOSRR4748CjBD9u28de//hU/+tGPcOONN+o3L6qNHXbYAStXrhyaHnzwQW6/BtHT04O9994b8Xgcf/jDH/DPf/4TV1xxBaZNmzb0M/Kh7eqrr8Z1112HRx55RL8pHXzwwfoDRJl8EPzHP/6Be+65B3fccYd+gzvxxBPr9Fc1Fzl3Dj/+ZBuIj370o/pfnkPD7bLLLsO1116L73znO/jXv/6lv5dj7tvf/vbQz/AYDLfPfOYz+rj7v//7P/z973/XF19y0SzBZcHtFy65XA677LILrrnmmjGfD2J79ff36/1AgmJPPPEEvvGNb+gbRtdff31N/sZm3n7y/D777KPPpePh+2I4t18+n8eTTz6pbwrIvxLMeuGFF/ChD31oxM/x+KMRVIMaGBhQ22yzjbrnnnvUe97zHnXaaafpx3t7e1U8Hle33HLL0M/+61//ktti6uGHH9bf//73v1emaapVq1YN/cy1116r2tvbValUqsNf01wuuOACtcsuu4z5HLdf+J199tlqn332Gfd53/fVnDlz1De+8Y0R2zWZTKqf/exn+vt//vOf+ph87LHHhn7mD3/4gzIMQ73xxhtV/gtoNDl/br311nrb8RgMv0MPPVR9+tOfHvHYkUceqY499lj9NY/BcMvn88qyLHXHHXeMePxtb3ub+vKXv8ztF3Ly3vXrX/966Pugjrfvfve7atq0aSM+h8r77Vvf+tYa/WXNuf2GW7JkiX7+qaeeGvE43xcbY/uVPfroo/rnli5dqr/n8UejNWwGiKRqSxaH3DEZTqLmkg41/HEZXrFgwQI8/PDD+nv5V1KlZs+ePfQzEqmX6LtE56n6JDVU0tS22morHZWVIUncfo3ht7/9LfbYYw+dLSDDx3bbbTd8//vfH3p+yZIlWLVq1YhjsKOjA3vuueeIY1BSgGU+ZfLzpmnqu2dUO5IJ95Of/ASf/vSndWopz6HhJ8Ml7r33Xrz44ov6+2eeeUZn0R1yyCH6ex6D4SbDbSUTVYY5DCdDJ2Q7cvs1lqC2l/zMvvvui0QiMeKzqdzNlsxLqh++LzaWvr4+/XlGjjnB449Ga8gAyM0336zTnC655JKNnpM3IXnzKO/0ZRLskOfKPzM8+FF+vvwcVZd8KJAhR3feeadO45YPDzLmVcZEc/uF36uvvqq32zbbbIO77roL//mf/4lTTz1VDyUbfgyNdYwNPwYleDJcLBZDV1cXj8Eak7G0vb29+NSnPjW0bXgODbdzzjkHxxxzjA7uy1A0CUJKPQkJJgseg+HW1taGvfbaS9dtkSG6EgyRIKR8SJchadx+jSWo7cXPpuHF98XGIcPOpCbIxz/+cV1vR/D4o9FiaDDLly/HaaedpsdQjr57Qo2hfJdSSP0WCYjImNdf/OIX+g4YhZvv+/ou1te//nX9vVx8Pffcc3rs8+LFi+u9eDRJP/jBD/QxKRlZ1BjkXPnTn/4UN910k66nJAX7JAAi25DHYGOQ2h+SdfWmN70JlmXhbW97m/7ALneaiYho8mQEwMc+9jFdlFhu1BFFJgNEPhysWbNGf1iQ6LlMUuhUik/J1xJxl5RuuaM5nHSBmTNnjv5a/h3dFab8fflnqHYkW+ctb3kLXn75Zb3+uf3CTarcb7/99iMe22677YaGMZWPobGOseHHoBzHo9PCpUo3j8HaWbp0Kf74xz/qgoxlPAbDT7qWlbNAZDjncccdpwv0lbMieQyGn3Tukc8u0gVEbuw8+uij+sO7DAvl9mssQW0vfjYNL74vNk7wQz7XyE3ycvaH4PFHDR8AOeCAA3TFdLnjVZ7kbrSk/pa/lpRgGR9dJuMn5eJMUk6F/CvzGP5mVD5YRl/YUfXJB8BXXnlFX1jvvvvu3H4hJx1g5JgaTmoRSBaPkNac8mYz/BiU+joyznn4MShByuF3O//0pz/p7BLJCKLauOGGG3RattRTKuMxGH5S9V5qBwwnWQRy/Ageg41DuoXIe5/UeJAhhYcffji3X4MJ6niTn5HOMHIhN/yz6Vvf+tYRXdao9vi+2BjBD6kvKDd1pJ3xcDz+aCMqAoZ3gRGf//zn1YIFC9Sf/vQn9fjjj6u99tpLT2Wu66odd9xRHXTQQerpp59Wd955p5o5c6Y699xz6/QXNJezzjpL3X///bra9kMPPaQOPPBANWPGDLVmzRr9PLdfuEl17Vgspr72ta+pl156Sf30pz9VmUxG/eQnPxn6mUsvvVR1dnaq3/zmN+rZZ59Vhx9+uFq0aJEqFApDP/P+979f7bbbbuqRRx5RDz74oO7q9PGPf7xOf1Xz8TxPnyely8BoPAbDbfHixepNb3qT7iIi59Fbb71Vn0O/9KUvDf0Mj8Fwk88d0gXk1VdfVXfffbfujLbnnnsq27b189x+4es8KJ1BZJKPzldeeaX+utxlIojtJZ1GZs+erY477jj13HPPqZtvvlm/t37ve9+ry9/cTNtv/fr1+vvf/e53+nlZ9/L9ypUrh+bB98Vwbj85Z37oQx9SW2yxhb6mk21WnoZ3VOLxR8NFMgAibzhf+MIXdDsxefP48Ic/POIkJl577TV1yCGHqHQ6rT84ykW54zh1WPrmc/TRR6u5c+eqRCKhP8TL9y+//PLQ89x+4Xf77bfrIKK0+dt2223V9ddfP+J5aQt43nnn6Q9z8jMHHHCAeuGFF0b8jHzgkA9/ra2tugX18ccfr9/kqDbuuusu/UFi9HYRPAbDrb+/X7/nSQArlUqprbbaSrdPHf5hj8dguP385z/X203eB6WF6kknnaQvgMu4/cLlvvvu0+fL0ZMEI4PcXs8884xuMy/zkM9HElih6m+/G264YcznL7jggqF58H0xnNuv3Lp4rEl+r4zHHw1nyP9tnBdCRERERERERBQdDVcDhIiIiIiIiIhoshgAISIiIiIiIqLIYwCEiIiIiIiIiCKPARAiIiIiIiIiijwGQIiIiIiIiIgo8hgAISIiIiIiIqLIYwCEiIiIiIiIiCKPARAiIiIiIiIiijwGQIiIiIiIiIgo8hgAISIiIiIiIqLIYwCEiIioSSxduhTpdBrZbLbei0JERERUcwyAEBERNYnf/OY32H///dHa2lrvRSEiIiKqOQZAiIiIGsx+++2HU045BaeffjqmTZuG2bNn4/vf/z5yuRyOP/54tLW14c1vfjP+8Ic/bBQA+dCHPqS/Ngxjo2nhwoV1+ovo/7d3hyzNRWEcwJ8XX7PBGYafQU2CLBgWXHZDsNhW/Ap+CYPJqIhVWFoUFAQdywtLFt0spgVRJ/eCQzG94b7Ds98PLtxzGIdz2/jzPOcAAMUTgADAL3RychKlUilub2/zMGR/fz92dnaiUqlEt9uNra2t2Nvbi9FolP/++fk5rq+vJwHIw8PD5On3+3lgsrm5OeWvAgAozp/xeDwucH0AoIAKkLe3t7i6usrH2fvCwkLU6/U4PT3N5x4fH6NcLsfNzU1sbGzE+fl5HB4ext3d3be1sr8BjUYj7u/v8/WyM0IAAFL0d9obAAD+3erq6uR9bm4uFhcXY2VlZTKXtcVkhsPhj/aXrw4ODvKQpNPpCD8AgKRpgQGAX2h+fv7bODvD4+tcNs68v7/Hy8tLtNvtHwHI2dlZXhVycXERy8vL/2nnAADTIQABgMRdXl7mh6Wura1N5rKqj2azGcfHx3mLDABA6rTAAEDiWq3Wt+qP7HyQ7e3t2N3djVqtlo8/W2mWlpamuFMAgOKoAAGAGQtAer1eDAaD/CaZ7KDUz2d9fX2q+wQAKJJbYAAgYdmVuNVqNZ6enn6cGwIAMEtUgABAwl5fX+Po6Ej4AQDMPBUgAAAAQPJUgAAAAADJE4AAAAAAyROAAAAAAMkTgAAAAADJE4AAAAAAyROAAAAAAMkTgAAAAADJE4AAAAAAyROAAAAAAJG6D9bJIxzd6pjdAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(12, 5))\n",
+    "ext = [mz_axis[0], mz_axis[-1], rt[-1], rt[0]]\n",
+    "im0 = ax.imshow(np.log1p(mzrt), aspect=\"auto\", extent=ext, cmap=\"magma\")\n",
+    "ax.set_xlabel(\"m/z\"); ax.set_ylabel(\"retention time (min)\")\n",
+    "ax.set_title(\"m/z–retention-time map (intensity, log1p)\")\n",
+    "fig.colorbar(im0, ax=ax, label=\"log1p intensity\")\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8aaaf296",
+   "metadata": {},
+   "source": [
+    "## 7 · Annotated fragment (MS2) frames\n",
+    "\n",
+    "Everything so far used **precursor (MS1)** frames. Fragment (MS2) frames work the same\n",
+    "way — same `TimsFrameAnnotated`, same `.df` and `to_dense_windows_with_labels` — but you\n",
+    "build them through the **unified factory** `create_frame_builder(..., with_annotations=True)`,\n",
+    "which auto-detects a frame's type from its `ms_type` and renders precursor **or** fragment\n",
+    "accordingly.\n",
+    "\n",
+    "A few things specific to fragment frames:\n",
+    "\n",
+    "- **They only exist if fragmentation was simulated** (`apply_fragmentation = true`). Check\n",
+    "  that `synthetic_data.db` has `frames` with `ms_type = 9` (DIA) / the DDA MS2 type and a\n",
+    "  populated `fragment_ions` table.\n",
+    "- **DIA MS2 frames are sparse.** Each MS2 frame covers one isolation window at one RT, so\n",
+    "  it only contains fragments of precursors that fell in that window — **many frames are\n",
+    "  empty**. Below we build a batch and pick the most populated one to visualize.\n",
+    "- **`with_annotations=True` uses standard (eager) loading** — it holds all peptide/ion/\n",
+    "  fragment data in memory, so it is heavier than the precursor builder (fine here; can be\n",
+    "  several GB on 250k-peptide runs). It needs only the `synthetic_data.db`, not the `.d`.\n",
+    "\n",
+    "> This section assumes a **DIA** dataset. For DDA, pass `AcquisitionMode.DDA`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e8793495",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:58.555062Z",
+     "iopub.status.busy": "2026-07-02T09:33:58.554994Z",
+     "iopub.status.idle": "2026-07-02T09:33:58.568656Z",
+     "shell.execute_reply": "2026-07-02T09:33:58.568297Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "32020 MS2 frames (ms_type=9); fragment_ions rows: 1094\n"
+     ]
+    }
+   ],
+   "source": [
+    "from imspy_simulation.builders import (\n",
+    "    create_frame_builder, AcquisitionMode, LoadingStrategy,\n",
+    ")\n",
+    "\n",
+    "with sqlite3.connect(DATASET_DB) as con:\n",
+    "    ms2_ids = pd.read_sql_query(\n",
+    "        \"SELECT frame_id FROM frames WHERE ms_type = 9 ORDER BY frame_id\", con\n",
+    "    ).frame_id.astype(int).tolist()\n",
+    "    n_frag_ions = con.execute(\"SELECT COUNT(*) FROM fragment_ions\").fetchone()[0]\n",
+    "\n",
+    "print(f\"{len(ms2_ids)} MS2 frames (ms_type=9); fragment_ions rows: {n_frag_ions}\")\n",
+    "HAVE_FRAGMENTS = len(ms2_ids) > 0 and n_frag_ions > 0\n",
+    "if not HAVE_FRAGMENTS:\n",
+    "    print(\"No fragment data in this run — re-simulate with apply_fragmentation=true to try this section.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4614adef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:58.569611Z",
+     "iopub.status.busy": "2026-07-02T09:33:58.569553Z",
+     "iopub.status.idle": "2026-07-02T09:33:59.357700Z",
+     "shell.execute_reply": "2026-07-02T09:33:59.357365Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "most populated sampled MS2 frame: id=11408  rt=20.05 min  peaks=5,902\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>tof</th>\n",
+       "      <th>mz</th>\n",
+       "      <th>scan</th>\n",
+       "      <th>inv_mobility</th>\n",
+       "      <th>intensity</th>\n",
+       "      <th>peptide_id</th>\n",
+       "      <th>charge_state</th>\n",
+       "      <th>isotope_peak</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>147.112804</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>222.096825</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>244.092797</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0</td>\n",
+       "      <td>251.107502</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>296.143269</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0</td>\n",
+       "      <td>413.538570</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0</td>\n",
+       "      <td>413.873309</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0</td>\n",
+       "      <td>416.176755</td>\n",
+       "      <td>698</td>\n",
+       "      <td>0.847033</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>442</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   tof          mz  scan  inv_mobility  intensity  peptide_id  charge_state  \\\n",
+       "0    0  147.112804   698      0.847033        3.0         442             1   \n",
+       "1    0  222.096825   698      0.847033        1.0         442             3   \n",
+       "2    0  244.092797   698      0.847033        2.0         442             1   \n",
+       "3    0  251.107502   698      0.847033        1.0         442             3   \n",
+       "4    0  296.143269   698      0.847033        1.0         442             3   \n",
+       "5    0  413.538570   698      0.847033        2.0         442             3   \n",
+       "6    0  413.873309   698      0.847033        1.0         442             3   \n",
+       "7    0  416.176755   698      0.847033        1.0         442             3   \n",
+       "\n",
+       "   isotope_peak  \n",
+       "0             0  \n",
+       "1             0  \n",
+       "2             0  \n",
+       "3             0  \n",
+       "4             0  \n",
+       "5             0  \n",
+       "6             1  \n",
+       "7             0  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if HAVE_FRAGMENTS:\n",
+    "    # Unified builder with annotations (standard loading required for annotations).\n",
+    "    frag_builder = create_frame_builder(\n",
+    "        db_path=DATASET_DB,\n",
+    "        acquisition_mode=AcquisitionMode.DIA,\n",
+    "        loading_strategy=LoadingStrategy.STANDARD,\n",
+    "        with_annotations=True,\n",
+    "    )\n",
+    "    # DIA MS2 frames are sparse — sample a mid-gradient batch and keep the busiest one.\n",
+    "    lo = len(ms2_ids) // 3\n",
+    "    sample = ms2_ids[lo:lo + 200]\n",
+    "    ms2_frames = frag_builder.build_frames_annotated(sample, fragment=True, num_threads=8)\n",
+    "    ms2_frames = sorted(ms2_frames, key=lambda f: len(f.mz), reverse=True)\n",
+    "    ms2 = ms2_frames[0]\n",
+    "    print(f\"most populated sampled MS2 frame: id={ms2.frame_id}  \"\n",
+    "          f\"rt={ms2.retention_time/60:.2f} min  peaks={len(ms2.mz):,}\")\n",
+    "    display(ms2.df.head(8))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "147a292a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:59.358735Z",
+     "iopub.status.busy": "2026-07-02T09:33:59.358677Z",
+     "iopub.status.idle": "2026-07-02T09:33:59.551925Z",
+     "shell.execute_reply": "2026-07-02T09:33:59.551601Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAGGCAYAAACqvTJ0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZcBJREFUeJzt3Qm8TeX6wPHnmGciY4aIMmRKXUmDG5Ekyq3bhMrlz6WBBrlXkwbdVGiiul2595LSzC0lpLooFImIEuEYinOOc44z7vX/PO/f2v+9jjOfPay91u/7+Wzv2XuvvfZaa6+9rPXs533eBMuyLAEAAAAAAACiqFw03wwAAAAAAABQBKUAAAAAAAAQdQSlAAAAAAAAEHUEpQAAAAAAABB1BKUAAAAAAAAQdQSlAAAAAAAAEHUEpQAAAAAAABB1BKUAAAAAAAAQdQSlAAAAAAAAEHUEpQAAiGM33XSTnHrqqeIFqamp8qc//UkaNWokCQkJcscdd8R6kYASWbt2rZx33nlSvXp1sw9v2LCBLQgAQCEISgEAYu6FF14wF3Ddu3cXN3rsscfk3XffLfXrt2zZIg8++KD8/PPPEiu9evUy27hNmzb5Pr906VLzvN7efPNNx3ObNm2SP/zhD9KiRQupUqWKnHLKKXLJJZfIs88+G5wmPT1dnn/+eenbt680btxYatasKV27dpVZs2ZJbm5usbfzq6++KmPGjJF//etfMnTo0DKutTfMnz9fZsyYIfHODd+DSMrOzparr75aDh8+LNOnTzf7sH5nvOCrr76SP//5z9KtWzepWLGiOU4URL/zuh2aN29uptPAeXGMHDnSTH/55Zfn+/z7778vZ511ljkG6bwfeOABycnJOWG69evXm3locLtGjRrSqVMneeaZZ4p9HAIARBdBKQBAzM2bN89k++iFz44dO8SLQamHHnoo5hfjejGn21e3c36fgT6f16pVq+Tss8+WjRs3movG5557zmQzlStXTmbOnBmc7qeffpJbb71VLMuSCRMmyJNPPiktW7Y0F7K33HJLsZZv+fLlcu6555qLzRtvvNFcAMNbQSk3fA8i5ccff5Rdu3bJXXfdJaNGjTL78EknnSRe8MEHH8jf//53EzRq1apVodP+7W9/M9/lDh06SIUKFYo1/3Xr1pmAdH7HIPXhhx/K4MGDpU6dOiYYrn8/8sgj5piTNyClmWq6j02cOFGeeuops7y33367OS4BANyneP9TAAAQITt37jSBj7ffflv+53/+xwRHNCiB8DvttNNMZsFrr70mv/vd74KPZ2RkyDvvvCMDBgyQt956y/GaRx99VGrXrm26JekFYaiDBw8G/9asBM2o0gtRm36eGpCaM2eO3HfffdK6detCl0/n1759+yLXQ5e3UqVKJjAGb9Lgpn7OVatWlXhhfx/yfk/yk5aWZrr4xQvNXtQgj34e48aNkx9++KHAaVeuXBnMktJMpeJ81rfddpsMGzZMli1blu80GujTjKePP/44GOiqVauW+cFAA05t27Y1j7344oum/eyzz6Ru3brB49BFF11kgl6hgXQAgDtwNgcAiCkNQmk2gQZEtIuY3s9Lf/XWCxzNvnnppZdMcKVy5cpyzjnnmGBJKO0qohdCe/fuNb+m69/169c3FzV5u2/oheGdd94pzZo1M/M744wzzHvoRZJN31enmzt3brB7m90dRbMiNBNIX6cXa/Xq1TPdVkIzQfRCSB9Tv//974Pz+PTTTx1ZABdccIG5SNVub7otNm/efMJ20GytM88802QTaKuBpJK67rrr5PXXX5dAIBB8bNGiRab73TXXXJNv9ocGmvK70G7QoEHw75NPPtkRkLJdeeWVpv3+++8LXCbdFrpNNED5n//8J7iNdDvazy1YsEAmT55sug5Wq1ZNUlJSTDcp/Vw7duxoPme9SO3fv7/J6spLP6srrrjCbGNd7vHjx8tHH310wmeh3Rx123777bfmQlbfS4NpdpdGveDWbqb6eevn/sknn5zwXrrvaTCuYcOGZr/S7fKPf/wj33V+4403TOCvadOm5nPt3bu3I1tQl0e3iS6/vV2KqiGmXTHPP/9885npdtHl/Mtf/nLCe+t+oI9rQFG3i26fX3755YT5ffnll3LppZea4KRuD90u//3vf/Nd7xEjRkiTJk3MemumnAYzsrKyivwe6Dpplyv9TDQzT7evBhjs776+Pi99XLsD2vRvfUwDJpqlpMur330NiOp3Wtdt0KBBZj/RddYsmnDRY4JuF6Xrqcuhn539nH4O+l267LLLzHf8hhtuMM99/vnnwa5uus30WKT75rFjx06Yv85j9+7dZjvp3/pd0C6zSgPCF198sfkctcugZtfllZSUZOq02cc73a81qyn0WFAQ3ZeLGyDU9y+se19e2s3xu+++M9+DgjLs9KbZZ6GZV3rs1c81tLuxHhf0e5T3eKVdiuMpwAkAfkKmFAAgpjQIddVVV5nMFw2YaD0SDTRpwCkvvdA6evSo+eVbL3qeeOIJ81rtOqZ1TmwafOrXr58JHmiQSQMHegGqwSy9SFZ6MaMX4StWrDAX0l26dDEXxHfffbe5uNaaMPYFk3ZX08wivShSOh+ly6lZXtdee60JKugFtC6/XozqRZRewF944YUmC0BrmmgAoF27dua1dqvzHz58uFlevUDU4JDOQ4MK33zzTTAAoRkCQ4YMMZlEU6dOld9++01uvvlm874lcf3115uLdw0G6EWsvV01GBIaZAq9wFy9erW5aNRgTUnt378/GLQqiG4L3Q56Ma7ro4FCpQEFO8D38MMPm31Eg1CZmZnmb93GGqjTi3oNgBw4cMAEMjQ4oM9pcERpUFHXNTEx0WRVaEBC11k/+/wcOXLEXPjr56rz1s9D/9Z9VS/qR48ebbbjtGnTTCBVgx0aaFC6DNoFUfdPzSjRddCgo+5jesGct3j7448/bjK+dL2Sk5PNPq0BCw0Eqb/+9a/m8T179gT3ycKyTzSYqcuuWSVTpkwxwQcNcuUXRNIggC6nZsBolo92EezTp48pzm1fwGs3LA30aVdKzWDUZdXMN92eGlCxM+727dtn/tbAh35PNHNFv0caMNB9uqjvgdq2bZs5Buj3W7uKajCtNP74xz+a+eq21YCedvPSrBndN3S59Xumn6Vucz3O6LKVlS6zBok0c0fXU+ergRybZijqd1y/13pM0mODWrhwodk+elzSoLZ2rdXuafp563Oh9Limn4Uur+4nug66j2kgSvcT3W/0eDh79myTddSjRw/zvVD6Hvq90M9El1WDYHrsmjRpkvlexKp7qB7Pdf+zg6P50eOg0mBlKP1+6/HCfl7psVeDrbqO2l1Pt7N+/zQTV7+vAAAXsgAAiJF169ZpSpK1dOlScz8QCFhNmza1br/9dsd0O3fuNNPVq1fPOnz4cPDx9957zzy+aNGi4GPDhw83j02ZMsUxj65du1rdunUL3n/33XfNdI888ohjuj/84Q9WQkKCtWPHjuBj1atXN/PNKz09/YTHVq9ebeb7z3/+M/jYwoULzWMrVqxwTHv06FGrTp061siRIx2P79+/36pdu7bj8S5duliNGze2kpKSgo99/PHHZr4tWrSwinLRRRdZHTp0MH+fffbZ1ogRI8zfR44csSpVqmTNnTvXLJ/OT5c39D3Kly9vbj169LDuuece66OPPrKysrKKfM/MzEyrffv2VsuWLa3s7Owip9f1GDBggOMxe5latWp1wvbOyMiwcnNzT9hXKleu7Pj8n3rqKTMP/cxtx44ds9q2bXvC56LbSR+bP39+8LGtW7eax8qVK2etWbMm+LhuB318zpw5wcd0u+rn9OuvvzqW69prrzWfqb0O9nq1a9fObCfbzJkzzeObNm0KPqbbpDifsZo+fbp5/aFDhwqcxn7vU045xUpJSQk+/sYbb5jHdRns72ObNm2sfv36mb9tug76mV5yySXBx4YNG2a2z9q1a094P/u1BX0PlK6fPrdkyZJ8v/uh29imjz/wwAPB+/q3PjZq1KjgYzk5OeaYot/pxx9/PPi47vdVq1bN93ud165du6zvv/++yOny+/6EHpPuvffeYh1Dpk6dapZX3zfvPB577LET1kGnXbBgwQn7a+i2efjhh81x7IcffnC8ly6Tfrd3795tFdfYsWPN/IujoGOn7a677jL7kn6XCzoGTJs2zbxffst4zjnnWOeee67j8x43bpxVsWJF8xq96frNmjWr2OsHAIguuu8BAGJGf+nXbALtzqM0a0OzHLSrVn4jJelzoYWDtcub0kypvDSbJZROGzqdFu4tX768yWoIpVk6er2rv64XJbQ7iI68pdlL2iVGu458/fXXRb5eu1lpZolmh/z666/Bmy6XZnnZmTyayaDZK5pRpV2SbDoCXnFqMOWlWT6aOaDdqjSTRd/P7maXl76HZkppVpl2i9MMDc340KwQHQ2rMJrFoRlLWhy9uAWPC6Lrnrf7jWYB2XWldH/R7W93Vwvd/kuWLDHLq+tg0y4+mo2TH52HZkbZdH76mWr2TegIkfbf9n6l+43W5Bo4cKD5O/Qz1W2mGU959wvNdtOsr+Ls08Vhd1t67733iuyWpdk0doaX0qwv7eak3w2l+9z27dvN/qLb1l4XzTzTzDqt26PvoTfNWNP1zpvNoorblUuzenQ7lZVmNtp039Zl0s9Ds9VCt5N+rsXZzrqdQjO6SsvO0gwVuk/rdtXtq4W6dXlDM4DyWzd7HTRTKrTrrb2/hq6bZl3pvqXHz9D9UjPj9Lujn2W0aTdLrfGkGUz6XS6I3ZUxv2n0exza1VE/b81k1f1Iu1xr1pTul1oQvSyDVQAAIofuewCAmNALIQ0+aUBKawmFXuhrVzsteNu3b1/Ha7TLSSg7QKXdrfJeqGi3qbzThk6nNXq0+0foRbmyLz71+aLoxZB2pdPuTNotJrQWlQYgiqIX/MruRpeX1r4JXZY2bdqcME3eAExxaMBFuy5p4E0Dg9rdK+92CKVdkewglgamtJaVdiXTIIYGLvILjOmF5ssvv2y63WkdnbKyuyGF0mCIXtS+8MILZh8KDWRqVyibbj+9UM0bHCmo8Lp2Cco7rQYDtRZP3seUvV8dOnTIBBm17pne8hNaHL4k+3RxaeBWR0nT4MW9995rgkfapUs/q7yF4fPuT7rOuk3sLpP2/qkBwYLofq77hXZNLE33zqI+49LIu031c9JjQt4upPq4BtuiQYOy+XW11RpR999/vwnw5v3M8x5D8juu6ToUtL+Gzk8/S62Tlvf1Be2X0aBdaTUAp92SC2MH7rTbbl55i+Frl009Juj62t1cNWCn/8+MHTvWHOvKGiAHAIQXR2UAQExorRrNANLAlN7y0mBJ3qCU/gqen9BgUGHThZv++q4BKa0TpPVb9EJQLw416FOc4sH2NFpPKb96KpG6eNJsGK29osE/rTWUd8S9gmhGjwao9Hb66aebLB/NwMg7WqIWpdY6MZqtpsXJwyG/IsVav0eLWGtRcQ1+ad0gDbzo51Gc7V+QgvafovY/+z21yHZBgRyt9VSSeZZmO2nWi2bZaT0lzRLTbBENfGpdspJ8N+z10QCj1lzLj174a8H5SH3GBWVZ5ZdJactvHcuynUML4ZdWaFZf6DpoJqJuP/2+aB0uzXrSALcWNs+7D5d2v1Q6L32ve+65J99p9fsc7eO/7psa7A4dGEJrb2mwXx/T77MG5vV4pfT/i7yBYX0sdCRRDVDrvp637ppmSWqNKZ1vUaOAAgCii6AUACAmNOikhbXt0aNC6YWKZuNowd5IjZikBby1ALoW2g3NEtq6dWvw+aIujLXrmwYfQkfx0l/uNVsmVEGvtwum63bQbjSFLWto5kooLQ5dGtolS7NptJtPaTKZ7G5aelEYSruN6Xw1Oye/zzacdPtrBsQrr7zieFy3f2hWjG4/7UaoF+mhn0XoKHfhoFkoui9psKGwz7OkSjKSmdLgh2ZI6e3pp582wTsthK2BqtDlyrs/6fbRbWIHzuz9UwMDha2PrrdOo8Xww7keoZljeb9TxclkdDsdMU+7sGk3M+0iGNqtN9z0s0xNTQ3rflkWmiGm9DiRlwblNGtOszE1wGwHRNetW+cIQGlxfS0Ibw9AYQ80kF/AUrtX20EvAIC7UFMKABB1+ku4Bp60K4V2K8p701pEGiwqqmZRWWggRi9etN5RKL0Q0otnHeXKptkLeS+K7QyFvJkWOnJW3osifb3KOw+te6IX8xo0sC+aQml3MKWZAnphphevoV169OJVgy2lodtZM5w0syC0plFeGsjIL5vErjsUOkKaZuholpiODqZBx7yZIeGW3/bXzC29qM27nfWx0P1Jg4favTDcy6NdkTTzLL8Ajf15lpTuP8XpDqryy1qyL+rzdn/65z//ab5noUE+DTLa+76OuKfBDB0tTgMaBa2Pfs6DBw+WRYsWmcBBXvZnVND3oDD6/dAAY96aR7rfxjs7wyl0H9a/tftZuGkXNq0NpyOM5qWfR7SDNZrNpD885L1pgFMD3vq31oJSHTp0MFlk2iU29Niqo2LqsVqPZaEZX3pcDO2Wqa954403TMDYDrQCANyDTCkAQNRpcEAvhkMLT4c699xzzcWJBja0Rk4k6AWPZtloBol26ejcubPp3qSZPvrrfOjFi16ca1aVZp1oHSr9FV9rX2lQTbveabc9raukF306XWg9IzsooBegOhS9Bhe0K49elGmGlF5YDR06VM466ywT0NH11iwC7XrVs2fPYNBMa1cNGDDADCmv3dU0+KABML1gyy9gUBRd5gcffLBYXRR1OHkthK4Xhlo/SIeS1y5hp556qunCZ2eu6OdpXyTmHc5es2/ydl0rK93+U6ZMMcugtWk080T3mVatWjmm0+HhdTtqQXmtY6NBPp1Oa/SUNoOnIFrTRgN5un9oIXXdL/Sz0rpfum+Upqub7n+6vbX7kXad1K5J9gV7Xro9NICj+4pmiGmtIA3gaN0h3XdCafcofUy3n2aYzJgxw3RtsgvAa7BJ61NpkEr3M51OC8ZrgE/XUQNGGohSGljV789FF11kMle0NpsGuHQ/+OKLL0xGXmHfg8Jo5p1uV201YKHrpxlG8U6/T3qc0fpuuk11e2pAs7T1xApz9913m+Oufme0a6DuU1pYXb8zGozUY2Demluh9PutxzplBx4feeQR0+p+pscwm+4TWntOabBda1nZ0+oxQo8DWvcrb+0vpcdeHfxCg5yhtAupvla7dOtxUoO++p3WfSK0CL3WUdPus/r90/1QM21fe+01Wb9+vVmGihUrlnFLAgDCLsqj/QEAYA0cONCqUqWKlZaWVuDWuOmmm8yw3r/++mtwWHgdGjyvvEOf6/DjOgx5XvZw8aGOHj1qjR8/3mrSpIl5rzZt2pj3sIewDx1i/cILLzTDr+s87CHOdUj2m2++2Tr55JOtGjVqWP369TPT6rDmeYdBf/nll61WrVqZ4cl1Hjp8vE3/1tfWrl3bbJfTTjvNrP+6desc83jrrbesdu3aWZUrV7bat29vvf322+Z99P2KctFFF1kdOnQo8ZD2H374oXXLLbdYbdu2NetYqVIlq3Xr1tatt95qHThw4ITXFnQL/YwKkt9w8Pktk02Hkb/zzjutxo0bm8+mZ8+e1urVq8266i3UTz/9ZOat09WvX9+8TrenznvNmjVFbqf8lk3p68eOHet4TLeLPtasWTOzXzVq1Mjq3bu39dJLLxW5Xva+PmfOnOBjqamp1vXXX2/VqVPHPFfY571s2TJr0KBBZp/Wz0rb6667zvrhhx9OeO/XXnvNmjRpktWgQQOzXXT9du3adcI8v/nmG+uqq66y6tWrZ/Y9ff9rrrnGvFcofe2wYcPM9tXpdH/X7ZCZmVnk96Cg7avS09OtESNGmO9HzZo1zXsfPHjwhP3K/o4fOnTI8fqCjgnF+U6UREGfaUHvr7Zs2WL16dPHfLf0ODJy5Ehr48aNJ+wDJV2H/LanHu/089bvr+4b+n7nnXee9eSTT1pZWVnFWrf8bnm/a7qsBU0buk75KWw/eOedd6wuXbqYfatp06bW5MmT813uJUuWmGXS9dP17NixozV79uxC3xcAEDsJ+k/4Q10AAADupplB48ePN3VpNAPIL7Rwt2YJahZTaNcnAACAaKOmFAAA8EUds1BaU+rFF1+UNm3a+CogBQAA4CbUlAIAAJ6no3xpDRuta6T1jP7973+bkRa1thQAAABig6AUAADwPB2BT4t2axBKR+PSAuQLFiyIWCF9AAAAFI2aUgAAAAAAAIg6akoBAAAAAAAg6ghKAQAAAAAAIOqoKSUigUBA9u3bJzVr1pSEhITofwoAAAAAAAAeYVmWHD16VJo0aSLlyhWcD0VQSsQEpJo1axbNzwcAAAAAAMDTfvnlF2natGmBzxOUEjEZUvbGqlWrVvQ+HQAAAAAAAI9JSUkxyT92vMWVQalZs2aZ288//2zud+jQQe6//37p37+/ud+rVy9ZuXKl4zX/8z//I7Nnzw7e3717t4wZM0ZWrFghNWrUkOHDh8vUqVOlQoXir5rdZU8DUgSlAAAAAAAAyq6oEkkxDUppCtfjjz8ubdq0Mf0N586dK4MGDZJvvvnGBKjUyJEjZcqUKcHXVKtWLfh3bm6uDBgwQBo1aiSrVq2SxMREGTZsmFSsWFEee+yxmKwTAAAAAAAAipZgaTTIRerWrSvTpk2TESNGmEypLl26yIwZM/Kd9sMPP5TLL7/c1IRq2LCheUyzqCZOnCiHDh2SSpUqFTutrHbt2pKcnEymFAAAAAAAQBkUN87imppSmvW0cOFCSUtLkx49egQfnzdvnvz73/822VADBw6U++67L5gttXr1aunYsWMwIKX69etnuvNt3rxZunbtmu97ZWZmmlvoxgIAAAAAIBzXttnZ2WxI+ELFihWlfPnypX59zINSmzZtMkGojIwMUxPqnXfekfbt25vnrr/+emnRooUZQvDbb781GVDbtm2Tt99+2zy/f/9+R0BK2ff1uYJozamHHnooousFAAAAAPCX1NRU2bNnjylPA/ilZlTTpk1NPCcug1JnnHGGbNiwwaR0vfnmm6ZQuRY318DUqFGjgtNpRlTjxo2ld+/e8uOPP8ppp51W6vecNGmSTJgw4YSq8AAAAAAAlDZDSgNS2rOnfv36RRZ4BuKdBl+1dJLu91orvDQZUzEPSmndp9atW5u/u3XrJmvXrpWZM2fKiy++eMK03bt3N+2OHTtMUEq79H311VeOaQ4cOGBafa4glStXNjcAAAAAAMJBu+zpRboGpKpWrcpGhS/Ur19ffv75Z7P/lyYoVU5cJhAIOOo9hdKMKqUZU0q7/Wn3v4MHDwanWbp0qSmiZXcBBAAAAAAgWsiQgp8klDEjMKZBKe1G99lnn5momgaX9P6nn34qN9xwg+mi9/DDD8v69evN8++//74MGzZMLrzwQunUqZN5fd++fU3waejQobJx40b56KOPZPLkyTJ27FgyoQAAAAAAyIdeY+vI9aFOPfXUYCIIoiMpKUkef/xxx2N/+tOfZMWKFflOf9ddd8mDDz5Y6vd74IEHTBApv895zpw55rl33303+NjNN98sp59+unTu3Fl69uxperaFW0yDUprhpIEmrSultaJ0BTWwdMkll5hufZ988okJPLVt21buvPNOGTJkiCxatCj4ek0NW7x4sWk1a+rGG28085syZUosVwsAAAAAgLgKSoVDTk5O2Ofpt6DU3//+d/n9738f9vfS0kcac9HB5PLbH15++WU599xzHY9feeWVsmXLFpMEpElEV199tbeCUq+88opZee2upwEqDUJpQEpp4XEteP7bb7+Zkfm2b98uTzzxhOmaF0o36AcffCDp6emmwNaTTz4pFSrEvFQWAAAAAAAxp4kfZ511lulxdNFFF5kgw+jRo83I9l26dJErrrgiOK2OdK8JHy1btpRHHnkk+LiObn/NNdfI7373OzMImfZQCs2wmjhxonlOBy7zMs0k0nXv2rWrySCaN29e8DkN+Fx88cVy9tlnm+cXLlxoHteYR506dUyWk34GHTp0MLEPNXr0aDl69Kj5HPR1qlevXsFspcTEROnXr5/pIdanTx9TUNymNZzuvfdes9319fr5HDlyJN/l1njJuHHj8q3drSWUNDvr2WefPaHHme4bdnxFA1Z79+4Ne+CR6A0AAAAAAB6kyR/XX3+9KZOjwSQNovzhD3+QWbNmyfjx40/oxqWZO6tXr5Zff/3VDC6m3bdOOeUUE2z6y1/+YoJaGpS4/PLLTdDFzpzRZJIvv/wy4vW0DqZkyMGj+degLosGNStLg1pVijWtruM333wjP/30kwkkabc2DTqNGjXKJMxoDWzdfhoIPO+888xrkpOTpV27diaJZs2aNSbYoyWLZs+ebQJKBXWbvO2220zQSQOLGhDSabUnmZo2bZpUr149OPiblj/SgNnzzz9/wnzuueceGTNmjEn+yevpp58266ADzxVGB6S77LLLwp4ERFDKQ/QL+vdPt8qferUt9hcKAAAAABA5GrA5fPhw2Odbt25dqVevXqHTaKBIg1F6U1q/WWswa4AjPxrAUieffLK0atVKdu7caQIuy5YtC450r1JTU02mle2mm26KSoH3eV/ulpnLtod9vrf3biPjLzm9WNNqVpHS7aM1r7VOtm4vDVL179/fMa1uI51OAzm6jeyMoyZNmpjAVvPmzQt9L93uGshSGhwMzWrTbCoNdr311lvmflZWlslay0sHg9u1a5c899xzJzz33XffmdfrOhTm3//+t7zxxhtFTlcaBKU8ZOv+FHlp1V45v20TglIAAAAA4AIaOCoqeOQWVar8f3KD1m7WrCjLssx9zfAJfT5UjRo1orJ8N3RvLpe0bxiRTKnS0mCcbiPtlrdq1aoTntfuewW9rqRCX6PvqV3utA53YZYvXy5ff/11MGClXQA140m78unfunxt2rQJdtPUjC/tNqiZVer111+Xhx56yATIGjZs6K2aUgivw2nZjhYAAAAA4F+alaMj3WtGjFqwYIHJuNGuZJplUxwacNLC26EFufft2+eobxQt2iPozFNqh/1Wkp5GOkqd0mDO559/LhdccIHppqdZZXatKKVd8jR7SWlw71//+pf5W7vb6fbTrni1atWSY8eOBafLS+tI/eMf/zB/a6Do/fffDz43ePBgmT59uqkXpbTdvHnzCfOYOnWqyYzT5dVb06ZNTTfDgQMHmsCTztd+TveXl156KRiQ0uwo7RKo61VUVldpkSkFAAAAAIAH1a9f39SR0lHqNTBy0kknmVpQWqRbM3vOPPNM070sNNiRH53HhAkTzPSaraO1jDTTRgMcfpObm2sKmaelpckzzzwTzED6z3/+Y4qZ33nnnaYIuQZx7ILltWvXNoHBzp07m89h/vz5UrNmTfOcfjZaAF2Df+vWrTuhjpN2+9NC5xpM1ELqNi0ur4PGde/ePZhBpY/p5xou2t2zUaNGMmjQoOBjmjEVzsy/BMvOxfOxlJQUs5NopDjv6H7x5N1v9sodr2+QGX/sIoO7nhLrxQEAAAAA39BR4zVbRkeuK6ibG+KbBn90hDuts1VcmoGkWVFaRN5P+31KMeMsdN/zkORj2Y4WAAAAAADArei+5yGJSemOFgAAAAAAhEdpOppp9z6vZkmFA5lSHpKametoAQAAAAAA3IqgFAAAAAAAAKKOoBQAAAAAAGHCWGLwE6uMY+dRUwoAAAAAgDKqWLGiGZ3t0KFDUr9+ffM34PWA1KFDh8y+rvt/aRCUAgAAAACgjMqXLy9NmzaVPXv2yM8//8z2hC8kJCSY/V73/9IgKOUh6Vm5jhYAAAAAED01atSQNm3aSHZ2NpsdvlCxYsVSB6QUQSkPOZad62gBAAAAANGlF+hluUgH/IRC5x6SmZ3jaAEAAAAAANyKoJSHZORYjhYAAAAAAMCtCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEoBAAAAAAAg6ghKAQAAAAAAIOoISgEAAAAAACDqCEp5SFZOwNECAAAAAAC4FUEpD0nPzHa0AAAAAAAAbkVQykOyAs4WAAAAAADArWIalJo1a5Z06tRJatWqZW49evSQDz/8MPh8RkaGjB07VurVqyc1atSQIUOGyIEDBxzz2L17twwYMECqVasmDRo0kLvvvltycnJisDYAAAAAAACIi6BU06ZN5fHHH5f169fLunXr5OKLL5ZBgwbJ5s2bzfPjx4+XRYsWycKFC2XlypWyb98+ueqqq4Kvz83NNQGprKwsWbVqlcydO1deffVVuf/++2O4VgAAAAAAAChKgmVZlrhI3bp1Zdq0afKHP/xB6tevL/Pnzzd/q61bt0q7du1k9erVcu6555qsqssvv9wEqxo2bGimmT17tkycOFEOHToklSpVKtZ7pqSkSO3atSU5OdlkbMWrPk+vlB0HU6V1gxryyYSLYr04AAAAAADAh1KKGWdxTU0pzXpasGCBpKWlmW58mj2VnZ0tffr0CU7Ttm1bad68uQlKKW07duwYDEipfv36mZW3s60AAAAAAADgPhVivQCbNm0yQSitH6V1o9555x1p3769bNiwwWQ61alTxzG9BqD2799v/tY2NCBlP28/V5DMzExzs2kQCwAAAAAAANET80ypM844wwSgvvzySxkzZowMHz5ctmzZEtH3nDp1qkkjs2/NmjWL6PsBAAAAAADAZUEpzYZq3bq1dOvWzQSLOnfuLDNnzpRGjRqZAuZJSUmO6XX0PX1OaZt3ND77vj1NfiZNmmT6Ndq3X375JSLrBgAAAAAAAJcGpfIKBAKma50GqSpWrCjLli0LPrdt2zbZvXu36e6ntNXufwcPHgxOs3TpUlNES7sAFqRy5cpmmtAbAAAAAAAAfFJTSjOW+vfvb4qXHz161Iy09+mnn8pHH31kutWNGDFCJkyYYEbk08DRrbfeagJROvKe6tu3rwk+DR06VJ544glTR2ry5MkyduxYE3gCAAAAAACAO8U0KKUZTsOGDZPExEQThOrUqZMJSF1yySXm+enTp0u5cuVkyJAhJntKR9Z74YUXgq8vX768LF682NSi0mBV9erVTU2qKVOmxHCtAAAAAAAAUJQEy7Is8TkdfU+DYlpfKp678vV5eqXsOJgqrRvUkE8mXBTrxQEAAAAAAD6UUsw4i+tqSqH0cnIDjhYAAAAAAMCtCEp5SE7AcrQAAAAAAABuRVAKAAAAAAAAUUdQykMCgYCjBQAAAAAAcCuCUh6SE3C2AAAAAAAAbkVQCgAAAAAAAFFHUAoAAAAAAABRR1AKAAAAAAAAUUdQCgAAAAAAAFFHUAoAAAAAAABRR1AKAAAAAAAAUUdQCgAAAAAAAFFHUAoAYuBgSoY89v4G0wIAAACAHxGUAoAY2Lo/RV5atde0AAAAAOBHBKUAIAYOp2U7WgAAAADwG4JSAAAAAAAAiDqCUgAAAAAAAIg6glIAEAN7j6Q5WgAAAADwG4JSHpIbsBwtAPdKTM50tAAAAADgNwSlPCRgWY4WAAAAAADArQhKAQBky75kGTRzhWkBAAAAIBoISnmIdTxDym4BoLh+OJAqGxPTTQsAAAAA0UBQykNyLWcLwL3Ss3IdLQAAAAD4DUEpAIiBpPRMRxtrjAYIAAAAINoISgFADGTkWI421hgNEAAAAEC0EZQCAAAAAABA1BGUAgAAAAAAQNQRlAIAAAAAAEDUEZQCAAAAAABA1BGUAgAAAAAAgL+CUlOnTpVzzjlHatasKQ0aNJDBgwfLtm3bHNP06tVLEhISHLfRo0c7ptm9e7cMGDBAqlWrZuZz9913S05OTpTXBgDi1+G0TEcLAAAAAJFWQWJo5cqVMnbsWBOY0iDSX/7yF+nbt69s2bJFqlevHpxu5MiRMmXKlOB9DT7ZcnNzTUCqUaNGsmrVKklMTJRhw4ZJxYoV5bHHHov6OgFAPEo6luNoAQAAAMDTQaklS5Y47r/66qsm02n9+vVy4YUXOoJQGnTKz8cff2yCWJ988ok0bNhQunTpIg8//LBMnDhRHnzwQalUqVLE1wMASiorJ+BoAQAAAMBvXFVTKjk52bR169Z1PD5v3jw5+eST5cwzz5RJkyZJenp68LnVq1dLx44dTUDK1q9fP0lJSZHNmzfn+z6ZmZnm+dAbAERTVm7A0QIAAACA38Q0UypUIBCQO+64Q3r27GmCT7brr79eWrRoIU2aNJFvv/3WZEBp3am3337bPL9//35HQErZ9/W5gmpZPfTQQxFdHwAoTE5OrqMFAAAAAL9xTVBKa0t999138sUXXzgeHzVqVPBvzYhq3Lix9O7dW3788Uc57bTTSvVemm01YcKE4H3NlGrWrFkZlh4ASiYr4GwBAAAAwG9c0X1v3LhxsnjxYlmxYoU0bdq00Gm7d+9u2h07dphWa00dOHDAMY19v6A6VJUrV5ZatWo5bgAAAAAAAPBJUMqyLBOQeuedd2T58uXSsmXLIl+zYcMG02rGlOrRo4ds2rRJDh48GJxm6dKlJtDUvn37CC49AKAstuxLlkEzV5gWAAAAgP9UiHWXvfnz58t7770nNWvWDNaAql27tlStWtV00dPnL7vsMqlXr56pKTV+/HgzMl+nTp3MtH379jXBp6FDh8oTTzxh5jF58mQzb82I8pOAZTlaAHDzaIA/HEiVjYnppm3fpHbU3hcAAACAO8Q0U2rWrFlmxL1evXqZzCf79vrrr5vnK1WqJJ988okJPLVt21buvPNOGTJkiCxatCg4j/Lly5uuf9pq1tSNN94ow4YNkylTpojf2LEoYlIASio9M9vRAgAAAICnM6W0+15htPj4ypUri5yPjs73wQcfiN/Z27Oo7QoAbii8vvdImqMFAAAA4C+uKHSO8CBTCkA8SUzOdLQAAAAA/IWgFAAAAAAAAKKOoBQAAAAAAACijqAUAMRATm7A0QIAAACA3xCUAoAYyAlYjhYAAAAA/IagFADEQCAQcLSxlpOb62ijIT0r19ECAAAA8BeCUgAQAzkBZxtrmccXxG6jISk909ECAAAA8BeCUgBc5WBKhjz2/gbTInrs0lbRLHGVkWM5WgAAAAD+QlAKgKts3Z8iL63aa1pET/bxbnt2Gw2pmTmOFgAAAIC/EJQC4CqH07IdLaIjK9dytNFATSkAAADA3whKAQDEspwtAAAAAEQaQSkArrL3SJqjRXRYx6NRdhsNGVk5jhYAAACAvxCUAuAqicmZjhbezZSKRZdBAAAAAO5BUAoAEBO5AcvRAgAAAPAXglIAAAmI5WijIXA8LctuAQAAAPgLQSkAiKHfUjNly75kX9aUisV7AgAAAHAPglIAXCU9K9fRep2WU/rhQKova0rlHO+2Z7cAAAAA/IWglIeQdQAvSErPdLTwLmpKAQAAAP5GUMpD7FwDP+ccaDeoQTNXuKI7FEonI8dytF4VWtx775E08aNYZGcBAAAAcA+CUh5iHQ9H2a0faTeojYnprugOBRQmNxAI/p2YTFYYAAAAAP8hKOUhZB2IJB/LdrSAm2tJAQAAAICfEZSCpyQmpTtaAAAAAADgTgSl4CmpmbmOFkAxUZQOAAAAQJQRlAKAGEvPin0QlZgUAAAAgGgjKAXAVbJyAo7WD5LSY1/o3B4MMGRQwMi/5/Fi73YLAAAAwF8ISsGTGSduyDxB6aRnZjtaP8jI8WfV81gEwgAAAAC4B0EpeDLjxA2ZJyidrICzhXe77xGUAgAAAPyNoBQ8mXHi18wTAAAAAADiBUEpAAAAAAAARB1BKQAAAAAAAPgrKDV16lQ555xzpGbNmtKgQQMZPHiwbNu2zTFNRkaGjB07VurVqyc1atSQIUOGyIEDBxzT7N69WwYMGCDVqlUz87n77rslJycnymsDAAAAAACAuAhKrVy50gSc1qxZI0uXLpXs7Gzp27evpKWlBacZP368LFq0SBYuXGim37dvn1x11VXB53Nzc01AKisrS1atWiVz586VV199Ve6///4YrRUAlExWDlXdAQAAAPhPhdK86IEHHpBbbrlFWrRoUaY3X7JkieO+BpM002n9+vVy4YUXSnJysrzyyisyf/58ufjii800c+bMkXbt2plA1rnnnisff/yxbNmyRT755BNp2LChdOnSRR5++GGZOHGiPPjgg1KpUqUyLSMARFp6ZjYbGQAAAIDvlCpT6r333pPTTjtNevfubQJGmZmZYVkYDUKpunXrmlaDU5o91adPn+A0bdu2lebNm8vq1avNfW07duxoAlK2fv36SUpKimzevDnf99Hl1edDb/BWxgmZJ3C7gPX/I0RmkSgFAAAAwIdKFZTasGGDrF27Vjp06CC33367NGrUSMaMGWMeK61AICB33HGH9OzZU84880zz2P79+02mU506dRzTagBKn7OnCQ1I2c/bzxVUy6p27drBW7NmzUq93HBnxgmZJ/ErJzfgaL0qJCYFAAAAAL5U6ppSXbt2lWeeecbUeNIudnv27DEBpU6dOsnMmTODWU/FpbWlvvvuO1mwYIFE2qRJk8zy2bdffvkl4u+J6LAzTsg8iV85AcvRwrvsT5hPGgAAAPCnMhc6tyzLdLHTQuP690knnSTPPfecyT56/fXXizWPcePGyeLFi2XFihXStGnT4OOagaXzTUpKckyvo+/pc/Y0eUfjs+/b0+RVuXJlqVWrluMGwB00azK09So9XgIAAACAn5U6KKX1njSY1LhxYzNCnmZOff/992aEvO3bt8ujjz4qt912W5EXZTqPd955R5YvXy4tW7Z0PN+tWzepWLGiLFu2LPjYtm3bZPfu3dKjRw9zX9tNmzbJwYMHg9PoSH4aaGrfvn1pVw9AjNgD0Xl9QDpiUmRKAQAAAH5XqtH3tLD41q1bpW/fvqbr3sCBA6V8+fKOaa677jpTb6qoLntaKF0Lp9esWTNYA0rrPFWtWtW0I0aMkAkTJpji5xpouvXWW00gSkfeU7oMGnwaOnSoPPHEE2YekydPNvPWjCg/sS9yudgFAAAAAACeDEpdc801csstt8gpp5xS4DQnn3xykd1vZs2aZdpevXo5Hp8zZ47cdNNN5u/p06dLuXLlZMiQIWbUPB1Z74UXXghOq8Ew7fqnhdY1WFW9enUZPny4TJkypTSrBgAAAAAAALcGpezaUXkdO3ZMpk2bJvfff3+x51OUKlWqyPPPP29uBWnRooV88MEHxXpPAAAAAAAAxGlNqYceekhSU1NPeDw9Pd08h9ig+x4Qn3JyPV5ACwAAAADCFZTSDKeEhIQTHt+4caOp/QQAKL6snFw2FwAAAADfKVH3Pe2yp8EovZ1++umOwFRubq7Jnho9enQklhMoUcYJmSeIJ14faRAAAAAAyhyUmjFjhsmS0iLn2k1PR8ezVapUSU499VRTbByIdcYJmScAAAAAAHgoKKWj2qmWLVvKeeedJxUrVozUcgFlyjgh8wQAAAAAAI8EpVJSUqRWrVrm765du5qR9vSWH3s6ACip3IDlaAEAAAAAPg9KaT2pxMREadCggdSpUyffQud2AXStLwUApRE4Poyk3QIAAAAAfB6UWr58eXBkvRUrVkRymQD4mAa3Q1sAAAAAgM+DUhdddFG+fwNAOOVazhYAAAAA4E3lSvOiJUuWyBdffBG8//zzz0uXLl3k+uuvlyNHjoRz+QDAk8gEAwAAAOB3pQpK3X333abwudq0aZNMmDBBLrvsMtm5c6f5GwBQOBLBAAAAAPhdsbvvhdLgU/v27c3fb731lgwcOFAee+wx+frrr01wCgBQOCskLMVIgwAAAAD8qFSZUpUqVZL09HTz9yeffCJ9+/Y1f2shdDuDCgBQsNA67ow0CAAAAMCPSpUpdf7555tuej179pSvvvpKXn/9dfP4Dz/8IE2bNg33MgLFZmeckHmCeEJ9KQAAAAB+VKpMqeeee04qVKggb775psyaNUtOOeUU8/iHH34ol156abiXESg2O+OEzBPEE0YaBAAAAOBHpcqUat68uSxevPiEx6dPnx6OZQLKnHFC5gkAAAAAAB4MSqlAICA7duyQgwcPmr9DXXjhheFYNqDUGSdkngAAAAAA4MGg1Jo1a+T666+XXbt2nZCRkpCQILm5ueFaPgAAAAAAAHhQqWpKjR49Ws4++2z57rvv5PDhw3LkyJHgTe8jNuzwoDNMCCCcDqZkyGPvbzAtAAAAACDKmVLbt283Rc5bt25dhrcGgPgrVr91f4q8tGqvnN+2iTSoVSXWiwMAAAAA/sqU6t69u6knBQDhFghYjtZtDqdlO1oAAAAAQBQzpW699Va58847Zf/+/dKxY0epWLGi4/lOnTqVcnFQFnTfgxfYCVIuTZSS5GPZjhYAAAAAEMWg1JAhQ0x7yy23OAqca9FzCp0D8LLEpHRHi9jYsi9ZJi38WqZefZa0b1KbjwEAAADwS1Bq586d4V8SAIgDqZm5jhax8cOBVNmYmG5aglIAAACAj4JSLVq0CP+SAIBPubWoOwAAAAC4rtC5+te//iU9e/aUJk2ayK5du8xjM2bMkPfeey+cywcArpKeletow4GYVMntPZLmaAEAAAD4JCg1a9YsmTBhglx22WWSlJQkubn/d3FWp04dE5gCYp1xQuYJIiUpPdPRhiMQpfX4UDKJyZmOFgAAAIBPglLPPvusvPzyy/LXv/5VypcvH3z87LPPlk2bNoVz+YASCQQsRwuEW0aO5WjDgZgUAAAAAD8qV9pC5127dj3h8cqVK0taGl0pEDv2xT0X+YC3RaIbJQAAAIA4CEq1bNlSNmzYcMLjS5YskXbt2hV7Pp999pkMHDjQ1KVKSEiQd9991/H8TTfdZB4PvV166aWOaQ4fPiw33HCD1KpVy3QfHDFihKSmppZmtQAgagicuqMbJQAAAIA4G31P60mNHTtWMjIyTC2Ur776Sl577TWZOnWq/P3vfy/2fDSrqnPnznLLLbfIVVddle80GoSaM2eOIxsrlAakEhMTZenSpZKdnS0333yzjBo1SubPn1+aVQMA+LQbJQAAAIA4CEr96U9/kqpVq8rkyZMlPT1drr/+epPtNHPmTLn22muLPZ/+/fubW2E0CNWoUaN8n/v+++9NdtbatWtNPSu73pUWYH/yySfNMgFAOKVlZDtaAAAAAEAUu+/ZGUrbt283XeX2798ve/bsMV3nwu3TTz+VBg0ayBlnnCFjxoyR3377Lfjc6tWrTZc9OyCl+vTpI+XKlZMvv/wy7MsCAGnZAUcLAAAAAIhiUOriiy+WpKQk83e1atVM0EilpKSY58JFu+7985//lGXLlsnf/vY3Wblypcmsys39v8K2Ggyz39tWoUIFqVu3rnmuIJmZmWZZQ28A3EG7BIe2AAAAAABvqlDa7KWsrKwTHtcaU59//rmES2hXwI4dO0qnTp3ktNNOM+/fu3fvUs9Xa1899NBDYVpKAOFkh6IISaEwWTkBRwsAAADA40Gpb7/9Nvj3li1bHNlImr2k9Z1OOeUUiZRWrVrJySefLDt27DBBKa01dfDgQcc0OTk5ZkS+gupQqUmTJpli7TbNlGrWrFnElhtA8VnHw1HZuZYcTMmQBrWqsPlwgvTMbEcLAAAAwONBqS5dukhCQoK55ddNT4ufa6HxSNG6VVpTqnHjxuZ+jx49TDfC9evXS7du3cxjy5cvl0AgIN27dy+0eHreUfwAuIPda0+brftTCEohX1kBZwsAAADA40GpnTt3mjovmrH01VdfSf369YPPVapUydR3Kl++fLHnp0XSNespdP4bNmwwNaH0pl3shgwZYrKefvzxR7nnnnukdevW0q9fPzN9u3btTN2pkSNHyuzZsyU7O1vGjRtnuv0x8h4Q/w6nkQUDAAAAAF5VoqBUixYtTKuZSOGwbt06+f3vfx+8b3epGz58uMyaNct0F5w7d67JhtIgU9++feXhhx92ZDnNmzfPBKK0O5+OuqdBrGeeeSYsywcgtvYeSXPdR5CTG3C04UBRdwAAAAB+VKpC52r79u2yYsUKU9Mpb5Dq/vvvL9Y8evXqVejF2EcffVTkPDSjav78+cV6PwDxJTE5U9wmJ2A52nAIUNYdAAAAgA+VKij18ssvy5gxY0zRce1apzWmbPp3cYNSQLjZQU4yTxApdhA+XBmjyo7Nb9mXLJMWfi1Trz5L2jepHbb5AwAAAIBnglKPPPKIPProozJx4sTwLxEQhowTMk+84XCaGzOlnG04/XAgVTYmppuWoFT0u1ECAAAAiK5ypXnRkSNH5Oqrrw7/0gDhGrktfD2rEENJx3J8tf2Tj2U7WhQsKyfX0QIAAADwSVBKA1Iff/xx+JcGAHwiv7hpYlK6o40X2u1w0MwVpvVCxhoAAAAAF3ffa926tdx3332yZs0a6dixo1SsWNHx/G233Rau5QMA30jNzHW08WLF1gOm26G2dDsEAAAAENGg1EsvvSQ1atSQlStXmlsoLXROUAoASp4plZ6V62jjbZREN46WCAAAAMBjQamdO3eGf0kAII8sn/XNSkrPdLQAAAAA4GXFDkpNmDBBHn74Yalevbr5uyCaKfXUU0+Fa/kA+Exokfr0TPcV/M4NWI42nDJyLEcLAAAAAF5W7KDUN998I9nZ2cG/CwtKAUA4ZLkwUSo3EHC0EDmcluloAQAAACCsQakVK1bk+zcARCpTyo1yLWcLkaRjOY4WAAAAAIqjXLGmAgBErYaW32ppua0bZVls2Zcsg2auMC0AAACAwhGUAgCXZIfZNbTcWEvLbdzajfKHA6myMTHdtAAAAAAKR1AKAFxWQ8uNtbTcxq3dKPceSXO0AAAAAApGUAqezDhxe10iFE9mNjWK4kFaRraj9bPE5ExHCwAAAKBgBKUAuFZmjj+ii/EeRE3LDjhaP0vPynW0AAAAAApGUAqeQqYUgFhKSs90tAAAAAAKRlAKAIAwyTie3We3AAAAAApGUAqexxDtiJdR3+waWtTSAgAAAOAHBKXgeSu2HjBDtGsLlJUdi4pATCpYQyveamnl5AYcLQAAAAAUB0EpeB6jYQGRlZWT62ijIXC8gJzdukVWTsDRAgAAACgYQSkAQJnY8ZdoxmHcOqhBema2owUAAABQMIJS8LzDaZmOFu4WGmPIyY1e5g3ii3U8GmW3bpEVcLYAAAAACkZQCp6XdCzH0SJ+ZHNhjzjLlAIAAABQfASlgAg5mJIhj72/wbQoPmIMAAAAAOAPBKWACNm6P0VeWrXXtEBx5AYsRwsAAAAAXkZQCoiQTXuSHC1QEDsElRsIOFrEn5zcgKMFAAAAUDCCUvDkxX1onklaRrajjZbE5ExHC2+IZIHtXMvZxgu7ID2F6UWycnIdLQAAAICCEZSC56Udr5Ztt9GSnpXraOHdwGe45hmv7K8WhelFcgLOFgAAAEDBCErBUyIRMCitpPRMRwtvsI7vXXYLAAAAACgdglJAhGTkWI4WJReIQBe5srIXyYWL5iuR7EYJAAAAwAdBqc8++0wGDhwoTZo0kYSEBHn33Xcdz+vFxv333y+NGzeWqlWrSp8+fWT79u2OaQ4fPiw33HCD1KpVS+rUqSMjRoyQ1NTUKK8J3IzCw/ErwCh0KGjfOJ6pZrcAAAAA4k9Mg1JpaWnSuXNnef755/N9/oknnpBnnnlGZs+eLV9++aVUr15d+vXrJxkZGcFpNCC1efNmWbp0qSxevNgEukaNGhXFtUC4bdmXLINmrjBtPBcezjpeVMZuUXIkwaCofSM79/+OGW6RezyQarcAAAAAClZBYqh///7mlh/NkpoxY4ZMnjxZBg0aZB775z//KQ0bNjQZVddee618//33smTJElm7dq2cffbZZppnn31WLrvsMnnyySdNBhbizw8HUmVjYrpp2zepHbeFh9Mzsx0tUNzuim7stuhm4TpWhENuIOBoAQAAAMRhTamdO3fK/v37TZc9W+3ataV79+6yevVqc19b7bJnB6SUTl+uXDmTWVWQzMxMSUlJcdzgHnuPpDnaeJUVcLZAcbsr0m2xZNx0rMi1nC0AAACAOAxKaUBKaWZUKL1vP6dtgwYNHM9XqFBB6tatG5wmP1OnTjUBLvvWrFmziKwDSicxOdPRwr8ycgKu6poVafFaRD3W2UEcKwAAAID45NqgVCRNmjRJkpOTg7dffvkl1ouEEIfTMh0t/G3F1gOxXgQUwY5FxarHGscKAAAAID65NijVqFEj0x444Lwg1fv2c9oePHjQ8XxOTo4Zkc+eJj+VK1c2o/WF3uAeScdyHG288tOof+EuTh+KLBgUJd6PFQAAAIBfuTYo1bJlSxNYWrZsWfAxrf2ktaJ69Ohh7mublJQk69evD06zfPlyCQQCpvYUEMvRsGI16l8srP35iClOr62futhFMhgHAAAAAF4X09H3UlNTZceOHY7i5hs2bDA1oZo3by533HGHPPLII9KmTRsTpLrvvvvMiHqDBw8207dr104uvfRSGTlypMyePVuys7Nl3LhxZmQ+Rt5DrOvdxGrUv1hITEp3tH7pmhXukSIBAAAAwE9iGpRat26d/P73vw/enzBhgmmHDx8ur776qtxzzz2SlpYmo0aNMhlR559/vixZskSqVKkSfM28efNMIKp3795m1L0hQ4bIM888E5P1QXikZWQ72rJiNKzIO3g0y9F6uWtWaKaUV0aKjEehxeDDdawIh8DxBbNbAAAAAC4NSvXq1UusQk7cExISZMqUKeZWEM2qmj9/foSWELGQlh1wtHC/pPRMR+sXPx5Kd7SIDTcdKwLHuwnbLQAAAIA4rCkFIH5k5FiONpyyXNz/MdzBODtInzdYT+2q/LaVuFKsatgBAAAA8YigFABXS890T9esSAfjAmI52vxqV7lRQcE0P6L7HgAAAFB8BKXgOpnZOY42XuXk5jracHFj1ky464CFynJvolQwiytc2Vyh9apCub12VUHBtGhx07GioM8wnrjxGAMAAABvIigF18k8nnVit/GauWCXuQl3uRs3Zs34tQ6YncUV6Wwut9euinUgJlzHinCwe+3Fc++9tT8fMccYbQEAAIBIIigFz/Na4WG3Z834iZ3FFelsLr8Wko9H9lEmno82iUnpjhYAAACIFIJS8LxYZ3GEW2JypqP1upxcf2VfRbuQPJBXamauo0V4HEzJkMfe32BaAAAA/B+CUkCcOZyW6Wi9LiuHC2Mgmvx2jImWrftT5KVVe00LAACA/0NQCq7DkOqFSzqW42i9Xpw+TDXEI9I9y87iinQ2VyQLyYf7s4pFcWz7mAHvHmO8YNOeJEcLAAAAglJwodxAwNHGKz8NDR/u4vRuFhqUsrO4wpXNVVBX03gqJL9i64GovE/oJor3YwX8we0DFgAAAMQCmVJwnVzL2carSBVYj5esGT+ws7jcls0VS7GodRbvxwq34RgTGQxYAAAAcCKCUkCcFVgvKGtGu00NmrkiJt2nIomuWe4Xuo+nZ0WnBhhxqMiJp8y8eMKABQAAACciKAXPC1gBR+tV2m1qY2J61LpPRasOmJ+6ZhUUyIxkza5IZYMAcDqUcszRAgAAgKAUfMCOk3i9FrLdbSom3aciWAfMzV2zolWU3+01u0KDaHY2CACnX9OyHC0AAAAISgFxp6CsmVgO4+6VOmB+LcofTtQ6i3/xlJkXT6hBBwAAcCK678F1uNAvXdYMw7hHn1+DcYWJRR0igoL+ysyLV4HjwWu7BQAAAEEpuJB9vh7v5+3RrmXl1RGzAuGuFB8HdI/5YvuhqHcTjFfxfqyAP2TnBhwtAAAACEoBnqll5dURswIuDsRYxwNmdhtOoUGpzJxcR+tmOVxwe8ZvqZmeG80zlrzygwsAAEA40X0PiDNuzJqxs5kikdXk5kSpcH8WoXM5ePT/iyFnHQ9G2a2bxcMyopj7tfV/o3pCwvr9dvEhDQAAIOoISsHz7KCGm4Mb8VZzS7MnBs1cEcyisLOZ3JzVFMmsoEhkByWlZ8bNCJJWPsWcEb9Cjy2xGM3Tq7z2fxEAAEA4EJQCPFJcO5IBkrzW/nxENiamm9bPF1vhDhaFziYjpMi0X7cvYiP02JKeReYbAAAAIoegFDxfINwvF/TR7OK140CKo/WrSGYwhRasd/s+HOvFitZgAn4UmrGHsrH3UvZWAACA/0dQCq7j9q5KbmV3m4pG96m9ScccrV9FskZMaMH6eLqYzcmNfmYNx4rISckgUwoAAJS93AfYXgUhKAVEiNuzW8rC7loW2sUsUiIxsh0ix2ODP4rfT7DSM/8/Yw8AAKC4dLAULffBoClsr6IQlALiLChVUKHzaI7Kl3U8Hctu7cBRJAJIbhplEPDDCVbosSXL40FGt/Jb8BMA4D32YCkMmsL2KgpBKSDO2NeLeQffi+aofHb2hN0Gjndgs9twylvQ3S8ys3NivQjIx+Z9KY7Wi0IPIdEYOAH+DH4CALztcFqmowXbqyAEpeB5kaz7Ew+j8kWCnT1ht5Hsquj1z60gmVHoGomSSzqW42i9LhoDJ8CfwU8AgLf57ZyprA4ezXK0fkJQCq7j5VpMXmFnT5BFgbyikamXF8eKyInGwAk40Z6kDEcLAEC8sUeSDh1RGsXvieInBKXgeX7JlIpF9oTdEkgMv3itpRWDmFRUcYKFaDiUkuFoAQCIN/ZI0qEjSqP4PVH8hKAUXMcrAY5IBcMCVsDRxqKmlJ09YbfR7DroF7HIOIpX0TxW+OEEK/TYkpNL971YSD3+K6ndAgBiiwEoSo6eFSWTdvz/fLv1E4JSQJyxE2jyJtIUVAAd8cnNAT4/n5j54QQr9Nji4dibq2XnOlsAQGwxAEXZe1agcEczchytn7g6KPXggw9KQkKC49a2bdvg8xkZGTJ27FipV6+e1KhRQ4YMGSIHDjBSDdzBy90G7ewJsij8yc8nZpxgIRpyjwc97RYAEFs/Hkp3tCh5zwoUsb1yLUfrJ64OSqkOHTpIYmJi8PbFF18Enxs/frwsWrRIFi5cKCtXrpR9+/bJVVddFdPlBfzAzp4gi8KfEpMzHW0oK9773RaBE6z4FU8ZfnSJBgB3SUrPdLSARKlEix9UEJerUKGCNGrU6ITHk5OT5ZVXXpH58+fLxRdfbB6bM2eOtGvXTtasWSPnnntuDJYWALxfU+pwWqajDRXwZG4gvJbh175J7VgvDgAgjmTkWI4WxR+0J14H74m2XLtWr3svAfybKbV9+3Zp0qSJtGrVSm644QbZvXu3eXz9+vWSnZ0tffr0CU6rXfuaN28uq1evLnSemZmZkpKS4rjBPbzc7S2SheD9HF33oljGpIrKJNl75JijDRWLRKlovqUfuq6GfoZuDo6W1OZ9KY7Wzeyt7p2tDwDxjdF3S84+h/gtLUsWbdwb9s/EayyPDPbluaBU9+7d5dVXX5UlS5bIrFmzZOfOnXLBBRfI0aNHZf/+/VKpUiWpU6eO4zUNGzY0zxVm6tSpUrt27eCtWbNmEV4TlARBqfAWQI+EaI70h+grqlaU20agi+b/3X7ruuqlr3jSsRxHCwBAcbnt3CcehJZGWrH1UCwXJS4E8rR+4urue/379w/+3alTJxOkatGihbzxxhtStWrVUs930qRJMmHChOB9zZQiMIV44YYoOiP9eRtFPP3Nq7/Q8Ss3AKC0MrNzHC1KhlpciNtMqbw0K+r000+XHTt2mDpTWVlZkpSU5JhGR9/LrwZVqMqVK0utWrUcNwBwk1gWDC/qxKGwEzOvBjQQ/5Izsh0tAADFlXm8lpTdomiBkJNCanHBM0Gp1NRU+fHHH6Vx48bSrVs3qVixoixbtiz4/LZt20zNqR49esR0OQG/ZlAhfGJZMPy31KxCn/fziZnfuq56qUZdUnqWowUAAJETCKkpYmcrA3HXfe+uu+6SgQMHmi57+/btkwceeEDKly8v1113nakFNWLECNMNr27duibb6dZbbzUBKUbeg5fFsuaWFsCetPBryTk+LISXLljdJpbBxbLUS/B6UNQPXVdDP0IvDZiTnpXraAEAKC4/DHQSbqHnhMkZdHtEnAal9uzZYwJQv/32m9SvX1/OP/98WbNmjflbTZ8+XcqVKydDhgwxI+r169dPXnjhhVgvNuDZTCl7SPUED16w4v/ZQceCcGKGeBTNwSCKE+Bv36R2rBcDAFBMfhvoJNyycgjmIU6DUgsWLCj0+SpVqsjzzz9vboBfxDJTyh5K3QXXdIjhiQMnZt7m1e+3m7LcNMBPUAoA4Jf6qDku+L8X7hVXNaUAFC1w/Ff4SGAo9eiJZTe4spw4xGqxB81cEbH9PpTdZZWuq/HHTUMt2wF+AEB8ScvIicr5hhfEsj4q4gtBKcAjQg/7C77aHZH3yFuksIheXojXoFQR9RLcWOxbu5VGar93axewaPB6jbBY2XvkWKwXAQBQAvY5j/4bjfMNr51DUIsLhSEoBXjQjkNpEZlv3iKFXK96U1H1EgrrBmV5cL/3M4JS7htMAAAQfaHnPJxvlBz/7aEwBKUAjwgNBkRq2FWKFMLNGG4Y8SIzm1GIACBecb5R8h+2AvzKhUIQlIKr0WfbXb/CU6QwemKZcRSvJw7RyD4pySiXizbujfjyID5l5sTndwwA/Cq0liTZrqXYfn6pe4BSISgFV6PPtrt+hac/uD8CqEWdOLi12Hc0sk9KEpT6cFOixDtOISODYykAxJfQUyOyXYsn9FwpTn/vRJQQlIKrbfwlKdaLEJci9Ss8/cELH+I9nGL5f3dRJw5uLfbttuwTLxSzdtcW9Q6OpQAQv9x2vhEPLKJSKARBKbga6bGlw6/w0eelId7dlgEVr/s9xy8AALyBkeRKsc1C/g7wMxcKQVAKrkZ6rLt+hbeHw8WJDh7N8sxmKSoDqiRd2LyWfWKvcnFWneMXCsKxFADiF9muxRN6ruS2c0a4C0EpuBrpse664CEmVbDk9EzxC7cGpaJxoV+SoFR6FkFc5I9jKQDEl9BzHn5YKNv2Q9EW+WywHIJScDW3dcfx+wVPrLp1xUMR8bQs7+yr8Xri4LYLfU5aURBqawBAHHdFc9n5BrznQw8MllMSBKXgaqTHukusCluHu4h4JHgpq6+ooFRJsoX8LJcNhAJQWwMA4Cfx+oNnrOz1wGA5JUFQCq5GpoG/ClXHcxFxP+2rbg1K5eS66zPw0z6BkuHkHADiOFPKY+fZcJ80n2VmEJSCq3FNV8rtZnnrQioefi0gKyb23JasxvELAADviVXPgXjmrxBL2WVm54ifEJTyqFmfbhcvKMsvEf9e87P4ldd+hT+c7v6R7byUFeOx3Sdm+CUVfjlGA4CfcAxHpKVlEpSCByzZtF/8/kuE3wrEReM/y1j9JxwPB+ZcD6VKeWdNYjsyCr+koiBc0ABA/OIYjkjL9s5v3cVCppRHJWe4/yI+0o6kuT+7Jt7EKlgRDwdmChf7T1GBb05aUeC+waYBAAA+6IFRHASlPCorxxvD05flou5oHGTXxNsFT6wupOLhwEwAwn/iodYZ3ImgFADEL47hiLSA+y99woqglEdlZHsjKFWW7i/x0OUrUrz2n2U8dI0jKOU/RdU6o/seAADeo2elD763KdaLAQ8L+GyER4JSHpWR468dOT9sA++Ih65xBKX8x8+BbwAA/OzTH36N9SLAw3J9dilPUMqjvJLyV5ZQhFe2AeIj4BMHi4gwyywig499AgAAb/JKqRTADQhKeZTfUv7ywzbwDoJScKMA/fMAAPAlr5RKgTtZPvtlk6CUR/kt5S8/bAPv4NofbhQPBfgR/xZt3BvrRQAA5EGZEESS5bPNS1DKo7iI91+E2cv4KOFGBL4RDa+v3c2GBgCXyeEkABFk+WzrEpSCZ/ntywwgulklBP8RDbt+S2dDA4DLEJNCpC3yUaY0QSmPIiDDNgDiyaxPt4dlPmSVwGsY5REA3IceGYi0132UKU1QCgAQc+98vTfuskoI/sevcAVBo4G6JQDgPpwDePv/XjfY5aNMaYJSAICYO5CSEZb5/JaWGZb5wNvmfxk/vz5mZ1NQHwDchqCUt//vdYPffHROS1AKABBzx8I0tHJmNqeJKNqvR+PnRC+HXRoA4AG/psbP/71ukOmjc1rPBKWef/55OfXUU6VKlSrSvXt3+eqrr2K9SACAYsoJT0yK4uMolqzc+DnRi58lBQCgYNn8ylIiAR+dAHgiKPX666/LhAkT5IEHHpCvv/5aOnfuLP369ZODBw/GetEA33nwvU2xXgTEoXB1UPLR/98oAz+d6AEA4AZx9HuQK1jiH54ISj399NMycuRIufnmm6V9+/Yye/ZsqVatmvzjH/+I9aIBxq3z1/tmSyzw0UgRsdDv6RXiJn+c/d9YLwIizItDEvvpRA8AALf838uP1/BkUCorK0vWr18vffr0CT5Wrlw5c3/16tXiZ8P+7u/1d5OPvtsvfpGRE+sl8LZtB901Esf6n5PEz/xwcvXo4i2xXgQAAFyHa62Se2M9P17Dg0GpX3/9VXJzc6Vhw4aOx/X+/v35BwIyMzMlJSXFcfOiNT8djvUi4LisCA2e5MUMBsSXHJ+fpL39tfe/g/uPZsV6EQAAcB2utUounVMKeDEoVRpTp06V2rVrB2/NmjUTL2pcu0qsFwHH1arsn6+aj1Y1JqpVFFdx2/JEW+PalcXr6latEOtFAADAdbjWKjk/XROh+BIsy7Livfue1o968803ZfDgwcHHhw8fLklJSfLee+/lmymlN5tmSmlgKjk5WWrVqhW1ZQcAAAAAAPAajbNoElBRcZa4D1VWqlRJunXrJsuWLQs+FggEzP0ePXrk+5rKlSubjRJ6AwAAAAAAQPR4Iid/woQJJjPq7LPPlt/97ncyY8YMSUtLM6PxAQAAAAAAwH08EZT64x//KIcOHZL777/fFDfv0qWLLFmy5ITi5wAAAAAAAHCHuK8pFc2+jgAAAAAAACicb2pKAQAAAAAAIP4QlAIAAAAAAEDUEZQCAAAAAABA1BGUAgAAAAAAQNQRlAIAAAAAAEDUEZQCAAAAAABA1BGUAgAAAAAAQNRViP5buo9lWaZNSUmJ9aIAAAAAAADENTu+YsdbCkJQSkSOHj1qNkazZs2i8dkAAAAAAAD4It5Su3btAp9PsIoKW/lAIBCQffv2Sc2aNSUhISHWi+OpyKgG+n755RepVatWrBcHLsA+AfYLcLwA/4eAcwtwzolo4zok+jTUpAGpJk2aSLlyBVeOIlNKC2uVKydNmzaN5ufjKxqQIigF9glwrAD/h4DzCnC+Ca5DEEtcm0ZXYRlSNgqdAwAAAAAAIOoISgEAAAAAACDqCEohYipXriwPPPCAaQH2CXCsAP+HgPMKcL6JaOA6BOwT8YNC5wAAAAAAAIg6MqUAAAAAAAAQdQSlAAAAAAAAEHUEpQAAAAAAABB1BKVQIlOnTpVzzjlHatasKQ0aNJDBgwfLtm3bHNNkZGTI2LFjpV69elKjRg0ZMmSIHDhwwDHN7t27ZcCAAVKtWjUzn7vvvltycnL4NDzg8ccfl4SEBLnjjjuCj7FP+NPevXvlxhtvNMeCqlWrSseOHWXdunXB5y3Lkvvvv18aN25snu/Tp49s377dMY/Dhw/LDTfcILVq1ZI6derIiBEjJDU1NQZrg3DIzc2V++67T1q2bGk+89NOO00efvhhsy/Y2C+87bPPPpOBAwdKkyZNzP8V7777ruP5cH3+3377rVxwwQVSpUoVadasmTzxxBNRWT+Ef7/Izs6WiRMnmv9DqlevbqYZNmyY7Nu3zzEP9gv/HS9CjR492kwzY8YMx+PsF/7bJ77//nu54oorpHbt2uaYodeueu1p47rEfQhKoURWrlxpAk5r1qyRpUuXmhOFvn37SlpaWnCa8ePHy6JFi2ThwoVmej1puOqqqxwXJRqQysrKklWrVsncuXPl1VdfNSehiG9r166VF198UTp16uR4nH3Cf44cOSI9e/aUihUryocffihbtmyRp556Sk466aTgNHqR+Mwzz8js2bPlyy+/NCcO/fr1MycLNr3w3Lx5szneLF682JyMjBo1KkZrhbL629/+JrNmzZLnnnvOnDTqfd0Pnn322eA07BfepucLnTt3lueffz7f58Px+aekpJhzkxYtWsj69etl2rRp8uCDD8pLL70UlXVEePeL9PR0+frrr01AW9u3337b/CCqF52h2C/8d7ywvfPOO+baRAMVebFf+Guf+PHHH+X888+Xtm3byqeffmp+oNBjh/5AYeO6xIUsoAwOHjyoP29bK1euNPeTkpKsihUrWgsXLgxO8/3335tpVq9ebe5/8MEHVrly5az9+/cHp5k1a5ZVq1YtKzMzk88jTh09etRq06aNtXTpUuuiiy6ybr/9dvM4+4Q/TZw40Tr//PMLfD4QCFiNGjWypk2bFnxM95XKlStbr732mrm/ZcsWc+xYu3ZtcJoPP/zQSkhIsPbu3RvhNUAkDBgwwLrlllscj1111VXWDTfcYP5mv/AX/X6/8847wfvh+vxfeOEF66STTnKcU+gx6YwzzojSmiGc+0V+vvrqKzPdrl27zH32C//uF3v27LFOOeUU67vvvrNatGhhTZ8+Pfgc+4X/9ok//vGP1o033ljga7gucScypVAmycnJpq1bt65p9RdJzZ7SdHubRqqbN28uq1evNve11RTshg0bBqfRX0H1l0395RPxSTPoNAMu9LNX7BP+9P7778vZZ58tV199temi27VrV3n55ZeDz+/cuVP279/v2F80zbp79+6OY4V2zdH52HT6cuXKmQwKxJ/zzjtPli1bJj/88IO5v3HjRvniiy+kf//+5j77hb+F6/PXaS688EKpVKmS4zxDs2s0ixPeOP/Urju6Lyj2C38KBAIydOhQUwakQ4cOJzzPfuG//eE///mPnH766eaYr+ef+v9HaBc/rkvciaAUyvTF17pB2kXnzDPPNI/pyaSeBNonCTYNQOlz9jShASn7efs5xJ8FCxaYlHqtOZYX+4Q//fTTT6abVps2beSjjz6SMWPGyG233Wa664Z+1/M7FoQeK/SEIlSFChVMEJxjRXy699575dprrzU/VmjXTg1W6v8j2r1CsV/4W7g+f84zvE27cmqNqeuuu87UFVPsF/6kXcD1+6/nF/lhv/CXgwcPmvqCWt/20ksvlY8//liuvPJKU0ZGS8oorkvcqUKsFwDxnRnz3XffmV+54V+//PKL3H777aa2R2h/bfibBq01k+Gxxx4z9zX4oMcLrRMzfPjwWC8eYuSNN96QefPmyfz5882v2hs2bDBBKa0Dwn4BoCiajX/NNdeYgvj6wwf8SzNeZs6caX4U1aw5QM891aBBg0zdKNWlSxdTw1jPPy+66CI2kkuRKYVSGTdunCkuumLFCmnatGnw8UaNGpkC5klJSY7pdfQ9fc6eJu9ofPZ9exrE10mB/jJx1llnmV+r9Ka/RmihWv1bf+Fmn/AfHTmrffv2jsfatWsXHP3E/q7ndywIPVbovhVKR+nUkXQ4VsQn7WJhZ0tpN27tdqEnjnaWJfuFv4Xr8+c8w9sBqV27dpkfwuwsKcV+4T+ff/65ORZoiRD7/FP3jTvvvFNOPfVUMw37hb+cfPLJZj8o6vyT6xL3ISiFEtFfpjQgpaNcLF++3AzrHapbt26mS4bWDLFpDQc9EPTo0cPc13bTpk2Ok0r75CLvQQTu17t3b/N5asaDfdMMGe2OY//NPuE/2q1Xv/uhtI6Qjoal9NihJwahxwqtK6c1YUKPFRrg1sCnTY87+kuY1ghA/NFRtLT2T6jy5csHf91kv/C3cH3+Oo2OyKdBjNDzjDPOOMMxAijiLyC1fft2+eSTT6RevXqO59kv/Ed/1NCR1ULPPzXrVn/80LIBiv3CX7SEzDnnnFPo+SfXqi4V60rriC9jxoyxateubX366adWYmJi8Jaenh6cZvTo0Vbz5s2t5cuXW+vWrbN69OhhbracnBzrzDPPtPr27Wtt2LDBWrJkiVW/fn1r0qRJMVorhFvo6HuKfcJ/dGSkChUqWI8++qi1fft2a968eVa1atWsf//738FpHn/8catOnTrWe++9Z3377bfWoEGDrJYtW1rHjh0LTnPppZdaXbt2tb788kvriy++MCM8XnfddTFaK5TV8OHDzShJixcvtnbu3Gm9/fbb1sknn2zdc889wWnYL7w/Uus333xjbnoa+vTTT5u/7VHUwvH56+hKDRs2tIYOHWpG5FqwYIE5/rz44osxWWeUbb/IysqyrrjiCqtp06bmvDH0/DN0hEX2C/8dL/LKO/qeYr/w1z6h5xU6EvxLL71kzj+fffZZq3z58tbnn38enAfXJe5DUAol22FE8r3NmTMnOI2eOP75z382wzHrSeCVV15pThxC/fzzz1b//v2tqlWrmguSO++808rOzubT8GhQin3CnxYtWmQC0Dqce9u2bc0JQigd/v2+++4zF486Te/eva1t27Y5pvntt9/MxWaNGjWsWrVqWTfffLM5IUF8SklJMccG/eGiSpUqVqtWray//vWvjgtL9gtvW7FiRb7nERqwDOfnv3HjRuv8888389BAqAa7EJ/7hQawCzr/1NfZ2C/8d7woTlCK/cJ/+8Qrr7xitW7d2pxndO7c2Xr33Xcd8+C6xH0S9J9YZ2sBAAAAAADAX6gpBQAAAAAAgKgjKAUAAAAAAICoIygFAAAAAACAqCMoBQAAAAAAgKgjKAUAAAAAAICoIygFAAAAAACAqCMoBQAAAAAAgKgjKAUAAAAAAICoIygFAAB8ybIsGTVqlNStW1cSEhJkw4YNsV4kAAAAXyEoBQAAfGnJkiXy6quvyuLFiyUxMVHOPPNM8apevXrJHXfcEdH3WLlypTRr1iyi7wEAALylQqwXAAAAIBZ+/PFHady4sZx33nkFTpOVlSWVKlWK6nLFq/fee08GDhwY68UAAABxhEwpAADgOzfddJPceuutsnv3btN179RTTw1mFI0bN85kFZ188snSr18/8/jTTz8tHTt2lOrVq5tsoD//+c+SmprqmOfLL79snqtWrZpceeWV5jV16tQJPv/ggw9Kly5d5B//+Ic0b95catSoYeaTm5srTzzxhDRq1EgaNGggjz76qGO+SUlJ8qc//Unq168vtWrVkosvvlg2btx4wnz/9a9/mfWoXbu2XHvttXL06NHgumoW08yZM8266u3nn3/Od7vo6x955BEZNmyYWb4WLVrI+++/L4cOHZJBgwaZxzp16iTr1q074bU63RVXXGHmbb9P6E23LQAAQCiCUgAAwHc0QDNlyhRp2rSp6bq3du3a4HNz58412VH//e9/Zfbs2eaxcuXKyTPPPCObN282zy9fvlzuueee4Gt02tGjR8vtt99ualNdcsklJwSX7OysDz/80HQdfO211+SVV16RAQMGyJ49e0zg6G9/+5tMnjxZvvzyy+Brrr76ajl48KB53fr16+Wss86S3r17y+HDhx3zfffdd01XRL3pvB5//PHguvbo0UNGjhxp1lVvhXWzmz59uvTs2VO++eYbs2xDhw41Qaobb7xRvv76aznttNPMfa3JZdPtosuoATOdt/0+etP51KtXTy688MIyfWYAAMB7EqzQMwoAAACfmDFjhrmFZg1pNk9KSooJvhTmzTffNEGoX3/91dzXzCTNnNKAkE2DOHpfM53sjKZp06bJ/v37pWbNmuaxSy+9VLZt22aCShr4Um3btjXZTffee6988cUXJjCkAZ/KlSsH5926dWsTFNNC7fnNV5/77LPPZM2aNcH10mwqXd/CaKbUBRdcYLKulM5Tuzjed999JoindJ4a5NKAk2Z3qccee8wEnxYuXOiYX0ZGhnlvzfLS7n32OgIAACjODAAAAEJ069bthO3xySefmOykU045xQR+NHvot99+k/T0dPO8BpZ+97vfOV6T974d9LEDR6phw4bSvn17R7BGH9MglNJuehrs0kwj7Tpn33bu3GkCWQXNVwNJ9jxKSrvnhS6L0q6LeR8Lnb8GnLTrXl633HKL6UY4f/58AlIAAOAEFDoHAAAIoXWjQmkm1eWXXy5jxowxXfLq1q1rMphGjBhhCqFrDaniqlixouO+1lrK77FAIGD+1oCUBpg+/fTTE+YVWq+qsHmUVOi8dD4FPWbP3+6ipxldobQ21UcffSRfffWVI2AGAABgIygFAABQCK3jpAGYp556Kpjt88YbbzimOeOMMxx1qVTe+6Wh9aO0C12FChWCxdhLQ2tkaUH1SFi0aJEZwVCDdba33nrLdPfTOlhagwoAACA/dN8DAAAohNZvys7OlmeffVZ++uknU2/JLoBu05H8PvjgAzPi3vbt2+XFF180ARk7q6i0+vTpY+o3DR48WD7++GOTtbVq1Sr561//mu8IeAXRgJYWT9fXax2s0mZR5ccedc/23XffmULoEydOlA4dOpigmt5CC7MDAAAoglIAAACF6Ny5swk26ch4Z555psybN0+mTp3qmEZHq9NAlU6n0+voeuPHj5cqVaqUadtqUEuDXTpy3c033yynn366Kaq+a9euYG2n4rjrrrukfPnypn6VFh3fvXu3hENaWposW7bMEZTSYJnW2tLue9r10L5dddVVYXlPAADgHYy+BwAAEAEjR46UrVu3yueff+7Z7fv222/L5MmTZcuWLbFeFAAAEIeoKQUAABAGTz75pFxyySWmULp23Zs7d6688MILnt62OhKgZpABAACUBplSAAAAYXDNNdeYUfKOHj0qrVq1MnWmRo8ezbYFAAAoAEEpAAAAAAAARB2FzgEAAAAAABB1BKUAAAAAAAAQdQSlAAAAAAAAEHUEpQAAAAAAABB1BKUAAAAAAAAQdQSlAAAAAAAAEHUEpQAAAAAAABB1BKUAAAAAAAAQdQSlAAAAAAAAINH2v5THbBcH05XuAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fragments per peptide (top):\n",
+      "            n_fragments  summed_intensity\n",
+      "peptide_id                               \n",
+      "442                5902          158377.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "if HAVE_FRAGMENTS and len(ms2.mz) > 0:\n",
+    "    d = ms2.df\n",
+    "    # A fragment spectrum, coloured by the peptide each fragment ion came from.\n",
+    "    fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "    top_peps = d.loc[d.peptide_id >= 0, \"peptide_id\"].value_counts().head(6).index\n",
+    "    ax.vlines(d.mz, 0, d.intensity, color=\"lightgray\", lw=0.6, label=\"other\")\n",
+    "    for pid in top_peps:\n",
+    "        s = d[d.peptide_id == pid]\n",
+    "        ax.vlines(s.mz, 0, s.intensity, lw=1.0, label=f\"peptide {pid}\")\n",
+    "    ax.set_xlabel(\"fragment m/z\"); ax.set_ylabel(\"intensity\")\n",
+    "    ax.set_title(f\"Annotated MS2 fragment spectrum · frame {ms2.frame_id}\")\n",
+    "    ax.legend(loc=\"upper right\", fontsize=8, ncol=2)\n",
+    "    plt.tight_layout(); plt.show()\n",
+    "\n",
+    "    # The peak-level labels: which peptide/charge/isotope each fragment belongs to.\n",
+    "    print(\"fragments per peptide (top):\")\n",
+    "    print(d.loc[d.peptide_id >= 0]\n",
+    "            .groupby(\"peptide_id\")\n",
+    "            .agg(n_fragments=(\"mz\", \"size\"), summed_intensity=(\"intensity\", \"sum\"))\n",
+    "            .sort_values(\"summed_intensity\", ascending=False).head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17450307",
+   "metadata": {},
+   "source": [
+    "## 8 · From annotations to an ML dataset\n",
+    "\n",
+    "The dense windows are already `(sample, feature)` matrices with aligned per-bin labels —\n",
+    "a per-pixel (here, per-m/z-bin) **segmentation** target. Below we assemble a dataset over\n",
+    "several frames: **input** = the intensity tile (log-scaled), **target** = per-bin binary\n",
+    "mask `signal (label ≥ 0)` vs `background`. Swap the target for `charge_labels` or\n",
+    "`iso_labels` for a multi-class problem.\n",
+    "\n",
+    "This section is framework-agnostic (pure NumPy) — the optional training cell in §8 needs\n",
+    "PyTorch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a4d9534a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:59.553109Z",
+     "iopub.status.busy": "2026-07-02T09:33:59.553035Z",
+     "iopub.status.idle": "2026-07-02T09:33:59.649618Z",
+     "shell.execute_reply": "2026-07-02T09:33:59.649134Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dataset: (6771, 101) -> (6771, 101) |  signal-bin fraction: 0.039\n"
+     ]
+    }
+   ],
+   "source": [
+    "def frames_to_windows(frames, **kw):\n",
+    "    \"\"\"Concatenate dense-window tiles from many frames into one dataset.\"\"\"\n",
+    "    Xs, Ys = [], []\n",
+    "    for f in frames:\n",
+    "        _, _, _, _, X, _, _, pep = f.to_dense_windows_with_labels(**kw)\n",
+    "        if X.shape[0] == 0:\n",
+    "            continue\n",
+    "        Xs.append(X.astype(np.float32))\n",
+    "        Ys.append((pep >= 0).astype(np.float32))        # signal vs background\n",
+    "    return np.concatenate(Xs), np.concatenate(Ys)\n",
+    "\n",
+    "X_all, Y_all = frames_to_windows(\n",
+    "    frames[:60], window_length=10.0, resolution=1,\n",
+    "    min_num_peaks=3, min_intensity=5.0, overlapping=True,\n",
+    ")\n",
+    "X_all = np.log1p(X_all)                                  # compress dynamic range\n",
+    "print(\"dataset:\", X_all.shape, \"->\", Y_all.shape,\n",
+    "      f\"|  signal-bin fraction: {Y_all.mean():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d47d7b2c",
+   "metadata": {},
+   "source": [
+    "## 9 · (Optional) Train a tiny model\n",
+    "\n",
+    "A minimal 1-D CNN that segments each 101-bin tile into signal / background. This is a toy\n",
+    "— a few epochs on CPU — meant to show that the annotations plug straight into a standard\n",
+    "training loop, not to be a good detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "3540508e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:33:59.650752Z",
+     "iopub.status.busy": "2026-07-02T09:33:59.650685Z",
+     "iopub.status.idle": "2026-07-02T09:34:00.241837Z",
+     "shell.execute_reply": "2026-07-02T09:34:00.241360Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import torch\n",
+    "    import torch.nn as nn\n",
+    "    HAVE_TORCH = True\n",
+    "except ImportError:\n",
+    "    HAVE_TORCH = False\n",
+    "    print(\"PyTorch not installed — skipping the training demo (data-prep in §7 stands alone).\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "99c171b7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:34:00.242972Z",
+     "iopub.status.busy": "2026-07-02T09:34:00.242856Z",
+     "iopub.status.idle": "2026-07-02T09:34:12.775869Z",
+     "shell.execute_reply": "2026-07-02T09:34:12.775472Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch  0  val_loss=0.786  val_acc=0.977  signal_recall=1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch  3  val_loss=0.071  val_acc=1.000  signal_recall=1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch  6  val_loss=0.016  val_acc=1.000  signal_recall=1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch  9  val_loss=0.005  val_acc=1.000  signal_recall=1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 12  val_loss=0.002  val_acc=1.000  signal_recall=1.000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 14  val_loss=0.002  val_acc=1.000  signal_recall=1.000\n",
+      "\n",
+      "Trained. The point: annotated frames -> (input, per-bin label) -> standard loop.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if HAVE_TORCH:\n",
+    "    torch.manual_seed(0)\n",
+    "    Xt = torch.from_numpy(X_all)[:, None, :]             # (N, 1, 101)\n",
+    "    Yt = torch.from_numpy(Y_all)[:, None, :]             # (N, 1, 101)\n",
+    "    n_val = max(1, len(Xt) // 5)\n",
+    "    tr = (Xt[:-n_val], Yt[:-n_val]); va = (Xt[-n_val:], Yt[-n_val:])\n",
+    "\n",
+    "    model = nn.Sequential(\n",
+    "        nn.Conv1d(1, 16, 5, padding=2), nn.ReLU(),\n",
+    "        nn.Conv1d(16, 16, 5, padding=2), nn.ReLU(),\n",
+    "        nn.Conv1d(16, 1, 1),\n",
+    "    )\n",
+    "    opt = torch.optim.Adam(model.parameters(), lr=1e-3)\n",
+    "    # class imbalance: signal bins are rare -> weight the positive class\n",
+    "    pos_w = torch.tensor([(1 - Y_all.mean()) / max(Y_all.mean(), 1e-6)])\n",
+    "    loss_fn = nn.BCEWithLogitsLoss(pos_weight=pos_w)\n",
+    "\n",
+    "    for epoch in range(15):\n",
+    "        model.train()\n",
+    "        perm = torch.randperm(len(tr[0]))\n",
+    "        for i in range(0, len(perm), 128):\n",
+    "            idx = perm[i:i + 128]\n",
+    "            opt.zero_grad()\n",
+    "            loss = loss_fn(model(tr[0][idx]), tr[1][idx])\n",
+    "            loss.backward(); opt.step()\n",
+    "        if epoch % 3 == 0 or epoch == 14:\n",
+    "            model.eval()\n",
+    "            with torch.no_grad():\n",
+    "                vp = (model(va[0]) > 0).float()\n",
+    "                acc = (vp == va[1]).float().mean().item()\n",
+    "                tp = ((vp == 1) & (va[1] == 1)).sum().item()\n",
+    "                recall = tp / max((va[1] == 1).sum().item(), 1)\n",
+    "            print(f\"epoch {epoch:2d}  val_loss={loss_fn(model(va[0]), va[1]):.3f}  \"\n",
+    "                  f\"val_acc={acc:.3f}  signal_recall={recall:.3f}\")\n",
+    "    print(\"\\nTrained. The point: annotated frames -> (input, per-bin label) -> standard loop.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08c71188",
+   "metadata": {},
+   "source": [
+    "## Recap & pointers\n",
+    "\n",
+    "- **`frame.df`** is the easy path: per-peak `mz / scan / inv_mobility / intensity` plus\n",
+    "  `peptide_id / charge_state / isotope_peak`. Grid it yourself for m/z–IM or m/z–RT maps.\n",
+    "- **`to_dense_windows_with_labels`** is the model-ready path: a stack of `N` fixed-width\n",
+    "  `(scan × m/z-window)` tiles, each `Y = round(window_length·10^resolution)+1` bins, with\n",
+    "  aligned per-bin label planes. Duplicate per-tile metadata is expected with\n",
+    "  `overlapping=True`.\n",
+    "- **Fragment (MS2) frames** come from the unified `create_frame_builder(...,\n",
+    "  with_annotations=True)` and behave identically to precursor frames (same\n",
+    "  `TimsFrameAnnotated`). They require `apply_fragmentation=true` at simulation time and use\n",
+    "  heavier eager loading. In DIA, MS2 frames are sparse — sample and keep the populated ones.\n",
+    "- **Molecule-level** ground truth lives in `synthetic_data.db` (tables `peptides`, `ions`,\n",
+    "  `fragment_ions`, …) if you need to join labels back to sequences.\n",
+    "\n",
+    "See `CONFIGURATION.md` for the full config reference and the annotated-API summary.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## What

A runnable, end-to-end onboarding notebook for the **peak-level annotation API**, written in response to **#425** (Philipp Weigand), plus a pointer to it from `CONFIGURATION.md`.

`packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb`

## Why

Philipp was confused by `to_dense_windows_with_labels` — specifically *what N and Y are*, *why the per-tile arrays contain duplicate values*, and *how to build an m/z–ion-mobility map* (and an m/z–RT map) from the annotations. The notebook answers each of those directly.

## Contents

1. Build annotated **precursor (MS1)** frames; the tidy per-peak `.df` view
2. Assemble an **m/z–ion-mobility map** + label overlay from `.df`
3. **`to_dense_windows_with_labels` demystified** — `N` = (scan × m/z-window) tiles, `Y` = `round(window_length·10^resolution)+1` bins; then **reconstruct the full m/z–IM image from the windowed output** to show exactly why `overlapping=True` produces the "duplicate" `scan`/`mz`/`mobility` values (3239 overlap duplicates collapsed, on the test run)
4. **m/z–retention-time map** by stacking frames along RT
5. Annotated **fragment (MS2)** frames via `create_frame_builder(..., with_annotations=True)`, incl. sparse-DIA handling and a peptide-coloured fragment spectrum
6. Annotations → ML dataset + an optional small PyTorch segmentation loop

## Validation

Executed **end-to-end headless** (`jupyter nbconvert --execute`) against a real DIA `synthetic_data.db` on the current `main` (pyo3-0.29 connector): **19 code cells, 0 errors, 5 plots**. Outputs/plots are committed for GitHub preview; no local paths leak into outputs (the setup cell prints only the run name). Users point `DATASET_DB` / `TIMSIM_DB` at their own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)