### PR TITLE
docs: dense-vs-sparse DL note in annotated-frame notebook

### DIFF
--- a/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
+++ b/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ba227d1d",
+   "id": "d0194504",
    "metadata": {},
    "source": [
     "# Working with Annotated Frames\n",
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "77a9440e",
+   "id": "43c2ce29",
    "metadata": {},
    "source": [
     "## 0 · Setup\n",
@@ -42,13 +42,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "b9128e3a",
+   "id": "4778cc55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:56.170227Z",
-     "iopub.status.busy": "2026-07-02T09:33:56.169961Z",
-     "iopub.status.idle": "2026-07-02T09:33:56.687931Z",
-     "shell.execute_reply": "2026-07-02T09:33:56.687538Z"
+     "iopub.execute_input": "2026-07-02T09:43:58.362534Z",
+     "iopub.status.busy": "2026-07-02T09:43:58.362153Z",
+     "iopub.status.idle": "2026-07-02T09:43:58.886822Z",
+     "shell.execute_reply": "2026-07-02T09:43:58.886442Z"
     }
    },
    "outputs": [
@@ -84,13 +84,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "3759689f",
+   "id": "145e6188",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:56.689112Z",
-     "iopub.status.busy": "2026-07-02T09:33:56.689002Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.433568Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.433172Z"
+     "iopub.execute_input": "2026-07-02T09:43:58.887939Z",
+     "iopub.status.busy": "2026-07-02T09:43:58.887833Z",
+     "iopub.status.idle": "2026-07-02T09:43:59.754529Z",
+     "shell.execute_reply": "2026-07-02T09:43:59.754032Z"
     }
    },
    "outputs": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86473feb",
+   "id": "0564d41e",
    "metadata": {},
    "source": [
     "## 1 · Enumerate precursor (MS1) frames\n",
@@ -125,13 +125,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "aa407da3",
+   "id": "58327b8e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.434866Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.434750Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.455177Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.454786Z"
+     "iopub.execute_input": "2026-07-02T09:43:59.755671Z",
+     "iopub.status.busy": "2026-07-02T09:43:59.755553Z",
+     "iopub.status.idle": "2026-07-02T09:43:59.776260Z",
+     "shell.execute_reply": "2026-07-02T09:43:59.775865Z"
     }
    },
    "outputs": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "848ba553",
+   "id": "6b3b8e83",
    "metadata": {},
    "source": [
     "## 2 · Build a single annotated frame\n",
@@ -170,13 +170,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "2344a071",
+   "id": "8208ac2a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.456245Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.456186Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.470653Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.470319Z"
+     "iopub.execute_input": "2026-07-02T09:43:59.777269Z",
+     "iopub.status.busy": "2026-07-02T09:43:59.777205Z",
+     "iopub.status.idle": "2026-07-02T09:43:59.791456Z",
+     "shell.execute_reply": "2026-07-02T09:43:59.791076Z"
     }
    },
    "outputs": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa016644",
+   "id": "ab984b46",
    "metadata": {},
    "source": [
     "## 3 · The `.df` view — the easy entry point\n",
@@ -221,13 +221,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c65cf2cc",
+   "id": "c83f2298",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.471667Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.471607Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.477703Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.477351Z"
+     "iopub.execute_input": "2026-07-02T09:43:59.792494Z",
+     "iopub.status.busy": "2026-07-02T09:43:59.792435Z",
+     "iopub.status.idle": "2026-07-02T09:43:59.798110Z",
+     "shell.execute_reply": "2026-07-02T09:43:59.797700Z"
     }
    },
    "outputs": [
@@ -398,13 +398,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "49a1918c",
+   "id": "20a4ac24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.478626Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.478570Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.480894Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.480578Z"
+     "iopub.execute_input": "2026-07-02T09:43:59.799168Z",
+     "iopub.status.busy": "2026-07-02T09:43:59.799107Z",
+     "iopub.status.idle": "2026-07-02T09:43:59.801450Z",
+     "shell.execute_reply": "2026-07-02T09:43:59.801198Z"
     }
    },
    "outputs": [
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "484a95d9",
+   "id": "80da78ee",
    "metadata": {},
    "source": [
     "## 4 · Build an m/z–ion-mobility map (with a label overlay)\n",
@@ -440,13 +440,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "767315aa",
+   "id": "3ef0ccb0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.481942Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.481881Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.484711Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.484381Z"
+     "iopub.execute_input": "2026-07-02T09:43:59.802546Z",
+     "iopub.status.busy": "2026-07-02T09:43:59.802493Z",
+     "iopub.status.idle": "2026-07-02T09:43:59.805313Z",
+     "shell.execute_reply": "2026-07-02T09:43:59.804966Z"
     }
    },
    "outputs": [],
