### PR TITLE
tims-viewer: fix serve-mode panic on .mbi sources + document the web viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,66 @@ The pipeline produces HTML reports with pass/fail metrics for identification rat
 
 See the full [Validation README](packages/imspy-simulation/src/imspy_simulation/timsim/integration/VALIDATION_README.md) for setup, configuration, and adding custom tests.
 
+### Interactive Visualization (tims-viewer)
+
+`tims-viewer` is a GPU point-cloud / volume viewer for raw IM-MS data. It runs as a native
+window, as a headless PNG renderer, or as a **web app** — the browser does the rendering on
+its own GPU (WebGPU, WebGL2 fallback) while a small local server streams the points.
+
+**Supported sources**
+
+| source | path to pass |
+| --- | --- |
+| Bruker timsTOF | a `.d` folder, or a directory containing several |
+| MOBILion SLIM / MOBIE | a single `.mbi` file (needs `--features mbi`) |
+| synthetic | the literal `DEMO` |
+
+**Prerequisites**
+
+```bash
+rustup target add wasm32-unknown-unknown   # web app only
+cargo install trunk                        # web app only
+sudo apt install libhdf5-dev               # only for --features mbi (MOBILion)
+```
+
+**TL;DR — web viewer in three commands**
+
+```bash
+# 1. build (drop --features mbi if you only need Bruker .d)
+cargo build -p tims-viewer --release --features mbi
+
+# 2. point server — pass a .d folder, a directory of them, an .mbi file, or DEMO
+./target/release/tims-viewer /path/to/run.mbi --serve 8090 --budget 12000000
+
+# 3. web app, in a second terminal
+cd tims-viewer/web && trunk serve --release
+```
+
+Then open **http://localhost:8080/?port=8090** and pick a dataset in the ① Data tab.
+
+Serving over a network? Add `--compress` to the point server: it zstd-compresses `/points`
+when the browser advertises support (~2.6x, e.g. 356 MB to 138 MB, decoded transparently).
+Leave it off for localhost, where raw is faster.
+
+**Without a browser**
+
+```bash
+# native window
+./target/release/tims-viewer /path/to/run.d
+
+# headless render to a PNG (no display needed)
+./target/release/tims-viewer /path/to/run.mbi --render-png out.png --ms ms1
+```
+
+The axes are m/z, ion mobility, and retention time. Mobility is `1/K0` for Bruker sources and
+arrival time in milliseconds for MOBILion (SLIM has no inverse reduced mobility). `--ms
+ms1|ms2|all` filters by MS level; for MOBILion MAF acquisitions that is the low- vs high-
+collision-energy frames.
+
+MOBILion reading is provided by [`mobilionmbi`](https://github.com/theGreatHerrLebert/mobilionmbi),
+an independent pure-Rust reader/writer for the `.mbi` format — no vendor SDK required. Public
+test data: MassIVE [MSV000099577](https://massive.ucsd.edu/ProteoSAFe/dataset.jsp?task=c613463dcd5a48a48c8ee04d62ea6bcd) (CC0).
+
 ## Architecture
 
 <p align="center">

--- a/tims-viewer/src/data/mod.rs
+++ b/tims-viewer/src/data/mod.rs
@@ -42,3 +42,18 @@ pub fn loader_mode_for(meta: &meta::MetaIndex, frame_ids: Vec<u32>) -> loader::L
     }
     loader::LoaderMode::Real { path: meta.data_path.clone(), frame_ids }
 }
+
+/// Whether a source can carry DIA isolation windows at all.
+///
+/// MOBILion MAF acquisitions are quadrupole-free — there are no isolation windows
+/// to draw, and trying to read them would mean opening the path as a Bruker
+/// dataset, which it is not.
+#[cfg(feature = "native")]
+pub fn has_isolation_windows(path: &str) -> bool {
+    #[cfg(feature = "mbi")]
+    if mbi::is_mbi_path(path) {
+        return false;
+    }
+    let _ = path;
+    true
+}

--- a/tims-viewer/src/serve.rs
+++ b/tims-viewer/src/serve.rs
@@ -558,7 +558,7 @@ fn get_or_build(state: &State, region: &Region4D, budget: usize) -> Result<Arc<L
 /// Build the static `/windows` JSON: `{ max_window_group, windows: [[group, mz0, mz1, im0, im1], …] }`
 /// in real units. Demo or non-DIA runs yield an empty set.
 fn build_windows_json(is_demo: bool, data_path: &str) -> Arc<[u8]> {
-    let json = if is_demo {
+    let json = if is_demo || !crate::data::has_isolation_windows(data_path) {
         serde_json::json!({ "max_window_group": 0, "windows": [] })
     } else {
         let ds = rustdf::data::dataset::TimsDataset::new("NO_SDK", data_path, false, false);


### PR DESCRIPTION
Follow-up to #446. Two things: a crash fix, and the README section that makes the feature usable by someone outside the project.

## The crash

Serve mode died immediately after loading points from an `.mbi` file:

```
thread 'main' panicked: unable to open database file:
  /path/to/run.mbi/analysis.tdf
```

`build_windows_json` unconditionally built a Bruker `TimsDataset` to read DIA isolation-window footprints. An `.mbi` is a file, not a `.d` directory, so SQLite fails.

MOBILion MAF acquisitions are quadrupole-free — `HasScanDefinitions()` is false and no isolation windows exist — so the right answer is the empty set the demo branch already returns.

This was the **seventh** Bruker-specific call site. The previous six were routed through `loader_mode_for`; this one reads the dataset directly for a different purpose. Added `data::has_isolation_windows` so the assumption has a name instead of being re-derived per site.

Verified with `--serve` against a real file:

```
/datasets  [{"id":0,"name":"200S-100ngHeLa-14.19.00"}]
/windows   {"max_window_group":0,"windows":[]}
/meta      im [0.0, 400.007] ms, mz [20.0, 1638.78], rt [0.0, 351.479]
/points    327,944,576 bytes
```

## The docs

A `### Interactive Visualization (tims-viewer)` section in the README: the three commands to get the browser viewer running (build, point server, `trunk serve`, open `localhost:8080/?port=8090`), which sources are accepted, the native-window and headless-PNG alternatives, and `--compress` for remote serving.

`libhdf5-dev` is listed as a prerequisite for `--features mbi` rather than vendoring a static HDF5 build — one apt line beats several minutes of extra compile on every build.

Also notes that mobility means `1/K0` for Bruker and arrival time in milliseconds for MOBILion, and links the CC0 MassIVE deposit so the instructions are runnable without your own data.