### PR TITLE
ci: stop one duplicate wheel from cancelling every other platform

### DIFF
--- a/.github/workflows/imspy-connector-publish.yml
+++ b/.github/workflows/imspy-connector-publish.yml
@@ -3,6 +3,10 @@ name: Build and Publish Rust Binding
 on:
   release:
     types: [published]
+  # Lets a partially-published version be completed without cutting a new
+  # release: re-run against the same ref and --skip-existing uploads only the
+  # wheels PyPI is still missing.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -11,8 +15,16 @@ jobs:
   build-and-publish:
     runs-on: ${{ matrix.os }}
     strategy:
+      # One platform failing must not cancel the others: they publish
+      # independent wheels, and a cancelled job means that platform gets no
+      # wheel at all for this version.
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14, macos-15]
+        # macos-14 and macos-15 are both arm64 and were both built with
+        # --target aarch64-apple-darwin, producing byte-identical wheel names
+        # (macosx_11_0_arm64). Whichever uploaded second failed with "File
+        # already exists" and, under the default fail-fast, cancelled the rest.
+        os: [ubuntu-latest, windows-latest, macos-14]
         python-version: ['3.11', '3.12', '3.13']
 
     steps:
@@ -31,7 +43,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ (matrix.os == 'macos-14' || matrix.os == 'macos-15') && 'aarch64-apple-darwin' || '' }}
+          targets: ${{ matrix.os == 'macos-14' && 'aarch64-apple-darwin' || '' }}
 
       - name: Clean Cargo Artifacts
         run: |
@@ -42,7 +54,7 @@ jobs:
         shell: bash
         run: |
           cd imspy_connector
-          if [ "${{ matrix.os }}" = "macos-14" ] || [ "${{ matrix.os }}" = "macos-15" ]; then
+          if [ "${{ matrix.os }}" = "macos-14" ]; then
             maturin build --release --target aarch64-apple-darwin
           else
             maturin build --release
@@ -53,4 +65,6 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.IMSPY_CONNECTOR_PYPI_API_TOKEN }}
         run: |
           cd imspy_connector
-          maturin publish --no-sdist
+          # Idempotent: a wheel this version already has on PyPI is skipped rather
+          # than failing the job, so a dispatch can fill in missing platforms.
+          maturin publish --no-sdist --skip-existing


### PR DESCRIPTION
## What happened

The v0.4.2 release published **Linux 3.11–3.13** and **macOS arm64 3.12/3.13**, then stopped. All three **Windows** jobs and **macOS 3.11** were cancelled, so those platforms have no 0.4.2 wheel.

Because every imspy package in this release now requires `imspy-connector>=0.4.2`, **installing the stack on Windows currently fails to resolve.** Linux is fully covered, so the original report that prompted the release is unblocked.

## Why

Two workflow bugs combined.

**1. A guaranteed duplicate.** `macos-14` and `macos-15` are both arm64, and both built with `--target aarch64-apple-darwin` — so they produce byte-identical wheel names. Whichever uploads second is always rejected:

```
Failed to upload "imspy_connector-0.4.2-cp312-cp312-macosx_11_0_arm64.whl" (6.6 MiB)
  Caused by: File already exists ('imspy_connector-0.4.2-cp312-cp312-macosx_11_0_arm64.whl' …)
```

**2. Default fail-fast.** That guaranteed-failing job then cancelled every platform still building. Windows takes longest, so Windows always loses.

This isn't new — the same signature appears on the `models-v0.6.0` release back in May, which also shows `Rust Binding: failure`. It's been silently costing platforms wheels for months; it only became visible now because the pins make the connector mandatory.

## Fix

- Drop the duplicate macOS runner (`macos-15`), keeping one arm64 builder.
- `fail-fast: false` — platforms publish independently; one failure can't cost another platform its wheel.
- `maturin publish --no-sdist --skip-existing` — an already-uploaded wheel is skipped instead of failing the job.
- Add `workflow_dispatch`, so a partially-published version can be completed by re-running against the same ref rather than cutting a new release. `--skip-existing` makes that safe to repeat.

## Publishing the missing v0.4.2 wheels

A re-run of the existing release run would use the workflow **as it was at the tag**, so it would hit the same bug. Once this merges, the missing Windows and macOS-3.11 wheels can be published by dispatching this workflow against `main` — the connector source there is identical to the `v0.4.2` tag, and `--skip-existing` will skip the wheels PyPI already has.

I have not dispatched anything; that's your call.

## Note

No Intel macOS (x86_64) wheels are produced — before or after this change, the matrix is arm64-only. Flagging rather than changing it, since adding `macos-13` is a separate decision.

https://claude.ai/code/session_01532ckxwR1fUorKF7CN66uA
