### PR TITLE
tims-viewer: MOBILion .mbi as a second native source

### DIFF
--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -39,6 +39,8 @@ pollster = { version = "0.3", optional = true }
 anyhow = { version = "1", optional = true }
 rustdf = { path = "../rustdf", version = "0.4.1", optional = true }
 mscore = { path = "../mscore", version = "0.4.1", optional = true }
+# MOBILion .mbi reader (HDF5), published on crates.io.
+mobilionmbi = { version = "0.1.1", optional = true }
 winit = { version = "=0.30.5", optional = true }
 egui-winit = { version = "=0.29.1", default-features = false, features = ["links", "wayland", "x11"], optional = true }
 env_logger = { version = "0.11", optional = true }
@@ -62,6 +64,9 @@ native = [
     "dep:env_logger", "dep:clap", "dep:rayon", "dep:crossbeam-channel", "dep:png",
     "dep:tiny_http", "dep:serde_json", "dep:zstd",
 ]
+# MOBILion .mbi support: adds the HDF5-backed reader as a second native source.
+# Opt-in rather than part of `native` because it builds/links HDF5.
+mbi = ["native", "dep:mobilionmbi"]
 # (reserved) Pack positions/intensity as f16 to roughly halve on-GPU/wire size. Not yet
 # implemented — see NATIVE_WEB.md Phase 3.
 compact = []

--- a/tims-viewer/Cargo.toml
+++ b/tims-viewer/Cargo.toml
@@ -41,7 +41,7 @@ rustdf = { path = "../rustdf", version = "0.4.1", optional = true }
 mscore = { path = "../mscore", version = "0.4.1", optional = true }
 # MOBILion .mbi reader (HDF5), published on crates.io.
 mobilionmbi = { version = "0.1.1", optional = true }
-winit = { version = "=0.30.5", optional = true }
+winit = { version = "0.30.5", optional = true }
 egui-winit = { version = "=0.29.1", default-features = false, features = ["links", "wayland", "x11"], optional = true }
 env_logger = { version = "0.11", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }

--- a/tims-viewer/src/app.rs
+++ b/tims-viewer/src/app.rs
@@ -481,10 +481,7 @@ impl App {
             LoaderMode::Demo(DemoSource::new(plan.meta.frames.len(), total))
         } else {
             let frame_ids = plan.meta.frames.iter().map(|f| f.id).collect();
-            LoaderMode::Real {
-                path: plan.meta.data_path.clone(),
-                frame_ids,
-            }
+            crate::data::loader_mode_for(&plan.meta, frame_ids)
         };
         let loader = LoaderHandle::spawn(mode, plan.meta.bounds, total, capacity as usize, None);
 
