### PR TITLE
fix: annotated-frame notebook corrections (Codex review)

### DIFF
--- a/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
+++ b/packages/imspy-simulation/notebooks/AnnotatedFrames_Onboarding.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0d21b463",
+   "id": "68ad067a",
    "metadata": {},
    "source": [
     "# Working with Annotated Frames\n",
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e475e4a0",
+   "id": "afadc010",
    "metadata": {},
    "source": [
     "## 0 · Setup\n",
@@ -42,13 +42,13 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "92e0409f",
+   "id": "58783349",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:54.211024Z",
-     "iopub.status.busy": "2026-07-02T09:45:54.210704Z",
-     "iopub.status.idle": "2026-07-02T09:45:54.790122Z",
-     "shell.execute_reply": "2026-07-02T09:45:54.789782Z"
+     "iopub.execute_input": "2026-07-02T09:57:38.021492Z",
+     "iopub.status.busy": "2026-07-02T09:57:38.021176Z",
+     "iopub.status.idle": "2026-07-02T09:57:38.811957Z",
+     "shell.execute_reply": "2026-07-02T09:57:38.811514Z"
     }
    },
    "outputs": [
@@ -84,13 +84,13 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "5021a07c",
+   "id": "5a381da5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:54.791580Z",
-     "iopub.status.busy": "2026-07-02T09:45:54.791467Z",
-     "iopub.status.idle": "2026-07-02T09:45:55.700923Z",
-     "shell.execute_reply": "2026-07-02T09:45:55.700529Z"
+     "iopub.execute_input": "2026-07-02T09:57:38.813235Z",
+     "iopub.status.busy": "2026-07-02T09:57:38.813132Z",
+     "iopub.status.idle": "2026-07-02T09:57:39.717092Z",
+     "shell.execute_reply": "2026-07-02T09:57:39.716690Z"
     }
    },
    "outputs": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "806eaaeb",
+   "id": "1e53ca10",
    "metadata": {},
    "source": [
     "## 1 · Enumerate precursor (MS1) frames\n",
@@ -125,13 +125,13 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fe696f84",
+   "id": "6dac0ad0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:55.702247Z",
-     "iopub.status.busy": "2026-07-02T09:45:55.702131Z",
-     "iopub.status.idle": "2026-07-02T09:45:55.725109Z",
-     "shell.execute_reply": "2026-07-02T09:45:55.724677Z"
+     "iopub.execute_input": "2026-07-02T09:57:39.718375Z",
+     "iopub.status.busy": "2026-07-02T09:57:39.718254Z",
+     "iopub.status.idle": "2026-07-02T09:57:39.740878Z",
+     "shell.execute_reply": "2026-07-02T09:57:39.740464Z"
     }
    },
    "outputs": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45d25da4",
+   "id": "bd8b460a",
    "metadata": {},
    "source": [
     "## 2 · Build a single annotated frame\n",
@@ -170,13 +170,13 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "7e7e6b7b",
+   "id": "249d1d79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:55.726141Z",
-     "iopub.status.busy": "2026-07-02T09:45:55.726077Z",
-     "iopub.status.idle": "2026-07-02T09:45:55.744531Z",
-     "shell.execute_reply": "2026-07-02T09:45:55.744205Z"
+     "iopub.execute_input": "2026-07-02T09:57:39.742016Z",
+     "iopub.status.busy": "2026-07-02T09:57:39.741954Z",
+     "iopub.status.idle": "2026-07-02T09:57:39.756729Z",
+     "shell.execute_reply": "2026-07-02T09:57:39.756302Z"
     }
    },
    "outputs": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffa65fed",
