### PR TITLE
fix(imspy-predictors): repair the Prosit/Koina fragment intensity path

### DIFF
--- a/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
@@ -435,13 +435,18 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
         data['sequence_length'] = data.apply(lambda r: len(remove_unimod_annotation(r.sequence)), axis=1)
 
         # Use Koina for prediction
-        I_pred = self._predict_with_koina(
+        I_pred, predicted = self._predict_with_koina(
             data.sequence.tolist(),
             data.charge.tolist(),
             data.collision_energy.tolist(),
             batch_size=batch_size,
+            return_mask=True,
         )
 
+        # False marks a precursor the model refused; its spectrum is all zeros,
+        # so a consumer can drop or flag it instead of treating the absence of
+        # fragments as a prediction.
+        data['intensity_predicted'] = predicted
         data['intensity_raw'] = list(I_pred)
         I_pred = self._to_prosit_tensors(post_process_predicted_fragment_spectra(data))
 
@@ -492,7 +497,13 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
     @classmethod
     def _assert_response_echoes_input(cls, result: pd.DataFrame, input_df: pd.DataFrame,
                                       rows: NDArray) -> None:
-        """Fail loudly if the response index no longer identifies the input row."""
+        """Fail loudly if the response index no longer identifies the input row.
+
+        Two submitted rows carrying an identical peptide, charge, collision energy
+        and instrument are indistinguishable to this check, so a reset index
+        would go unnoticed between them -- harmless, because the prediction they
+        would swap is by definition the same one.
+        """
         for column in cls._KOINA_ECHO_COLUMNS:
             if column not in result.columns or column not in input_df.columns:
                 continue
@@ -641,12 +652,19 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
             charges: List[int],
             collision_energies: List[float],
             batch_size: int = 512,
-    ) -> NDArray:
+            return_mask: bool = False,
+    ):
         """Predict fragment intensities via Koina.
+
+        Args:
+            return_mask: also return the boolean mask of precursors Koina
+                answered for. The rest keep an all-zero spectrum because the
+                model rejected them, which a caller may want to record or act
+                on rather than only read in the log.
 
         Returns:
             (len(sequences), 174) array of Prosit-layout intensities, aligned
-            row-for-row with ``sequences``.
+            row-for-row with ``sequences``; and the mask when ``return_mask``.
         """
         koina_model = self._get_koina_model()
 
@@ -662,8 +680,8 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
 
         result = koina_model.predict(input_df)
 
