### PR TITLE
rustdf: fix ModelType-2 m/z calibration, per-frame temperature compensation, SDK-free default

### DIFF
--- a/rustdf/BRUKER_TRANSLATORS.md
+++ b/rustdf/BRUKER_TRANSLATORS.md
@@ -36,13 +36,19 @@ m/z      = s^2 - C4        (invert the curve for s, given t)
   `a1→√(1e12/C1)`, `a2→C2`. The cubic `C3·s³` term is real only for ModelType 1
   (in ModelType 2 the `C3` column duplicates `C0` and is dropped).
 
-**Temperature compensation** (applied to `C1`, and to `c2` for ModelType 1):
+**Temperature compensation** (applied to `C1` and `C2`):
 
 ```
 tc = 1 + ( dC1*(T1 - T1_frame) + dC2*(T2 - T2_frame) ) / 1e6
 ```
 
-where `T1_frame`, `T2_frame` are the per-frame `Frames.T1`, `Frames.T2`.
+where `T1_frame`, `T2_frame` are the per-frame `Frames.T1`, `Frames.T2`. `dC1` is
+~20 ppm/degC on the instruments seen here, so this is not a rounding detail: a run
+whose digitizer temperature drifts by 1 degC is ~20 ppm of mass error if a single
+frame's temperature is pinned for the whole run, and ~200 ppm for the 10 degC
+offset of a failed chiller. `BrukerFormulaConverter` therefore reads `Frames.T1`
+/`T2` for *every* frame and compensates per frame; `temperature_spread()` reports
+how far the temperatures actually moved over the run.
 
 ### `MzCalibration` table parameters
 
@@ -57,7 +63,7 @@ where `T1_frame`, `T2_frame` are the per-frame `Frames.T1`, `Frames.T2`.
 | `C1` | `C1` | governs the dominant √ term: `b = sqrt(1e12 / C1)` |
 | `C2` | `C2` | quadratic `s²` term of the curve — **used by both ModelTypes** |
 | `C3` | `C3` | cubic `s³` term — **ModelType 1 only** (in ModelType 2 this column duplicates C0 and is dropped) |
-| `C4` | `C4` | "reduced mass" shift `m0` (`x = m − m0`); the element claimed by Bruker patent US 7,851,746 |
+| `C4` | `C4` | "reduced mass" shift `m0` (`x = m − m0`); the element claimed by Bruker patent US 7,851,746 — **ModelType 1 only** (in ModelType 2 this column duplicates C2 and is dropped, exactly like C3) |
 | `C5` | window low  | ModelType-2 fine correction: **lower m/z bound** of the correction window. A **universal constant** `225.951491` across every dataset seen. |
 | `C6` | window high | ModelType-2 fine correction: **upper m/z bound** of the correction window (per-dataset, e.g. 1383.7 / 1519.7). |
 | `C7` | degree | ModelType-2 fine correction: polynomial **degree = 7** (matches the fit below). |
@@ -122,11 +128,17 @@ Measured by `examples/compare_calibration.rs` (residual of this formula vs
 | Dataset | m/z ModelType | TOF → m/z residual | scan → 1/K0 residual |
 |---|---|---|---|
 | `synchro-hela.d` | **1** | **0.0000 ppm (bit-exact)** | ~4e-16 (machine ε) |
-| `G8602.d` | **2** | mean 2.5 ppm / max 11.1 ppm | ~7e-16 (machine ε) |
-| `G8027.d` | **2** | mean 3.6 ppm / max 20.8 ppm | ~4e-16 (machine ε) |
+| `G8602.d` | **2** | median 0.57 / p90 3.2 / max 4.8 ppm | ~7e-16 (machine ε) |
 
-(ModelType-2 m/z figures are with the `C0/C1/C2` quadratic; the older base-only
-curve without `C2` was ~9 ppm mean.)
+(ModelType-2 m/z figures are with the `C0/C1/C2` quadratic and the duplicated
+`C3`/`C4` columns dropped. For reference on `G8602.d`: keeping `C4` as if it were
+the reduced-mass shift costs median 1.9 / max 11.1 ppm, and the base-only curve
+without `C2` was ~9 ppm mean. `G8027.d` was measured at mean 3.6 ppm before the
+`C4` fix and has not been re-measured since.)
+
+A useful consequence of the window: **below `C5` (225.95 m/z) the ModelType-2 base
+curve is the entire model**, and agreement with the SDK there is exact (< 0.01 ppm),
+which is what the unit tests in `src/data/calibration.rs` assert.
 
 **Takeaways**
 
@@ -134,9 +146,13 @@ curve without `C2` was ~9 ppm mean.)
   the floating-point rounding limit). The mobility formula *is* what we were
   looking for.
 - **TOF → m/z is exact for ModelType-1** data (bit-for-bit). For **ModelType-2**