+   "id": "ba125223",
    "metadata": {},
    "source": [
     "## 3 · The `.df` view — the easy entry point\n",
@@ -211,23 +211,26 @@
     "| column | meaning |\n",
     "|---|---|\n",
     "| `mz`, `scan`, `inv_mobility`, `intensity`, `tof` | the peak itself |\n",
-    "| `peptide_id` | which peptide it belongs to (`-2` = random noise) |\n",
-    "| `charge_state` | charge of the contributing ion |\n",
-    "| `isotope_peak` | which isotope in the envelope (0 = monoisotopic) |\n",
+    "| `peptide_id` | which peptide the peak's dominant contributor belongs to (`-1` if it has no signal attributes — i.e. unannotated / noise) |\n",
+    "| `charge_state` | charge of the contributing ion (`-1` if unannotated) |\n",
+    "| `isotope_peak` | which isotope in the envelope (0 = monoisotopic; `-1` if unannotated) |\n",
     "\n",
-    "For most analysis and visualization, this is all you need — no windowing required."
+    "These are the `*_first_only` labels — the **first (dominant) contributor** per peak. In\n",
+    "`.df`, non-signal peaks are simply `-1`; the finer `-2 = random noise` distinction only\n",
+    "appears in the **dense-window** label planes (§5). For most analysis and visualization,\n",
+    "this table is all you need — no windowing required."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "ddd01a8f",
+   "id": "4b9d7c9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:55.745714Z",
-     "iopub.status.busy": "2026-07-02T09:45:55.745631Z",
-     "iopub.status.idle": "2026-07-02T09:45:55.752032Z",
-     "shell.execute_reply": "2026-07-02T09:45:55.751683Z"
+     "iopub.execute_input": "2026-07-02T09:57:39.757732Z",
+     "iopub.status.busy": "2026-07-02T09:57:39.757671Z",
+     "iopub.status.idle": "2026-07-02T09:57:39.763311Z",
+     "shell.execute_reply": "2026-07-02T09:57:39.762977Z"
     }
    },
    "outputs": [
@@ -398,13 +401,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "805ad268",
+   "id": "2c72de77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:55.752970Z",
-     "iopub.status.busy": "2026-07-02T09:45:55.752910Z",
-     "iopub.status.idle": "2026-07-02T09:45:55.755317Z",
-     "shell.execute_reply": "2026-07-02T09:45:55.754981Z"
+     "iopub.execute_input": "2026-07-02T09:57:39.764315Z",
+     "iopub.status.busy": "2026-07-02T09:57:39.764238Z",
+     "iopub.status.idle": "2026-07-02T09:57:39.766901Z",
+     "shell.execute_reply": "2026-07-02T09:57:39.766444Z"
     }
    },
    "outputs": [
@@ -412,21 +415,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "signal peaks: 10,849   noise peaks: 0   distinct peptides: 7\n"
+      "signal peaks: 10,849   unannotated (incl. noise, label -1): 0   distinct peptides: 7\n"
      ]
     }
    ],
    "source": [
-    "# label composition of this frame\n",
+    "# label composition of this frame (in .df, unannotated/noise peaks are -1)\n",
     "n_signal = int((df.peptide_id >= 0).sum())\n",
-    "n_noise  = int((df.peptide_id == -2).sum())\n",
-    "print(f\"signal peaks: {n_signal:,}   noise peaks: {n_noise:,}   \"\n",
+    "n_unann  = int((df.peptide_id < 0).sum())\n",
+    "print(f\"signal peaks: {n_signal:,}   unannotated (incl. noise, label -1): {n_unann:,}   \"\n",
     "      f\"distinct peptides: {df.loc[df.peptide_id >= 0, 'peptide_id'].nunique()}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "deb46b06",
+   "id": "581fc568",
    "metadata": {},
    "source": [
     "## 4 · Build an m/z–ion-mobility map (with a label overlay)\n",
@@ -440,13 +443,13 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "058b6093",
+   "id": "07fe9261",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:55.756364Z",
-     "iopub.status.busy": "2026-07-02T09:45:55.756305Z",
-     "iopub.status.idle": "2026-07-02T09:45:55.759107Z",
-     "shell.execute_reply": "2026-07-02T09:45:55.758801Z"
+     "iopub.execute_input": "2026-07-02T09:57:39.767953Z",
+     "iopub.status.busy": "2026-07-02T09:57:39.767891Z",
+     "iopub.status.idle": "2026-07-02T09:57:39.770903Z",
+     "shell.execute_reply": "2026-07-02T09:57:39.770501Z"
     }
    },
    "outputs": [],
