### PR TITLE
ci: authenticate the private sciexwiff git dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,10 +59,24 @@ jobs:
 
   build-rust-docs:
     runs-on: ubuntu-latest
+    env:
+      # cargo's built-in libgit2 ignores SSH config; shell out to real git instead
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Auth for private git dependency (sciexwiff)
+        env:
+          SSH_KEY: ${{ secrets.SCIEXWIFF_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/sciexwiff_deploy
+          chmod 600 ~/.ssh/sciexwiff_deploy
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          printf 'Host github.com\n  IdentityFile ~/.ssh/sciexwiff_deploy\n' >> ~/.ssh/config
+          git config --global url."git@github.com:theGreatHerrLebert/sciexwiff".insteadOf "https://github.com/theGreatHerrLebert/sciexwiff"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # cargo's built-in libgit2 ignores SSH config; shell out to real git instead
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
 jobs:
   build:
@@ -16,6 +18,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Auth for private git dependency (sciexwiff)
+      env:
+        SSH_KEY: ${{ secrets.SCIEXWIFF_DEPLOY_KEY }}
+      run: |
+        mkdir -p ~/.ssh
+        printf '%s\n' "$SSH_KEY" > ~/.ssh/sciexwiff_deploy
+        chmod 600 ~/.ssh/sciexwiff_deploy
+        ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+        printf 'Host github.com\n  IdentityFile ~/.ssh/sciexwiff_deploy\n' >> ~/.ssh/config
+        git config --global url."git@github.com:theGreatHerrLebert/sciexwiff".insteadOf "https://github.com/theGreatHerrLebert/sciexwiff"
     - name: Build mscore
       working-directory: ./mscore
       run: cargo build --verbose


### PR DESCRIPTION
CI has failed on every run since `rustdf` gained its git dependency on the private `sciexwiff` repo — cargo clones **all** git deps during resolution, even optional feature-gated ones, and the runner's default token cannot read a private repo.

## Fix
- A **read-only deploy key** on `sciexwiff` is stored as the `SCIEXWIFF_DEPLOY_KEY` Actions secret (least privilege: one repo, read-only)
- Both workflows write the key, rewrite `https://github.com/theGreatHerrLebert/sciexwiff` → SSH for that one URL, and set `CARGO_NET_GIT_FETCH_WITH_CLI=true` (cargo's libgit2 ignores SSH config; real git honors it)

Unblocks #444 and every future build on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)