@@ -481,13 +481,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "15584a36",
+   "id": "def0cae0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.485723Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.485659Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.739795Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.734408Z"
+     "iopub.execute_input": "2026-07-02T09:43:59.806175Z",
+     "iopub.status.busy": "2026-07-02T09:43:59.806113Z",
+     "iopub.status.idle": "2026-07-02T09:44:00.062303Z",
+     "shell.execute_reply": "2026-07-02T09:44:00.061342Z"
     }
    },
    "outputs": [
@@ -527,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d6aed7c",
+   "id": "92d0e720",
    "metadata": {},
    "source": [
     "## 5 · `to_dense_windows_with_labels` — demystified\n",
@@ -564,13 +564,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "9e1cb7f3",
+   "id": "84709872",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.742522Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.742345Z",
-     "iopub.status.idle": "2026-07-02T09:33:57.777964Z",
-     "shell.execute_reply": "2026-07-02T09:33:57.777567Z"
+     "iopub.execute_input": "2026-07-02T09:44:00.064680Z",
+     "iopub.status.busy": "2026-07-02T09:44:00.064514Z",
+     "iopub.status.idle": "2026-07-02T09:44:00.102047Z",
+     "shell.execute_reply": "2026-07-02T09:44:00.101707Z"
     }
    },
    "outputs": [
@@ -599,13 +599,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "10538647",
+   "id": "be7d40de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:57.778984Z",
-     "iopub.status.busy": "2026-07-02T09:33:57.778913Z",
-     "iopub.status.idle": "2026-07-02T09:33:58.003402Z",
-     "shell.execute_reply": "2026-07-02T09:33:58.003019Z"
+     "iopub.execute_input": "2026-07-02T09:44:00.103169Z",
+     "iopub.status.busy": "2026-07-02T09:44:00.103100Z",
+     "iopub.status.idle": "2026-07-02T09:44:00.322782Z",
+     "shell.execute_reply": "2026-07-02T09:44:00.322405Z"
     }
    },
    "outputs": [
@@ -638,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "acb56ce9",
+   "id": "1634e527",
    "metadata": {},
    "source": [
     "### \"But I expected to build an m/z–ion-mobility image from *these*…\"\n",
@@ -657,13 +657,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "8b66c0fd",
+   "id": "35e2462c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:58.004730Z",
-     "iopub.status.busy": "2026-07-02T09:33:58.004612Z",
-     "iopub.status.idle": "2026-07-02T09:33:58.310003Z",
-     "shell.execute_reply": "2026-07-02T09:33:58.309576Z"
+     "iopub.execute_input": "2026-07-02T09:44:00.323938Z",
+     "iopub.status.busy": "2026-07-02T09:44:00.323875Z",
+     "iopub.status.idle": "2026-07-02T09:44:00.697818Z",
+     "shell.execute_reply": "2026-07-02T09:44:00.697406Z"
     }
    },
    "outputs": [
@@ -718,7 +718,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b9729a5",
+   "id": "d653ea60",
    "metadata": {},
    "source": [
     "## 6 · Build an m/z–retention-time map\n",
@@ -732,13 +732,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "d9839076",
+   "id": "39dac6d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:58.311041Z",
-     "iopub.status.busy": "2026-07-02T09:33:58.310979Z",
-     "iopub.status.idle": "2026-07-02T09:33:58.405251Z",
-     "shell.execute_reply": "2026-07-02T09:33:58.404901Z"
+     "iopub.execute_input": "2026-07-02T09:44:00.699143Z",
+     "iopub.status.busy": "2026-07-02T09:44:00.699062Z",
+     "iopub.status.idle": "2026-07-02T09:44:00.795902Z",
+     "shell.execute_reply": "2026-07-02T09:44:00.795517Z"
     }
    },
    "outputs": [
@@ -782,13 +782,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "fb8953f0",
+   "id": "b330da56",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:58.406325Z",
-     "iopub.status.busy": "2026-07-02T09:33:58.406258Z",
-     "iopub.status.idle": "2026-07-02T09:33:58.553837Z",
-     "shell.execute_reply": "2026-07-02T09:33:58.553540Z"
+     "iopub.execute_input": "2026-07-02T09:44:00.796912Z",
+     "iopub.status.busy": "2026-07-02T09:44:00.796844Z",
+     "iopub.status.idle": "2026-07-02T09:44:00.946641Z",
+     "shell.execute_reply": "2026-07-02T09:44:00.946359Z"
     }
    },
    "outputs": [
@@ -815,7 +815,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8aaaf296",
+   "id": "14b1d2dd",
    "metadata": {},
    "source": [
     "## 7 · Annotated fragment (MS2) frames\n",
@@ -844,13 +844,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "e8793495",
+   "id": "194880cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:58.555062Z",
-     "iopub.status.busy": "2026-07-02T09:33:58.554994Z",
-     "iopub.status.idle": "2026-07-02T09:33:58.568656Z",
-     "shell.execute_reply": "2026-07-02T09:33:58.568297Z"
+     "iopub.execute_input": "2026-07-02T09:44:00.947907Z",
+     "iopub.status.busy": "2026-07-02T09:44:00.947838Z",
+     "iopub.status.idle": "2026-07-02T09:44:00.961621Z",
+     "shell.execute_reply": "2026-07-02T09:44:00.961294Z"
     }
    },
    "outputs": [
@@ -882,13 +882,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "4614adef",
+   "id": "c3dc40df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:58.569611Z",
-     "iopub.status.busy": "2026-07-02T09:33:58.569553Z",
-     "iopub.status.idle": "2026-07-02T09:33:59.357700Z",
-     "shell.execute_reply": "2026-07-02T09:33:59.357365Z"
+     "iopub.execute_input": "2026-07-02T09:44:00.962853Z",
+     "iopub.status.busy": "2026-07-02T09:44:00.962776Z",
+     "iopub.status.idle": "2026-07-02T09:44:01.799187Z",
+     "shell.execute_reply": "2026-07-02T09:44:01.798730Z"
     }
    },
    "outputs": [
@@ -1072,13 +1072,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "147a292a",
+   "id": "f22622cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:59.358735Z",
-     "iopub.status.busy": "2026-07-02T09:33:59.358677Z",
-     "iopub.status.idle": "2026-07-02T09:33:59.551925Z",
-     "shell.execute_reply": "2026-07-02T09:33:59.551601Z"
+     "iopub.execute_input": "2026-07-02T09:44:01.800143Z",
+     "iopub.status.busy": "2026-07-02T09:44:01.800075Z",
+     "iopub.status.idle": "2026-07-02T09:44:01.997483Z",
+     "shell.execute_reply": "2026-07-02T09:44:01.997100Z"
     }
    },
    "outputs": [
@@ -1128,31 +1128,96 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17450307",
+   "id": "f784ca56",
    "metadata": {},
    "source": [
     "## 8 · From annotations to an ML dataset\n",
     "\n",
-    "The dense windows are already `(sample, feature)` matrices with aligned per-bin labels —\n",
-    "a per-pixel (here, per-m/z-bin) **segmentation** target. Below we assemble a dataset over\n",
-    "several frames: **input** = the intensity tile (log-scaled), **target** = per-bin binary\n",
-    "mask `signal (label ≥ 0)` vs `background`. Swap the target for `charge_labels` or\n",
-    "`iso_labels` for a multi-class problem.\n",
+    "### The core tension: dense models vs. sparse spectra\n",
     "\n",
-    "This section is framework-agnostic (pure NumPy) — the optional training cell in §8 needs\n",
-    "PyTorch."
+    "Before the data prep, it is worth naming the central challenge of deep learning on raw MS\n",
+    "data. Most DL architectures — CNNs, vision transformers — expect **dense** tensors and\n",
+    "learn from populated local context. Mass spectra are the opposite: **extremely sparse**,\n",
+    "and ion-mobility data makes it worse, because adding the mobility axis inflates the\n",
+    "`(m/z × mobility)` (and, over a run, `× retention time`) volume while the number of real\n",
+    "peaks stays roughly the same. A naïve dense voxelization is therefore almost entirely\n",
+    "zeros — wasteful in memory and compute, and badly class-imbalanced (very few \"signal\"\n",
+    "pixels), which is exactly what makes training hard.\n",
+    "\n",
+    "There is no single right answer; the common strategies each trade off differently, and the\n",
+    "annotations here support all of them:\n",
+    "\n",
+    "- **Dense windowing / tiling** — carve fixed-size dense patches around populated regions\n",
+    "  (what `to_dense_windows_with_labels` does). Model-friendly, but you choose the window\n",
+    "  size and still carry some empty bins.\n",
+    "- **Sparse / point-cloud representations** — treat each spectrum as a list of\n",
+    "  `(m/z, mobility, intensity)` points and run point-cloud / set / graph models or sparse\n",
+    "  convolutions directly on the peaks. The per-peak `.df` **is** exactly this point cloud,\n",
+    "  already carrying per-point labels.\n",
+    "- **Hybrid** — sparse encoders that densify only locally, or attention over peaks.\n",
+    "\n",
+    "The cell below quantifies the sparsity on one frame to make the tension concrete; then we\n",
+    "build a simple dense-windowed dataset because it plugs straight into a standard loop."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "a4d9534a",
+   "id": "513eeaa4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:59.553109Z",
-     "iopub.status.busy": "2026-07-02T09:33:59.553035Z",
-     "iopub.status.idle": "2026-07-02T09:33:59.649618Z",
-     "shell.execute_reply": "2026-07-02T09:33:59.649134Z"
+     "iopub.execute_input": "2026-07-02T09:44:01.998613Z",
+     "iopub.status.busy": "2026-07-02T09:44:01.998550Z",
+     "iopub.status.idle": "2026-07-02T09:44:02.001005Z",
+     "shell.execute_reply": "2026-07-02T09:44:02.000623Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "frame 17073: 10,849 peaks in a 626 x 84042 = 52,610,292-cell dense grid\n",
+      "  -> occupancy 0.0206%  (i.e. ~4,849x more empty cells than populated ones)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# How empty is a dense voxelization of a single frame?\n",
+    "mz_a  = df.mz.to_numpy(); scan_a = df.scan.to_numpy()\n",
+    "n_mz_cells   = int(np.ceil((mz_a.max() - mz_a.min()) / 0.01)) + 1      # 0.01 Th bins\n",
+    "n_scan_cells = int(scan_a.max() - scan_a.min()) + 1\n",
+    "dense_cells  = n_mz_cells * n_scan_cells\n",
+    "occupancy    = len(df) / dense_cells\n",
+    "print(f\"frame {frame.frame_id}: {len(df):,} peaks in a \"\n",
+    "      f\"{n_scan_cells} x {n_mz_cells} = {dense_cells:,}-cell dense grid\")\n",
+    "print(f\"  -> occupancy {occupancy*100:.4f}%  (i.e. ~{1/occupancy:,.0f}x more empty cells \"\n",
+    "      f\"than populated ones)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d17ee32",
+   "metadata": {},
+   "source": [
+    "Now the dataset itself. The dense windows are already `(sample, feature)` matrices with\n",
+    "aligned per-bin labels — a per-bin **segmentation** target. We use **input** = the\n",
+    "intensity tile (log-scaled), **target** = per-bin binary mask `signal (label ≥ 0)` vs\n",
+    "`background`. Swap the target for `charge_labels` or `iso_labels` for a multi-class\n",
+    "problem. This part is framework-agnostic (pure NumPy); the optional training cell in §9\n",
+    "needs PyTorch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "8d5a4e1e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T09:44:02.002002Z",
+     "iopub.status.busy": "2026-07-02T09:44:02.001940Z",
+     "iopub.status.idle": "2026-07-02T09:44:02.099795Z",
+     "shell.execute_reply": "2026-07-02T09:44:02.099378Z"
     }
    },
    "outputs": [
@@ -1187,7 +1252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d47d7b2c",
+   "id": "ffe24317",
    "metadata": {},
    "source": [
     "## 9 · (Optional) Train a tiny model\n",
@@ -1199,14 +1264,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "3540508e",
+   "execution_count": 19,
+   "id": "2b661ee7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:33:59.650752Z",
-     "iopub.status.busy": "2026-07-02T09:33:59.650685Z",
-     "iopub.status.idle": "2026-07-02T09:34:00.241837Z",
-     "shell.execute_reply": "2026-07-02T09:34:00.241360Z"
+     "iopub.execute_input": "2026-07-02T09:44:02.100864Z",
+     "iopub.status.busy": "2026-07-02T09:44:02.100789Z",
+     "iopub.status.idle": "2026-07-02T09:44:02.826973Z",
+     "shell.execute_reply": "2026-07-02T09:44:02.826630Z"
     }
    },
    "outputs": [],
@@ -1222,14 +1287,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "99c171b7",
+   "execution_count": 20,
+   "id": "86929597",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:34:00.242972Z",
-     "iopub.status.busy": "2026-07-02T09:34:00.242856Z",
-     "iopub.status.idle": "2026-07-02T09:34:12.775869Z",
-     "shell.execute_reply": "2026-07-02T09:34:12.775472Z"
+     "iopub.execute_input": "2026-07-02T09:44:02.828371Z",
+     "iopub.status.busy": "2026-07-02T09:44:02.828257Z",
+     "iopub.status.idle": "2026-07-02T09:44:15.485209Z",
+     "shell.execute_reply": "2026-07-02T09:44:15.484809Z"
     }
    },
    "outputs": [
@@ -1318,7 +1383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08c71188",
+   "id": "a7ac2311",
    "metadata": {},
    "source": [
     "## Recap & pointers\n",

--- a/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
+++ b/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d0194504",
+   "id": "0d21b463",
    "metadata": {},
    "source": [
     "# Working with Annotated Frames\n",
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43c2ce29",
+   "id": "e475e4a0",
    "metadata": {},
    "source": [
     "## 0 · Setup\n",
@@ -42,13 +42,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "4778cc55",
+   "id": "92e0409f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:58.362534Z",
-     "iopub.status.busy": "2026-07-02T09:43:58.362153Z",
-     "iopub.status.idle": "2026-07-02T09:43:58.886822Z",
-     "shell.execute_reply": "2026-07-02T09:43:58.886442Z"
+     "iopub.execute_input": "2026-07-02T09:45:54.211024Z",
+     "iopub.status.busy": "2026-07-02T09:45:54.210704Z",
+     "iopub.status.idle": "2026-07-02T09:45:54.790122Z",
+     "shell.execute_reply": "2026-07-02T09:45:54.789782Z"
     }
    },
    "outputs": [
@@ -84,13 +84,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "145e6188",
+   "id": "5021a07c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:58.887939Z",
-     "iopub.status.busy": "2026-07-02T09:43:58.887833Z",
-     "iopub.status.idle": "2026-07-02T09:43:59.754529Z",
-     "shell.execute_reply": "2026-07-02T09:43:59.754032Z"
+     "iopub.execute_input": "2026-07-02T09:45:54.791580Z",
+     "iopub.status.busy": "2026-07-02T09:45:54.791467Z",
+     "iopub.status.idle": "2026-07-02T09:45:55.700923Z",
+     "shell.execute_reply": "2026-07-02T09:45:55.700529Z"
     }
    },
    "outputs": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0564d41e",
+   "id": "806eaaeb",
    "metadata": {},
    "source": [
     "## 1 · Enumerate precursor (MS1) frames\n",
@@ -125,13 +125,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "58327b8e",
+   "id": "fe696f84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:59.755671Z",
-     "iopub.status.busy": "2026-07-02T09:43:59.755553Z",
-     "iopub.status.idle": "2026-07-02T09:43:59.776260Z",
-     "shell.execute_reply": "2026-07-02T09:43:59.775865Z"
+     "iopub.execute_input": "2026-07-02T09:45:55.702247Z",
+     "iopub.status.busy": "2026-07-02T09:45:55.702131Z",
+     "iopub.status.idle": "2026-07-02T09:45:55.725109Z",
+     "shell.execute_reply": "2026-07-02T09:45:55.724677Z"
     }
    },
    "outputs": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b3b8e83",