@@ -481,13 +484,13 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "2464ba68",
+   "id": "7854fe71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:55.760126Z",
-     "iopub.status.busy": "2026-07-02T09:45:55.760068Z",
-     "iopub.status.idle": "2026-07-02T09:45:56.006554Z",
-     "shell.execute_reply": "2026-07-02T09:45:56.005752Z"
+     "iopub.execute_input": "2026-07-02T09:57:39.771906Z",
+     "iopub.status.busy": "2026-07-02T09:57:39.771818Z",
+     "iopub.status.idle": "2026-07-02T09:57:40.062249Z",
+     "shell.execute_reply": "2026-07-02T09:57:40.018252Z"
     }
    },
    "outputs": [
@@ -527,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3519570",
+   "id": "0ebfe8b4",
    "metadata": {},
    "source": [
     "## 5 · `to_dense_windows_with_labels` — demystified\n",
@@ -564,13 +567,13 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "11965354",
+   "id": "edba8f31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:56.008721Z",
-     "iopub.status.busy": "2026-07-02T09:45:56.008554Z",
-     "iopub.status.idle": "2026-07-02T09:45:56.048716Z",
-     "shell.execute_reply": "2026-07-02T09:45:56.047828Z"
+     "iopub.execute_input": "2026-07-02T09:57:40.063676Z",
+     "iopub.status.busy": "2026-07-02T09:57:40.063567Z",
+     "iopub.status.idle": "2026-07-02T09:57:40.087051Z",
+     "shell.execute_reply": "2026-07-02T09:57:40.086707Z"
     }
    },
    "outputs": [
@@ -599,13 +602,13 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "e0b08783",
+   "id": "395be304",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:56.050494Z",
-     "iopub.status.busy": "2026-07-02T09:45:56.050327Z",
-     "iopub.status.idle": "2026-07-02T09:45:56.285190Z",
-     "shell.execute_reply": "2026-07-02T09:45:56.284739Z"
+     "iopub.execute_input": "2026-07-02T09:57:40.088429Z",
+     "iopub.status.busy": "2026-07-02T09:57:40.088321Z",
+     "iopub.status.idle": "2026-07-02T09:57:40.340459Z",
+     "shell.execute_reply": "2026-07-02T09:57:40.339858Z"
     }
    },
    "outputs": [
@@ -638,7 +641,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38c0c6c1",
+   "id": "a26e5f28",
    "metadata": {},
    "source": [
     "### \"But I expected to build an m/z–ion-mobility image from *these*…\"\n",
@@ -657,13 +660,13 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "bdd2c3c5",
+   "id": "b94b6a17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:56.286401Z",
-     "iopub.status.busy": "2026-07-02T09:45:56.286321Z",
-     "iopub.status.idle": "2026-07-02T09:45:56.655934Z",
-     "shell.execute_reply": "2026-07-02T09:45:56.655478Z"
+     "iopub.execute_input": "2026-07-02T09:57:40.341722Z",
+     "iopub.status.busy": "2026-07-02T09:57:40.341637Z",
+     "iopub.status.idle": "2026-07-02T09:57:40.670529Z",
+     "shell.execute_reply": "2026-07-02T09:57:40.670183Z"
     }
    },
    "outputs": [
@@ -718,7 +721,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "356beb2d",
+   "id": "1afa7a4d",
    "metadata": {},
    "source": [
     "## 6 · Build an m/z–retention-time map\n",
@@ -726,19 +729,21 @@
     "For feature-detection-style views you want **m/z vs retention time**. There is no\n",
     "built-in helper yet, so we stack frames along RT ourselves: build many precursor frames,\n",
     "collapse each over the ion-mobility axis, and index the rows by `retention_time`. The\n",
-    "dominant-label logic gives us an aligned peptide-id map on the same grid."
+    "dominant-label logic gives us an aligned peptide-id map on the same grid — here each cell's\n",
+    "label is the single **highest-intensity peak** in that `(RT, m/z)` bin (not the peptide\n",
+    "with the largest summed intensity after the mobility collapse)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "d2821517",
+   "id": "9cdba13a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:56.657033Z",
-     "iopub.status.busy": "2026-07-02T09:45:56.656962Z",
-     "iopub.status.idle": "2026-07-02T09:45:56.764638Z",
-     "shell.execute_reply": "2026-07-02T09:45:56.764127Z"
+     "iopub.execute_input": "2026-07-02T09:57:40.671627Z",
+     "iopub.status.busy": "2026-07-02T09:57:40.671564Z",
+     "iopub.status.idle": "2026-07-02T09:57:40.770013Z",
+     "shell.execute_reply": "2026-07-02T09:57:40.769616Z"
     }
    },
    "outputs": [
@@ -782,13 +787,13 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e7a0a581",
+   "id": "1ff8578f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:56.765774Z",
-     "iopub.status.busy": "2026-07-02T09:45:56.765712Z",
-     "iopub.status.idle": "2026-07-02T09:45:56.941091Z",
-     "shell.execute_reply": "2026-07-02T09:45:56.940355Z"
+     "iopub.execute_input": "2026-07-02T09:57:40.771176Z",
+     "iopub.status.busy": "2026-07-02T09:57:40.771116Z",
+     "iopub.status.idle": "2026-07-02T09:57:40.921430Z",
+     "shell.execute_reply": "2026-07-02T09:57:40.920988Z"
     }
    },
    "outputs": [
@@ -815,7 +820,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6b9efc6f",
+   "id": "abad50a6",
    "metadata": {},
    "source": [
     "## 7 · Annotated fragment (MS2) frames\n",
@@ -844,13 +849,13 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "62f35564",
+   "id": "125de04e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:56.942832Z",
-     "iopub.status.busy": "2026-07-02T09:45:56.942695Z",
-     "iopub.status.idle": "2026-07-02T09:45:56.958257Z",
-     "shell.execute_reply": "2026-07-02T09:45:56.957855Z"
+     "iopub.execute_input": "2026-07-02T09:57:40.922569Z",
+     "iopub.status.busy": "2026-07-02T09:57:40.922502Z",
+     "iopub.status.idle": "2026-07-02T09:57:40.936113Z",
+     "shell.execute_reply": "2026-07-02T09:57:40.935830Z"
     }
    },
    "outputs": [
@@ -871,7 +876,11 @@
     "    ms2_ids = pd.read_sql_query(\n",
     "        \"SELECT frame_id FROM frames WHERE ms_type = 9 ORDER BY frame_id\", con\n",
     "    ).frame_id.astype(int).tolist()\n",
-    "    n_frag_ions = con.execute(\"SELECT COUNT(*) FROM fragment_ions\").fetchone()[0]\n",
+    "    # the fragment_ions table only exists if fragmentation was simulated\n",
+    "    has_frag_tbl = con.execute(\n",
+    "        \"SELECT name FROM sqlite_master WHERE type='table' AND name='fragment_ions'\"\n",
+    "    ).fetchone() is not None\n",
+    "    n_frag_ions = con.execute(\"SELECT COUNT(*) FROM fragment_ions\").fetchone()[0] if has_frag_tbl else 0\n",
     "\n",
     "print(f\"{len(ms2_ids)} MS2 frames (ms_type=9); fragment_ions rows: {n_frag_ions}\")\n",
     "HAVE_FRAGMENTS = len(ms2_ids) > 0 and n_frag_ions > 0\n",
@@ -882,13 +891,13 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "1aeb7f42",
+   "id": "770711d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:56.959501Z",
-     "iopub.status.busy": "2026-07-02T09:45:56.959425Z",
-     "iopub.status.idle": "2026-07-02T09:45:57.793553Z",
-     "shell.execute_reply": "2026-07-02T09:45:57.793138Z"
+     "iopub.execute_input": "2026-07-02T09:57:40.937165Z",
+     "iopub.status.busy": "2026-07-02T09:57:40.937107Z",
+     "iopub.status.idle": "2026-07-02T09:57:41.745648Z",
+     "shell.execute_reply": "2026-07-02T09:57:41.745271Z"
     }
    },
    "outputs": [
@@ -1072,13 +1081,13 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "5c270e5a",
+   "id": "774374d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:57.794618Z",
-     "iopub.status.busy": "2026-07-02T09:45:57.794547Z",
-     "iopub.status.idle": "2026-07-02T09:45:57.989857Z",
-     "shell.execute_reply": "2026-07-02T09:45:57.989454Z"
+     "iopub.execute_input": "2026-07-02T09:57:41.746713Z",
+     "iopub.status.busy": "2026-07-02T09:57:41.746642Z",
+     "iopub.status.idle": "2026-07-02T09:57:41.939955Z",
+     "shell.execute_reply": "2026-07-02T09:57:41.939576Z"
     }
    },
    "outputs": [
@@ -1128,7 +1137,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "956bc7f2",
+   "id": "33a8c4ae",
    "metadata": {},
    "source": [
     "## 8 · From annotations to an ML dataset\n",
@@ -1163,13 +1172,13 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "abc55c32",
+   "id": "5e165e72",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:57.991050Z",
-     "iopub.status.busy": "2026-07-02T09:45:57.990981Z",
-     "iopub.status.idle": "2026-07-02T09:45:57.993513Z",
-     "shell.execute_reply": "2026-07-02T09:45:57.993212Z"
+     "iopub.execute_input": "2026-07-02T09:57:41.941112Z",
+     "iopub.status.busy": "2026-07-02T09:57:41.941038Z",
+     "iopub.status.idle": "2026-07-02T09:57:41.945782Z",
+     "shell.execute_reply": "2026-07-02T09:57:41.945526Z"
     }
    },
    "outputs": [
@@ -1177,7 +1186,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "frame 17073: 10,849 peaks in a 626 x 84042 = 52,610,292-cell dense grid"
+      "frame 17073: 10,849 peaks -> 4,277 populated cells in a 626 x 84042 = 52,610,292-cell dense grid"
      ]
     },
     {
@@ -1185,7 +1194,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "  -> occupancy 0.0206%  (i.e. ~4,849x more empty cells than populated ones)\n"
+      "  -> occupancy 0.0081%  (~12,301x more empty than populated cells)\n"
      ]
     }
    ],
