### PR TITLE
fix(timsim-gui): repair 3D preview — stale imports and wrong simulated-output path

### DIFF
--- a/packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/plots.py
@@ -57,7 +57,7 @@ def get_precursor_data(reference_path: str, num_frames: int = 10, max_points: in
         return _precursor_cache[cache_key]
 
     try:
-        from imspy_timstof.dia import TimsDatasetDIA
+        from imspy_core.timstof.dia import TimsDatasetDIA
         from pathlib import Path
 
         ref_path = Path(reference_path)
@@ -110,7 +110,7 @@ def get_scan_mobility_converter(reference_path: str) -> Optional[Callable[[np.nd
         return _calibration_cache[reference_path]
 
     try:
-        from imspy_timstof.dia import TimsDatasetDIA
+        from imspy_core.timstof.dia import TimsDatasetDIA
 
         ref_path = Path(reference_path)
         if not ref_path.exists() or ref_path.suffix != ".d":

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/visualization3d.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/gui/components/visualization3d.py
@@ -26,7 +26,7 @@ def prepare_point_cloud(
         or None if loading fails
     """
     try:
-        from imspy_timstof.dia import TimsDatasetDIA
+        from imspy_core.timstof.dia import TimsDatasetDIA
 
         dataset = TimsDatasetDIA(data_path, in_memory=False, use_bruker_sdk=True)
 

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/gui/pages/advanced.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/gui/pages/advanced.py
@@ -1144,7 +1144,7 @@ def create_3d_preview_panel(state: "SimulationState") -> None:
             "[PLACEHOLDER]", state.config.experiment.acquisition_type
         )
         exp_name = exp_name.replace(" ", "_").replace("/", "_")
-        return str(Path(save_path) / f"{exp_name}.d")
+        return str(Path(save_path) / exp_name / f"{exp_name}.d")
 
     sim_current_path[0] = get_sim_output_path()
 


### PR DESCRIPTION
## What

Two small bugs that together disabled the GUI's 3D point-cloud previews:

1. **Stale module name** — `plots.py` and `visualization3d.py` still imported `TimsDatasetDIA` from the pre-split `imspy_timstof`. The lazy import failed inside a `try/except`, so the reference-dataset previews degraded silently: empty isolation-window plot and the "No reference dataset - using approximate conversion" fallback, with no visible error. Fixed to `imspy_core.timstof.dia`.

2. **Wrong simulated-output path** — `get_sim_output_path()` in `pages/advanced.py` built `save_path/NAME.d`, but the simulator writes `save_path/NAME/NAME.d` (cf. the `Path(save_path) / name / …` convention in `simulator.py`). The Simulated Dataset preview therefore always reported `Invalid path` after a run. Fixed to include the experiment subfolder.

## Verified

- `imspy_core.timstof.dia.TimsDatasetDIA` loads a `.d` on macOS (SDK gracefully downgrades), `scan_to_inverse_mobility` and `sample_precursor_signal` return real data
- The corrected sim path resolves an actual simulator output (`…/TIMSIM-DIA/TIMSIM-DIA.d`)
- Both GUI component modules import cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)