@@ -775,10 +772,7 @@ impl Gfx {
         let mode = if self.is_demo {
             LoaderMode::Demo(DemoSource::new(frame_ids.len(), demo_source_total))
         } else {
-            LoaderMode::Real {
-                path: self.full_meta.data_path.clone(),
-                frame_ids,
-            }
+            crate::data::loader_mode_for(&self.full_meta, frame_ids)
         };
         self.loader = LoaderHandle::spawn(mode, bounds, total, capacity, filter);
         // Reset GPU/CPU buffers for a fresh stream.

--- a/tims-viewer/src/data/loader.rs
+++ b/tims-viewer/src/data/loader.rs
@@ -90,6 +90,11 @@ pub struct RegionFilter {
 pub enum LoaderMode {
     Real { path: String, frame_ids: Vec<u32> },
     Demo(DemoSource),
+    /// MOBILion `.mbi`. Carries the frames themselves rather than just ids: RT and the
+    /// MS1/MS2 split come from per-frame HDF5 attributes, and re-reading them here would
+    /// repeat the metadata sweep the index already paid for.
+    #[cfg(feature = "mbi")]
+    Mbi { path: String, frames: Vec<super::meta::FrameInfo> },
 }
 
 /// Owns the loader thread and the channels to talk to it.
@@ -312,6 +317,8 @@ fn run_loader(
     let n_frames = match &mode {
         LoaderMode::Real { frame_ids, .. } => frame_ids.len(),
         LoaderMode::Demo(d) => d.num_frames(),
+        #[cfg(feature = "mbi")]
+        LoaderMode::Mbi { frames, .. } => frames.len(),
     };
     if n_frames == 0 {
         let _ = tx.send(LoadMsg::Error("run has no frames".into()));
@@ -322,6 +329,8 @@ fn run_loader(
     let dataset = match &mode {
         LoaderMode::Real { path, .. } => Some(TimsDataset::new("NO_SDK", path, false, false)),
         LoaderMode::Demo(_) => None,
+        #[cfg(feature = "mbi")]
+        LoaderMode::Mbi { .. } => None,
     };
 
     let mut last_progress = -1.0f32;
@@ -421,6 +430,44 @@ fn run_loader(
                 }
                 start = end;
                 let progress = end as f32 / n_frames as f32;
+                if progress - last_progress >= 0.01 {
+                    let _ = tx.try_send(LoadMsg::Progress(progress));
+                    last_progress = progress;
+                }
+            }
+        }
+        #[cfg(feature = "mbi")]
+        LoaderMode::Mbi { path, frames } => {
+            // One m/z lookup for the run turns a sqrt + residual polynomial per point
+            // into an array index; at ~10^8 points that is the difference between
+            // seconds and minutes.
+            let (file, lookup) = match super::mbi::open_for_points(path) {
+                Ok(v) => v,
+                Err(e) => {
+                    let _ = tx.send(LoadMsg::Error(format!("{e:#}")));
+                    return;
+                }
+            };
+            for (idx, info) in frames.iter().enumerate() {
+                if cancelled!() {
+                    return;
+                }
+                let fid = info.id as usize;
+                let (frame, axis) = match (file.frame(fid), file.drift_axis(fid)) {
+                    (Ok(f), Ok(a)) => (f, a),
+                    _ => continue, // a single unreadable frame should not kill the load
+                };
+                let rt = info.retention_time;
+                let is_ms2 = info.is_ms2;
+                for row in 0..frame.n_rows {
+                    let at = axis.arrival_time_ms(row);
+                    let (a, b) = (frame.indptr[row] as usize, frame.indptr[row + 1] as usize);
+                    for k in a..b {
+                        let mz = lookup.get(frame.indices[k]);
+                        handle_point!(mz, at, rt, frame.data[k] as f32, is_ms2);
+                    }
+                }
+                let progress = (idx + 1) as f32 / n_frames as f32;
                 if progress - last_progress >= 0.01 {
                     let _ = tx.try_send(LoadMsg::Progress(progress));
                     last_progress = progress;

--- a/tims-viewer/src/data/mbi.rs
+++ b/tims-viewer/src/data/mbi.rs
@@ -1,0 +1,157 @@
+//! MOBILion `.mbi` source: metadata index + m/z lookup.
+//!
+//! The viewer's cube is `(x = m/z, y = mobility, z = RT)`. MBI supplies all three:
+//! m/z from the TOF calibration, mobility as **arrival time in milliseconds** (SLIM
+//! has no `1/K0`; see `MetaIndex::im_unit`), and RT from each frame's start time.
+//!
+//! Fragment frames are identified by collision energy rather than an MS-level field:
+//! these acquisitions are quadrupole-free Mobility-Aligned Fragmentation, alternating
+//! low-CE precursor frames with high-CE fragment frames.
+
+use anyhow::{Context, Result};
+
+use mobilionmbi::{MbiFile, TofCalibration};
+
+use super::meta::{FrameInfo, MetaIndex};
+use super::point::{AxisBounds, AxisTransform};
+
+/// Does this path look like an MBI file?
+pub fn is_mbi_path(path: &str) -> bool {
+    std::path::Path::new(path)
+        .extension()
+        .map(|e| e.eq_ignore_ascii_case("mbi"))
+        .unwrap_or(false)
+}
+
+/// A frame counts as fragment data when its collision energy is above zero.
+fn frame_is_ms2(file: &MbiFile, index: usize) -> bool {
+    file.collision_energy(index)
+        .ok()
+        .flatten()
+        .map(|v| v > 0.0)
+        .unwrap_or(false)
+}
+
+/// Precomputed `m/z` for every TOF bin.
+///
+/// The calibration is stored per frame but is constant within a file in practice, so
+/// one table serves the whole run. Computing it once turns a sqrt + polynomial per
+/// point into an array index — worth it at ~10^8 points.
+pub struct MzLookup {
+    pub mz: Vec<f64>,
+}
+
+impl MzLookup {
+    pub fn build(cal: &TofCalibration, n_tof: usize) -> Self {
+        let mz = (0..n_tof as u64).map(|i| cal.index_to_mz(i)).collect();
+        MzLookup { mz }
+    }
+
+    #[inline]
+    pub fn get(&self, tof: u64) -> f64 {
+        // Out-of-range cannot happen for data read from the same file, but a corrupt
+        // index should not panic the loader thread.
+        self.mz.get(tof as usize).copied().unwrap_or(f64::NAN)
+    }
+}
+
+/// Read a run's metadata without decoding any frame data.
+///
+/// Frame point counts come from the `data-counts` dataset *shape*, which HDF5 stores
+/// in the object header — no decompression, so this stays a metadata-only pass.
+pub fn load_meta(path: &str) -> Result<MetaIndex> {
+    let file = MbiFile::open(path).with_context(|| format!("opening {path}"))?;
+    let n = file.n_frames();
+    if n == 0 {
+        anyhow::bail!("{path} contains no frames");
+    }
+
+    let rts = file
+        .retention_times()
+        .context("reading per-frame retention times")?;
+
+    let mut frames = Vec::with_capacity(n);
+    let mut total: u64 = 0;
+    for i in 1..=n {
+        let npts = file.frame_nnz(i).unwrap_or(0) as u64;
+        total += npts;
+        frames.push(FrameInfo {
+            id: i as u32,
+            retention_time: rts.get(i - 1).copied().unwrap_or(f64::NAN),
+            is_ms2: frame_is_ms2(&file, i),
+            num_peaks: npts,
+        });
+    }
+
+    // Mobility axis: the full drift cycle of the first frame. Scan counts can differ by
+    // one between frames, so take the longest ramp seen rather than frame 1's.
+    let mut n_scans = 0u32;
+    let mut period_ms = 0.0f64;
+    for i in 1..=n.min(64) {
+        if let Ok(axis) = file.drift_axis(i) {
+            if axis.n_scans as u32 > n_scans {
+                n_scans = axis.n_scans as u32;
+                period_ms = axis.period_ms;
+            }
+        }
+    }
+    let im_max = (n_scans as f64) * period_ms;
+
+    // m/z axis: the calibrated span of the TOF axis. `adc-record-size` is the full
+    // digitiser record; the low bins are pre-injection and calibrate to ~0, so clamp
+    // the low end to the first sensible m/z rather than showing a dead decade.
+    let cal = file
+        .calibration(1)
+        .context("reading the mass calibration of frame 1")?;
+    let n_tof = file
+        .global_metadata()
+        .get("adc-record-size")
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    let mz_hi = cal.index_to_mz(n_tof.saturating_sub(1) as u64);
+    let mz_lo = mz_at_first_useful_bin(&cal, n_tof);
+
+    let rt_lo = frames.first().map(|f| f.retention_time).unwrap_or(0.0);
+    let rt_hi = frames.last().map(|f| f.retention_time).unwrap_or(1.0);
+
+    Ok(MetaIndex {
+        data_path: path.to_string(),
+        frames,
+        bounds: AxisBounds {
+            mz: AxisTransform::new(mz_lo, mz_hi),
+            im: AxisTransform::new(0.0, im_max),
+            rt: AxisTransform::new(rt_lo, rt_hi),
+        },
+        total_points_estimate: total,
+        num_scans: n_scans,
+        im_unit: "ms",
+    })
+}
+
+/// The m/z of the first TOF bin worth showing.
+///
+/// The TOF axis starts at t = 0, which calibrates to ~0 m/z; those bins hold no data
+/// (the SDK exposes a valid window starting around bin 30000). Rather than hardcode
+/// that offset, walk up to the first bin above a floor of 20 m/z.
+fn mz_at_first_useful_bin(cal: &TofCalibration, n_tof: usize) -> f64 {
+    const FLOOR_MZ: f64 = 20.0;
+    let idx = cal.mz_to_index(FLOOR_MZ);
+    if (idx as usize) < n_tof {
+        cal.index_to_mz(idx)
+    } else {
+        cal.index_to_mz(0)
+    }
+}
+
+/// Open a file and build its m/z lookup, for the loader thread.
+pub fn open_for_points(path: &str) -> Result<(MbiFile, MzLookup)> {
+    let file = MbiFile::open(path).with_context(|| format!("opening {path}"))?;
+    let cal = file.calibration(1).context("reading the mass calibration")?;
+    let n_tof = file
+        .global_metadata()
+        .get("adc-record-size")
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    let lookup = MzLookup::build(&cal, n_tof);
+    Ok((file, lookup))
+}

--- a/tims-viewer/src/data/meta.rs
+++ b/tims-viewer/src/data/meta.rs
@@ -32,6 +32,10 @@ pub struct MetaIndex {
     /// TIMS scans per frame (the mobility ramp length; constant across frames). Used to anchor the
     /// clustering's 1/K0 reach to a fixed number of scans (run-level, focus-independent).
     pub num_scans: u32,
+    /// Unit of the mobility (y) axis: `1/K0` for Bruker TIMS, `ms` (arrival time) for
+    /// SLIM sources, which have no inverse reduced mobility. Axis labels and any
+    /// mobility read-out should use this rather than assuming 1/K0.
+    pub im_unit: &'static str,
 }
 
 impl MetaIndex {
@@ -127,6 +131,7 @@ impl MetaIndex {
             bounds,
             total_points_estimate: total,
             num_scans,
+            im_unit: "1/K0",
         })
     }
 
@@ -153,6 +158,7 @@ impl MetaIndex {
             bounds,
             total_points_estimate: total_points,
             num_scans: 709, // a typical timsTOF mobility ramp length
+            im_unit: "1/K0",
         }
     }
 }

--- a/tims-viewer/src/data/mod.rs
+++ b/tims-viewer/src/data/mod.rs
@@ -7,3 +7,38 @@ pub mod point;
 pub mod loader;
 #[cfg(feature = "native")]
 pub mod meta;
+// Native-only: the MOBILion `.mbi` reader (HDF5). Opt-in, since it pulls libhdf5.
+#[cfg(feature = "mbi")]
+pub mod mbi;
+
+/// Build a metadata index for any supported source, dispatching on the path.
+///
+/// Bruker `.d` folders and MOBILion `.mbi` files carry the same three axes, so the
+/// rest of the viewer never needs to know which it is looking at.
+#[cfg(feature = "native")]
+pub fn load_meta_any(path: &str) -> anyhow::Result<meta::MetaIndex> {
+    #[cfg(feature = "mbi")]
+    if mbi::is_mbi_path(path) {
+        return mbi::load_meta(path);
+    }
+    meta::MetaIndex::load(path)
+}
+
+/// Pick the loader mode matching a run's source format.
+#[cfg(feature = "native")]
+pub fn loader_mode_for(meta: &meta::MetaIndex, frame_ids: Vec<u32>) -> loader::LoaderMode {
+    #[cfg(feature = "mbi")]
+    if mbi::is_mbi_path(&meta.data_path) {
+        // Carry the FrameInfo through: the MBI loader needs RT and the MS1/MS2 split,
+        // which live in per-frame HDF5 attributes the index has already read.
+        let wanted: std::collections::HashSet<u32> = frame_ids.iter().copied().collect();
+        let frames = meta
+            .frames
+            .iter()
+            .filter(|f| wanted.contains(&f.id))
+            .copied()
+            .collect();
+        return loader::LoaderMode::Mbi { path: meta.data_path.clone(), frames };
+    }
+    loader::LoaderMode::Real { path: meta.data_path.clone(), frame_ids }
+}

--- a/tims-viewer/src/main.rs
+++ b/tims-viewer/src/main.rs
@@ -106,7 +106,10 @@ fn discover_datasets(input: &str) -> Result<Vec<PathBuf>> {
     if is_dataset_dir(p) {
         return Ok(vec![p.to_path_buf()]);
     }
-    anyhow::ensure!(p.is_dir(), "{input} is not a .d folder or a directory of them");
+    if p.is_file() && p.extension().map(|e| e.eq_ignore_ascii_case("mbi")).unwrap_or(false) {
+        return Ok(vec![p.to_path_buf()]);
+    }
+    anyhow::ensure!(p.is_dir(), "{input} is not a .d folder, an .mbi file, or a directory of them");
     let mut v = Vec::new();
     collect_datasets(p, 0, &mut v);
     v.sort();
@@ -145,7 +148,7 @@ fn main() -> Result<()> {
         (MetaIndex::demo(args.demo_frames, args.demo_points), true)
     } else {
         log::info!("loading metadata from {}", args.input);
-        let meta = MetaIndex::load(&args.input)?;
+        let meta = tims_viewer::data::load_meta_any(&args.input)?;
         log::info!(
             "{} frames, ~{} points, RT [{:.1}, {:.1}] s, m/z [{:.1}, {:.1}], 1/K0 [{:.3}, {:.3}]",
             meta.frames.len(),

--- a/tims-viewer/src/offscreen.rs
+++ b/tims-viewer/src/offscreen.rs
@@ -118,10 +118,7 @@ pub fn render_png(plan: Plan, out: &Path, opts: &Options) -> Result<()> {
     let mode = if plan.is_demo {
         LoaderMode::Demo(DemoSource::new(plan.meta.frames.len(), total))
     } else {
-        LoaderMode::Real {
-            path: plan.meta.data_path.clone(),
-            frame_ids: plan.meta.frames.iter().map(|f| f.id).collect(),
-        }
+        crate::data::loader_mode_for(&plan.meta, plan.meta.frames.iter().map(|f| f.id).collect())
     };
     let loader = LoaderHandle::spawn(mode, bounds, total, capacity as usize, None);
     let keep = |p: &GpuPoint| match opts.ms {

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -217,7 +217,7 @@ impl Hub {
                 let p = paths
                     .get(id)
                     .ok_or_else(|| anyhow::anyhow!("dataset {id} out of range"))?;
-                let meta = MetaIndex::load(&p.display().to_string())?;
+                let meta = crate::data::load_meta_any(&p.display().to_string())?;
                 Ok(Plan::new(meta, false, self.budget))
             }
         }
@@ -633,10 +633,7 @@ fn build_load_result(
     let mode = if is_demo {
         LoaderMode::Demo(DemoSource::new(frame_ids.len(), rt_total))
     } else {
-        LoaderMode::Real {
-            path: meta.data_path.clone(),
-            frame_ids,
-        }
+        crate::data::loader_mode_for(meta, frame_ids)
     };
 
     let (mut points, stats, hist) = collect(mode, bounds, estimate, budget, filter)?;

--- a/tims-viewer/src/ui.rs
+++ b/tims-viewer/src/ui.rs
@@ -414,7 +414,7 @@ fn minimap(
     ui.painter().rect_stroke(
         wr,
         egui::Rounding::ZERO,
-        egui::Stroke::new(1.5, egui::Color32::from_rgb(120, 200, 255)),
+        egui::Stroke::new(1.5_f32, egui::Color32::from_rgb(120, 200, 255)),
     );
 }
 
@@ -591,7 +591,7 @@ fn draw_colorbar(ctx: &egui::Context, state: &AppState) {
     painter.rect_stroke(
         bar,
         0.0,
-        egui::Stroke::new(1.0, egui::Color32::from_gray(120)),
+        egui::Stroke::new(1.0_f32, egui::Color32::from_gray(120)),
     );
 
     let font = egui::FontId::proportional(11.0);


### PR DESCRIPTION
Lets `tims-viewer` open MOBILion SLIM/MOBIE `.mbi` files alongside Bruker `.d`, behind an opt-in `mbi` feature.

## Why it's small

`GpuPoint` carries `(m/z, mobility, RT)` + intensity + an MS1/MS2 flag, none of which is vendor-specific. So the existing pipeline — stratified sampling, peak grid, histograms, projections, the web serve path — is reused unchanged. The new code is one module plus dispatch.

```
data/mbi.rs        metadata index + m/z lookup table   (new)
data/mod.rs        load_meta_any / loader_mode_for     (one dispatch point)
data/loader.rs     LoaderMode::Mbi -> handle_point!
data/meta.rs       MetaIndex::im_unit
```

## Three things that are not obvious

- **The m/z lookup is precomputed** for all 232,992 TOF bins per run. The calibration is a sqrt plus a ppm residual polynomial; evaluating it per point at ~10^8 points is the difference between seconds and minutes, and it is constant within a file.
- **Mobility is arrival time in milliseconds, not 1/K0.** SLIM has no inverse reduced mobility. `MetaIndex::im_unit` carries the unit so read-outs can label the axis correctly.
- **Frame point counts come from the `data-counts` dataset shape** (HDF5 object header), so building the index costs seeks rather than a gzip pass.

There were six `LoaderMode::Real` construction sites, not the five a first grep suggested — `offscreen.rs` was missed and fell through to the Bruker loader, which tried to open `analysis.tdf` inside the `.mbi`. Hence the single dispatch helper rather than a conditional per site.

## Verified

Against MassIVE MSV000099577 (CC0), headless via `--render-png`:

| check | result |
|---|---|
| `--features mbi` build | pass |
| reads a real file | 829 frames, 87,004,212 points, RT 0-351.5 s, m/z 20-1638.8, mobility 0-400 ms |
| DEMO path (shared loader machinery) | no regression |
| default build | pass |
| `--no-default-features` (wasm render lib) | pass |

Those axis bounds match values independently validated against MOBILion's own SDK. The MS1 view shows two sharp charge-state trend lines; the MS2 view shows them washed out across m/z at inherited drift times, which is what all-ion mobility-aligned fragmentation should look like.

The second commit fixes two pre-existing `float_literal_f32_fallback` warnings in `ui.rs` (rustc will reject these outright in a future release) and relaxes `winit` from `=0.30.5` to `0.30.5`, picking up 0.30.13. The exact pins on wgpu/egui/egui-wgpu/egui-winit are load-bearing and untouched.

## Not covered

- Axis labels in `app.rs` still read `1/K0`; the unit is plumbed through `MetaIndex::im_unit` but the drawn labels do not read it yet.
- Serve mode routes through the same dispatch but has only been exercised headless, not against a browser.
- Built and run on x86-64 Linux only.
- Multiplexed acquisitions (`frm-mux-gate`) are not exercised by any test file.

Reader: https://github.com/theGreatHerrLebert/mobilionmbi (`mobilionmbi` 0.1.1 on crates.io)