@@ -1195,16 +1204,18 @@
     "n_mz_cells   = int(np.ceil((mz_a.max() - mz_a.min()) / 0.01)) + 1      # 0.01 Th bins\n",
     "n_scan_cells = int(scan_a.max() - scan_a.min()) + 1\n",
     "dense_cells  = n_mz_cells * n_scan_cells\n",
-    "occupancy    = len(df) / dense_cells\n",
-    "print(f\"frame {frame.frame_id}: {len(df):,} peaks in a \"\n",
+    "col = np.round((mz_a - mz_a.min()) / 0.01).astype(int)\n",
+    "row = (scan_a - scan_a.min()).astype(int)\n",
+    "occ_cells = len({*zip(row.tolist(), col.tolist())})     # unique populated cells (peaks can share one)\n",
+    "occupancy = occ_cells / dense_cells\n",
+    "print(f\"frame {frame.frame_id}: {len(df):,} peaks -> {occ_cells:,} populated cells in a \"\n",
     "      f\"{n_scan_cells} x {n_mz_cells} = {dense_cells:,}-cell dense grid\")\n",
-    "print(f\"  -> occupancy {occupancy*100:.4f}%  (i.e. ~{1/occupancy:,.0f}x more empty cells \"\n",
-    "      f\"than populated ones)\")"
+    "print(f\"  -> occupancy {occupancy*100:.4f}%  (~{1/occupancy:,.0f}x more empty than populated cells)\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4b07e971",
+   "id": "62b3c733",
    "metadata": {},
    "source": [
     "Now the dataset itself. The dense windows are already `(sample, feature)` matrices with\n",
@@ -1218,13 +1229,13 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "d774c89e",
+   "id": "30fefb9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:57.994525Z",
-     "iopub.status.busy": "2026-07-02T09:45:57.994470Z",
-     "iopub.status.idle": "2026-07-02T09:45:58.090746Z",
-     "shell.execute_reply": "2026-07-02T09:45:58.090347Z"
+     "iopub.execute_input": "2026-07-02T09:57:41.947020Z",
+     "iopub.status.busy": "2026-07-02T09:57:41.946949Z",
+     "iopub.status.idle": "2026-07-02T09:57:42.045060Z",
+     "shell.execute_reply": "2026-07-02T09:57:42.044689Z"
     }
    },
    "outputs": [
@@ -1259,7 +1270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e099ba5",
+   "id": "d880e3d5",
    "metadata": {},
    "source": [
     "## 9 · (Optional) Train a tiny model\n",
@@ -1272,13 +1283,13 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "7457a2b4",
+   "id": "7ed25129",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:58.091786Z",
-     "iopub.status.busy": "2026-07-02T09:45:58.091719Z",
-     "iopub.status.idle": "2026-07-02T09:45:58.873791Z",
-     "shell.execute_reply": "2026-07-02T09:45:58.873364Z"
+     "iopub.execute_input": "2026-07-02T09:57:42.046302Z",
+     "iopub.status.busy": "2026-07-02T09:57:42.046235Z",
+     "iopub.status.idle": "2026-07-02T09:57:42.818880Z",
+     "shell.execute_reply": "2026-07-02T09:57:42.818518Z"
     }
    },
    "outputs": [],
