### PR TITLE
fix(imspy-simulation): diagnose a locked output .d instead of a bare pandas traceback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Python bindings organized as 21 submodules:
 | **imspy-predictors** | 0.5.1 | `imspy_predictors` | PyTorch models for CCS, RT, fragment intensities |
 | **imspy-dia** | 0.4.0 | `imspy_dia` | DIA-PASEF clustering and feature extraction |
 | **imspy-search** | 0.4.0 | `imspy_search` | Database search integration (sagepy, mokapot) |
-| **imspy-simulation** | 0.4.1 | `imspy_simulation` | TimSim synthetic data generation & EVAL pipeline |
+| **imspy-simulation** | 0.4.2 | `imspy_simulation` | TimSim synthetic data generation & EVAL pipeline |
 | **imspy-vis** | 0.4.0 | `imspy_vis` | Visualization and plotting tools |
 
 #### imspy-core
@@ -311,7 +311,7 @@ Versions are maintained in:
 - `packages/imspy-predictors/pyproject.toml` (0.5.1)
 - `packages/imspy-dia/pyproject.toml` (0.4.0)
 - `packages/imspy-search/pyproject.toml` (0.4.0)
-- `packages/imspy-simulation/pyproject.toml` (0.4.1)
+- `packages/imspy-simulation/pyproject.toml` (0.4.2)
 - `packages/imspy-vis/pyproject.toml` (0.4.0)
 
 Dependencies between Rust crates reference specific versions (e.g., `mscore = { version = "0.4.1" }`).

--- a/packages/imspy-simulation/pyproject.toml
+++ b/packages/imspy-simulation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imspy-simulation"
-version = "0.4.1"
+version = "0.4.2"
 description = "TimsTOF data simulation tools for proteomics."
 authors = [
     { name = "theGreatHerrLebert", email = "davidteschner@googlemail.com" }

--- a/packages/imspy-simulation/src/imspy_simulation/acquisition.py
+++ b/packages/imspy-simulation/src/imspy_simulation/acquisition.py
@@ -109,6 +109,8 @@ class TimsTofAcquisitionBuilder:
             path=instance.path,
             helper_handle=reference_ds,
             exp_name=exp_name,
+            # Reopening an already-written .d is the point of from_existing.
+            expect_existing=True,
         )
 
         return instance
@@ -377,6 +379,8 @@ class TimsTofAcquisitionBuilderDIA(TimsTofAcquisitionBuilder, ABC):
             path=instance.path,
             helper_handle=reference_ds,
             exp_name=exp_name,
+            # Reopening an already-written .d is the point of from_existing.
+            expect_existing=True,
         )
 
         # Ensure use_reference_ds_layout is supported

--- a/packages/imspy-simulation/src/imspy_simulation/tdf.py
+++ b/packages/imspy-simulation/src/imspy_simulation/tdf.py
@@ -1,4 +1,7 @@
+import os
 import sqlite3
+import warnings
+
 import pandas as pd
 import numpy as np
 
@@ -46,8 +49,92 @@ def validate_frames_id_uniqueness(meta_df: pd.DataFrame) -> None:
     )
 
 