+   "id": "45d25da4",
    "metadata": {},
    "source": [
     "## 2 · Build a single annotated frame\n",
@@ -170,13 +170,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "8208ac2a",
+   "id": "7e7e6b7b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:59.777269Z",
-     "iopub.status.busy": "2026-07-02T09:43:59.777205Z",
-     "iopub.status.idle": "2026-07-02T09:43:59.791456Z",
-     "shell.execute_reply": "2026-07-02T09:43:59.791076Z"
+     "iopub.execute_input": "2026-07-02T09:45:55.726141Z",
+     "iopub.status.busy": "2026-07-02T09:45:55.726077Z",
+     "iopub.status.idle": "2026-07-02T09:45:55.744531Z",
+     "shell.execute_reply": "2026-07-02T09:45:55.744205Z"
     }
    },
    "outputs": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab984b46",
+   "id": "ffa65fed",
    "metadata": {},
    "source": [
     "## 3 · The `.df` view — the easy entry point\n",
@@ -221,13 +221,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "c83f2298",
+   "id": "ddd01a8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:59.792494Z",
-     "iopub.status.busy": "2026-07-02T09:43:59.792435Z",
-     "iopub.status.idle": "2026-07-02T09:43:59.798110Z",
-     "shell.execute_reply": "2026-07-02T09:43:59.797700Z"
+     "iopub.execute_input": "2026-07-02T09:45:55.745714Z",
+     "iopub.status.busy": "2026-07-02T09:45:55.745631Z",
+     "iopub.status.idle": "2026-07-02T09:45:55.752032Z",
+     "shell.execute_reply": "2026-07-02T09:45:55.751683Z"
     }
    },
    "outputs": [
@@ -398,13 +398,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "20a4ac24",
+   "id": "805ad268",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:59.799168Z",
-     "iopub.status.busy": "2026-07-02T09:43:59.799107Z",
-     "iopub.status.idle": "2026-07-02T09:43:59.801450Z",
-     "shell.execute_reply": "2026-07-02T09:43:59.801198Z"
+     "iopub.execute_input": "2026-07-02T09:45:55.752970Z",
+     "iopub.status.busy": "2026-07-02T09:45:55.752910Z",
+     "iopub.status.idle": "2026-07-02T09:45:55.755317Z",
+     "shell.execute_reply": "2026-07-02T09:45:55.754981Z"
     }
    },
    "outputs": [
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80da78ee",
+   "id": "deb46b06",
    "metadata": {},
    "source": [
     "## 4 · Build an m/z–ion-mobility map (with a label overlay)\n",
@@ -440,13 +440,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3ef0ccb0",
+   "id": "058b6093",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:59.802546Z",
-     "iopub.status.busy": "2026-07-02T09:43:59.802493Z",
-     "iopub.status.idle": "2026-07-02T09:43:59.805313Z",
-     "shell.execute_reply": "2026-07-02T09:43:59.804966Z"
+     "iopub.execute_input": "2026-07-02T09:45:55.756364Z",
+     "iopub.status.busy": "2026-07-02T09:45:55.756305Z",
+     "iopub.status.idle": "2026-07-02T09:45:55.759107Z",
+     "shell.execute_reply": "2026-07-02T09:45:55.758801Z"
     }
    },
    "outputs": [],