-  data (modern instruments) the `C0/C1/C2` quadratic reproduces the SDK to a few
-  ppm; the last few ppm come from the `C8…C14` correction whose exact form is not
-  resolved (see the ModelType-2 note above).
+  data (modern instruments) the `C0/C1/C2` quadratic reproduces the SDK to ~1 ppm
+  (exactly, below the correction window); the remainder comes from the `C8…C14`
+  correction whose exact form is not resolved (see the ModelType-2 note above).
+- This makes the SDK-free converter more accurate than the SDK-*derived*
+  regression fit (`Calibrated`/`Lookup`, median 0.09–1.6 ppm m/z but a linear
+  mobility model that is 2000–6000 ppm off), which is why
+  `build_index_converter` now prefers it whenever the live SDK is not used.
 
 ## Reproduce
 

--- a/rustdf/src/data/calibration.rs
+++ b/rustdf/src/data/calibration.rs
@@ -33,6 +33,8 @@
 /// * `c3`       — cubic term `C3*s^3`; ModelType 1 only (in ModelType 2 the C3
 ///               column is a duplicate of C0 and is dropped).
 /// * `c4`       — "reduced mass" shift m0 (`x = m - m0`); patent US7,851,746.
+///               ModelType 1 only (in ModelType 2 the C4 column is a duplicate of
+///               C2 and is dropped, exactly like C3).
 /// Temperature compensation (`T1/T2` = reference temps in `MzCalibration`,
 /// `dC1/dC2` its sensitivities, `T1f/T2f` = per-frame `Frames.T1/Frames.T2`):
 /// `tc = 1 + (dC1*(T1-T1f) + dC2*(T2-T2f)) / 1e6`, applied as `C1 *= tc`.
@@ -78,8 +80,38 @@ impl MzCalibrator {
         // C8..C14 fine correction (~few ppm, worst at low m/z) that is NOT an
         // additive polynomial in m/z and is left unmodelled here.
         let c2 = c2 / tc;
-        let c3 = if model_type == 1 { c3 } else { 0.0 };
+        // ModelType 2 reuses the C3 *and* C4 columns as duplicates of C0/C2
+        // (verified bit-for-bit on real files: C3 == C0, C4 == C2), so neither is
+        // the cubic term nor the reduced-mass shift there and both must be
+        // dropped. Subtracting the duplicated C4 as if it were m0 costs ~1.4 ppm
+        // mean / 6 ppm max against the SDK on ModelType-2 data.
+        let (c3, c4) = if model_type == 1 { (c3, c4) } else { (0.0, 0.0) };
         Self { timebase, delay, c0, b, c2, c3, c4 }
+    }
+
+    /// Build a calibrator straight from an `MzCalibration` row plus the
+    /// per-frame digitizer temperatures (`Frames.T1`, `Frames.T2`).
+    pub fn from_calibration(
+        cal: &crate::data::meta::MzCalibration,
+        t1_frame: f64,
+        t2_frame: f64,
+    ) -> Self {
+        Self::new(
+            cal.model_type,
+            cal.digitizer_timebase,
+            cal.digitizer_delay,
+            cal.t1,
+            cal.t2,
+            cal.dc1,
+            cal.dc2,
+            cal.c0,
+            cal.c1,
+            cal.c2,
+            cal.c3,
+            cal.c4,
+            t1_frame,
+            t2_frame,
+        )
     }
 
     /// Flight time (digitizer units) for a TOF index.
@@ -193,6 +225,13 @@ impl MobilityCalibrator {
         }
     }
 
