### PR TITLE
feat(tims-viewer): loading veil during initial load & dataset switches

### DIFF
--- a/tims-viewer/web/index.html
+++ b/tims-viewer/web/index.html
@@ -314,6 +314,23 @@
       font-family: var(--mono); font-size: 12px; color: var(--accent-2); background: rgba(20,12,4,0.9);
       border: 1px solid rgba(255,178,62,0.3); border-radius: 8px; padding: 8px 14px; max-width: 80vw; }
     .err:empty { display: none; }
+
+    /* ---- loading veil (initial load + dataset switch, which reloads the page) ---- */
+    /* Visible by default so it paints the instant the page (re)loads; the wasm removes it once the
+       cloud is fetched, built, and about to render. */
+    #loading { position: fixed; inset: 0; z-index: 5; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 15px;
+      background: radial-gradient(120% 100% at 50% 40%, rgba(11,15,23,0.78) 0%, rgba(5,7,11,0.86) 100%);
+      transition: opacity .4s ease; }
+    #loading.hidden { opacity: 0; visibility: hidden; pointer-events: none; }
+    #loading .spinner { width: 40px; height: 40px; border-radius: 50%;
+      border: 3px solid var(--accent-dim); border-top-color: var(--accent);
+      animation: spin .8s linear infinite; }
+    #loading .load-txt { font-family: var(--mono); font-size: 11.5px; letter-spacing: .16em;
+      text-transform: uppercase; color: var(--dim); }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    /* Reduced motion: drop the spin, keep a static ring so the state is still legible. */
+    @media (prefers-reduced-motion: reduce) { #loading .spinner { animation: none; } }
     /* Feedback widget (PROD only — hidden until /clientconfig reports feedback:true) */
     .feedback-btn { position: fixed; z-index: 6; right: 16px; bottom: 16px; display: none;
       font-family: var(--mono); font-size: 12px; color: var(--accent); cursor: pointer;
@@ -371,6 +388,13 @@
 <body>
   <canvas id="tims-canvas"></canvas>
   <div id="axis-labels" aria-hidden="true"></div>
+
+  <!-- Loading veil: shown on page (re)load — including a dataset switch — until the cloud is ready.
+       The wasm adds `.hidden` (see hide_loading) once run() has fetched + built the first cloud. -->
+  <div id="loading" role="status" aria-live="polite">
+    <div class="spinner" aria-hidden="true"></div>
+    <div class="load-txt">loading…</div>
+  </div>
 
   <input type="checkbox" id="railtgl" class="railtgl" />
   <label for="railtgl" class="railbtn" title="Toggle panel" aria-label="Toggle panel">

--- a/tims-viewer/web/src/lib.rs
+++ b/tims-viewer/web/src/lib.rs
@@ -136,6 +136,7 @@ pub fn start() {
     wasm_bindgen_futures::spawn_local(async {
         if let Err(e) = run().await {
             log::error!("{e}");
+            hide_loading(); // don't leave the veil covering the error
             show_status(&format!("tims-viewer could not start: {e}"));
         }
     });
@@ -1038,6 +1039,9 @@ async fn run() -> Result<(), String> {
         cb.forget(); // lives for the page; cancellation is a Phase-4 (embedding) concern
     }
 
+    // The cloud is fetched, built, and uploaded — drop the loading veil so the first frame shows through.
+    hide_loading();
+
     // requestAnimationFrame render loop (the callback receives the frame timestamp).
     let f = Rc::new(RefCell::new(None));
     let g = f.clone();
@@ -1170,6 +1174,19 @@ fn show_status(msg: &str) {
         .and_then(|d| d.get_element_by_id("status"))
     {
         el.set_text_content(Some(msg));
+    }
+}
+
+/// Dismiss the loading veil (the `#loading` overlay is visible by default on every page load, so it
+/// covers the initial load AND a dataset switch — a switch reloads the page). Idempotent: called
+/// once the first cloud is built and about to render, and again on a fatal start error so the veil
+/// never traps the page (the error surfaces via `#status`).
+fn hide_loading() {
+    if let Some(el) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id("loading"))
+    {
+        let _ = el.set_class_name("hidden");
     }
 }
 


### PR DESCRIPTION
## What

Adds a loading veil (spinner + "loading…") to the `tims-viewer` WebAssembly frontend so the user gets feedback while data loads, instead of an empty canvas.

## Why

Selecting a dataset in the ① Data dropdown calls `switch_dataset()`, which sets `?dataset=N` and triggers a **full page reload**. The new page's `run()` then awaits `/meta` + `/points` — and for a not-yet-built dataset the server does a multi-second full-run build. Throughout that gap the canvas was just the empty background gradient with zero feedback. The very first page load has the same gap.

## How

- **`web/index.html`** — a `#loading` overlay (CSS-keyframe spinner + "loading…" label), **visible by default** so it paints the instant the page (re)loads. Because a dataset switch *is* a reload, one mechanism covers both the switch and the first load. Includes a `prefers-reduced-motion` fallback (static ring, no spin) and sits at `z-index: 5` — above the canvas/rail but below `#status` (fatal errors) and the feedback widgets.
- **`web/src/lib.rs`** — a `hide_loading()` helper (adds class `hidden`) called (1) at the end of `run()` right before the render loop starts — the cloud is fetched, built, and uploaded by then — and (2) in the fatal-error arm of the startup closure, so a failed start never traps the page behind the veil (the error still surfaces via `#status`).

## Testing

- `cargo build -p tims-viewer-web --target wasm32-unknown-unknown` — clean.
- `trunk build` — success; `dist/index.html` contains the overlay. (`dist/` is gitignored.)
- Independent Codex review: confirmed the hide logic (including the fatal-error path and reduced-motion), and flagged a z-index collision with the rail toggle button — fixed here (`#loading` raised to 5).

## Notes / follow-ups

- Covers dataset selection and initial load (both page reloads). The in-place **Load** / **Focus** re-fetches (the `reloading` flag) don't navigate, so they don't show this veil — out of scope here.
- Pre-existing robustness gap (not introduced here): the startup `/meta`/`/points` fetches are unbounded, so a socket that accepts-but-never-responds would leave the spinner up. All erroring failures already fall back to the demo cloud and hide the veil. An `AbortController` timeout would close this — a candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)