@@ -481,13 +481,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "def0cae0",
+   "id": "2464ba68",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:43:59.806175Z",
-     "iopub.status.busy": "2026-07-02T09:43:59.806113Z",
-     "iopub.status.idle": "2026-07-02T09:44:00.062303Z",
-     "shell.execute_reply": "2026-07-02T09:44:00.061342Z"
+     "iopub.execute_input": "2026-07-02T09:45:55.760126Z",
+     "iopub.status.busy": "2026-07-02T09:45:55.760068Z",
+     "iopub.status.idle": "2026-07-02T09:45:56.006554Z",
+     "shell.execute_reply": "2026-07-02T09:45:56.005752Z"
     }
    },
    "outputs": [
@@ -527,7 +527,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92d0e720",
+   "id": "d3519570",
    "metadata": {},
    "source": [
     "## 5 · `to_dense_windows_with_labels` — demystified\n",
@@ -564,13 +564,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "84709872",
+   "id": "11965354",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:00.064680Z",
-     "iopub.status.busy": "2026-07-02T09:44:00.064514Z",
-     "iopub.status.idle": "2026-07-02T09:44:00.102047Z",
-     "shell.execute_reply": "2026-07-02T09:44:00.101707Z"
+     "iopub.execute_input": "2026-07-02T09:45:56.008721Z",
+     "iopub.status.busy": "2026-07-02T09:45:56.008554Z",
+     "iopub.status.idle": "2026-07-02T09:45:56.048716Z",
+     "shell.execute_reply": "2026-07-02T09:45:56.047828Z"
     }
    },
    "outputs": [
@@ -599,13 +599,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "be7d40de",
+   "id": "e0b08783",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:00.103169Z",
-     "iopub.status.busy": "2026-07-02T09:44:00.103100Z",
-     "iopub.status.idle": "2026-07-02T09:44:00.322782Z",
-     "shell.execute_reply": "2026-07-02T09:44:00.322405Z"
+     "iopub.execute_input": "2026-07-02T09:45:56.050494Z",
+     "iopub.status.busy": "2026-07-02T09:45:56.050327Z",
+     "iopub.status.idle": "2026-07-02T09:45:56.285190Z",
+     "shell.execute_reply": "2026-07-02T09:45:56.284739Z"
     }
    },
    "outputs": [
@@ -638,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1634e527",
+   "id": "38c0c6c1",
    "metadata": {},
    "source": [
     "### \"But I expected to build an m/z–ion-mobility image from *these*…\"\n",
@@ -657,13 +657,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "35e2462c",
+   "id": "bdd2c3c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:00.323938Z",
-     "iopub.status.busy": "2026-07-02T09:44:00.323875Z",
-     "iopub.status.idle": "2026-07-02T09:44:00.697818Z",
-     "shell.execute_reply": "2026-07-02T09:44:00.697406Z"
+     "iopub.execute_input": "2026-07-02T09:45:56.286401Z",
+     "iopub.status.busy": "2026-07-02T09:45:56.286321Z",
+     "iopub.status.idle": "2026-07-02T09:45:56.655934Z",
+     "shell.execute_reply": "2026-07-02T09:45:56.655478Z"
     }
    },
    "outputs": [
@@ -718,7 +718,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d653ea60",
+   "id": "356beb2d",
    "metadata": {},
    "source": [
     "## 6 · Build an m/z–retention-time map\n",
@@ -732,13 +732,13 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "39dac6d3",
+   "id": "d2821517",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:00.699143Z",
-     "iopub.status.busy": "2026-07-02T09:44:00.699062Z",
-     "iopub.status.idle": "2026-07-02T09:44:00.795902Z",
-     "shell.execute_reply": "2026-07-02T09:44:00.795517Z"
+     "iopub.execute_input": "2026-07-02T09:45:56.657033Z",
+     "iopub.status.busy": "2026-07-02T09:45:56.656962Z",
+     "iopub.status.idle": "2026-07-02T09:45:56.764638Z",
+     "shell.execute_reply": "2026-07-02T09:45:56.764127Z"
     }
    },
    "outputs": [
@@ -782,13 +782,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "b330da56",
+   "id": "e7a0a581",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:00.796912Z",
-     "iopub.status.busy": "2026-07-02T09:44:00.796844Z",
-     "iopub.status.idle": "2026-07-02T09:44:00.946641Z",
-     "shell.execute_reply": "2026-07-02T09:44:00.946359Z"
+     "iopub.execute_input": "2026-07-02T09:45:56.765774Z",
+     "iopub.status.busy": "2026-07-02T09:45:56.765712Z",
+     "iopub.status.idle": "2026-07-02T09:45:56.941091Z",
+     "shell.execute_reply": "2026-07-02T09:45:56.940355Z"
     }
    },
    "outputs": [
@@ -815,7 +815,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14b1d2dd",
+   "id": "6b9efc6f",
    "metadata": {},
    "source": [
     "## 7 · Annotated fragment (MS2) frames\n",
@@ -844,13 +844,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "194880cf",
+   "id": "62f35564",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:00.947907Z",
-     "iopub.status.busy": "2026-07-02T09:44:00.947838Z",
-     "iopub.status.idle": "2026-07-02T09:44:00.961621Z",
-     "shell.execute_reply": "2026-07-02T09:44:00.961294Z"
+     "iopub.execute_input": "2026-07-02T09:45:56.942832Z",
+     "iopub.status.busy": "2026-07-02T09:45:56.942695Z",
+     "iopub.status.idle": "2026-07-02T09:45:56.958257Z",
+     "shell.execute_reply": "2026-07-02T09:45:56.957855Z"
     }
    },
    "outputs": [
@@ -882,13 +882,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "c3dc40df",
+   "id": "1aeb7f42",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:00.962853Z",
-     "iopub.status.busy": "2026-07-02T09:44:00.962776Z",
-     "iopub.status.idle": "2026-07-02T09:44:01.799187Z",
-     "shell.execute_reply": "2026-07-02T09:44:01.798730Z"
+     "iopub.execute_input": "2026-07-02T09:45:56.959501Z",
+     "iopub.status.busy": "2026-07-02T09:45:56.959425Z",
+     "iopub.status.idle": "2026-07-02T09:45:57.793553Z",
+     "shell.execute_reply": "2026-07-02T09:45:57.793138Z"
     }
    },
    "outputs": [
@@ -1072,13 +1072,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "f22622cc",
+   "id": "5c270e5a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:01.800143Z",
-     "iopub.status.busy": "2026-07-02T09:44:01.800075Z",
-     "iopub.status.idle": "2026-07-02T09:44:01.997483Z",
-     "shell.execute_reply": "2026-07-02T09:44:01.997100Z"
+     "iopub.execute_input": "2026-07-02T09:45:57.794618Z",
+     "iopub.status.busy": "2026-07-02T09:45:57.794547Z",
+     "iopub.status.idle": "2026-07-02T09:45:57.989857Z",
+     "shell.execute_reply": "2026-07-02T09:45:57.989454Z"
     }
    },
    "outputs": [
@@ -1128,7 +1128,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f784ca56",
+   "id": "956bc7f2",
    "metadata": {},
    "source": [
     "## 8 · From annotations to an ML dataset\n",
@@ -1163,13 +1163,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "513eeaa4",
+   "id": "abc55c32",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:01.998613Z",
-     "iopub.status.busy": "2026-07-02T09:44:01.998550Z",
-     "iopub.status.idle": "2026-07-02T09:44:02.001005Z",
-     "shell.execute_reply": "2026-07-02T09:44:02.000623Z"
+     "iopub.execute_input": "2026-07-02T09:45:57.991050Z",
+     "iopub.status.busy": "2026-07-02T09:45:57.990981Z",
+     "iopub.status.idle": "2026-07-02T09:45:57.993513Z",
+     "shell.execute_reply": "2026-07-02T09:45:57.993212Z"
     }
    },
    "outputs": [
@@ -1177,7 +1177,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "frame 17073: 10,849 peaks in a 626 x 84042 = 52,610,292-cell dense grid\n",
+      "frame 17073: 10,849 peaks in a 626 x 84042 = 52,610,292-cell dense grid"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "  -> occupancy 0.0206%  (i.e. ~4,849x more empty cells than populated ones)\n"
      ]
     }