+# SQLite's default busy timeout (5 s via the sqlite3 module) is short enough
+# that ordinary contention surfaces as a hard failure; 30 s absorbs a slow
+# flush without masking a genuinely stuck lock.
+_SQLITE_BUSY_TIMEOUT_S = 30.0
+
+# Filesystems on which SQLite's POSIX advisory locking is unreliable or simply
+# absent. Writing a `.d` onto one of these reports "database is locked" even
+# with a single writer, which is the failure people hit when they move a run to
+# a VM and point --save_path at a mounted share.
+_UNSAFE_LOCK_FILESYSTEMS = {
+    "nfs", "nfs4", "cifs", "smbfs", "smb3", "vboxsf", "9p", "virtiofs",
+    "afs", "lustre", "gpfs", "fuse", "fuseblk", "fuse.sshfs", "fuse.s3fs",
+    "fuse.rclone", "fuse.glusterfs",
+}
+
+
+def _filesystem_type(path) -> str:
+    """Best-effort filesystem type of the mount that ``path`` lives on.
+
+    Linux-only (reads ``/proc/mounts``); returns ``"unknown"`` anywhere the
+    lookup is unavailable. Used only to enrich a diagnostic, never for control
+    flow.
+    """
+    try:
+        target = os.path.realpath(str(path))
+        best_mount, best_type = "", "unknown"
+        with open("/proc/mounts", "r") as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                mount_point = parts[1].replace("\\040", " ")
+                fstype = parts[2]
+                if target == mount_point or target.startswith(mount_point.rstrip("/") + "/"):
+                    if len(mount_point) >= len(best_mount):
+                        best_mount, best_type = mount_point, fstype
+        return best_type
+    except OSError:
+        return "unknown"
+
+
+def _locked_database_error(db_path, exc: Exception) -> RuntimeError:
+    """Turn SQLite's bare "database is locked" into an actionable diagnostic.
+
+    The bare message says nothing about *why* the file is locked, and the two
+    causes need opposite fixes: a live process still holding the lock, versus a
+    filesystem that cannot take the lock at all.
+    """
+    fstype = _filesystem_type(Path(db_path).parent)
+    if fstype in _UNSAFE_LOCK_FILESYSTEMS:
+        fs_verdict = (
+            f"Detected filesystem: '{fstype}' — SQLite locking does not work "
+            f"reliably there, so this is almost certainly the cause."
+        )
+    else:
+        fs_verdict = (
+            f"Detected filesystem: '{fstype}' — locking should work there, so "
+            f"cause (1) or (3) is more likely."
+        )
+
+    return RuntimeError(
+        f"Cannot write the output .d, SQLite reports the database as locked:\n"
+        f"    {db_path}\n"
+        f"\n"
+        f"'database is locked' means another process holds a write lock on this "
+        f"file, or the filesystem it lives on cannot take the lock. Check, in "
+        f"this order:\n"
+        f"\n"
+        f"  1. Is an earlier timsim still running? A run holds this lock from "
+        f"start to finish, and a backgrounded / Ctrl+Z-suspended run (or one "
+        f"alive in another ssh or tmux session) keeps holding it:\n"
+        f"         ps aux | grep timsim\n"
+        f"         fuser -v '{db_path}'      # or: lsof '{db_path}'\n"
+        f"  2. Is the output on a network or shared mount (NFS, CIFS/SMB, "
+        f"VirtualBox vboxsf, 9p/virtiofs, sshfs)? {fs_verdict}\n"
+        f"     Fix: point --save_path at local disk (e.g. ~/timsim_out) and "
+        f"copy the finished .d to the share afterwards.\n"
+        f"  3. Is this output folder left over from an earlier run? Use a fresh "
+        f"experiment name, or an empty output directory.\n"
+        f"\n"
+        f"Original error: {exc}"
+    )
+
+
 class TDFWriter:
-    def __init__(self, helper_handle: TimsDataset, path: str = "./", exp_name: str = "RAW.d", offset_bytes: int = 64, verbose: bool=False, use_rust_compression: bool=False) -> None:
+    def __init__(self, helper_handle: TimsDataset, path: str = "./", exp_name: str = "RAW.d", offset_bytes: int = 64, verbose: bool=False, use_rust_compression: bool=False, expect_existing: bool = False) -> None:
 
         self.path = Path(path)
         self.exp_name = exp_name
@@ -59,6 +146,9 @@ class TDFWriter:
         self.helper_handle = helper_handle
         self.offset_bytes = offset_bytes
         self.verbose = verbose
+        # Set by the ``from_existing`` builders, which legitimately reopen an
+        # already-written .d; suppresses the re-used-output-folder warning.
+        self.expect_existing = expect_existing
         # When True, the per-frame tdf_bin realdata is produced by the Rust
         # encoder (imspy_connector get_data_for_compression) instead of the
         # NumPy/Numba get_compressible_data. The Python dedup+lexsort over
