### PR TITLE
fix(imspy-core): select the Bruker SDK binary by platform, not by obb order

### DIFF
--- a/packages/imspy-core/src/imspy_core/timstof/data.py
+++ b/packages/imspy-core/src/imspy_core/timstof/data.py
@@ -27,6 +27,39 @@ def is_amd64():
     return arch in ("amd64", "x86_64")
 
 
+def sdk_candidate_paths() -> List[str]:
+    """Bruker SDK shared-library candidates for *this* platform, best guess first.
+
+    open-tims-bruker-bridge ships the vendor binaries for every platform, so
+    checking ``Path(p).exists()`` never rules one out. It orders
+    ``get_so_paths()`` by ``platform.architecture()``, which shells out to the
+    ``file`` command; when ``file`` is missing -- common in slim Docker images --
+    that reports ``('64bit', '')`` instead of ``('64bit', 'ELF')`` and the
+    Windows ``timsdata.dll`` is returned first. Handing that DLL to the reader
+    makes the Rust ``dlopen`` fail with "invalid ELF header". Filter by the real
+    operating system instead of trusting the order.
+
+    Returns an empty list where no usable SDK exists (macOS, non-amd64).
+    """
+    system = platform.system()
+    if not is_amd64():
+        return []
+    if system == "Windows":
+        marker = ".dll"
+    elif system == "Linux":
+        marker = ".so"
+    else:
+        # macOS and friends: Bruker ships no binary we could load.
+        return []
+
+    try:
+        paths = list(obb.get_so_paths())
+    except Exception:
+        return []
+
+    return [p for p in paths if marker in Path(p).name.lower() and Path(p).exists()]
+
+
 class AcquisitionMode(RustWrapperObject):
     def __init__(self, mode: str):
         """AcquisitionMode class.
@@ -121,20 +154,13 @@ class TimsDataset(ABC):
                 self.use_bruker_sdk = False
 
         # Try to find SDK path (needed for calibration even when use_bruker_sdk=False).
-        # NOTE: open-tims-bruker-bridge ships the vendor binaries for *all* platforms, so
-        # Path(so_path).exists() is True even for the Windows timsdata.dll on macOS. Loading
-        # a foreign-platform binary makes the Rust dlopen panic ("slice is not valid mach-o
-        # file"). There is no usable Bruker SDK on macOS / non-amd64, so stay on NO_SDK there
-        # (the reader degrades to the boundary m/z model, matching the native viewer).
-        sdk_path = "NO_SDK"
-        if current_os != "Darwin" and is_amd64():
-            try:
-                for so_path in obb.get_so_paths():
-                    if Path(so_path).exists():
-                        sdk_path = so_path
-                        break
-            except Exception:
-                pass
+        # sdk_candidate_paths() already restricts to binaries for this platform: passing a
+        # foreign-platform binary makes the Rust dlopen fail ("invalid ELF header" on Linux,
+        # "slice is not valid mach-o file" on macOS). Where no candidate exists (macOS,
+        # non-amd64) we stay on NO_SDK and the reader degrades to the boundary m/z model,
+        # matching the native viewer.
+        candidates = sdk_candidate_paths()
+        sdk_path = candidates[0] if candidates else "NO_SDK"
 
         if not self.use_bruker_sdk:
             # Pass SDK path for calibration derivation, but use_bruker_sdk=False for fast parallel access
@@ -144,7 +170,7 @@ class TimsDataset(ABC):
         else:
             # Try to load the data with the first binary found
             appropriate_found = False
-            for so_path in obb.get_so_paths():
+            for so_path in candidates:
                 try:
                     self.__dataset = ims.PyTimsDataset(self.data_path, so_path, in_memory, self.use_bruker_sdk)
                     self.binary_path = so_path
@@ -152,7 +178,8 @@ class TimsDataset(ABC):
                     break
                 except Exception:
                     continue
-            assert appropriate_found is True, ("No appropriate bruker binary could be found, please check if your "
+            assert appropriate_found is True, ("No appropriate bruker binary could be found for "
+                                               f"{current_os}/{platform.machine()}, please check if your "
                                                "operating system is supported by open-tims-bruker-bridge.")
 
     @property

--- a/packages/imspy-core/tests/test_sdk_candidate_paths.py
+++ b/packages/imspy-core/tests/test_sdk_candidate_paths.py
@@ -1,0 +1,76 @@
+"""Regression tests for Bruker SDK binary selection (issue #442).
+
+open-tims-bruker-bridge ships the vendor binaries for every platform and orders
+``get_so_paths()`` by ``platform.architecture()``. That call shells out to the
+``file`` command; in slim Docker images ``file`` is absent, so architecture is
+reported as ``('64bit', '')`` and the *Windows* ``timsdata.dll`` comes back
+first. Passing it to the Rust reader fails with "invalid ELF header".
+"""
+
+import pytest
+
+from imspy_core.timstof import data as data_mod
+
+
+@pytest.fixture
+def so_dir(tmp_path):
+    """A fake open-tims-bruker-bridge install containing every vendor binary."""
+    (tmp_path / "libtimsdata.so").touch()
+    for sub in ("win32", "win64"):
+        (tmp_path / sub).mkdir()
+        (tmp_path / sub / "timsdata.dll").touch()
+    return tmp_path
+
+
+def _patch(monkeypatch, so_dir, order, system, machine):
+    paths = [str(so_dir / rel) for rel in order]
+    monkeypatch.setattr(data_mod.obb, "get_so_paths", lambda: paths)
+    monkeypatch.setattr(data_mod.platform, "system", lambda: system)
+    monkeypatch.setattr(data_mod.platform, "machine", lambda: machine)
+
+
+# The order obb returns when `file` is missing: Windows DLL first.
+BROKEN_ORDER = ["win64/timsdata.dll", "libtimsdata.so", "win32/timsdata.dll"]
+# The order obb returns on a host with `file` installed.
+HEALTHY_ORDER = ["libtimsdata.so", "win64/timsdata.dll", "win32/timsdata.dll"]
+
+
+@pytest.mark.parametrize("order", [BROKEN_ORDER, HEALTHY_ORDER])
+def test_linux_never_selects_windows_dll(monkeypatch, so_dir, order):
+    _patch(monkeypatch, so_dir, order, "Linux", "x86_64")
+    candidates = data_mod.sdk_candidate_paths()
+    assert candidates == [str(so_dir / "libtimsdata.so")]
+
+
+def test_windows_selects_dlls_only(monkeypatch, so_dir):
+    _patch(monkeypatch, so_dir, BROKEN_ORDER, "Windows", "AMD64")
+    candidates = data_mod.sdk_candidate_paths()
+    assert candidates == [str(so_dir / "win64" / "timsdata.dll"),
+                          str(so_dir / "win32" / "timsdata.dll")]
+
+
+@pytest.mark.parametrize("system,machine", [("Darwin", "x86_64"),
+                                            ("Darwin", "arm64"),
+                                            ("Linux", "aarch64")])
+def test_no_candidates_where_sdk_is_unusable(monkeypatch, so_dir, system, machine):
+    """macOS and non-amd64 have no loadable Bruker binary: stay on NO_SDK."""
+    _patch(monkeypatch, so_dir, BROKEN_ORDER, system, machine)
+    assert data_mod.sdk_candidate_paths() == []
+
+
+def test_missing_bridge_does_not_raise(monkeypatch, so_dir):
+    def boom():
+        raise RuntimeError("open-tims-bruker-bridge is broken")
+
+    monkeypatch.setattr(data_mod.obb, "get_so_paths", boom)
+    monkeypatch.setattr(data_mod.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(data_mod.platform, "machine", lambda: "x86_64")
+    assert data_mod.sdk_candidate_paths() == []
+
+
+def test_nonexistent_paths_are_dropped(monkeypatch, so_dir, tmp_path):
+    monkeypatch.setattr(data_mod.obb, "get_so_paths",
+                        lambda: [str(tmp_path / "gone" / "libtimsdata.so")])
+    monkeypatch.setattr(data_mod.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(data_mod.platform, "machine", lambda: "x86_64")
+    assert data_mod.sdk_candidate_paths() == []


### PR DESCRIPTION
Fixes #442.

## What happens

`opentims_bruker_bridge` ships the Bruker vendor binaries for *every* platform in a single wheel, so `Path(p).exists()` is true for all of them. It orders `get_so_paths()` by `platform.architecture()`:

```python
_paths = {("64bit", "ELF"): libtimsdata.so,
          ("64bit", "WindowsPE"): win64/timsdata.dll,
          ("64bit", ""): win64/timsdata.dll,   # <-- fallback
          ...}
```

`platform.architecture()` derives the `"ELF"` part by shelling out to the `file` command. Slim Docker images — including `pytorch/pytorch:*-runtime`, which the reporter uses — do not ship `file`, and CPython's fallback table only knows `win32`/`win16`/`dos`. So on Linux it returns `('64bit', '')`, and `get_so_paths()` puts the **Windows DLL first**:

```
with `file`:     ('64bit', 'ELF') -> libtimsdata.so, win32/timsdata.dll, win64/timsdata.dll
without `file`:  ('64bit', '')    -> win64/timsdata.dll, libtimsdata.so, win32/timsdata.dll
```

`TimsDataset.__init__` took the first path that exists and handed it to the Rust reader.

## Two defects, one of them still live on main

1. **Rust aborted on an unloadable SDK.** Already fixed on `main` by 064ed3a2 (`try_new` instead of `new().unwrap()`). But `imspy-connector` 0.4.1 was published to PyPI on 2026-02-06, before that commit, so every user on the released wheel still gets a hard abort — `panic = "abort"` in the release profile means the surrounding `except Exception` can never fire.
2. **We pick the wrong binary in the first place.** Still broken on `main`. With the current Rust code it no longer crashes, but it silently falls back to the 2-point boundary m/z model.

Defect 2 is the one this PR fixes, and it is the more dangerous of the two: wrong m/z instead of a crash.

## The fix

New `sdk_candidate_paths()` filters candidates by the real `platform.system()` rather than trusting obb's ordering, and both the SDK and SDK-free branches consume it. Empty list on macOS / non-amd64, where no loadable binary exists — those keep the existing `NO_SDK` behaviour.

This is pure Python, so an `imspy-core` release fixes affected users **without** needing a new connector wheel: we simply never hand the reader a DLL.

## Verification

Reproduced on a real dataset (`DIA-250K-NOISY-CHRONO.d`) by running with `PATH=/nonexistent` so `file` is unavailable:

| | binary picked | frame 10 m/z sum |
|---|---|---|
| pre-fix, `file` present | `libtimsdata.so` | 1196887.600893 |
| pre-fix, no `file` | `win64/timsdata.dll` :warning: | 1196885.416133 (degraded) |
| post-fix, no `file` | `libtimsdata.so` | 1196887.600893 :white_check_mark: |

First peak of frame 10 reads `865.21194` in the degraded case versus `865.2142` correct. All four `use_bruker_sdk` × `in_memory` combinations now produce identical results with and without `file` present.

Adds `packages/imspy-core/tests/test_sdk_candidate_paths.py` — 8 tests covering both obb orderings, Windows, macOS (x86_64 and arm64), Linux aarch64, a raising `get_so_paths()`, and non-existent paths.

## Follow-up

A new `imspy-connector` release would additionally pick up the 064ed3a2 abort fix, which is worth doing but is not required to unblock #442.