@@ -1197,7 +1204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d17ee32",
+   "id": "4b07e971",
    "metadata": {},
    "source": [
     "Now the dataset itself. The dense windows are already `(sample, feature)` matrices with\n",
@@ -1211,13 +1218,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "8d5a4e1e",
+   "id": "d774c89e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:02.002002Z",
-     "iopub.status.busy": "2026-07-02T09:44:02.001940Z",
-     "iopub.status.idle": "2026-07-02T09:44:02.099795Z",
-     "shell.execute_reply": "2026-07-02T09:44:02.099378Z"
+     "iopub.execute_input": "2026-07-02T09:45:57.994525Z",
+     "iopub.status.busy": "2026-07-02T09:45:57.994470Z",
+     "iopub.status.idle": "2026-07-02T09:45:58.090746Z",
+     "shell.execute_reply": "2026-07-02T09:45:58.090347Z"
     }
    },
    "outputs": [
@@ -1252,7 +1259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffe24317",
+   "id": "8e099ba5",
    "metadata": {},
    "source": [
     "## 9 · (Optional) Train a tiny model\n",
@@ -1265,13 +1272,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "2b661ee7",
+   "id": "7457a2b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:02.100864Z",
-     "iopub.status.busy": "2026-07-02T09:44:02.100789Z",
-     "iopub.status.idle": "2026-07-02T09:44:02.826973Z",
-     "shell.execute_reply": "2026-07-02T09:44:02.826630Z"
+     "iopub.execute_input": "2026-07-02T09:45:58.091786Z",
+     "iopub.status.busy": "2026-07-02T09:45:58.091719Z",
+     "iopub.status.idle": "2026-07-02T09:45:58.873791Z",
+     "shell.execute_reply": "2026-07-02T09:45:58.873364Z"
     }
    },
    "outputs": [],