@@ -1295,13 +1306,13 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "b1158d66",
+   "id": "9d6a7fad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-02T09:45:58.875019Z",
-     "iopub.status.busy": "2026-07-02T09:45:58.874892Z",
-     "iopub.status.idle": "2026-07-02T09:46:11.591658Z",
-     "shell.execute_reply": "2026-07-02T09:46:11.591210Z"
+     "iopub.execute_input": "2026-07-02T09:57:42.820213Z",
+     "iopub.status.busy": "2026-07-02T09:57:42.820094Z",
+     "iopub.status.idle": "2026-07-02T09:57:55.886501Z",
+     "shell.execute_reply": "2026-07-02T09:57:55.886129Z"
     }
    },
    "outputs": [
@@ -1309,35 +1320,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch  0  val_loss=0.786  val_acc=0.977  signal_recall=1.000\n"
+      "epoch  0  val_loss=0.870  val_acc=0.977  signal_recall=1.000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch  3  val_loss=0.071  val_acc=1.000  signal_recall=1.000\n"
+      "epoch  3  val_loss=0.098  val_acc=1.000  signal_recall=0.999\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch  6  val_loss=0.016  val_acc=1.000  signal_recall=1.000\n"
+      "epoch  6  val_loss=0.017  val_acc=1.000  signal_recall=1.000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch  9  val_loss=0.005  val_acc=1.000  signal_recall=1.000\n"
+      "epoch  9  val_loss=0.006  val_acc=1.000  signal_recall=1.000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "epoch 12  val_loss=0.002  val_acc=1.000  signal_recall=1.000\n"
+      "epoch 12  val_loss=0.003  val_acc=1.000  signal_recall=1.000\n"
      ]
     },
     {
@@ -1355,6 +1366,8 @@
     "    torch.manual_seed(0)\n",
     "    Xt = torch.from_numpy(X_all)[:, None, :]             # (N, 1, 101)\n",
     "    Yt = torch.from_numpy(Y_all)[:, None, :]             # (N, 1, 101)\n",
+    "    perm0 = torch.randperm(len(Xt))                      # shuffle before split (tiles are RT-ordered)\n",
+    "    Xt, Yt = Xt[perm0], Yt[perm0]\n",
     "    n_val = max(1, len(Xt) // 5)\n",
     "    tr = (Xt[:-n_val], Yt[:-n_val]); va = (Xt[-n_val:], Yt[-n_val:])\n",
     "\n",
@@ -1390,7 +1403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "706215b4",
+   "id": "52aa58be",
    "metadata": {},
    "source": [
     "> **This is one illustration, not a recommendation.** The dense-window + per-bin\n",
@@ -1405,7 +1418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bbee0f2",
+   "id": "2fac2ce1",
    "metadata": {},
    "source": [
     "## Recap & pointers\n",


### PR DESCRIPTION
Corrections to the onboarding notebook (#436/#437) from an independent Codex review, grounded against the `imspy_simulation` source + the Rust `to_dense_windows_with_labels` implementation.

**Material fix**
- **`.df` noise label is `-1`, not `-2`.** `peptide_ids_first_only` (and the charge/isotope variants) return `-1` when the dominant contributor has no signal attributes — including random noise (`imspy_connector/src/py_annotation.rs:168`). `-2` is *only* assigned in the dense-window label planes for `SourceType::RandomNoise` (`mscore/src/simulation/annotation.rs:936`). Section 3's label table + peak-composition count are corrected; verified empirically on a noisy dataset (`.df` shows no `-2`).

**Robustness / precision**
- Guard the fragment section against a **missing** `fragment_ions` table (the `COUNT(*)` would raise on precursor-only runs, not just return 0).
- Sparsity stat now counts **unique populated `(scan, m/z)` cells** rather than peaks (peaks can share a cell), so occupancy isn't overstated.
- m/z–RT map: clarified the per-cell label is the single highest-intensity peak, not the largest-summed-intensity peptide after mobility collapse.
- Shuffle before the train/val split (tiles are RT-ordered).

Codex confirmed the rest is correct: `grid_peaks` accumulation + dominant-label logic, the dense-window reconstruction formula vs the Rust start-index/`n_cols`, the N/Y + overlap-duplicates explanation, the fragment API usage, and the PyTorch shapes.

Re-executed end-to-end against a real DIA `synthetic_data.db`: 20 cells, 0 errors, 5 plots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)