-        intensities, _predicted = self._koina_result_to_prosit_array(result, input_df)
-        return intensities
+        intensities, predicted = self._koina_result_to_prosit_array(result, input_df)
+        return (intensities, predicted) if return_mask else intensities
     def predict_intensities(
             self,
             sequences: List[str],

--- a/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
@@ -9,7 +9,9 @@ Classes:
     - IonIntensityPredictor: Abstract base class for intensity predictors
 """
 
+import logging
 import os
+import re
 from typing import List, Tuple, Optional
 
 from numpy.typing import NDArray
@@ -37,6 +39,8 @@ from imspy_predictors.lazy_imports import (
 
 from imspy_predictors.utility import InMemoryCheckpoint
 from imspy_predictors.losses import masked_spectral_distance
+
+logger = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------
@@ -448,6 +452,169 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
 
         return data
 
+    # Prosit fragment layout: 174 flat slots = 29 fragment ordinals x 6 ion
+    # types, ordered y+1, y+2, y+3, b+1, b+2, b+3. Must stay in step with
+    # utility.reshape_dims (174 -> 29 x 6) and utility.mask_outofcharge,
+    # which assume exactly this ordering.
+    _PROSIT_MAX_ORDINAL = 29
+    _PROSIT_MAX_ION_CHARGE = 3
+    _PROSIT_ION_TYPES = 6
+    _PROSIT_VECTOR_LENGTH = _PROSIT_MAX_ORDINAL * _PROSIT_ION_TYPES
+    _PROSIT_ION_TYPE_OFFSET = {"y": 0, "b": 3}
+    _KOINA_ANNOTATION_RE = re.compile(r"^([by])(\d+)\+(\d+)$")
+
+    # Columns Koina echoes back unchanged. Comparing them against the submitted
+    # frame is what proves the response index still identifies the peptide it
+    # was built from -- a bare range check cannot tell a preserved index from a
+    # reset one, and a reset index is precisely the silent-corruption case.
+    _KOINA_ECHO_COLUMNS = ("peptide_sequences", "precursor_charges", "instrument_types")
+
+    @classmethod
+    def _assert_response_echoes_input(cls, result: pd.DataFrame, input_df: pd.DataFrame,
+                                      rows: NDArray) -> None:
+        """Fail loudly if the response index no longer identifies the input row."""
+        for column in cls._KOINA_ECHO_COLUMNS:
+            if column not in result.columns or column not in input_df.columns:
+                continue
+            expected = input_df[column].to_numpy()[rows]
+            got = result[column].to_numpy()
+            mismatch = expected != got
+            if mismatch.any():
+                i = int(np.argmax(mismatch))
+                raise ValueError(
+                    f"Koina response row {i} echoes {column}={got[i]!r}, but input row "
+                    f"{int(rows[i])} holds {expected[i]!r}. The response index no longer "
+                    f"identifies the submitted peptide, so fragment intensities would be "
+                    f"assigned to the wrong precursor. Refusing to continue."
+                )
+
+        if "collision_energies" in result.columns and "collision_energies" in input_df.columns:
+            expected = input_df["collision_energies"].to_numpy(dtype=np.float64)[rows]
+            got = result["collision_energies"].to_numpy(dtype=np.float64)
+            mismatch = ~np.isclose(expected, got, rtol=0.0, atol=1e-4)
+            if mismatch.any():
+                i = int(np.argmax(mismatch))
+                raise ValueError(
+                    f"Koina response row {i} echoes collision_energies={got[i]!r}, but input "
+                    f"row {int(rows[i])} holds {expected[i]!r}. Refusing to continue."
+                )
+
+    @classmethod
+    def _koina_result_to_prosit_array(cls, result: pd.DataFrame, input_df: pd.DataFrame) -> NDArray:
+        """Fold Koina's long-format response into one Prosit vector per input row.
+
+        Koina returns one row *per fragment ion*, not one row per peptide, and
+        ``ModelFromKoina.predict`` silently drops peptides that violate the
+        model's requirements (length > 30, unsupported modifications, charge out
+        of range). Surviving rows keep the index of the input frame, so keying on
+        that index is the only safe way back: assigning positionally shifts every
+        spectrum after the first dropped peptide onto the wrong precursor, which
+        no downstream step can detect. See the warning in
+        ``koina_models.access_models.ModelFromKoina.predict``.
+
+        Every assumption this makes about the response is checked rather than
+        trusted, because the failure mode is silent corruption of simulated
+        ground truth, not a crash. Peptides the filter rejected keep an all-zero
+        spectrum and are reported by the returned mask.
+
+        Returns:
+            (intensities, predicted) where ``intensities`` is
+            (len(input_df), 174) in Prosit layout and ``predicted`` is a boolean
+            mask marking the rows Koina actually returned fragments for.
+        """
+        n_inputs = len(input_df)
+        out = np.zeros((n_inputs, cls._PROSIT_VECTOR_LENGTH), dtype=np.float32)
+        predicted = np.zeros(n_inputs, dtype=bool)
+
+        if result is None or len(result) == 0:
+            logger.warning(
+                "Koina returned no predictions for %d peptides (model %s); "
+                "all fragment spectra will be empty.", n_inputs, cls.KOINA_MODEL_NAME,
+            )
+            return out, predicted
+
+        missing = [c for c in ("intensities", "annotation") if c not in result.columns]
+        if missing:
+            raise ValueError(
+                f"Koina response for {cls.KOINA_MODEL_NAME} is missing column(s) "
+                f"{missing}; got {list(result.columns)}. Cannot map fragment "
+                f"intensities back to their precursors."
+            )
+
+        rows = np.asarray(result.index, dtype=np.int64)
+        if rows.min() < 0 or rows.max() >= n_inputs:
+            raise ValueError(
+                f"Koina response index is out of range for the {n_inputs} peptides "
+                f"submitted (saw [{rows.min()}, {rows.max()}]). Refusing to guess the "
+                f"peptide each fragment belongs to."
+            )
+
+        cls._assert_response_echoes_input(result, input_df, rows)
+
+        intensities = result["intensities"].to_numpy(dtype=np.float32)
+        if not np.isfinite(intensities).all():
+            n_bad = int((~np.isfinite(intensities)).sum())
+            raise ValueError(
+                f"Koina returned {n_bad} non-finite fragment intensities for "
+                f"{cls.KOINA_MODEL_NAME}. These would propagate through base-peak "
+                f"normalisation into corrupted spectra."
+            )
+
+        slots = np.full(rows.shape, -1, dtype=np.int64)
+        unmapped = []
+        for i, annotation in enumerate(result["annotation"].to_numpy()):
+            if isinstance(annotation, (bytes, bytearray)):
+                annotation = annotation.decode("ascii", errors="replace")
+            annotation = str(annotation).strip()
+            match = cls._KOINA_ANNOTATION_RE.match(annotation)
+            if match is None:
+                unmapped.append(annotation)
+                continue
+            ion_type, ordinal, ion_charge = match.group(1), int(match.group(2)), int(match.group(3))
+            if not 1 <= ordinal <= cls._PROSIT_MAX_ORDINAL:
+                unmapped.append(annotation)
+                continue
+            if not 1 <= ion_charge <= cls._PROSIT_MAX_ION_CHARGE:
+                unmapped.append(annotation)
+                continue
+            slots[i] = ((ordinal - 1) * cls._PROSIT_ION_TYPES
+                        + cls._PROSIT_ION_TYPE_OFFSET[ion_type]
+                        + (ion_charge - 1))
+
+        if unmapped:
+            raise ValueError(
+                f"{len(unmapped)} of {len(result)} fragment annotations from "
+                f"{cls.KOINA_MODEL_NAME} do not fit the Prosit b/y layout "
+                f"(e.g. {sorted(set(unmapped))[:5]}). The response format has changed; "
+                f"refusing to silently drop that signal."
+            )
+
+        # One flat slot must be written at most once. 'Last row wins' would make
+        # the result depend on response ordering.
+        flat = rows * cls._PROSIT_VECTOR_LENGTH + slots
+        unique_flat, counts = np.unique(flat, return_counts=True)
+        if (counts > 1).any():
+            n_dup = int((counts > 1).sum())
+            raise ValueError(
+                f"Koina returned {n_dup} duplicated (peptide, fragment) slots for "
+                f"{cls.KOINA_MODEL_NAME}. Which intensity wins would depend on response "
+                f"ordering, so the result is not reproducible. Refusing to continue."
+            )
+
+        out.reshape(-1)[flat] = intensities
+        predicted[np.unique(rows)] = True
+
+        n_dropped = n_inputs - int(predicted.sum())
+        if n_dropped:
+            logger.warning(
+                "%d/%d peptides were rejected by the Koina input filter for %s and keep an "
+                "all-zero fragment spectrum (no MS2 signal will be simulated for them). "
+                "Prosit supports only unmodified residues, C[UNIMOD:4] and M[UNIMOD:35], "
+                "sequences up to 30 aa and charges 1-6.",
+                n_dropped, n_inputs, cls.KOINA_MODEL_NAME,
+            )
+
+        return out, predicted
     def _predict_with_koina(
             self,
             sequences: List[str],
@@ -455,10 +622,17 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
             collision_energies: List[float],
             batch_size: int = 512,
     ) -> NDArray:
-        """Predict intensities using Koina API."""
+        """Predict fragment intensities via Koina.
+
+        Returns:
+            (len(sequences), 174) array of Prosit-layout intensities, aligned
+            row-for-row with ``sequences``.
+        """
         koina_model = self._get_koina_model()
 
-        # Prepare input DataFrame for Koina
+        # Prepare input DataFrame for Koina. The default RangeIndex is what
+        # _koina_result_to_prosit_array keys the response back on, so it must
+        # stay 0..n-1 and positional.
         input_df = pd.DataFrame({
             'peptide_sequences': sequences,
             'precursor_charges': charges,
@@ -466,23 +640,10 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
             'instrument_types': ['TIMSTOF'] * len(sequences),
         })
 
-        # Get predictions from Koina
         result = koina_model.predict(input_df)
 
-        # Extract intensities from result
-        # Koina returns a DataFrame with intensities column
-        if 'intensities' in result.columns:
-            intensities = np.vstack(result['intensities'].values)
-        else:
-            # Fallback: try to extract from first numeric column
-            numeric_cols = result.select_dtypes(include=[np.number]).columns
-            if len(numeric_cols) > 0:
-                intensities = result[numeric_cols].values
-            else:
-                raise ValueError("Could not extract intensities from Koina response")
-
+        intensities, _predicted = self._koina_result_to_prosit_array(result, input_df)
         return intensities
-
     def predict_intensities(
             self,
             sequences: List[str],

--- a/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
+++ b/packages/imspy-predictors/src/imspy_predictors/intensity/predictors.py
@@ -443,14 +443,34 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
         )
 
         data['intensity_raw'] = list(I_pred)
-        I_pred = np.squeeze(reshape_dims(post_process_predicted_fragment_spectra(data)))
+        I_pred = self._to_prosit_tensors(post_process_predicted_fragment_spectra(data))
 
         if flatten:
-            I_pred = np.vstack([flatten_prosit_array(r) for r in I_pred])
+            I_pred = [flatten_prosit_array(r) for r in I_pred]
 
-        data['intensity'] = list(I_pred)
+        data['intensity'] = I_pred
 
         return data
+
+    @staticmethod
+    def _to_prosit_tensors(processed: NDArray) -> List[NDArray]:
+        """Turn post-processed (n, 174) intensities into one (29, 2, 3) tensor per precursor.
+
+        Consumers index these as [ordinal, ion_type, charge] with ion_type 0 = y
+        and 1 = b -- see ``imspy_simulation.utility.flatten_prosit_array``, which
+        reads ``array[:, 0, c]`` / ``array[:, 1, c]`` and therefore requires three
+        dimensions. A C-order reshape of the (29, 6) layout produces exactly that,
+        because the 6 slots per ordinal are already ordered y+1, y+2, y+3, b+1,
+        b+2, b+3.
+
+        ``np.squeeze`` must not be used here: for a single-precursor batch it drops
+        the batch axis, and every consumer then reads the 29 ordinals as if they
+        were 29 separate precursors.
+        """
+        cube = reshape_dims(processed)          # (n, 29, 6), or (29, 6) for n == 1
+        if cube.ndim == 2:
+            cube = cube[None, ...]
+        return [arr.reshape(29, 2, 3) for arr in cube]
 
     # Prosit fragment layout: 174 flat slots = 29 fragment ordinals x 6 ion
     # types, ordered y+1, y+2, y+3, b+1, b+2, b+3. Must stay in step with
@@ -668,13 +688,13 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
         )
 
         I_pred = list(I_pred)
-        I_pred = np.squeeze(reshape_dims(post_process_predicted_fragment_spectra(pd.DataFrame({
+        I_pred = self._to_prosit_tensors(post_process_predicted_fragment_spectra(pd.DataFrame({
             'sequence': sequences,
             'charge': charges,
             'collision_energy': collision_energies,
             'sequence_length': sequence_length,
             'intensity_raw': I_pred,
-        }))))
+        })))
 
         if flatten:
             I_pred = np.vstack([flatten_prosit_array(r) for r in I_pred])
@@ -704,13 +724,13 @@ class Prosit2023TimsTofWrapper(IonIntensityPredictor):
         )
 
         I_pred = list(I_pred)
-        I_pred = np.squeeze(reshape_dims(post_process_predicted_fragment_spectra(pd.DataFrame({
+        I_pred = self._to_prosit_tensors(post_process_predicted_fragment_spectra(pd.DataFrame({
             'sequence': sequences,
             'charge': charges,
             'collision_energy': collision_energies,
             'sequence_length': sequence_length,
             'intensity_raw': I_pred,
-        }))))
+        })))
 
         intensities = np.vstack([flatten_prosit_array(r) for r in I_pred])
         peptide_sequences = [PeptideSequence(s) for s in sequences]

--- a/packages/imspy-predictors/tests/test_koina_intensity_alignment.py
+++ b/packages/imspy-predictors/tests/test_koina_intensity_alignment.py
@@ -1,0 +1,202 @@
+"""Tests for the Koina fragment-intensity response mapping.
+
+Koina answers a fragment-intensity request with one row *per fragment ion*,
+keyed by the index of the submitted frame, and silently drops peptides that
+violate the model's requirements. Mapping that back onto the input by position
+instead of by index assigns spectra to the wrong precursors -- an error nothing
+downstream can detect, because a shifted spectrum is still a plausible one.
+
+These tests build the response by hand so the mapping can be pinned without
+network access; the live-server checks are collected at the bottom and skipped
+by default.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from imspy_predictors.intensity.predictors import Prosit2023TimsTofWrapper
+
+
+VECTOR_LENGTH = Prosit2023TimsTofWrapper._PROSIT_VECTOR_LENGTH
+
+
+def make_input(sequences, charges=None, collision_energies=None):
+    n = len(sequences)
+    return pd.DataFrame({
+        "peptide_sequences": list(sequences),
+        "precursor_charges": list(charges) if charges else [2] * n,
+        "collision_energies": list(collision_energies) if collision_energies else [0.3] * n,
+        "instrument_types": ["TIMSTOF"] * n,
+    })
+
+
+def make_response(input_df, rows, annotations, intensities):
+    """Build a Koina-shaped response: one row per fragment, indexed by input row."""
+    return pd.DataFrame(
+        {
+            "peptide_sequences": input_df["peptide_sequences"].to_numpy()[rows],
+            "precursor_charges": input_df["precursor_charges"].to_numpy()[rows],
+            "collision_energies": input_df["collision_energies"].to_numpy()[rows],
+            "instrument_types": input_df["instrument_types"].to_numpy()[rows],
+            "intensities": np.asarray(intensities, dtype=np.float32),
+            "annotation": [a.encode() for a in annotations],
+        },
+        index=np.asarray(rows),
+    )
+
+
+class TestPrositSlotLayout:
+    """The 174 flat slots are 29 ordinals x (y+1, y+2, y+3, b+1, b+2, b+3)."""
+
+    @pytest.mark.parametrize("annotation,expected_slot", [
+        ("y1+1", 0), ("y1+2", 1), ("y1+3", 2),
+        ("b1+1", 3), ("b1+2", 4), ("b1+3", 5),
+        ("y2+1", 6), ("y29+3", 170), ("b29+3", 173),
+    ])
+    def test_annotation_maps_to_expected_slot(self, annotation, expected_slot):
+        inp = make_input(["PEPTIDEK"])
+        res = make_response(inp, [0], [annotation], [0.5])
+        out, predicted = Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+        assert out.shape == (1, VECTOR_LENGTH)
+        assert out[0, expected_slot] == pytest.approx(0.5)
+        assert out[0].sum() == pytest.approx(0.5), "intensity landed in more than one slot"
+        assert predicted.tolist() == [True]
+
+    def test_layout_matches_reshape_dims(self):
+        """(29, 6) after reshape, y ions on 0-2 and b ions on 3-5 as mask_outofcharge assumes."""
+        from imspy_predictors.intensity.utility import reshape_dims
+
+        inp = make_input(["PEPTIDEK"])
+        res = make_response(inp, [0, 0], ["y3+2", "b3+2"], [0.25, 0.75])
+        out, _ = Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+        cube = reshape_dims(out)
+        assert cube.shape == (1, 29, 6)
+        assert cube[0, 2, 1] == pytest.approx(0.25)   # y3, charge 2
+        assert cube[0, 2, 4] == pytest.approx(0.75)   # b3, charge 2
+
+
+class TestFilteredPeptideAlignment:
+    """Peptides the input filter drops must not shift their neighbours."""
+
+    @pytest.mark.parametrize("dropped", [0, 1, 2])
+    def test_dropped_peptide_keeps_neighbours_in_place(self, dropped):
+        inp = make_input(["AAAAAK", "BBBBBK", "CCCCCK"])
+        kept = [r for r in range(3) if r != dropped]
+        rows = [r for r in kept for _ in range(2)]
+        annotations = ["y1+1", "b1+1"] * len(kept)
+        intensities = [0.1 * (r + 1) for r in kept for _ in range(2)]
+        res = make_response(inp, rows, annotations, intensities)
+
+        out, predicted = Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+        assert not out[dropped].any(), "dropped peptide should keep an all-zero spectrum"
+        assert predicted[dropped] is np.False_
+        for r in kept:
+            assert out[r, 0] == pytest.approx(0.1 * (r + 1)), f"row {r} got another peptide's spectrum"
+            assert predicted[r] is np.True_
+
+    def test_all_peptides_dropped_yields_empty_spectra(self):
+        inp = make_input(["AAAAAK", "BBBBBK"])
+        out, predicted = Prosit2023TimsTofWrapper._koina_result_to_prosit_array(pd.DataFrame(), inp)
+        assert out.shape == (2, VECTOR_LENGTH)
+        assert not out.any()
+        assert not predicted.any()
+
+
+class TestResponseIntegrityGuards:
+    """Every assumption about the response is checked, not trusted."""
+
+    def test_reset_index_is_rejected(self):
+        """A response re-indexed 0..n_survivors-1 stays in range but means something else."""
+        inp = make_input(["AAAAAK", "BBBBBK", "CCCCCK"])
+        res = make_response(inp, [1, 2], ["y1+1", "y1+1"], [0.4, 0.6])
+        res.index = pd.Index([0, 1])          # what reset_index(drop=True) would produce
+        with pytest.raises(ValueError, match="no longer identifies the submitted peptide"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    def test_reordered_response_is_rejected(self):
+        inp = make_input(["AAAAAK", "BBBBBK"])
+        res = make_response(inp, [0, 1], ["y1+1", "y1+1"], [0.4, 0.6])
+        res.index = pd.Index([1, 0])          # index no longer describes the echoed peptide
+        with pytest.raises(ValueError, match="no longer identifies the submitted peptide"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    def test_collision_energy_mismatch_is_rejected(self):
+        inp = make_input(["AAAAAK"], collision_energies=[0.30])
+        res = make_response(inp, [0], ["y1+1"], [0.4])
+        res["collision_energies"] = 0.35
+        with pytest.raises(ValueError, match="collision_energies"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    def test_out_of_range_index_is_rejected(self):
+        inp = make_input(["AAAAAK"])
+        res = make_response(inp, [0], ["y1+1"], [0.4])
+        res.index = pd.Index([7])
+        with pytest.raises(ValueError, match="out of range"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    def test_duplicate_slot_is_rejected(self):
+        """Which duplicate wins would depend on response ordering."""
+        inp = make_input(["AAAAAK"])
+        res = make_response(inp, [0, 0], ["y1+1", "y1+1"], [0.4, 0.6])
+        with pytest.raises(ValueError, match="duplicated"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    def test_unmappable_annotation_is_rejected(self):
+        """An annotation format change must not silently remove signal."""
+        inp = make_input(["AAAAAK"])
+        res = make_response(inp, [0, 0], ["y1+1", "y1-NH3+1"], [0.4, 0.6])
+        with pytest.raises(ValueError, match="do not fit the Prosit b/y layout"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    @pytest.mark.parametrize("annotation", ["y30+1", "y1+4", "y0+1"])
+    def test_out_of_layout_fragment_is_rejected(self, annotation):
+        inp = make_input(["AAAAAK"])
+        res = make_response(inp, [0], [annotation], [0.4])
+        with pytest.raises(ValueError, match="do not fit the Prosit b/y layout"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    @pytest.mark.parametrize("bad_value", [np.nan, np.inf])
+    def test_non_finite_intensity_is_rejected(self, bad_value):
+        inp = make_input(["AAAAAK"])
+        res = make_response(inp, [0, 0], ["y1+1", "b1+1"], [0.4, bad_value])
+        with pytest.raises(ValueError, match="non-finite"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+    def test_missing_annotation_column_is_rejected(self):
+        inp = make_input(["AAAAAK"])
+        res = make_response(inp, [0], ["y1+1"], [0.4]).drop(columns=["annotation"])
+        with pytest.raises(ValueError, match="missing column"):
+            Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
+
+
+@pytest.mark.skipif(
+    True,  # Set to False to run network tests
+    reason="Network tests disabled by default"
+)
+class TestKoinaIntensityAlignmentLive:
+    """Same alignment contract, against the live Koina server."""
+
+    def test_filtered_peptide_does_not_shift_the_batch(self):
+        wrapper = Prosit2023TimsTofWrapper(verbose=False)
+        good_a, too_long, good_b = "LGGNEQVTR", "A" * 38, "KLVSMHK"
+
+        solo_a = wrapper._predict_with_koina([good_a], [2], [0.3])
+        solo_b = wrapper._predict_with_koina([good_b], [2], [0.3])
+        batched = wrapper._predict_with_koina(
+            [good_a, too_long, good_b], [2, 2, 2], [0.3, 0.3, 0.3])
+
+        # Koina serves float32 and batches server-side, so repeated calls differ
+        # by ~1e-7; compare with a tolerance rather than bit-exactly.
+        assert np.allclose(batched[0], solo_a[0], atol=1e-5)
+        assert not batched[1].any()
+        assert np.allclose(batched[2], solo_b[0], atol=1e-5)
+
+    def test_n_terminal_acetylation_is_filtered_not_misassigned(self):
+        wrapper = Prosit2023TimsTofWrapper(verbose=False)
+        solo = wrapper._predict_with_koina(["KLVSMHK"], [2], [0.3])
+        batched = wrapper._predict_with_koina(
+            ["[UNIMOD:1]KLVSMHK", "KLVSMHK"], [2, 2], [0.3, 0.3])
+        assert not batched[0].any(), "Prosit does not support N-terminal acetylation"
+        assert np.allclose(batched[1], solo[0], atol=1e-5)

--- a/packages/imspy-predictors/tests/test_koina_intensity_alignment.py
+++ b/packages/imspy-predictors/tests/test_koina_intensity_alignment.py
@@ -171,6 +171,57 @@ class TestResponseIntegrityGuards:
             Prosit2023TimsTofWrapper._koina_result_to_prosit_array(res, inp)
 
 
+class TestPrositTensorShape:
+    """The Prosit path must hand consumers (29, 2, 3) tensors, not (29, 6).
+
+    ``imspy_simulation.utility.flatten_prosit_array`` reads ``array[:, 0, c]``
+    and ``array[:, 1, c]``, so a 2-D array raises a numba TypingError deep in
+    frame assembly; and ``np.squeeze`` on a single-precursor batch silently
+    turns 29 ordinals into 29 'precursors'.
+    """
+
+    def test_flat_vector_maps_onto_ordinal_iontype_charge(self):
+        # Label every slot with its own index so each one can be traced.
+        processed = np.arange(VECTOR_LENGTH, dtype=np.float32)[None, :]
+        tensors = Prosit2023TimsTofWrapper._to_prosit_tensors(processed)
+
+        assert len(tensors) == 1
+        assert tensors[0].shape == (29, 2, 3)
+        t = tensors[0]
+        assert t[0, 0, 0] == 0      # y1+1
+        assert t[0, 0, 2] == 2      # y1+3
+        assert t[0, 1, 0] == 3      # b1+1
+        assert t[1, 0, 0] == 6      # y2+1
+        assert t[28, 1, 2] == 173   # b29+3
+
+    @pytest.mark.parametrize("n_precursors", [1, 2, 5])
+    def test_one_tensor_per_precursor(self, n_precursors):
+        """A batch of one must not collapse into 29 pseudo-precursors."""
+        processed = np.zeros((n_precursors, VECTOR_LENGTH), dtype=np.float32)
+        tensors = Prosit2023TimsTofWrapper._to_prosit_tensors(processed)
+        assert len(tensors) == n_precursors
+        assert all(t.shape == (29, 2, 3) for t in tensors)
+
+    def test_flatten_prosit_array_accepts_the_tensor(self):
+        """The simulation-side consumer needs 3 dimensions and a lossless layout."""
+        from imspy_predictors.lazy_imports import get_simulation_flatten_prosit
+
+        flatten_prosit_array = get_simulation_flatten_prosit()
+        processed = np.arange(VECTOR_LENGTH, dtype=np.float32)[None, :]
+        tensor = Prosit2023TimsTofWrapper._to_prosit_tensors(processed)[0]
+
+        flat = flatten_prosit_array(tensor)
+
+        assert flat.shape == (VECTOR_LENGTH,)
+        # Block layout: [y c1][b c1][y c2][b c2][y c3][b c3], 29 entries each.
+        assert flat[0] == 0 and flat[1] == 6      # y1+1, y2+1
+        assert flat[29] == 3 and flat[30] == 9    # b1+1, b2+1
+        assert flat[58] == 1                      # y1+2
+        assert flat[87] == 4                      # b1+2
+        # A permutation: nothing lost, nothing duplicated.
+        assert sorted(flat.tolist()) == sorted(float(i) for i in range(VECTOR_LENGTH))
+
+
 @pytest.mark.skipif(
     True,  # Set to False to run network tests
     reason="Network tests disabled by default"

--- a/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_fragment_intensities.py
+++ b/packages/imspy-simulation/src/imspy_simulation/timsim/jobs/simulate_fragment_intensities.py
@@ -76,6 +76,87 @@ def _koina_input_df(model, data: pd.DataFrame, encoded_ce) -> pd.DataFrame:
     return pd.DataFrame(cols)
 
 
+def _fill_prosit_rejects_with_local_model(
+    i_pred: pd.DataFrame,
+    transmitted_fragment_ions: pd.DataFrame,
+    batch_size: int,
+    verbose: bool,
+) -> pd.DataFrame:
+    """Predict the precursors Prosit refused with the local PyTorch model.
+
+    Prosit accepts only unmodified residues, C[UNIMOD:4] and M[UNIMOD:35], up to
+    30 aa. Everything else -- N-terminal acetylation and cysteinylation above all,
+    both common in immunopeptidomics -- comes back with an empty spectrum, which
+    would simulate a precursor that no search engine can ever identify. The local
+    model has no such restriction, so it covers exactly those precursors.
+
+    The subset is taken from ``transmitted_fragment_ions`` rather than from
+    ``i_pred`` because both predictors normalise ``collision_energy`` in place
+    (dividing by 100, which the Rust frame builder keys on); re-predicting from an
+    already-normalised frame would divide a second time and quietly shift every
+    fallback spectrum to a collision energy 100x too low.
+    """
+    if "intensity_predicted" not in i_pred.columns:
+        return i_pred
+
+    rejected = ~i_pred["intensity_predicted"].to_numpy(dtype=bool)
+    n_rejected = int(rejected.sum())
+    if n_rejected == 0:
+        return i_pred
+
+    if len(i_pred) != len(transmitted_fragment_ions):
+        raise ValueError(
+            f"Prosit returned {len(i_pred)} rows for {len(transmitted_fragment_ions)} "
+            f"transmitted ions. Row order is the only thing tying the two frames "
+            f"together, so the fallback subset cannot be identified safely."
+        )
+
+    # Row order is the only link between the two frames; verify the whole column
+    # rather than trust it, since a mismatch would predict the wrong peptide's
+    # spectrum. Checking every row, not just the rejected ones, catches a frame
+    # that has been reordered somewhere upstream even when the rejected rows
+    # happen to land on themselves.
+    got = i_pred["sequence"].to_numpy()
+    expected = transmitted_fragment_ions["sequence"].to_numpy()
+    if not np.array_equal(got, expected):
+        i = int(np.argmax(got != expected))
+        raise ValueError(
+            f"Prosit result row {i} holds sequence {got[i]!r} but the transmitted ion "
+            f"at that position is {expected[i]!r}. The two frames are no longer in the "
+            f"same order, so refusing to predict a fallback spectrum for the wrong peptide."
+        )
+
+    positions = np.flatnonzero(rejected)
+    source = transmitted_fragment_ions.iloc[positions]
+
+    logger.info(
+        "Falling back to the local intensity model for %d/%d precursor(s) Prosit rejected ...",
+        n_rejected, len(i_pred),
+    )
+
+    local_predictor = DeepPeptideIntensityPredictor(verbose=verbose)
+    filled = local_predictor.simulate_ion_intensities_pandas_batched(
+        source.copy(),
+        batch_size_tf_ds=batch_size,
+    )
+    if len(filled) != n_rejected:
+        raise ValueError(
+            f"Local intensity model returned {len(filled)} spectra for {n_rejected} "
+            f"rejected precursors; refusing to splice a misaligned result."
+        )
+
+    # Positional splice: the local model's batching resets the index, so only the
+    # row order carries the correspondence back.
+    intensities = list(i_pred["intensity"])
+    for position, spectrum in zip(positions, list(filled["intensity"])):
+        intensities[position] = spectrum
+    i_pred["intensity"] = intensities
+    i_pred["intensity_predicted"] = True
+    i_pred["intensity_model"] = np.where(rejected, "local", "prosit")
+
+    return i_pred
+
+
 def _predict_intensities_with_koina(
     data: pd.DataFrame,
     model_name: str,
@@ -396,6 +477,9 @@ def _simulate_fragment_intensities_standard(
         i_pred = IntensityPredictor.simulate_ion_intensities_pandas_batched(
             transmitted_fragment_ions,
             batch_size_tf_ds=batch_size,
+        )
+        i_pred = _fill_prosit_rejects_with_local_model(
+            i_pred, transmitted_fragment_ions, batch_size=batch_size, verbose=verbose,
         )
         intensity_already_flat = False  # (len,2,3) tensors
 

--- a/packages/imspy-simulation/tests/test_prosit_local_fallback.py
+++ b/packages/imspy-simulation/tests/test_prosit_local_fallback.py
@@ -1,0 +1,113 @@
+"""Tests for the Prosit -> local-model fallback in the fragment-intensity job.
+
+Prosit rejects N-terminal acetylation, cysteinylation and sequences over 30 aa,
+which would leave those precursors with no MS2 signal at all. The fallback
+predicts them with the local model instead. It splices results back by row
+position, so these tests pin the position handling: a spectrum landing on the
+wrong precursor is a plausible spectrum, and nothing downstream would notice.
+
+The local predictor is stubbed so none of this needs network or model weights.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from imspy_simulation.timsim.jobs import simulate_fragment_intensities as job
+
+
+def tensor(fill):
+    return np.full((29, 2, 3), fill, dtype=np.float32)
+
+
+@pytest.fixture
+def transmitted():
+    return pd.DataFrame({
+        "sequence": ["PEPTIDEK", "[UNIMOD:1]ACETYLK", "OTHERK"],
+        "charge": [2, 2, 2],
+        "collision_energy": [30.0, 30.0, 30.0],
+    })
+
+
+@pytest.fixture
+def prosit_result(transmitted):
+    """What the Prosit wrapper returns: row 1 rejected, CE already normalised."""
+    out = transmitted.copy()
+    out["collision_energy"] = out["collision_energy"] / 100.0
+    out["intensity_predicted"] = [True, False, True]
+    out["intensity"] = [tensor(0.1), tensor(0.0), tensor(0.3)]
+    return out
+
+
+@pytest.fixture
+def stub_local(monkeypatch):
+    """Stand in for the local model, recording what it was asked to predict."""
+    seen = {}
+
+    class StubPredictor:
+        def __init__(self, verbose=False):
+            pass
+
+        def simulate_ion_intensities_pandas_batched(self, data, batch_size_tf_ds=None):
+            seen["sequences"] = data["sequence"].tolist()
+            seen["collision_energies"] = data["collision_energy"].tolist()
+            out = data.copy().reset_index(drop=True)   # the real one resets the index
+            out["intensity"] = [tensor(0.9) for _ in range(len(out))]
+            return out
+
+    monkeypatch.setattr(job, "DeepPeptideIntensityPredictor", StubPredictor)
+    return seen
+
+
+class TestPrositLocalFallback:
+
+    def test_only_the_rejected_row_is_replaced(self, prosit_result, transmitted, stub_local):
+        filled = job._fill_prosit_rejects_with_local_model(
+            prosit_result, transmitted, batch_size=512, verbose=False)
+
+        assert filled["intensity"].iloc[0].max() == pytest.approx(0.1), "Prosit row was overwritten"
+        assert filled["intensity"].iloc[1].max() == pytest.approx(0.9), "fallback did not land on the rejected row"
+        assert filled["intensity"].iloc[2].max() == pytest.approx(0.3), "Prosit row was overwritten"
+
+    def test_the_rejected_peptide_is_what_gets_predicted(self, prosit_result, transmitted, stub_local):
+        job._fill_prosit_rejects_with_local_model(
+            prosit_result, transmitted, batch_size=512, verbose=False)
+        assert stub_local["sequences"] == ["[UNIMOD:1]ACETYLK"]
+
+    def test_collision_energy_is_not_normalised_twice(self, prosit_result, transmitted, stub_local):
+        """The subset must come from the raw frame, not from the normalised result."""
+        job._fill_prosit_rejects_with_local_model(
+            prosit_result, transmitted, batch_size=512, verbose=False)
+        assert stub_local["collision_energies"] == [30.0], "fallback was fed an already-normalised CE"
+
+    def test_provenance_is_recorded(self, prosit_result, transmitted, stub_local):
+        filled = job._fill_prosit_rejects_with_local_model(
+            prosit_result, transmitted, batch_size=512, verbose=False)
+        assert filled["intensity_model"].tolist() == ["prosit", "local", "prosit"]
+        assert filled["intensity_predicted"].all()
+
+    def test_nothing_to_do_when_prosit_took_everything(self, prosit_result, transmitted, stub_local):
+        prosit_result["intensity_predicted"] = True
+        filled = job._fill_prosit_rejects_with_local_model(
+            prosit_result, transmitted, batch_size=512, verbose=False)
+        assert "sequences" not in stub_local, "local model should not have been called"
+        assert filled["intensity"].iloc[1].max() == pytest.approx(0.0)
+
+    def test_reordered_frames_are_rejected(self, prosit_result, transmitted, stub_local):
+        scrambled = transmitted.iloc[::-1].reset_index(drop=True)
+        with pytest.raises(ValueError, match="no longer in the same order"):
+            job._fill_prosit_rejects_with_local_model(
+                prosit_result, scrambled, batch_size=512, verbose=False)
+
+    def test_length_mismatch_is_rejected(self, prosit_result, transmitted, stub_local):
+        with pytest.raises(ValueError, match="Row order is the only|cannot be identified safely"):
+            job._fill_prosit_rejects_with_local_model(
+                prosit_result, transmitted.iloc[:2], batch_size=512, verbose=False)
+
+    def test_missing_mask_is_a_no_op(self, prosit_result, transmitted, stub_local):
+        """Older predictors that do not report a mask must not break the job."""
+        prosit_result = prosit_result.drop(columns=["intensity_predicted"])
+        filled = job._fill_prosit_rejects_with_local_model(
+            prosit_result, transmitted, batch_size=512, verbose=False)
+        assert "sequences" not in stub_local
+        assert "intensity_model" not in filled.columns


### PR DESCRIPTION
## Summary

`intensity_model = "prosit"` could not complete a timsim run. Fixing the first
failure exposed a second one behind it; both are in the Prosit/Koina fragment
intensity path, and both were capable of corrupting spectra silently rather than
crashing.

### 1. The Koina response was mapped back by position, not by index

`Prosit2023TimsTofWrapper._predict_with_koina` assumed the response holds one row
per peptide, aligned with the request. It holds **one row per fragment ion**,
keyed by the index of the submitted frame, and `ModelFromKoina.predict` drops
peptides that violate the model's requirements before sending. A 2,510-peptide
batch came back as 54,036 rows:

```
ValueError: Length of values (54036) does not match length of index (2510)
```

The crash was the lucky outcome. Had the counts lined up, every spectrum after
the first dropped peptide would have been attributed to the wrong precursor —
and a shifted spectrum is still a plausible spectrum, so nothing downstream
could have flagged it. `predict()`'s own docstring already warns that callers
must key results back by index rather than assign positionally.

### 2. The Prosit path emitted (29, 6) where every consumer expects (29, 2, 3)

With the mapping fixed the run reached frame assembly and died in numba:

```
NumbaTypeError: cannot index array(float32, 2d, C) with 3 indices
```

`imspy_simulation.utility.flatten_prosit_array` reads `array[:, 0, c]` (y ions)
and `array[:, 1, c]` (b ions), and `simulate_fragment_intensities` documents the
column as `(len,2,3) tensors` in all three places it sets
`intensity_already_flat = False`. `DeepPeptideIntensityPredictor`, the local
model on the same code path, does the final `.reshape(29, 2, 3)` and works; the
Koina wrapper stopped at `np.squeeze(reshape_dims(...))`, at three call sites.

Dropping `np.squeeze` also fixes a latent single-precursor bug: for a batch of
one it collapsed the batch axis, leaving consumers to read 29 fragment ordinals
as if they were 29 precursors.

### 3. Prosit's input filter is not negligible on immunopeptidomics data

Prosit accepts only unmodified residues, `C[UNIMOD:4]` and `M[UNIMOD:35]`, up to
30 aa. On an MHC-I seed that rejected **1,860 of 53,923 precursors (3.45%)**,
almost all N-terminally acetylated (1,050) or cysteinylated (802) — precisely
the population an immunopeptidomics benchmark is measuring. Those precursors
were simulated with MS1 and no fragments, so no search engine could ever
identify them.

They are now predicted with the local model instead, and each precursor records
which model produced its spectrum in a new `intensity_model` column. The subset
is taken from `transmitted_fragment_ions` rather than from the Prosit result
because **both predictors normalise `collision_energy` in place** (dividing by
100, which the Rust frame builder keys on); re-predicting from an
already-normalised frame would divide a second time and quietly shift every
fallback spectrum to a collision energy 100x too low.

## Because the failure mode is silence, the response is checked rather than trusted

- the echoed peptide / charge / collision energy / instrument must match the
  input row the index points at — a bare range check cannot tell a preserved
  index from a reset one, and a reset index is the dangerous case
- no flat slot may be written twice (last-row-wins would depend on response order)
- no annotation may fall outside the b/y layout (a format change must not
  silently remove signal)
- no intensity may be non-finite
- the fallback compares both frames' sequence columns in full before splicing,
  since row position is the only thing connecting them

## Tests

39 tests, none needing network or model weights: the Koina response is built by
hand and the local predictor is stubbed.

- slot arithmetic tied to `reshape_dims` / `mask_outofcharge`: `y1+1 -> 0`,
  `b1+1 -> 3`, `y2+1 -> 6`, `b29+3 -> 173`
- peptides dropped at the start, middle and end of a batch leave their
  neighbours in place
- batches of 1, 2 and 5 all yield one tensor per precursor
- `flatten_prosit_array` accepts the tensor, and the round trip is asserted to
  be a permutation of 0..173 — nothing lost, nothing duplicated
- every integrity guard, including a response re-indexed `0..n_survivors-1`
- the fallback's position handling, provenance column, and the
  double-normalisation trap

## Verified end to end

Five DDA replicates of a 53,923-peptide MHC-I seed against a Thunder-PASEF blank,
9m30s each:

- `.d` reads back as valid Bruker TDF — 22,018 frames (3,146 MS1 + 18,872 PASEF
  MS/MS), 10,596 MS/MS windows, 5,820 precursors, matching the transmitted count
- of 5,820 precursors with a spectrum, **0 have no positive fragment intensity**
  (37-44 per replicate came from the fallback)
- `collision_energy` in the ground-truth DB reads `0.391` — normalised once

Before these commits the run failed at intensity prediction; after the first
commit it failed in frame assembly.

## Review

The index-keying approach and the reshape were reviewed independently by GPT-5
Codex. The echo validation, the duplicate-slot check, hard-erroring on
unmappable annotations, the finite check, and exposing the `predicted` mask all
came from that review.

https://claude.ai/code/session_018PgxSygv4SWJT8yAS3JD9U