@@ -1288,13 +1295,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "86929597",
+   "id": "b1158d66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:44:02.828371Z",
-     "iopub.status.busy": "2026-07-02T09:44:02.828257Z",
-     "iopub.status.idle": "2026-07-02T09:44:15.485209Z",
-     "shell.execute_reply": "2026-07-02T09:44:15.484809Z"
+     "iopub.execute_input": "2026-07-02T09:45:58.875019Z",
+     "iopub.status.busy": "2026-07-02T09:45:58.874892Z",
+     "iopub.status.idle": "2026-07-02T09:46:11.591658Z",
+     "shell.execute_reply": "2026-07-02T09:46:11.591210Z"
     }
    },
    "outputs": [
@@ -1383,7 +1390,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7ac2311",
+   "id": "706215b4",
+   "metadata": {},
+   "source": [
+    "> **This is one illustration, not a recommendation.** The dense-window + per-bin\n",
+    "> segmentation above is deliberately simple — it shows *how* the annotations plug into a\n",
+    "> standard training loop, not that it is the best way to model this data. Better approaches\n",
+    "> very likely exist: sparse / point-cloud models operating directly on the raw peaks,\n",
+    "> attention over peak sets, multi-task heads that jointly predict charge / isotope /\n",
+    "> peptide, or models that use 2-D/3-D context across scans and retention time. Treat the\n",
+    "> per-peak labels as ground truth you can build almost any supervised task on — the\n",
+    "> representation and architecture are yours to choose."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bbee0f2",
    "metadata": {},
    "source": [
     "## Recap & pointers\n",


### PR DESCRIPTION
Follow-up to #436. Adds a conceptual callout to the onboarding notebook's ML section on the central challenge of DL for MS raw data:

- DL models want **dense** tensors; MS spectra are **extremely sparse**, and ion mobility worsens it (the `(m/z × mobility [× RT])` volume grows while peak count stays flat) → naïve voxelization is mostly zeros + severe class imbalance.
- Names the common strategies and ties each to the annotations exposed here: **dense windowing** (`to_dense_windows_with_labels`), **sparse/point-cloud** (the per-peak `.df`), and hybrids.
- Grounded with a computed occupancy stat (~**0.02%** on a real frame — ~4,800× more empty cells than populated).

Re-executed end-to-end against a real DIA `synthetic_data.db`: 20 cells, 0 errors, 5 plots, no local-path leaks. (Notebook line-count stays out of language stats via the existing `*.ipynb linguist-vendored` in `.gitattributes`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)