### PR TITLE
test: repair two stale tests and run the Python suites in CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,82 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  # Cheap, no-build guard: the connector's version is declared in BOTH
+  # Cargo.toml and pyproject.toml, and maturin takes the WHEEL version from
+  # pyproject.toml. Bumping only Cargo.toml compiles the new version but emits a
+  # wheel carrying the old one, which PyPI rejects as a duplicate — the release
+  # then publishes nothing while reporting success.
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Connector Cargo.toml and pyproject.toml agree
+        run: |
+          cargo_v=$(grep -m1 '^version' imspy_connector/Cargo.toml | cut -d'"' -f2)
+          py_v=$(grep -m1 '^version' imspy_connector/pyproject.toml | cut -d'"' -f2)
+          echo "Cargo.toml=$cargo_v  pyproject.toml=$py_v"
+          if [ "$cargo_v" != "$py_v" ]; then
+            echo "::error::imspy_connector version mismatch: Cargo.toml=$cargo_v but pyproject.toml=$py_v (maturin uses pyproject.toml for the wheel version)"
+            exit 1
+          fi
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.11", "3.12" ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: imspy_connector
+
+      # Default features only — the vendor extractors (thermo/sciex) need extra
+      # repositories and are not what these tests exercise. This mirrors what the
+      # published wheels contain.
+      - name: Build and install imspy-connector
+        run: |
+          python -m pip install --upgrade pip maturin
+          cd imspy_connector
+          maturin build --release
+          pip install ../target/wheels/*.whl
+
+      # CPU-only torch: the default index resolves CUDA wheels (~2 GB) that a CI
+      # runner neither needs nor has a GPU for.
+      - name: Install CPU torch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install packages under test
+        run: |
+          pip install ./packages/imspy-core
+          pip install ./packages/imspy-predictors
+          pip install ./packages/imspy-search
+          pip install ./packages/imspy-simulation
+          pip install pytest
+
+      - name: imspy-core
+        run: cd packages/imspy-core && pytest tests/ -q
+
+      - name: imspy-predictors
+        run: cd packages/imspy-predictors && pytest tests/ -q
+
+      - name: imspy-simulation
+        run: cd packages/imspy-simulation && pytest tests/ -q

--- a/packages/imspy-predictors/tests/test_utility.py
+++ b/packages/imspy-predictors/tests/test_utility.py
@@ -248,12 +248,33 @@ class TestGetDevice:
 class TestResourcePaths:
     """Test suite for resource path functions."""
 
-    def test_get_model_path(self):
-        """Test getting model path."""
+    def test_get_model_path_rejects_unknown_model(self):
+        """An unrecognised model name is refused, and the error lists what exists.
+
+        Models are no longer bundled in the wheel: get_model_path falls through
+        to the hub, which downloads and hash-verifies against a fixed registry.
+        An unknown name therefore cannot resolve to a path, and must say so
+        rather than returning one that will never exist.
+        """
         from imspy_predictors.utility import get_model_path
 
-        path = get_model_path('test_model')
-        assert 'test_model' in str(path)
+        with pytest.raises(ValueError, match="Unknown model"):
+            get_model_path('test_model')
+
+    def test_known_models_are_registered(self):
+        """The registry carries the models the predictors actually ask for.
+
+        Registry membership is asserted instead of calling get_model_path on a
+        real name: on a wheel install that would download ~21 MB per model, so
+        the resolution path stays out of the unit tests.
+        """
+        from imspy_predictors.pretrained.hub import MODELS
+
+        for name in ('ccs/best_model.pt', 'rt/best_model.pt',
+                     'charge/best_model.pt', 'intensity/best_model.pt',
+                     'pretrained_encoder.pt'):
+            assert name in MODELS, f"{name} missing from the model registry"
+            assert MODELS[name].get('sha256'), f"{name} has no pinned hash"
 
     def test_get_tokenizer_path(self):
         """Test getting tokenizer path."""

--- a/packages/imspy-simulation/tests/test_template_acquisition_common.py
+++ b/packages/imspy-simulation/tests/test_template_acquisition_common.py
@@ -6,6 +6,8 @@ names exist, the ``astral_acquisition`` back-compat aliases still point at them
 the same objects.
 """
 
+import pandas as pd
+
 from imspy_simulation.timsim.jobs import astral_acquisition as A
 from imspy_simulation.timsim.jobs import sciex_acquisition as S
 from imspy_simulation.timsim.jobs import template_acquisition_common as C
@@ -166,11 +168,30 @@ def test_rt_cycle_length_uses_ms1_spacing_not_scan_spacing():
 
 
 def test_rt_cycle_length_raises_on_single_ms1():
-    import pytest
-    ft, *_ = C.build_frame_tables_from_schedule(
-        [(1, 0.0, 1, None, None, None), (2, 0.33, 2, 500.0, 20.0, 25.0)], num_scans=10
-    )
-    with pytest.raises(ValueError):
+    # The frame table is built directly rather than through
+    # build_frame_tables_from_schedule: the schedule gate now rejects a
+    # single-MS1 schedule at ingestion (covered by
+    # test_schedule_gate_rejects_single_ms1), so routing through the builder
+    # never reaches the helper's own guard — which is what this test is for.
+    ft = pd.DataFrame({
+        "frame_id": [1, 2],
+        "time": [0.0, 0.33],
+        "ms_type": [0, 9],  # one MS1 survey => the MS1->MS1 interval is undefined
+    })
+    with pytest.raises(ValueError, match="rt_cycle_length"):
+        C.rt_cycle_length_from_ms1(ft)
+
+
+def test_rt_cycle_length_raises_when_ms1_surveys_share_a_timestamp():
+    # Two MS1 frames, but at the same time: every diff is zero, so the cycle
+    # interval is as undefined as with a single survey. Falling back to a zero
+    # (or per-scan) cycle length is the bug this guard exists to prevent.
+    ft = pd.DataFrame({
+        "frame_id": [1, 2, 3],
+        "time": [1.0, 1.0, 1.5],
+        "ms_type": [0, 0, 9],
+    })
+    with pytest.raises(ValueError, match="rt_cycle_length"):
         C.rt_cycle_length_from_ms1(ft)
 
 


### PR DESCRIPTION
## Why

Two Python tests were failing on `main`. Neither was a real defect — both asserted contracts that deliberate changes had already replaced. They survived because **no CI workflow runs the Python suites**: only `rust.yml` runs, and only for the crates. That same blind spot is why `imspy-connector` drifted 108 commits past its published version without anyone noticing.

## The two tests

**`test_rt_cycle_length_raises_on_single_ms1`** built its fixture by calling `build_frame_tables_from_schedule` with a single-MS1 schedule. The build-from-template schedule gate (`f465dbc6`) now rejects that at ingestion, so the *setup* line raised and the test never reached its assertion:

```
tests/test_template_acquisition_common.py:170: in test_rt_cycle_length_raises_on_single_ms1
    ft, *_ = C.build_frame_tables_from_schedule(...)
E   ValueError: template schedule has 1 MS1 survey(s); a valid DIA acquisition has >= 2
```

The gate is correct and already covered by `test_schedule_gate_rejects_single_ms1`. What this test exists for is the *helper's* own guard in `rt_cycle_length_from_ms1`, which the gate does not replace — that guard was silently untested. The frame table is now built directly so the guard is actually exercised, plus a second case for MS1 surveys sharing a timestamp, where every diff is zero and the cycle interval is equally undefined.

**`test_get_model_path`** called `get_model_path('test_model')` and asserted the returned path contained that name. True when the function merely joined a resource path; since models moved to lazy download (#381) it falls through to the hub, which resolves against a fixed registry and correctly refuses an unknown name. The test now asserts that refusal, plus a registry-membership check that every model the predictors ask for is present with a pinned hash.

Membership is asserted rather than resolution deliberately: on a wheel install, resolving a real model name downloads ~21 MB, which does not belong in a unit test.

## The CI workflow

`.github/workflows/python-tests.yml` runs `imspy-core`, `imspy-predictors` and `imspy-simulation` on Python 3.11 and 3.12. It builds the connector from source first with **default features** — mirroring what the published wheels contain, and avoiding the vendor extractors' extra repositories — and installs **CPU-only torch** so the runner doesn't pull ~2 GB of CUDA wheels it has no GPU for.

It also carries a **version-consistency job**. The connector declares its version in *both* `Cargo.toml` and `pyproject.toml`, and maturin takes the wheel version from `pyproject.toml`. Bumping only `Cargo.toml` compiles the new version but emits a wheel labelled with the old one — PyPI rejects it as a duplicate, so the release publishes nothing while reporting success. That trap was hit during the v0.4.2 preparation and caught by hand; this job catches it automatically:

```
::error::imspy_connector version mismatch: Cargo.toml=0.4.2 but pyproject.toml=0.4.1
         (maturin uses pyproject.toml for the wheel version)
```

## Verification

Green locally against the installed v0.4.2 artifacts:

| Package | Result |
|---|---|
| imspy-core | 8 passed |
| imspy-predictors | 287 passed, 6 skipped |
| imspy-simulation | 148 passed, 15 skipped |

The workflow YAML parses and the version guard was checked against both the current (passing) and the pre-fix (failing) state. The first run on this PR is what proves the runner steps themselves — if the install sequence needs adjusting, it'll show up there.

https://claude.ai/code/session_01532ckxwR1fUorKF7CN66uA