+    /// Build a mobility calibrator straight from a `TimsCalibration` row.
+    pub fn from_calibration(cal: &crate::data::meta::TimsCalibration) -> Self {
+        Self::new(
+            cal.c0, cal.c1, cal.c2, cal.c3, cal.c4, cal.c5, cal.c6, cal.c7, cal.c8, cal.c9,
+        )
+    }
+
     /// scan index -> trapping voltage (clamped to the valid window).
     #[inline]
     fn voltage(&self, scan: f64) -> f64 {
@@ -212,5 +251,160 @@ impl MobilityCalibrator {
         let v = self.c1m / (inv - self.c0m);
         let scan = (v - self.dv_start) / self.slope + self.ttrans + self.ndelay;
         scan.round().max(0.0) as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `synchro-hela.d`: `MzCalibration` ModelType 1, frame 1 temperatures.
+    fn model1() -> MzCalibrator {
+        MzCalibrator::new(
+            1,
+            0.2,
+            25585.2,
+            25.432518231649194,
+            22.91046717419208,
+            21.0,
+            0.0,
+            319.4836862507276,
+            156650.78463959479,
+            -4.7797946742077594e-05,
+            0.0,
+            2.6639979911791643e-05,
+            25.454778878245186,
+            23.065621750666164,
+        )
+    }
+
+    /// `G8602.d`: `MzCalibration` ModelType 2, frame 1 temperatures. Note that
+    /// C3 duplicates C0 and C4 duplicates C2 in this model — the calibrator has
+    /// to ignore both.
+    fn model2() -> MzCalibrator {
+        MzCalibrator::new(
+            2,
+            0.2,
+            18290.2,
+            25.3488367593942,
+            25.618275892137202,
+            20.0,
+            0.0,
+            319.95445850882476,
+            154831.91077331622,
+            -0.0005550791433026118,
+            319.95445850882476,
+            -0.0005550791433026118,
+            25.37849141449188,
+            26.171382195221447,
+        )
+    }
+
+    fn ppm(got: f64, want: f64) -> f64 {
+        (got - want).abs() / want * 1e6
+    }
+
+    /// ModelType 1 is fully modelled, so it must reproduce
+    /// `tims_index_to_mz` bit-for-bit (reference values read from the SDK).
+    #[test]
+    fn model1_is_bit_exact_against_the_sdk() {
+        let cal = model1();
+        for (tof, sdk) in [
+            (1u32, 100.00058181811438),
+            (50000, 194.8219835433269),
+            (150000, 478.458543155091),
+            (250000, 887.4159830461258),
+            (350000, 1421.6944158188035),
+        ] {
+            let got = cal.tof_to_mz(tof);
+            assert!(
+                (got - sdk).abs() / sdk < 1e-12,
+                "tof {tof}: got {got}, SDK {sdk}"
+            );
+        }
+    }
+
+    /// In ModelType 2 the C3/C4 columns are duplicates of C0/C2, not the cubic
+    /// term and the reduced-mass shift, so the calibrator must zero both.
+    #[test]
+    fn model2_drops_duplicated_c3_and_c4() {
+        let cal = model2();
+        assert_eq!(cal.c3, 0.0);
+        assert_eq!(cal.c4, 0.0);
+    }
+
+    /// The ModelType-2 fine correction is windowed to `[C5, C6]` in m/z, so
+    /// *below* that window (here C5 = 225.95) the C0/C1/C2 base curve is the
+    /// whole model and must match the SDK exactly. This is what regresses --
+    /// by 4.6 to 11.1 ppm -- if the duplicated C4 is subtracted as if it were m0.
+    #[test]
+    fn model2_is_exact_below_the_correction_window() {
+        let cal = model2();
+        for (tof, sdk) in [(1u32, 50.00106408611359), (50000, 121.13087702783326)] {
+            let got = cal.tof_to_mz(tof);
+            assert!(ppm(got, sdk) < 0.01, "tof {tof}: got {got}, SDK {sdk}");
+        }
+    }
+
+    /// Inside the correction window the unmodelled C8..C14 polynomial leaves a
+    /// small residual; it stays within a few ppm of the SDK.
+    #[test]
+    fn model2_is_within_a_few_ppm_inside_the_correction_window() {
+        let cal = model2();
+        for (tof, sdk) in [
+            (150000u32, 356.29356381674006),
+            (250000, 715.3229449956262),
+            (350000, 1198.2257163072832),
+        ] {
+            let got = cal.tof_to_mz(tof);
+            assert!(ppm(got, sdk) < 3.0, "tof {tof}: got {got}, SDK {sdk}");
+        }
+    }
+
+    #[test]
+    fn mz_tof_round_trips() {
+        for cal in [model1(), model2()] {
+            for tof in [1u32, 50_000, 150_000, 250_000, 350_000] {
+                let back = cal.mz_to_tof(cal.tof_to_mz(tof));
+                assert!(
+                    back.abs_diff(tof) <= 1,
+                    "round trip {tof} -> {} -> {back}",
+                    cal.tof_to_mz(tof)
+                );
+            }
+        }
+    }
+
+    /// `synchro-hela.d` `TimsCalibration` (ModelType 2) against
+    /// `tims_scannum_to_oneoverk0`: the mobility model is the SDK computation,
+    /// so agreement is at the floating-point rounding limit.
+    #[test]
+    fn mobility_matches_the_sdk() {
+        let cal = MobilityCalibrator::new(
+            1.0,
+            926.0,
+            174.99089000590644,
+            89.34134412781896,
+            33.333333333333336,
+            1.0,
+            0.031163511286580903,
+            129.15504635187241,
+            12.75853947905552,
+            3135.217073581985,
+        );
+        for (scan, sdk) in [
+            (0u32, 1.3226192435624091),
+            (1, 1.321960900558156),
+            (100, 1.2566451818439914),
+            (400, 1.0570143319893166),
+            (900, 0.7184888610899344),
+        ] {
+            let got = cal.scan_to_one_over_k0(scan);
+            assert!(
+                (got - sdk).abs() / sdk < 1e-12,
+                "scan {scan}: got {got}, SDK {sdk}"
+            );
+            assert_eq!(cal.one_over_k0_to_scan(sdk), scan);
+        }
     }
 }

--- a/rustdf/src/data/handle.rs
+++ b/rustdf/src/data/handle.rs
@@ -365,52 +365,124 @@ impl IndexConverter for BrukerLibTimsDataConverter {
 
 /// SDK-free converter using the exact Bruker calibration formulas.
 ///
-/// Reads the `MzCalibration` and `TimsCalibration` tables from analysis.tdf and
-/// evaluates the published calibration curves directly (see
+/// Reads the `MzCalibration`, `TimsCalibration` and `Frames` tables from
+/// analysis.tdf and evaluates the published calibration curves directly (see
 /// [`crate::data::calibration`]). Verified against the Bruker SDK:
 ///   * scan <-> 1/K0 : machine-precision exact (ModelType 2).
 ///   * TOF  <-> m/z  : bit-exact for MzCalibration ModelType 1; ModelType 2 uses
-///     the same C0/C1/C2 quadratic-in-sqrt(m) curve and reproduces the SDK to a
-///     few ppm (the proprietary ModelType-2 C8..C14 fine correction is not
+///     the same C0/C1/C2 quadratic-in-sqrt(m) curve and reproduces the SDK to
+///     ~1 ppm (the proprietary ModelType-2 C8..C14 fine correction is not
 ///     modelled).
 ///
-/// This is a **fixed-calibration** converter: it captures one frame's
-/// calibration rows + temperatures at build time and applies them to every
-/// frame, ignoring the per-call `frame_id` (like the other SDK-free converters
-/// `Simple`/`Calibrated`/`Lookup`). Valid because the coefficients are
-/// effectively constant across a run; use the SDK-backed `BrukerLib` converter
-/// if a run genuinely carries multiple calibration rows.
+/// The calibration is resolved **per frame**: every frame's `Frames.T1`/`T2` and
+/// its `MzCalibration`/`TimsCalibration` foreign keys are read, so a run that
+/// carries more than one calibration row is handled, and the temperature
+/// compensation is evaluated for the frame the caller asks about. That matters
+/// because `dC1` is ~20 ppm/degC: pinning one frame's temperature for a whole run
+/// costs ~20 ppm of mass accuracy per degC the digitizer drifts.
+/// [`Self::temperature_spread`] reports how far the temperatures actually moved,
+/// so callers can tell a quiet run from a drifting one.
+///
+/// Frame ids that are not in the file, and frames whose calibration rows use an
+/// unsupported ModelType, fall back to the calibrators built from
+/// `fallback_frame_id`.
 pub struct BrukerFormulaConverter {
+    /// Calibrator built from `fallback_frame_id`; also used for unknown frames.
     pub mz: crate::data::calibration::MzCalibrator,
+    /// Mobility calibrator for `fallback_frame_id`; also used for unknown frames.
     pub im: crate::data::calibration::MobilityCalibrator,
+    /// `MzCalibration.ModelType` of the fallback frame's row.
     pub mz_model_type: i64,
+    /// Supported `MzCalibration` rows, by `Id`.
+    mz_rows: std::collections::HashMap<i64, crate::data::meta::MzCalibration>,
+    /// Ready-built mobility calibrators, by `TimsCalibration.Id`.
+    im_rows: std::collections::HashMap<i64, crate::data::calibration::MobilityCalibrator>,
+    /// Per-frame calibration linkage and digitizer temperatures.
+    frames: std::collections::HashMap<u32, FrameCalibrationRef>,
+    /// (T1, T2) spread (max - min) over all frames of the run, in degC.
+    temp_spread: (f64, f64),
+}
+
+/// One frame's link into the calibration tables, plus its digitizer temperatures.
+struct FrameCalibrationRef {
+    mz_id: i64,
+    tims_id: i64,
+    t1: f64,
+    t2: f64,
 }
 
 impl BrukerFormulaConverter {
-    /// Build the converter from a `.d` folder, using `frame_id`'s calibration
-    /// row and per-frame temperatures (coefficients are near-constant per run).
+    /// Build the converter from a `.d` folder.
+    ///
+    /// `fallback_frame_id` (conventionally 1) selects the calibration used for
+    /// frames that are missing from the `Frames` table or whose calibration rows
+    /// this converter cannot evaluate; every frame that *is* in the file uses its
+    /// own rows and temperatures.
     pub fn from_d_folder(
         data_path: &str,
-        frame_id: u32,
+        fallback_frame_id: u32,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         use crate::data::calibration::{MobilityCalibrator, MzCalibrator};
         use crate::data::meta::{read_mz_calibration, read_tims_calibration};
+        use std::collections::HashMap;
 
         let tdf = PathBuf::from(data_path).join("analysis.tdf");
         let con = rusqlite::Connection::open(&tdf)?;
-        let (t1, t2, mz_id, tims_id): (f64, f64, i64, i64) = con.query_row(
-            "SELECT T1, T2, MzCalibration, TimsCalibration FROM Frames WHERE Id = ?1",
-            [frame_id],
-            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
-        )?;
 
-        let mzc = read_mz_calibration(data_path)?
-            .into_iter()
-            .find(|c| c.id == mz_id)
+        // Per-frame calibration linkage + digitizer temperatures for the whole run.
+        // T1/T2 are nullable in Bruker's schema; frames without them cannot be
+        // temperature compensated and are left to the fallback calibration.
+        let mut stmt =
+            con.prepare("SELECT Id, T1, T2, MzCalibration, TimsCalibration FROM Frames")?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, i64>(0)?,
+                r.get::<_, Option<f64>>(1)?,
+                r.get::<_, Option<f64>>(2)?,
+                r.get::<_, i64>(3)?,
+                r.get::<_, i64>(4)?,
+            ))
+        })?;
+
+        let mut frames: HashMap<u32, FrameCalibrationRef> = HashMap::new();
+        let (mut t1_min, mut t1_max) = (f64::INFINITY, f64::NEG_INFINITY);
+        let (mut t2_min, mut t2_max) = (f64::INFINITY, f64::NEG_INFINITY);
+        for row in rows {
+            let (id, t1, t2, mz_id, tims_id) = row?;
+            let (t1, t2) = match (t1, t2) {
+                (Some(t1), Some(t2)) => (t1, t2),
+                _ => continue,
+            };
+            t1_min = t1_min.min(t1);
+            t1_max = t1_max.max(t1);
+            t2_min = t2_min.min(t2);
+            t2_max = t2_max.max(t2);
+            frames.insert(
+                id as u32,
+                FrameCalibrationRef {
+                    mz_id,
+                    tims_id,
+                    t1,
+                    t2,
+                },
+            );
+        }
+        drop(stmt);
+
+        let fallback = frames
+            .get(&fallback_frame_id)
+            .ok_or("fallback frame has no calibration/temperature row in Frames")?;
+
+        let mz_all = read_mz_calibration(data_path)?;
+        let tims_all = read_tims_calibration(data_path)?;
+
+        let mzc = mz_all
+            .iter()
+            .find(|c| c.id == fallback.mz_id)
             .ok_or("MzCalibration row not found")?;