@@ -66,7 +156,6 @@ class TDFWriter:
         # Rust encoder reproduces it byte-for-byte (see scripts/parity_tof_writer.py).
         # Also togglable globally via TIMSIM_RUST_COMPRESSION=1 so a stock
         # `timsim` run can exercise the Rust writer without code changes.
-        import os
         self.use_rust_compression = use_rust_compression or os.environ.get(
             "TIMSIM_RUST_COMPRESSION", "0"
         ) not in ("0", "", "false", "False")
@@ -77,7 +166,14 @@ class TDFWriter:
     def _setup_connections(self) -> None:
         # Create the directory and connect to DB
         self.full_path.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(f'{self.full_path}/analysis.tdf')
+        db_path = self.full_path / "analysis.tdf"
+        self.conn = sqlite3.connect(str(db_path), timeout=_SQLITE_BUSY_TIMEOUT_S)
+
+        # Take the write lock up front: if the file is locked by another process
+        # (or sits on a filesystem that cannot lock), fail here with a diagnostic
+        # that names the cause, instead of deep inside a pandas `to_sql` stack.
+        self._acquire_write_lock(db_path)
+        self._warn_if_output_reused(db_path)
 
         # Create the tables for the analysis.tdf
         frame_ms_ms_info = self.helper_handle.get_table("FrameMsmsInfo")
@@ -91,11 +187,62 @@ class TDFWriter:
         segments.iloc[0, segments.columns.get_loc("LastFrame")] = last_frame
 
         # Save table to analysis.tdf
-        self._create_table(self.conn, self.helper_handle.mz_calibration, "MzCalibration")
-        self._create_table(self.conn, self.helper_handle.tims_calibration, "TimsCalibration")
-        self._create_table(self.conn, self.helper_handle.global_meta_data_pandas, "GlobalMetadata")
-        self._create_table(self.conn, frame_ms_ms_info, "FrameMsmsInfo")
-        self._create_table(self.conn, segments, "Segments")
+        try:
+            self._create_table(self.conn, self.helper_handle.mz_calibration, "MzCalibration")
+            self._create_table(self.conn, self.helper_handle.tims_calibration, "TimsCalibration")
+            self._create_table(self.conn, self.helper_handle.global_meta_data_pandas, "GlobalMetadata")
+            self._create_table(self.conn, frame_ms_ms_info, "FrameMsmsInfo")
+            self._create_table(self.conn, segments, "Segments")
+        except Exception as e:
+            # pandas wraps the sqlite3 error, so match on the message rather than
+            # the exception type; anything else propagates untouched.
+            if "database is locked" in str(e).lower():
+                raise _locked_database_error(db_path, e) from e
+            raise
+
+    def _acquire_write_lock(self, db_path) -> None:
+        """Probe that this process can actually take SQLite's write lock.
+
+        ``BEGIN IMMEDIATE`` reserves the database without writing anything, so a
+        contended or unlockable file is detected before the first table is
+        touched.
+        """
+        try:
+            self.conn.execute("BEGIN IMMEDIATE")
+            self.conn.execute("COMMIT")
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e).lower() or "busy" in str(e).lower():
+                raise _locked_database_error(db_path, e) from e
+            raise
+
+    def _warn_if_output_reused(self, db_path) -> None:
+        """Warn when writing into a `.d` that an earlier run already populated.
+
+        ``mkdir(exist_ok=True)`` plus ``to_sql(if_exists='replace')`` silently
+        overwrites the metadata tables while the old ``analysis.tdf_bin`` blob
+        file is kept, so a re-run into a used folder can produce a `.d` whose
+        metadata and binary disagree.
+        """
+        if self.expect_existing:
+            return
+        try:
+            existing = self.conn.execute(
+                "SELECT count(*) FROM sqlite_master WHERE type = 'table'"
+            ).fetchone()[0]
+        except sqlite3.Error:
+            return
+        if existing == 0:
+            return
+        warnings.warn(
+            f"Output .d already contains an analysis.tdf with {existing} tables: "
+            f"{db_path}. Re-running into an existing output folder overwrites the "
+            f"metadata tables while the old analysis.tdf_bin is kept, which can "
+            f"silently produce a corrupt .d. Use a fresh experiment name or an "
+            f"empty output directory unless you are resuming (--resume / "
+            f"--from_existing).",
+            RuntimeWarning,
+            stacklevel=3,
+        )
 
         # Create the binary file and add the offset bytes
         # TODO: check if this is necessary