-        let tc = read_tims_calibration(data_path)?
-            .into_iter()
-            .find(|c| c.id == tims_id)
+        let tc = tims_all
+            .iter()
+            .find(|c| c.id == fallback.tims_id)
             .ok_or("TimsCalibration row not found")?;
 
         // Reject calibration models this converter does not implement, rather
@@ -422,50 +494,95 @@ impl BrukerFormulaConverter {
             return Err(format!("unsupported TimsCalibration ModelType {}", tc.model_type).into());
         }
 
-        let mz = MzCalibrator::new(
-            mzc.model_type,
-            mzc.digitizer_timebase,
-            mzc.digitizer_delay,
-            mzc.t1,
-            mzc.t2,
-            mzc.dc1,
-            mzc.dc2,
-            mzc.c0,
-            mzc.c1,
-            mzc.c2,
-            mzc.c3,
-            mzc.c4,
-            t1,
-            t2,
-        );
-        let im = MobilityCalibrator::new(
-            tc.c0, tc.c1, tc.c2, tc.c3, tc.c4, tc.c5, tc.c6, tc.c7, tc.c8, tc.c9,
-        );
-        Ok(Self { mz, im, mz_model_type: mzc.model_type })
+        let mz = MzCalibrator::from_calibration(mzc, fallback.t1, fallback.t2);
+        let im = MobilityCalibrator::from_calibration(tc);
+        let mz_model_type = mzc.model_type;
+
+        // Keep only the rows this converter can evaluate; frames pointing at any
+        // other row fall back to the calibration above.
+        let mz_rows: HashMap<i64, crate::data::meta::MzCalibration> = mz_all
+            .into_iter()
+            .filter(|c| c.model_type == 1 || c.model_type == 2)
+            .map(|c| (c.id, c))
+            .collect();
+        let im_rows: HashMap<i64, MobilityCalibrator> = tims_all
+            .iter()
+            .filter(|c| c.model_type == 2)
+            .map(|c| (c.id, MobilityCalibrator::from_calibration(c)))
+            .collect();
+
+        let temp_spread = if frames.is_empty() {
+            (0.0, 0.0)
+        } else {
+            (t1_max - t1_min, t2_max - t2_min)
+        };
+
+        Ok(Self {
+            mz,
+            im,
+            mz_model_type,
+            mz_rows,
+            im_rows,
+            frames,
+            temp_spread,
+        })
+    }
+
+    /// Spread (max - min, in degC) of `Frames.T1` and `Frames.T2` across the run.
+    ///
+    /// A near-zero spread means per-frame and fixed-frame calibration agree; a
+    /// large one means the digitizer temperature moved and per-frame
+    /// compensation is doing real work (~20 ppm of m/z per degC).
+    pub fn temperature_spread(&self) -> (f64, f64) {
+        self.temp_spread
+    }
+
+    /// m/z calibrator for `frame_id`, falling back to the default calibration.
+    fn mz_for(&self, frame_id: u32) -> crate::data::calibration::MzCalibrator {
+        self.frames
+            .get(&frame_id)
+            .and_then(|f| {
+                self.mz_rows.get(&f.mz_id).map(|row| {
+                    crate::data::calibration::MzCalibrator::from_calibration(row, f.t1, f.t2)
+                })
+            })
+            .unwrap_or_else(|| self.mz.clone())
+    }
+
+    /// Mobility calibrator for `frame_id`, falling back to the default one.
+    fn im_for(&self, frame_id: u32) -> &crate::data::calibration::MobilityCalibrator {
+        self.frames
+            .get(&frame_id)
+            .and_then(|f| self.im_rows.get(&f.tims_id))
+            .unwrap_or(&self.im)
     }
 }
 
 impl IndexConverter for BrukerFormulaConverter {
-    fn tof_to_mz(&self, _frame_id: u32, tof_values: &Vec<u32>) -> Vec<f64> {
-        tof_values.iter().map(|&t| self.mz.tof_to_mz(t)).collect()
+    fn tof_to_mz(&self, frame_id: u32, tof_values: &Vec<u32>) -> Vec<f64> {
+        let mz = self.mz_for(frame_id);
+        tof_values.iter().map(|&t| mz.tof_to_mz(t)).collect()
     }
-    fn mz_to_tof(&self, _frame_id: u32, mz_values: &Vec<f64>) -> Vec<u32> {
-        mz_values.iter().map(|&m| self.mz.mz_to_tof(m)).collect()
+    fn mz_to_tof(&self, frame_id: u32, mz_values: &Vec<f64>) -> Vec<u32> {
+        let mz = self.mz_for(frame_id);
+        mz_values.iter().map(|&m| mz.mz_to_tof(m)).collect()
     }
-    fn scan_to_inverse_mobility(&self, _frame_id: u32, scan_values: &Vec<u32>) -> Vec<f64> {
+    fn scan_to_inverse_mobility(&self, frame_id: u32, scan_values: &Vec<u32>) -> Vec<f64> {
+        let im = self.im_for(frame_id);
         scan_values
             .iter()
-            .map(|&s| self.im.scan_to_one_over_k0(s))
+            .map(|&s| im.scan_to_one_over_k0(s))
             .collect()
     }
     fn inverse_mobility_to_scan(
         &self,
-        _frame_id: u32,
+        frame_id: u32,
         inverse_mobility_values: &Vec<f64>,
     ) -> Vec<u32> {
+        let im = self.im_for(frame_id);
         inverse_mobility_values
             .iter()
-            .map(|&v| self.im.one_over_k0_to_scan(v))
+            .map(|&v| im.one_over_k0_to_scan(v))
             .collect()
     }
 }
@@ -953,8 +1070,11 @@ pub enum TimsDataLoader {
 /// - `use_bruker_sdk` → try the live Bruker SDK converter; if the SDK shared library can't be
 ///   loaded (missing / wrong arch / mismatched version) this now **falls back** (with a warning)
 ///   instead of panicking.
-/// - Otherwise (or after that fallback): derive an accurate calibration from the SDK if the
-///   `bruker_lib_path` is usable, else the simple boundary model (~5 Da error on some datasets).
+/// - Otherwise (or after that fallback): evaluate the calibration curves stored in the file
+///   itself ([`BrukerFormulaConverter`]) — no SDK needed, 1/K0 machine-exact and m/z within
+///   ~1 ppm of the SDK. Only if those tables cannot be read does it fall back to the
+///   SDK-derived regression, and finally to the simple boundary model (which is ~5 Da off on
+///   some datasets for m/z and thousands of ppm off on the mobility axis).
 fn build_index_converter(
     bruker_lib_path: &str,
     data_path: &str,
@@ -975,6 +1095,16 @@ fn build_index_converter(
             ),
         }
     }
+    // SDK-free, and better than anything derived: evaluate the calibration curves the tdf
+    // carries for this very run (per-frame temperature compensated, exact 1/K0).
+    match BrukerFormulaConverter::from_d_folder(data_path, 1) {
+        Ok(converter) => return TimsIndexConverter::BrukerFormula(converter),
+        Err(e) => eprintln!(
+            "Warning: could not build the SDK-free Bruker formula converter ({e}); \
+            falling back to derived/simple m/z calibration."
+        ),
+    }
+
     // Derive an accurate calibration via the SDK if possible, else the simple boundary model.
     match derive_mz_calibration(bruker_lib_path, data_path, tof_max_index) {
         Some((intercept, slope)) => TimsIndexConverter::Calibrated(CalibratedIndexConverter::new(
@@ -1167,7 +1297,7 @@ impl TimsDataLoader {
     /// `TimsCalibration` tables (frame `calibration_frame_id`, default 1 — the
     /// coefficients are near-constant per run). Needs no Bruker SDK at build or
     /// runtime; 1/K0 is machine-exact and m/z is bit-exact for MzCalibration
-    /// ModelType 1 (few ppm for ModelType 2).
+    /// ModelType 1 (~1 ppm for ModelType 2).
     pub fn new_lazy_with_bruker_formula(data_path: &str, calibration_frame_id: u32) -> Self {
         let raw_data_layout = TimsRawDataLayout::new(data_path);
         let index_converter = TimsIndexConverter::BrukerFormula(


### PR DESCRIPTION
Came out of the discussion in [rusteomics/mzcore#64](https://github.com/rusteomics/mzcore/issues/64), where @jspaezp shared [timsrust-calibration](https://github.com/jspaezp/timsrust-calibration) — the same idea as our `BrukerFormulaConverter` (read the calibration Bruker stores in the tdf instead of approximating it). Comparing the two implementations against the actual SDK turned up one real bug in ours and one design idea worth taking.

Everything below is measured with `libtimsdata.so` as ground truth on `synchro-hela.d` (m/z ModelType 1) and `G8602.d` (ModelType 2), full axis grid, via `examples/compare_all_converters`.

## 1. ModelType 2 must drop the C4 column (bug fix)

ModelType 2 reuses `C3` and `C4` as duplicates of `C0` and `C2` — bit-for-bit on real files. We already dropped `C3`, but still subtracted `C4` as if it were the reduced-mass shift `m0`, which biased every ModelType-2 m/z.

| `G8602.d`, TOF → m/z vs SDK | median | p90 | max |
|---|---|---|---|
| before | 1.93 | 6.55 | 11.10 ppm |
| after | **0.57** | **3.22** | **4.84 ppm** |

ModelType 1 is untouched and stays bit-exact.

A nice side effect: the ModelType-2 fine correction is windowed to `[C5, C6]` in m/z, so *below* `C5` (225.95) the `C0/C1/C2` quadratic is the entire model and now matches the SDK exactly (< 0.01 ppm). That is the sharpest test of the fix — with the duplicated `C4` subtracted, the error there is 4.6–11.1 ppm on a stretch where we should be exact.

## 2. Per-frame temperature compensation (idea borrowed from timsrust-calibration)

`BrukerFormulaConverter` captured one frame's calibration rows and temperatures and applied them to the whole run, ignoring the per-call `frame_id`. It now reads `Frames.T1`/`T2` and both calibration foreign keys for every frame and uses the ones belonging to the frame being converted; unknown frames and unsupported ModelTypes fall back to the old fixed calibration.

`dC1` is ~20 ppm/°C on these instruments, so pinning one frame's temperature costs ~20 ppm per °C of drift. On `synchro-hela.d` (T1 spread 0.006 °C) per-frame stays bit-exact from frame 1 to frame 11217, while pinning frame 1 drifts to 0.09 ppm by the end — small here, but it is the same mechanism that made jspaezp's run with a failed chiller (10 °C offset, ~200 ppm) unusable with a fixed calibration.

`temperature_spread()` reports the T1/T2 range over the run, so callers can tell a quiet run from a drifting one.

## 3. Use it by default when the SDK is not in play

`build_index_converter` fell back to an SDK-derived regression fit, or to the boundary model, whenever `use_bruker_sdk` was false or the SDK failed to load. Both of those use the **linear** scan → 1/K0 model:

| `G8602.d`, scan → 1/K0 vs SDK | median | p90 | max |
|---|---|---|---|
| Simple / Calibrated (linear) | 6396 | 8578 | 8673 ppm |
| BrukerFormula (tables) | **0.000** | **0.000** | **0.000** |

So the SDK-free path was giving up ~0.5 % on the mobility axis for no reason. Reading the file's own calibration needs no SDK at build or runtime, is machine-exact on 1/K0, and after change 1 also beats the SDK-derived regression on m/z (0.57 vs 1.58 ppm median on `G8602.d`, 0.000 vs 0.089 on `synchro-hela.d`). It is now the first choice; derived and boundary remain as fallbacks with a warning.

**Behaviour-change note:** on machines without the SDK, TimSim writes TOF indices with whatever converter this function returns. Writer and reader move together, so newly generated files are consistent (and now consistent with their own calibration tables), but simulated files generated on a no-SDK machine *before* this change encode the boundary model and will read back up to ~10 ppm shifted. Worth a mention in the release notes.

## Tests

Six unit tests in `src/data/calibration.rs` pin the above to SDK reference values (no SDK needed to run them): ModelType-1 bit-exactness, ModelType-2 exactness below the correction window and few-ppm inside it, `C3`/`C4` being zeroed for ModelType 2, m/z ↔ TOF round trip, and scan ↔ 1/K0 against `tims_scannum_to_oneoverk0`. Reverting the `C4` gate fails two of them. Full `cargo test` for rustdf passes (54 tests).

`BRUKER_TRANSLATORS.md` is updated with the new residuals and the windowing observation.