--- a/packages/imspy-simulation/tests/test_tdf_writer_guards.py
+++ b/packages/imspy-simulation/tests/test_tdf_writer_guards.py
@@ -9,6 +9,8 @@ change reintroduces a class of bug we haven't anticipated.
 
 from __future__ import annotations
 
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -73,3 +75,123 @@ def test_validate_reports_multiple_duplicate_ids():
     # Both Id=1 and Id=2 should show up in the top-N report.
     assert "1:" in msg or "1," in msg
     assert "2:" in msg or "2," in msg
+
+
+# ---------------------------------------------------------------------------
+# Locked-output diagnostics.
+#
+# The failure these cover, verbatim from a user running timsim on a VM:
+#
+#   pandas.errors.DatabaseError: Execution failed on sql
+#   'DROP TABLE "MzCalibration"': database is locked
+#
+# It says nothing about *why*, and the two causes need opposite fixes: a
+# second live writer, or a filesystem that cannot take a POSIX lock at all
+# (NFS/CIFS/vboxsf/virtiofs — i.e. exactly what you hit when you move a run
+# onto a VM and write to a mounted share).
+# ---------------------------------------------------------------------------
+
+import sqlite3
+
+from imspy_simulation import tdf as tdf_mod
+from imspy_simulation.tdf import TDFWriter, _filesystem_type, _locked_database_error
+
+
+class _FakeHelperHandle:
+    """Minimal stand-in for the reference ``TimsDataset``.
+
+    Supplies only what ``_setup_connections`` reads, so the writer's guards can
+    be exercised without a real Bruker `.d`.
+    """
+
+    mz_calibration = pd.DataFrame({"Id": [1], "ModeIndex": [0]})
+    tims_calibration = pd.DataFrame({"Id": [1], "ModeIndex": [0]})
+    global_meta_data_pandas = pd.DataFrame({"Key": ["MzAcqRangeLower"], "Value": ["100"]})
+    meta_data = pd.DataFrame({"Id": [1, 2, 3]})
+
+    def get_table(self, name: str) -> pd.DataFrame:
+        if name == "Segments":
+            return pd.DataFrame({"Id": [1], "FirstFrame": [1], "LastFrame": [0]})
+        return pd.DataFrame({"Frame": [1], "WindowGroup": [1]})
+
+
+def test_locked_output_raises_actionable_error(tmp_path):
+    # Simulate the real cause: another writer holding an open write transaction
+    # on the output analysis.tdf (a backgrounded or suspended timsim run).
+    exp = "RAW.d"
+    db = tmp_path / exp / "analysis.tdf"
+    db.parent.mkdir(parents=True)
+    squatter = sqlite3.connect(str(db))
+    squatter.execute("CREATE TABLE MzCalibration (Id INT)")
+    squatter.execute("INSERT INTO MzCalibration VALUES (1)")  # holds the write lock
+    assert squatter.in_transaction
+
+    try:
+        with pytest.raises(RuntimeError) as exc:
+            # Short timeout: we want the diagnostic, not a 30 s wait.
+            tdf_mod._SQLITE_BUSY_TIMEOUT_S, saved = 0.1, tdf_mod._SQLITE_BUSY_TIMEOUT_S
+            try:
+                TDFWriter(helper_handle=_FakeHelperHandle(), path=str(tmp_path), exp_name=exp)
+            finally:
+                tdf_mod._SQLITE_BUSY_TIMEOUT_S = saved
+    finally:
+        squatter.close()
+
+    msg = str(exc.value)
+    # Must name the file, both causes, and the commands that tell them apart.
+    assert "database as locked" in msg
+    assert str(db) in msg
+    assert "ps aux | grep timsim" in msg
+    assert "fuser" in msg
+    assert "vboxsf" in msg or "NFS" in msg
+    assert "--save_path" in msg
+    # And must preserve the original SQLite wording so the error stays greppable.
+    assert "database is locked" in msg
+
+
+def test_lock_diagnostic_flags_unsafe_filesystem(monkeypatch, tmp_path):
+    monkeypatch.setattr(tdf_mod, "_filesystem_type", lambda _p: "vboxsf")
+    msg = str(_locked_database_error(tmp_path / "analysis.tdf", sqlite3.OperationalError("database is locked")))
+    assert "'vboxsf'" in msg
+    assert "almost certainly the cause" in msg
+
+
+def test_lock_diagnostic_on_local_filesystem_points_elsewhere(monkeypatch, tmp_path):
+    monkeypatch.setattr(tdf_mod, "_filesystem_type", lambda _p: "ext4")
+    msg = str(_locked_database_error(tmp_path / "analysis.tdf", sqlite3.OperationalError("database is locked")))
+    assert "'ext4'" in msg
+    assert "cause (1) or (3) is more likely" in msg
+
+
+def test_filesystem_type_resolves_a_real_path(tmp_path):
+    # Whatever the CI filesystem is, the lookup must return a concrete type
+    # rather than blowing up — it only ever enriches a diagnostic.
+    fstype = _filesystem_type(tmp_path)
+    assert isinstance(fstype, str) and fstype
+
+
+def test_fresh_output_writes_without_warning(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        writer = TDFWriter(helper_handle=_FakeHelperHandle(), path=str(tmp_path), exp_name="RAW.d")
+    tables = {
+        r[0] for r in writer.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert {"MzCalibration", "TimsCalibration", "GlobalMetadata", "Segments"} <= tables
+    # LastFrame must be patched from the reference meta data.
+    assert writer.conn.execute("SELECT LastFrame FROM Segments").fetchone()[0] == 3
+
+
+def test_reused_output_folder_warns(tmp_path):
+    TDFWriter(helper_handle=_FakeHelperHandle(), path=str(tmp_path), exp_name="RAW.d")
+    with pytest.warns(RuntimeWarning, match="already contains an analysis.tdf"):
+        TDFWriter(helper_handle=_FakeHelperHandle(), path=str(tmp_path), exp_name="RAW.d")
+
+
+def test_expect_existing_suppresses_reuse_warning(tmp_path):
+    # from_existing / resume legitimately reopen a written .d.
+    TDFWriter(helper_handle=_FakeHelperHandle(), path=str(tmp_path), exp_name="RAW.d")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        TDFWriter(helper_handle=_FakeHelperHandle(), path=str(tmp_path),
+                  exp_name="RAW.d", expect_existing=True)


### PR DESCRIPTION
## The report

A user running `timsim` on a Linux VM hit this at acquisition build time:

```
pandas.errors.DatabaseError: Execution failed on sql 'DROP TABLE "MzCalibration"': database is locked
```

Two facts are encoded in that one line, and neither is stated:

1. **`DROP TABLE` was reached at all** → the output `analysis.tdf` already exists with its tables. `to_sql(..., if_exists='replace')` only issues a DROP when the table is there; a fresh output folder would have produced a plain `CREATE TABLE`. So the run targeted a directory a previous run had already written into.
2. **`database is locked`** → something holds a write lock *right now*. SQLite releases locks when a process dies, so this is not leftover state from a cancelled run.

The two causes need opposite fixes:

- **A live second writer.** `TDFWriter.conn` is opened and never closed, and the sim writes `Frames`/`DiaFrameMsMsInfo` through it for the whole run, committing only at checkpoints. An earlier run that is backgrounded, Ctrl+Z-suspended, or alive in another ssh/tmux session holds that lock for hours.
- **A filesystem that cannot take a POSIX lock** — NFS, CIFS/SMB, VirtualBox `vboxsf`, 9p/virtiofs, sshfs. SQLite reports exactly "database is locked" there. This is the likely explanation for *"works on my laptop, fails on the VM"*: the VM is where you suddenly write to a mounted share instead of local disk.

Ruled out: the reference dataset. `rustdf` opens the reference `.d` with a short-lived `rusqlite::Connection::open` per query (`rustdf/src/data/meta.rs`), so the reader never holds a lock across the writer's setup.

## The change

`TDFWriter` now:

- connects with a **30 s busy timeout** instead of `sqlite3`'s 5 s default, so ordinary contention no longer hard-fails;
- **takes the write lock up front** via `BEGIN IMMEDIATE`/`COMMIT`, failing before any table is touched rather than midway through a pandas `to_sql` stack;
- **replaces the bare error** with a diagnostic naming the file, the three causes in likelihood order, the commands that tell them apart, and — via `/proc/mounts` — the actual filesystem type of the output path, plus a verdict on whether that filesystem can lock. The original SQLite wording is preserved so the error stays greppable:

```
Cannot write the output .d, SQLite reports the database as locked:
    /mnt/share/out/RAW.d/analysis.tdf

'database is locked' means another process holds a write lock on this file, or the
filesystem it lives on cannot take the lock. Check, in this order:

  1. Is an earlier timsim still running? A run holds this lock from start to finish,
     and a backgrounded / Ctrl+Z-suspended run (or one alive in another ssh or tmux
     session) keeps holding it:
         ps aux | grep timsim
         fuser -v '/mnt/share/out/RAW.d/analysis.tdf'      # or: lsof '...'
  2. Is the output on a network or shared mount (NFS, CIFS/SMB, VirtualBox vboxsf,
     9p/virtiofs, sshfs)? Detected filesystem: 'vboxsf' — SQLite locking does not work
     reliably there, so this is almost certainly the cause.
     Fix: point --save_path at local disk (e.g. ~/timsim_out) and copy the finished .d
     to the share afterwards.
  3. Is this output folder left over from an earlier run? Use a fresh experiment name,
     or an empty output directory.

Original error: database is locked
```

- **warns when the target `.d` already holds tables.** `mkdir(exist_ok=True)` plus `to_sql(if_exists='replace')` overwrites the metadata tables while the old `analysis.tdf_bin` is kept, so a re-run into a used folder can silently produce a `.d` whose metadata and binary disagree — a corruption path independent of the lock. The new `expect_existing` flag suppresses it for the two `from_existing` builders in `acquisition.py`, which reopen a written `.d` by design.

Note: `--resume` and `--from_existing` reach the writer through the normal `build_acquisition` path, so those runs will emit the reuse warning. Deliberate for now — the message names both flags — but it is noise worth routing differently later.

## Tests

7 new tests in `test_tdf_writer_guards.py`, including an end-to-end reproduction of the reported failure: a squatter connection holding an open write transaction on `MzCalibration`, driven through a real `TDFWriter` against a fake helper handle. Also covers both filesystem verdicts, the `/proc/mounts` lookup, a clean fresh-output write, and the reuse warning with its suppression.

```
tests/test_tdf_writer_guards.py ............    12 passed
```

`test_acquisition_scheme_parity.py` fails to collect in my local env (stale `imspy_connector` without `py_acquisition`) — verified identical on stashed `HEAD`, unrelated to this change.

Version bumped to **0.4.2** (pure-Python change, no connector rebuild needed).

https://claude.ai/code/session_01532ckxwR1fUorKF7CN66uA
